### PR TITLE
refactor: deduplicate policy patient helper logic

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -38,6 +38,42 @@ class ApplicationPolicy
 
   private
 
+  def record_person_id
+    return if record.nil? || record.is_a?(Class)
+    return record.id if record.is_a?(Person)
+
+    return record.prescription&.person_id if record.respond_to?(:prescription)
+
+    if record.respond_to?(:person)
+      person = record.person
+      return person.id if person
+    end
+
+    record.person_id if record.respond_to?(:person_id)
+  end
+
+  def patient_for_carer?(person_id)
+    return false unless user&.carer? && user.person && person_id
+
+    user.person.patients.exists?(id: person_id)
+  end
+
+  def patient_for_parent?(person_id, minors_only: false)
+    return false unless user&.parent? && user.person && person_id
+
+    relation = user.person.patients
+    relation = relation.where(person_type: :minor) if minors_only
+    relation.exists?(id: person_id)
+  end
+
+  def caregiver_has_patient?(person_id)
+    patient_for_carer?(person_id) || patient_for_parent?(person_id)
+  end
+
+  def parent_has_minor_patient?(person_id)
+    patient_for_parent?(person_id, minors_only: true)
+  end
+
   def admin?
     user&.administrator? || false
   end
@@ -98,6 +134,22 @@ class ApplicationPolicy
 
     def carer_or_parent?
       user&.carer? || user&.parent? || false
+    end
+
+    def carer_patient_ids
+      return [] unless user&.carer? && user.person
+
+      Array(user.person.patient_ids)
+    end
+
+    def parent_minor_patient_ids
+      return [] unless user&.parent? && user.person
+
+      Person.where(id: user.person.patient_ids, person_type: :minor).pluck(:id)
+    end
+
+    def care_relationship_patient_ids
+      (carer_patient_ids + parent_minor_patient_ids).uniq
     end
   end
 end

--- a/app/policies/person_medicine_policy.rb
+++ b/app/policies/person_medicine_policy.rb
@@ -46,9 +46,7 @@ class PersonMedicinePolicy < ApplicationPolicy
   end
 
   def carer_with_patient?
-    return false unless record.respond_to?(:person) && record.person
-
-    (carer_or_parent? && user.person.patients.exists?(id: record.person.id)) || false
+    caregiver_has_patient?(record_person_id)
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -32,15 +32,11 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def carer_with_patient?
-    return false unless carer_or_parent? && user&.person
-
-    user.person.patients.exists?(record.id)
+    caregiver_has_patient?(record_person_id)
   end
 
   def parent_with_minor?
-    return false unless user&.parent? && user.person
-
-    user.person.patients.where(person_type: :minor).exists?(record.id)
+    parent_has_minor_patient?(record_person_id)
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/prescription_policy.rb
+++ b/app/policies/prescription_policy.rb
@@ -68,15 +68,11 @@ class PrescriptionPolicy < ApplicationPolicy
   end
 
   def carer_with_patient?
-    return false unless user&.carer? && user.person
-
-    user.person.patients.exists?(record.person_id)
+    caregiver_has_patient?(record_person_id)
   end
 
   def parent_with_minor?
-    return false unless user&.parent? && user.person
-
-    user.person.patients.where(person_type: :minor).exists?(record.person_id)
+    parent_has_minor_patient?(record_person_id)
   end
 
   class Scope < ApplicationPolicy::Scope
@@ -96,11 +92,11 @@ class PrescriptionPolicy < ApplicationPolicy
     end
 
     def care_relationships?
-      accessible_patient_ids.any?
+      care_relationship_patient_ids.any?
     end
 
     def carer_parent_scope
-      scope.where(person_id: accessible_patient_ids)
+      scope.where(person_id: care_relationship_patient_ids)
     end
 
     def own_prescriptions_scope
@@ -109,29 +105,6 @@ class PrescriptionPolicy < ApplicationPolicy
 
     def owns_record?
       user&.person
-    end
-
-    def carer_with_patient?
-      user&.carer? && user.person
-    end
-
-    def parent_with_minor?
-      user&.parent? && user.person
-    end
-
-    def accessible_patient_ids
-      [].tap do |ids|
-        ids.concat(carer_patient_ids) if user.carer?
-        ids.concat(parent_minor_patient_ids) if user.parent?
-      end
-    end
-
-    def carer_patient_ids
-      Array(user.person&.patient_ids)
-    end
-
-    def parent_minor_patient_ids
-      Array(Person.where(id: user.person&.patient_ids, person_type: :minor).pluck(:id))
     end
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationPolicy do
+  fixtures :people
+
+  let(:policy_class) do
+    Class.new(ApplicationPolicy) do
+      public :record_person_id
+    end
+  end
+
+  let(:user) { nil }
+
+  def policy(record)
+    policy_class.new(user, record)
+  end
+
+  describe '#record_person_id' do
+    it 'returns nil for nil record' do
+      expect(policy(nil).record_person_id).to be_nil
+    end
+
+    it 'returns nil for Class records' do
+      expect(policy(Person).record_person_id).to be_nil
+    end
+
+    it 'returns id when record is a Person' do
+      person = people(:john)
+      expect(policy(person).record_person_id).to eq(person.id)
+    end
+
+    it 'returns prescription.person_id when present' do
+      prescription = instance_double('Prescription', person_id: 123)
+      record = instance_double('RecordWithPrescription', prescription:)
+
+      expect(policy(record).record_person_id).to eq(123)
+    end
+
+    it 'returns person.id when record has a person association' do
+      person = people(:john)
+      record = instance_double('RecordWithPerson', person:)
+
+      expect(policy(record).record_person_id).to eq(person.id)
+    end
+
+    it 'returns person_id attribute when available' do
+      record = instance_double('RecordWithPersonId', person_id: 456, person: nil)
+
+      expect(policy(record).record_person_id).to eq(456)
+    end
+  end
+end


### PR DESCRIPTION
Summary:
Simplify 
record_person_id
 with guard clauses and shared use across policies.
Standardize care-relationship checks in person, prescription, medication take, and person medicine policies.
Add coverage for 
record_person_id
 helper.
Testing:
task test TEST_FILE=spec/policies