### PR TITLE
fix: remove redundant Current Supply card from medicine show

### DIFF
--- a/app/components/medicines/show_view.rb
+++ b/app/components/medicines/show_view.rb
@@ -39,7 +39,6 @@ module Components
         div(class: 'grid grid-cols-1 md:grid-cols-2 gap-6 mb-8') do
           render_description_card
           render_dosage_card
-          render_supply_card
           render_stock_card
           render_reorder_card
           render_warnings_card if medicine.warnings.present?

--- a/spec/components/medicines/show_view_spec.rb
+++ b/spec/components/medicines/show_view_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medicines::ShowView, type: :component do
+  let(:medicine) { create(:medicine, name: 'Paracetamol', current_supply: 50, stock: 100) }
+
+  it 'renders the medicine name' do
+    rendered = render_inline(described_class.new(medicine: medicine))
+
+    expect(rendered.text).to include('Paracetamol')
+  end
+
+  it 'does not show both Current Supply and Stock cards (signal-to-noise)' do
+    rendered = render_inline(described_class.new(medicine: medicine))
+
+    headings = rendered.css('h2').map(&:text)
+    supply_headings = headings.grep(/supply|stock/i)
+    expect(supply_headings.length).to eq(1),
+                                      "Expected 1 inventory heading but found #{supply_headings.length}: " \
+                                      "#{supply_headings.inspect}. Redundant inventory cards violate " \
+                                      'signal-to-noise ratio.'
+  end
+end


### PR DESCRIPTION
## Summary

Removes the redundant "Current Supply" card from the medicine show page. Both "Current Supply" and "Stock on Hand" displayed the same type of information (inventory count), creating signal noise.

## Changes

- **app/components/medicines/show_view.rb** — Remove `render_supply_card` from `render_details`
- **spec/components/medicines/show_view_spec.rb** — New spec asserting only one inventory heading

## UI Principle

**Signal-to-Noise Ratio**: Redundant information degrades the interface. Users had to parse two nearly identical numbers to understand inventory status.

## Testing

- 456 examples, 0 failures
- RuboCop: 406 files, no offenses

Closes: med-tracker-mey6