### PR TITLE
refactor: isolate Docker environments with unique project names

### DIFF
--- a/Taskfiles/dev.yml
+++ b/Taskfiles/dev.yml
@@ -2,9 +2,22 @@
 # Development Environment Tasks
 # All tasks operate on the 'dev' environment (docker-compose.dev.yml)
 # Usage: task dev:<command>
-version: '3'
+version: "3"
 
 tasks:
+  build:
+    desc: Build development Docker images
+    summary: |
+      Build Docker images for development environment.
+      Use NO_CACHE=true to force a fresh build.
+      Usage: task dev:build
+      Usage: task dev:build NO_CACHE=true
+    cmds:
+      - task: :internal:build
+        vars:
+          ENVIRONMENT: dev
+          NO_CACHE: '{{ .NO_CACHE | default "" }}'
+
   up:
     desc: Start development server
     summary: |
@@ -49,7 +62,7 @@ tasks:
       - task: :internal:stop
         vars:
           ENVIRONMENT: dev
-      - docker compose -f docker-compose.dev.yml down -v  # Remove volumes (drops database)
+      - docker compose -p medtracker-dev -f docker-compose.dev.yml down -v # Remove volumes (drops database)
       - task: :internal:build
         vars:
           ENVIRONMENT: dev
@@ -60,7 +73,7 @@ tasks:
         vars:
           ENVIRONMENT: dev
           SERVICE: web
-          COMMAND: 'rails db:create db:migrate'
+          COMMAND: "rails db:create db:migrate"
       - task: :internal:seed
         vars:
           ENVIRONMENT: dev
@@ -75,9 +88,9 @@ tasks:
       Press Ctrl+C to stop following.
       Usage: task dev:logs
     cmds:
-    - task: :internal:logs
-      vars:
-        ENVIRONMENT: dev
+      - task: :internal:logs
+        vars:
+          ENVIRONMENT: dev
 
   open-ui:
     desc: Open development server UI

--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -2,7 +2,7 @@
 # Internal Tasks - Reusable Docker Compose operations
 # These tasks are marked 'internal: true' and should only be called by other taskfiles
 # They require ENVIRONMENT variable (dev or test) to determine which docker-compose file to use
-version: '3'
+version: "3"
 
 tasks:
   # Execute arbitrary commands in Docker containers
@@ -13,11 +13,11 @@ tasks:
     desc: Run arbitrary command in Docker container
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
       SERVICE: '{{ if eq .ENVIRONMENT "test" }}web-test{{ else if eq .ENVIRONMENT "dev" }}web-dev{{ else }}web{{ end }}'
-      COMMAND: {ref: .COMMAND}
+      COMMAND: { ref: .COMMAND }
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml run --rm --remove-orphans {{ .SERVICE }} {{ .COMMAND }}
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml run --rm {{ .SERVICE }} {{ .COMMAND }}
 
   # Build Docker images for specified environment
   # Required vars: ENVIRONMENT
@@ -27,10 +27,10 @@ tasks:
     desc: Build Docker images
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
       NO_CACHE: '{{ .NO_CACHE | default "" }}'
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml build {{ if .NO_CACHE }}--no-cache{{ end }}
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml build {{ if .NO_CACHE }}--no-cache{{ end }}
 
   # Start Docker containers in detached mode
   # Required vars: ENVIRONMENT
@@ -40,9 +40,9 @@ tasks:
     desc: Start Docker containers
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml up -d --remove-orphans
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml up -d
       - echo "✓ {{ .ENVIRONMENT | title }} environment started"
       - echo "Visit http://localhost:3000 to see the app"
 
@@ -54,9 +54,9 @@ tasks:
     desc: Stop and remove Docker containers
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml down
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml down
       - echo "✓ {{ .ENVIRONMENT | title }} environment stopped"
 
   # Follow logs from Docker containers
@@ -67,17 +67,17 @@ tasks:
     desc: Follow container logs
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml logs -f
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml logs -f
 
   ps:
     desc: Get current status of Docker Compose Stack
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
-      - docker compose -f docker-compose.{{ .ENVIRONMENT }}.yml ps
+      - docker compose -p medtracker-{{ .ENVIRONMENT }} -f docker-compose.{{ .ENVIRONMENT }}.yml ps
 
   seed:
     desc: Seed database with fixtures
@@ -88,20 +88,20 @@ tasks:
       Example: task internal:seed ENVIRONMENT=test
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
       - echo "Seeding {{ .ENVIRONMENT }} database..."
       - task: run
         vars:
-          ENVIRONMENT: {ref: .ENVIRONMENT}
-          COMMAND: 'rails db:seed'
+          ENVIRONMENT: { ref: .ENVIRONMENT }
+          COMMAND: "rails db:seed"
       - defer: echo "✓ Database seeding completed"
 
   open-ui:
     desc: Open development server UI
     internal: true
     vars:
-      ENVIRONMENT: {ref: .ENVIRONMENT}
+      ENVIRONMENT: { ref: .ENVIRONMENT }
     cmds:
       - |
         PORT=$(docker ps --format "{{.Ports}}" -f name=med-tracker-web | grep -oE '0\.0\.0\.0:[0-9]+' | cut -d: -f2)

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -1,17 +1,30 @@
 ---
-version: '3'
+version: "3"
 
 tasks:
+  build:
+    desc: Build test Docker images
+    summary: |
+      Build Docker images for test environment.
+      Use NO_CACHE=true to force a fresh build.
+      Usage: task test:build
+      Usage: task test:build NO_CACHE=true
+    cmds:
+      - task: :internal:build
+        vars:
+          ENVIRONMENT: test
+          NO_CACHE: '{{ .NO_CACHE | default "" }}'
+
   up:
     desc: Start test server
     summary: |
-        Start the test server
-        Creates and starts all containers in detached mode
-        Database data persists between restarts
-        Usage: task test:up
+      Start the test server
+      Creates and starts all containers in detached mode
+      Database data persists between restarts
+      Usage: task test:up
     cmds:
       - task: :internal:up
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
 
   seed:
     desc: Seed test database with fixtures
@@ -22,7 +35,7 @@ tasks:
       Usage: task test:seed
     cmds:
       - task: :internal:seed
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
 
   stop:
     desc: Stop test server
@@ -32,7 +45,7 @@ tasks:
       Usage: task test:stop
     cmds:
       - task: :internal:stop
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
 
   ps:
     desc: List current status of Docker Compose Stack
@@ -41,7 +54,7 @@ tasks:
       Usage: task test:ps
     cmds:
       - task: :internal:ps
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
 
   rebuild:
     desc: Rebuild test server (drops database)
@@ -56,19 +69,19 @@ tasks:
       Usage: task test:rebuild
     cmds:
       - task: :internal:stop
-        vars: {ENVIRONMENT: test}
-      - docker compose -f docker-compose.test.yml down -v  # Remove volumes (drops database)
+        vars: { ENVIRONMENT: test }
+      - docker compose -p medtracker-test -f docker-compose.test.yml down -v # Remove volumes (drops database)
       - task: :internal:build
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
       - task: :internal:up
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
       - task: :internal:run
         vars:
           ENVIRONMENT: test
           SERVICE: web
-          COMMAND: 'rails db:create db:migrate'
+          COMMAND: "rails db:create db:migrate"
       - task: :internal:seed
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }
 
   logs:
     desc: View test server logs
@@ -78,4 +91,4 @@ tasks:
       Usage: task test:logs
     cmds:
       - task: :internal:logs
-        vars: {ENVIRONMENT: test}
+        vars: { ENVIRONMENT: test }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: medtracker_password
       POSTGRES_DB: medtracker_development
     volumes:
-      - postgres_data_dev:/var/lib/postgresql/data
+      - medtracker_dev_postgres:/var/lib/postgresql/data
     ports:
       - "5432"
     healthcheck:
@@ -35,12 +35,13 @@ services:
       - "3000:3000"
     volumes:
       - .:/app
-      - bundle_cache:/usr/local/bundle
-      - node_modules:/app/node_modules
-      - storage_data:/app/storage
+      - medtracker_dev_bundle:/usr/local/bundle
+      - medtracker_dev_node_modules:/app/node_modules
+      - medtracker_dev_storage:/app/storage
     stdin_open: true
     tty: true
-    command: ["bash", "-c", "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0"]
+    command:
+      ["bash", "-c", "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/up || exit 1"]
       interval: 10s
@@ -49,7 +50,11 @@ services:
       start_period: 30s
 
 volumes:
-  postgres_data_dev:
-  bundle_cache:
-  node_modules:
-  storage_data:
+  medtracker_dev_postgres:
+  medtracker_dev_bundle:
+  medtracker_dev_node_modules:
+  medtracker_dev_storage:
+
+networks:
+  default:
+    name: medtracker-dev-network

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,10 +14,6 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-    networks:
-      default:
-        aliases:
-          - db-test
 
   web-test:
     build:
@@ -35,12 +31,16 @@ services:
       - "3001:3000"
     volumes:
       - .:/app
-      - bundle_cache:/usr/local/bundle
-      - node_modules:/app/node_modules
+      - medtracker_test_bundle:/usr/local/bundle
+      - medtracker_test_node_modules:/app/node_modules
       - ./tmp/capybara:/app/tmp/capybara
     stdin_open: true
     tty: true
 
 volumes:
-  bundle_cache:
-  node_modules:
+  medtracker_test_bundle:
+  medtracker_test_node_modules:
+
+networks:
+  default:
+    name: medtracker-test-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: medtracker_password
       POSTGRES_DB: medtracker_production
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - medtracker_prod_postgres:/var/lib/postgresql/data
     ports:
       - "5432"
     healthcheck:
@@ -31,7 +31,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - storage_data:/rails/storage
+      - medtracker_prod_storage:/rails/storage
       - ./config/credentials/production.key:/app/config/credentials/production.key:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/up || exit 1"]
@@ -41,5 +41,9 @@ services:
       start_period: 60s
 
 volumes:
-  postgres_data:
-  storage_data:
+  medtracker_prod_postgres:
+  medtracker_prod_storage:
+
+networks:
+  default:
+    name: medtracker-prod-network


### PR DESCRIPTION
- Use unique volume names per environment (medtracker_dev_*, medtracker_test_*, medtracker_prod_*)
- Use unique network names per environment (medtracker-dev-network, medtracker-test-network, medtracker-prod-network)
- Add docker compose project names (-p medtracker-dev, -p medtracker-test) to all commands
- Remove --remove-orphans flag that was killing other environments
- Add task dev:build and task test:build commands

This allows dev, test, and production environments to run completely side-by-side without any resource conflicts:
- Dev: port 3000
- Test: port 3001
- Production: port 3000 (separate network)