### PR TITLE
fix: reduce Delete button visual weight on dashboard

### DIFF
--- a/app/components/dashboard/prescription_helpers.rb
+++ b/app/components/dashboard/prescription_helpers.rb
@@ -10,7 +10,7 @@ module Components
 
       def delete_classes
         'inline-flex items-center justify-center rounded-full text-sm font-medium transition-colors ' \
-          'min-h-[44px] min-w-[44px] px-4 py-2 bg-red-100 text-red-700 hover:bg-red-200'
+          'min-h-[44px] min-w-[44px] px-4 py-2 text-red-600 hover:bg-red-50 hover:text-red-700'
       end
 
       def format_dosage

--- a/spec/components/dashboard/prescription_helpers_spec.rb
+++ b/spec/components/dashboard/prescription_helpers_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Components::Dashboard::PrescriptionHelpers do
   end
 
   describe '#delete_classes' do
-    it 'returns the correct CSS classes for delete button' do
-      expected_classes = 'inline-flex items-center justify-center rounded-full text-sm font-medium transition-colors ' \
-                         'min-h-[44px] min-w-[44px] px-4 py-2 bg-red-100 text-red-700 hover:bg-red-200'
-      expect(instance.delete_classes).to eq(expected_classes)
+    it 'uses visually subordinate styling (not filled red background)' do
+      classes = instance.delete_classes
+      expect(classes).not_to include('bg-red-100')
+      expect(classes).to include('text-red-600')
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes the **visual hierarchy** issue where the Delete button had equal or greater visual prominence than Take Now on the dashboard medication schedule. Delete is a rare, destructive action while Take Now is the primary workflow action.

## Changes

- **app/components/dashboard/prescription_helpers.rb** — Change Delete from filled red (`bg-red-100`) to ghost style (`text-red-600 hover:bg-red-50`)
- **spec/components/dashboard/prescription_helpers_spec.rb** — Update spec to assert subordinate styling

## UI Principle

**Visual Hierarchy / Affordance**: The primary action (Take Now) should have the strongest visual weight. Destructive actions (Delete) should be visually subordinate to prevent accidental clicks and guide users toward the intended workflow.

## Testing

- 454 examples, 0 failures
- RuboCop: 405 files, no offenses

Closes: med-tracker-un80