### PR TITLE
fix: add min-w-[80px] to card footer Take buttons for visual stability

### DIFF
--- a/app/components/person_medicines/card.rb
+++ b/app/components/person_medicines/card.rb
@@ -159,7 +159,7 @@ module Components
               type: :submit,
               variant: :primary,
               size: :sm,
-              class: 'inline-flex items-center gap-1'
+              class: 'inline-flex items-center gap-1 min-w-[80px]'
             ) do
               plain '💊 Take'
             end

--- a/app/components/prescriptions/card.rb
+++ b/app/components/prescriptions/card.rb
@@ -138,7 +138,7 @@ module Components
               type: :submit,
               variant: :primary,
               size: :md,
-              class: 'inline-flex items-center gap-1'
+              class: 'inline-flex items-center gap-1 min-w-[80px]'
             ) do
               plain '💊 Take'
             end

--- a/spec/components/prescriptions/card_button_min_width_spec.rb
+++ b/spec/components/prescriptions/card_button_min_width_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Prescriptions::Card, type: :component do
+  describe 'Take button min-width' do
+    it 'has min-w-[80px] for visual stability in Prescriptions::Card' do
+      source = Rails.root.join('app/components/prescriptions/card.rb').read
+      take_button_section = source[/Button\(\s*type: :submit.*?end/m]
+      expect(take_button_section).to include('min-w-[80px]'),
+                                     'Prescriptions Take button should have min-w-[80px] for visual stability'
+    end
+
+    it 'has min-w-[80px] for visual stability in PersonMedicines::Card' do
+      source = Rails.root.join('app/components/person_medicines/card.rb').read
+      take_button_section = source[/Button\(\s*type: :submit.*?end/m]
+      expect(take_button_section).to include('min-w-[80px]'),
+                                     'PersonMedicines Take button should have min-w-[80px] for visual stability'
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Card footer buttons (Take, Edit, Delete, Remove) have varying text lengths but no min-width, causing visual instability. Added `min-w-[80px]` to primary Take action buttons in both card components.

## Changes

- **app/components/prescriptions/card.rb**: Added `min-w-[80px]` to Take button
- **app/components/person_medicines/card.rb**: Added `min-w-[80px]` to Take button
- **New spec**: verifies min-width presence in both card components

Closes: med-tracker-f9zx