### PR TITLE
fix: remove redundant Success/Error titles from flash messages

### DIFF
--- a/app/components/layouts/flash.rb
+++ b/app/components/layouts/flash.rb
@@ -24,7 +24,6 @@ module Components
         div(data: { controller: 'flash', flash_dismiss_after_value: 3000 }, class: 'pointer-events-auto') do
           Alert(variant: :success) do
             check_icon
-            AlertTitle { 'Success' }
             AlertDescription { @notice }
           end
         end
@@ -34,7 +33,6 @@ module Components
         div(data: { controller: 'flash', flash_dismiss_after_value: 0 }, class: 'pointer-events-auto') do
           Alert(variant: :destructive) do
             alert_icon
-            AlertTitle { 'Error' }
             AlertDescription { @alert }
           end
         end

--- a/spec/components/layouts/flash_spec.rb
+++ b/spec/components/layouts/flash_spec.rb
@@ -10,4 +10,34 @@ RSpec.describe Components::Layouts::Flash, type: :component do
     expect(rendered.to_html).to include('top-4')
     expect(rendered.to_html).to include('z-[60]')
   end
+
+  describe 'notice flash' do
+    it 'renders the notice message directly without redundant title' do
+      rendered = render_inline(described_class.new(notice: 'Medicine added successfully'))
+
+      expect(rendered.text).to include('Medicine added successfully')
+      expect(rendered.text).not_to include('Success')
+    end
+
+    it 'renders the success icon' do
+      rendered = render_inline(described_class.new(notice: 'Saved'))
+
+      expect(rendered.css('svg').any?).to be true
+    end
+  end
+
+  describe 'alert flash' do
+    it 'renders the alert message directly without redundant title' do
+      rendered = render_inline(described_class.new(alert: 'Something went wrong'))
+
+      expect(rendered.text).to include('Something went wrong')
+      expect(rendered.text).not_to include('Error')
+    end
+
+    it 'renders the alert icon' do
+      rendered = render_inline(described_class.new(alert: 'Failed'))
+
+      expect(rendered.css('svg').any?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Removes redundant "Success" and "Error" AlertTitle elements from the Flash component. The icons and color styling (green/red) already convey message severity — the titles added noise without information value.

**UI Principle:** Signal-to-noise ratio — every element must justify its presence. The generic titles were redundant with the visual styling.

## Changes

- **app/components/layouts/flash.rb** — Removed AlertTitle 'Success' and AlertTitle 'Error' from notice/alert rendering
- **spec/components/layouts/flash_spec.rb** — Added tests asserting flash messages render without redundant titles, and that icons are still present

## Testing

- 454 examples, 0 failures, 14 pending
- RuboCop: 405 files inspected, no offenses

Closes: med-tracker-q3fj