### PR TITLE
fix: use notice flash for login redirect instead of error

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -270,9 +270,21 @@ class RodauthMain < Rodauth::Rails::Auth
       Person.where(account_id: account_id).find_each { |p| p.update!(account_id: nil) }
     end
 
+    # ==> Flash overrides
+    # Login redirect is routine, not an error — use notice instead of alert
+    require_login_error_flash { I18n.t('authentication.login_required', default: 'Please login to continue') }
+
     # ==> Views
     # Render Phlex components directly for speed (no ERB indirection)
     auth_class_eval do
+      def set_redirect_error_flash(message) # rubocop:disable Naming/AccessorMethodName
+        if message == require_login_error_flash
+          set_notice_flash(message)
+        else
+          super
+        end
+      end
+
       def view(page, title)
         phlex_class = "Views::Rodauth::#{page.to_s.tr('-', '_').camelize}".safe_constantize
         if phlex_class

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       unauthorized: "You are not authorized to perform this action."
 
   authentication:
+    login_required: "Please login to continue"
     two_factor_required: "For enhanced security, please set up two-factor authentication for your account."
 
   invitation_mailer:


### PR DESCRIPTION
## Summary

Fixes the **Boy Who Cried Wolf** anti-pattern where being redirected to the login page showed a red error flash ("Please login to continue"). Being redirected to login is a routine state, not an error.

## Changes

- **app/misc/rodauth_main.rb** — Override `set_redirect_error_flash` to use notice flash for the require_login message
- **config/locales/en.yml** — Add `authentication.login_required` locale key

## UI Principle

**Boy Who Cried Wolf**: Using error/destructive styling for routine messages trains users to ignore actual errors. The login redirect now uses the notice (success) variant which correctly signals "here's what to do next" rather than "something went wrong".

## Testing

- 454 examples, 0 failures
- RuboCop: 405 files, no offenses

Closes: med-tracker-5enb