### PR TITLE
fix(auth): resolve authorization test failures and fixture issues

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   # People and prescriptions management
   resources :prescriptions do
     resources :take_medicines, only: [:create]
+    resources :medication_takes, only: [:create]
   end
 
   resources :people, except: [:edit] do

--- a/spec/features/dashboard_authorization_spec.rb
+++ b/spec/features/dashboard_authorization_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Dashboard Authorization', type: :system do
+  fixtures :users, :people, :prescriptions, :medicines, :dosages, :carer_relationships
+
+  describe 'viewing the dashboard' do
+    context 'when signed in as an administrator' do
+      let(:admin) { users(:admin) }
+
+      it 'sees all people and prescriptions' do
+        sign_in(admin)
+
+        visit dashboard_path
+
+        # Should see multiple people
+        expect(page).to have_content('John Doe')
+        expect(page).to have_content('Jane Doe')
+        expect(page).to have_content('Bob Smith')
+        expect(page).to have_content('Adult Patient')
+        expect(page).to have_content('Child Patient')
+      end
+    end
+
+    context 'when signed in as a doctor' do
+      let(:doctor) { users(:doctor) }
+
+      it 'sees all people and prescriptions' do
+        sign_in(doctor)
+
+        visit dashboard_path
+
+        # Should see multiple people
+        expect(page).to have_content('John Doe')
+        expect(page).to have_content('Jane Doe')
+        expect(page).to have_content('Bob Smith')
+        expect(page).to have_content('Adult Patient')
+      end
+    end
+
+    context 'when signed in as a nurse' do
+      let(:nurse) { users(:nurse) }
+
+      it 'sees all people and prescriptions' do
+        sign_in(nurse)
+
+        visit dashboard_path
+
+        # Should see multiple people
+        expect(page).to have_content('John Doe')
+        expect(page).to have_content('Jane Doe')
+        expect(page).to have_content('Bob Smith')
+      end
+    end
+
+    context 'when signed in as a carer' do
+      let(:carer) { users(:carer) }
+
+      it 'sees only assigned patients' do
+        sign_in(carer)
+
+        visit dashboard_path
+
+        # Should see assigned patients
+        expect(page).to have_content('Child Patient')
+        expect(page).to have_content('Child User')
+
+        # Should NOT see unassigned patients
+        expect(page).to have_no_content('Bob Smith')
+        expect(page).to have_no_content('John Doe')
+        expect(page).to have_no_content('Jane Doe')
+      end
+
+      it 'sees only prescriptions for assigned patients' do
+        sign_in(carer)
+
+        visit dashboard_path
+
+        # Should see prescriptions for assigned patients
+        # child_patient has ibuprofen prescription
+        expect(page).to have_content('Ibuprofen')
+
+        # Should NOT see Bob's aspirin prescription
+        expect(page).to have_no_content('Aspirin')
+      end
+    end
+
+    context 'when signed in as a parent' do
+      let(:parent) { users(:parent) }
+
+      it 'sees only their minor children' do
+        sign_in(parent)
+
+        visit dashboard_path
+
+        # Should see their child
+        expect(page).to have_content('Child User')
+
+        # Should NOT see other people
+        expect(page).to have_no_content('Bob Smith')
+        expect(page).to have_no_content('John Doe')
+        expect(page).to have_no_content('Jane Doe')
+        expect(page).to have_no_content('Adult Patient')
+      end
+
+      it 'sees only prescriptions for their children' do
+        sign_in(parent)
+
+        visit dashboard_path
+
+        # Should see child's prescription
+        expect(page).to have_content('Paracetamol')
+
+        # Should NOT see other prescriptions
+        expect(page).to have_no_content('Aspirin')
+      end
+    end
+
+    context 'when signed in as an adult patient' do
+      let(:adult_patient) { users(:adult_patient) }
+
+      it 'sees only themselves' do
+        sign_in(adult_patient)
+
+        visit dashboard_path
+
+        # Should see themselves
+        expect(page).to have_content('Adult Patient')
+
+        # Should NOT see other people
+        expect(page).to have_no_content('Bob Smith')
+        expect(page).to have_no_content('John Doe')
+        expect(page).to have_no_content('Jane Doe')
+        expect(page).to have_no_content('Child Patient')
+      end
+
+      it 'sees only their own prescriptions' do
+        sign_in(adult_patient)
+
+        visit dashboard_path
+
+        # Should see their own prescription (paracetamol)
+        expect(page).to have_content('Paracetamol')
+
+        # Should NOT see other prescriptions
+        expect(page).to have_no_content('Aspirin')
+        expect(page).to have_no_content('Ibuprofen')
+      end
+    end
+  end
+end

--- a/spec/fixtures/carer_relationships.yml
+++ b/spec/fixtures/carer_relationships.yml
@@ -15,6 +15,13 @@ nurse_cares_for_john:
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
+adult_patient_self_care:
+  carer: adult_patient_person
+  patient: adult_patient_person
+  relationship_type: 0  # self
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
 parent_cares_for_child:
   carer: parent_person
   patient: child_user_person

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -83,7 +83,7 @@ adult_patient:
   person: adult_patient_person
   email_address: adult.patient@example.com
   password_digest: <%= BCrypt::Password.create("password") %>
-  role: 4  # parent (adult managing own care)
+  role: 3  # carer (adult managing own care)
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RequestHelpers
+  def sign_in_as(user)
+    # Go through the actual login flow to properly set up the session
+    post login_path, params: {
+      email_address: user.email_address,
+      password: 'password'
+    }
+    # The session cookie is now set by the controller
+  end
+end
+
+RSpec.configure do |config|
+  config.include RequestHelpers, type: :request
+end


### PR DESCRIPTION
- Update dashboard tests to use correct /dashboard path instead of root
- Fix adult patient role from parent to carer with self-care relationship
- Add medication_takes route nested under prescriptions
- Remove complex Playwright HTTP tests in favor of policy-level testing
- Clean up request_helpers to use simple login flow

All dashboard authorization tests now passing (9/9). Adult patients can
properly view only their own data through carer role with self-care setup.

Signed-off-by: Dan Webb <dan.webb@damacus.io>
