### PR TITLE
fix: use amber/warning styling for countdown notices distinct from notes

### DIFF
--- a/app/components/person_medicines/card.rb
+++ b/app/components/person_medicines/card.rb
@@ -86,8 +86,8 @@ module Components
       end
 
       def render_countdown_notice
-        div(class: 'p-3 bg-blue-50 border border-blue-200 rounded-md') do
-          Text(size: '2', class: 'text-blue-800') do
+        div(class: 'p-3 bg-amber-50 border border-amber-200 rounded-md') do
+          Text(size: '2', class: 'text-amber-800') do
             span(class: 'font-semibold') { '🕐 Next dose available in: ' }
             plain person_medicine.countdown_display
           end

--- a/app/components/prescriptions/card.rb
+++ b/app/components/prescriptions/card.rb
@@ -81,8 +81,8 @@ module Components
       end
 
       def render_notes
-        div(class: 'p-3 bg-amber-50 border border-amber-200 rounded-md') do
-          Text(size: '2', class: 'text-amber-800') do
+        div(class: 'p-3 bg-blue-50 border border-blue-200 rounded-md') do
+          Text(size: '2', class: 'text-blue-800') do
             span(class: 'font-semibold') { '📝 Notes: ' }
             plain prescription.notes
           end
@@ -90,8 +90,8 @@ module Components
       end
 
       def render_countdown_notice
-        div(class: 'p-3 bg-blue-50 border border-blue-200 rounded-md') do
-          Text(size: '2', class: 'text-blue-800') do
+        div(class: 'p-3 bg-amber-50 border border-amber-200 rounded-md') do
+          Text(size: '2', class: 'text-amber-800') do
             span(class: 'font-semibold') { '🕐 Next dose available in: ' }
             plain prescription.countdown_display
           end

--- a/spec/components/person_medicines/card_countdown_spec.rb
+++ b/spec/components/person_medicines/card_countdown_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::PersonMedicines::Card, type: :component do
+  let(:person) { create(:person) }
+  let(:medicine) { create(:medicine, name: 'Paracetamol') }
+
+  let(:person_medicine) do
+    PersonMedicine.create!(
+      person: person,
+      medicine: medicine,
+      notes: 'Take with food',
+      max_daily_doses: 4,
+      min_hours_between_doses: 4
+    )
+  end
+
+  def render_card
+    vc = view_context
+    vc.singleton_class.define_method(:current_user) { nil }
+    policy_stub = Struct.new(:take_medicine?, :destroy?).new(false, false)
+    vc.singleton_class.define_method(:policy) { |_record| policy_stub }
+
+    html = vc.render(described_class.new(person_medicine: person_medicine, person: person))
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  describe 'countdown notice styling' do
+    before do
+      MedicationTake.create!(person_medicine: person_medicine, taken_at: 1.hour.ago)
+      allow(person_medicine).to receive_messages(can_take_now?: false, countdown_display: '3 hours')
+    end
+
+    it 'uses amber/warning styling distinct from notes' do
+      rendered = render_card
+
+      countdown_div = rendered.css('[class*="bg-amber-50"]').detect { |el| el.text.include?('Next dose') }
+      notes_div = rendered.css('[class*="bg-blue-50"]').detect { |el| el.text.include?('Notes') }
+
+      expect(countdown_div).to be_present, 'countdown notice should use amber (warning) background'
+      expect(notes_div).to be_present, 'notes should use blue (info) background'
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes countdown notice styling that was visually indistinguishable from notes sections. Both used the same blue info styling, making it impossible to distinguish time-sensitive countdown alerts from static notes.

## Changes

- **PersonMedicines::Card**: countdown notice blue → amber (was identical to notes)
- **Prescriptions::Card**: countdown notice blue → amber
- **Prescriptions::Card**: notes amber → blue (restore correct info styling)
- **New spec**: verifies countdown uses amber and notes uses blue

## Design Pattern

| Element | Color | Semantic |
|---------|-------|----------|
| Notes | Blue (bg-blue-50) | Informational |
| Countdown | Amber (bg-amber-50) | Time-sensitive warning |

Closes: med-tracker-b6nl