### PR TITLE
fix: replace raw CSS button classes with RubyUI Link variants in dashboard

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -36,11 +36,13 @@ module Components
         div(class: 'flex flex-row flex-wrap gap-2 sm:gap-3') do
           Link(
             href: url_helpers&.new_medicine_path || '#',
-            class: "#{button_primary_classes} min-h-[44px]"
+            variant: :primary,
+            class: 'min-h-[44px]'
           ) { 'Add Medicine' }
           Link(
             href: url_helpers&.new_person_path || '#',
-            class: "#{button_secondary_classes} min-h-[44px]"
+            variant: :secondary,
+            class: 'min-h-[44px]'
           ) { 'Add Person' }
         end
       end
@@ -51,16 +53,6 @@ module Components
           render Components::Dashboard::StatCard.new(title: 'Active Prescriptions', value: active_prescriptions.count,
                                                      icon_type: 'pill')
         end
-      end
-
-      def button_primary_classes
-        'inline-flex items-center justify-center rounded-md font-medium transition-colors ' \
-          'px-4 py-2 h-9 min-h-[36px] text-sm bg-primary text-primary-foreground shadow hover:bg-primary/90'
-      end
-
-      def button_secondary_classes
-        'inline-flex items-center justify-center rounded-md font-medium transition-colors ' \
-          'px-4 py-2 h-9 min-h-[36px] text-sm bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80'
       end
 
       def render_prescriptions_section

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
+  describe 'quick actions' do
+    it 'renders Add Medicine and Add Person links' do
+      rendered = render_inline(dashboard_view)
+      expect(rendered.text).to include('Add Medicine')
+      expect(rendered.text).to include('Add Person')
+    end
+
+    it 'does not define hand-rolled button CSS helper methods' do
+      expect(described_class.private_instance_methods).not_to include(:button_primary_classes)
+      expect(described_class.private_instance_methods).not_to include(:button_secondary_classes)
+    end
+  end
+
   context 'when there are people but no prescriptions' do
     let(:active_prescriptions) { [] }
     let(:upcoming_prescriptions) { {} }


### PR DESCRIPTION
## Summary

Dashboard quick actions used hand-rolled `button_primary_classes`/`button_secondary_classes` methods that duplicated RubyUI Button/Link component logic. Replaced with proper RubyUI `Link` component variants.

## Changes

- **app/components/dashboard/index_view.rb**: Use `Link(variant: :primary)` and `Link(variant: :secondary)` instead of raw CSS class strings
- **app/components/dashboard/index_view.rb**: Removed dead `button_primary_classes` and `button_secondary_classes` helper methods
- **spec/components/dashboard/index_view_spec.rb**: Added specs verifying quick actions render and dead code is removed

## Before/After

```ruby
# Before
Link(href: url, class: "\#{button_primary_classes} min-h-[44px]") { 'Add Medicine' }

# After
Link(href: url, variant: :primary, class: 'min-h-[44px]') { 'Add Medicine' }
```

Closes: med-tracker-r0r4