### PR TITLE
fix: add space between dosage amount and unit for consistency

### DIFF
--- a/app/components/dashboard/prescription_helpers.rb
+++ b/app/components/dashboard/prescription_helpers.rb
@@ -9,7 +9,7 @@ module Components
         return '—' unless amount && unit
 
         formatted_amount = amount == amount.to_i ? amount.to_i : amount
-        "#{formatted_amount}#{unit}"
+        "#{formatted_amount} #{unit}"
       end
 
       def format_end_date

--- a/spec/components/dashboard/prescription_helpers_spec.rb
+++ b/spec/components/dashboard/prescription_helpers_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Components::Dashboard::PrescriptionHelpers do
   describe '#format_dosage' do
     context 'when dosage has amount and unit' do
       it 'formats integer amounts without decimal' do
-        expect(instance.format_dosage).to eq('500mg')
+        expect(instance.format_dosage).to eq('500 mg')
       end
 
       it 'formats decimal amounts with decimal' do
@@ -45,7 +45,7 @@ RSpec.describe Components::Dashboard::PrescriptionHelpers do
         custom_prescription = Prescription.new(person: person, medicine: medicine, dosage: dosage)
         custom_instance = test_class.new(prescription: custom_prescription, current_user: user)
 
-        expect(custom_instance.format_dosage).to eq('2.5ml')
+        expect(custom_instance.format_dosage).to eq('2.5 ml')
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes dosage format inconsistency where PrescriptionHelpers#format_dosage output 500mg (no space) while PersonMedicines::Card#medicine_description output 500 mg (with space).

## Changes

- **app/components/dashboard/prescription_helpers.rb**: Added space between amount and unit in format_dosage method
- **spec/components/dashboard/prescription_helpers_spec.rb**: Updated expectations to match new format

## UI Principle

**Consistency** - Same data (dosage) should be displayed identically across all views.

## Before/After

| Before | After |
|--------|-------|
| 500mg | 500 mg |
| 2.5ml | 2.5 ml |

Closes: med-tracker-thvl