### PR TITLE
fix: standardize medicine icon color to violet across medication cards

### DIFF
--- a/app/components/person_medicines/card.rb
+++ b/app/components/person_medicines/card.rb
@@ -57,7 +57,7 @@ module Components
       end
 
       def render_medicine_icon
-        div(class: 'w-10 h-10 rounded-xl flex items-center justify-center bg-success-light text-success mb-2') do
+        div(class: 'w-10 h-10 rounded-xl flex items-center justify-center bg-violet-100 text-violet-700 mb-2') do
           render Icons::Pill.new(size: 20)
         end
       end

--- a/spec/components/person_medicines/card_icon_spec.rb
+++ b/spec/components/person_medicines/card_icon_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::PersonMedicines::Card, type: :component do
+  let(:person) { create(:person) }
+  let(:medicine) { create(:medicine, name: 'Paracetamol') }
+
+  let(:person_medicine) do
+    PersonMedicine.create!(
+      person: person,
+      medicine: medicine,
+      max_daily_doses: 4,
+      min_hours_between_doses: 4
+    )
+  end
+
+  def render_card
+    vc = view_context
+    vc.singleton_class.define_method(:current_user) { nil }
+    policy_stub = Struct.new(:take_medicine?, :destroy?).new(false, false)
+    vc.singleton_class.define_method(:policy) { |_record| policy_stub }
+
+    html = vc.render(described_class.new(person_medicine: person_medicine, person: person))
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  describe 'medicine icon color' do
+    it 'uses violet styling consistent with Prescriptions::Card' do
+      rendered = render_card
+
+      icon_container = rendered.css('div').detect { |d| d['class']&.include?('w-10') && d['class'].include?('h-10') }
+      expect(icon_container).to be_present, 'Expected to find a 10x10 icon container div'
+      expect(icon_container['class']).to include('bg-violet-100')
+      expect(icon_container['class']).to include('text-violet-700')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Medicine icons used different background colors without semantic meaning - PersonMedicines::Card used green while Prescriptions::Card used violet. Standardized to violet for all medicine pill icons.

## Changes

- **app/components/person_medicines/card.rb**: Icon color `bg-success-light text-success` → `bg-violet-100 text-violet-700`
- **New spec**: verifies icon color matches Prescriptions::Card

## Rationale

Same entity type (medicine) should have consistent visual treatment. Violet is used for medicine icons across Prescriptions::Card and People::PersonCard. Green is reserved for success states (dose counter).

Closes: med-tracker-fqyg