### PR TITLE
fix: use RubyUI::Badge for Needs Carer badge instead of inline styles

### DIFF
--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -67,14 +67,11 @@ module Components
       end
 
       def render_needs_carer_badge
-        badge_classes = 'inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs ' \
-                        'font-medium text-amber-800 ring-1 ring-inset ring-amber-600/20'
-        span(
-          class: badge_classes,
+        render RubyUI::Badge.new(
+          variant: :warning,
+          size: :md,
           data: { testid: 'needs-carer-badge' }
-        ) do
-          plain 'Needs Carer'
-        end
+        ) { 'Needs Carer' }
       end
 
       def render_card_footer

--- a/spec/components/people/person_card_spec.rb
+++ b/spec/components/people/person_card_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::People::PersonCard, type: :component do
+  let(:person) do
+    build(:person, :dependent_adult, id: 1, name: 'Jane Doe')
+  end
+
+  it 'renders Needs Carer badge using RubyUI::Badge component (not inline styles)' do
+    rendered = render_inline(described_class.new(person: person))
+
+    badge = rendered.at_css('[data-testid="needs-carer-badge"]')
+    expect(badge).to be_present, 'Expected Needs Carer badge to be rendered'
+    expect(badge.name).to eq('span')
+    expect(badge['class']).to include('ring-warning/20'),
+                              'Expected badge to use RubyUI::Badge warning variant classes'
+  end
+end


### PR DESCRIPTION
## Summary

Replaces inline badge styling on the PersonCard "Needs Carer" badge with the `RubyUI::Badge` component (`:warning` variant). This ensures consistency with other badges in the system and follows DRY principles.

## Changes

- **app/components/people/person_card.rb** — Replace inline `span` with `RubyUI::Badge.new(variant: :warning)`
- **spec/components/people/person_card_spec.rb** — New spec asserting badge uses RubyUI::Badge warning variant

## UI Principle

**Consistency**: All badges should use the same component so styling changes propagate uniformly.

## Testing

- 455 examples, 0 failures
- RuboCop: 406 files, no offenses

Closes: med-tracker-v0dz