### PR TITLE
fix: add min-h-[24px] to desktop nav links for WCAG 2.5.8 compliance

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -191,7 +191,7 @@
 	}
 
 	.nav__link {
-		@apply inline-flex items-center rounded-md px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-900 hover:bg-slate-100;
+		@apply inline-flex items-center rounded-md px-3 py-2 min-h-[24px] text-sm font-medium text-slate-600 transition-colors hover:text-slate-900 hover:bg-slate-100;
 	}
 
 	.nav__user-menu {

--- a/spec/components/layouts/desktop_nav_spec.rb
+++ b/spec/components/layouts/desktop_nav_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Layouts::DesktopNav, type: :component do
+  it 'renders nav links with nav__link class' do
+    rendered = render_inline(described_class.new)
+
+    links = rendered.css('a.nav__link')
+    expect(links.length).to eq(3)
+    expect(links.map(&:text)).to contain_exactly('Medicines', 'People', 'Medicine Finder')
+  end
+end


### PR DESCRIPTION
## Summary

Desktop nav links were missing minimum height for touch targets, unlike BottomNav which correctly had it. Added `min-h-[24px]` to the shared `.nav__link` CSS class.

## Changes

- **app/assets/tailwind/application.css**: Added `min-h-[24px]` to `.nav__link` class
- **New spec**: DesktopNav component spec verifying nav links render correctly

## WCAG Reference

SC 2.5.8 requires interactive targets to be at least 24x24 CSS pixels. The `.nav__link` class is shared across desktop nav, mobile menu, and login links.

Closes: med-tracker-ps8t