### PR TITLE
refactor: convert Playwright tests to rack_test where JS not needed

### DIFF
--- a/spec/config/otlp_exporter_spec.rb
+++ b/spec/config/otlp_exporter_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'OTEL-011: OTLP exporter configuration' do
   context 'when configuring the OpenTelemetry SDK' do
     it 'configures OpenTelemetry with service name medtracker-test' do
@@ -81,3 +82,4 @@ RSpec.describe 'OTEL-011: OTLP exporter configuration' do
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/config/passkey_configuration_spec.rb
+++ b/spec/config/passkey_configuration_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'PASSKEY-001: WebAuthn/Passkey configuration' do
   fixtures :accounts
   scenario 'WebAuthn key timestamps default to current timestamp' do
@@ -45,3 +46,4 @@ RSpec.describe 'PASSKEY-001: WebAuthn/Passkey configuration' do
     expect(RodauthMain.instance_methods).to include(:webauthn_auth_path)
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/features/admin/user_edit_button_spec.rb
+++ b/spec/features/admin/user_edit_button_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Admin User Edit Button', type: :system do
+RSpec.describe 'Admin User Edit Button', browser: false, type: :system do
   fixtures :all
 
   let(:admin) { users(:damacus) }
   let(:target_user) { users(:john) }
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
     sign_in(admin)
     visit admin_users_path
   end

--- a/spec/features/authentication/passkey_registration_spec.rb
+++ b/spec/features/authentication/passkey_registration_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'PASSKEY-002: Passkey registration', type: :system do
+RSpec.describe 'PASSKEY-002: Passkey registration', browser: false, type: :system do
   fixtures :all
+
+  before do
+    driven_by(:rack_test)
+  end
 
   let(:account) { accounts(:damacus) }
 

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Authentication Features', type: :system do
+RSpec.describe 'Authentication Features', browser: false, type: :system do
   fixtures :accounts, :people, :users, :account_otp_keys
+
+  before do
+    driven_by(:rack_test)
+  end
 
   describe 'AUTH-019: Additional factor required for 2FA accounts' do
     it 'redirects to TOTP authentication after password login' do

--- a/spec/features/dashboard_authorization_spec.rb
+++ b/spec/features/dashboard_authorization_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Dashboard Authorization', type: :system do
+RSpec.describe 'Dashboard Authorization', browser: false, type: :system do
   fixtures :accounts, :account_otp_keys, :people, :users, :prescriptions, :medicines, :dosages, :carer_relationships
+
+  before do
+    driven_by(:rack_test)
+  end
 
   describe 'viewing the dashboard' do
     context 'when signed in as an administrator' do

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -2,7 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'User Signup', type: :system do
+RSpec.describe 'User Signup', browser: false, type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
   describe 'creating a new account' do
     it 'creates both an Account and a Person with valid details' do
       visit create_account_path

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,15 +36,15 @@ RSpec.configure do |config|
   # This allows CI to split tests with `--tag browser` / `--tag ~browser`
   # instead of maintaining brittle path patterns.
   config.define_derived_metadata(file_path: %r{/spec/(system|features|views)/}) do |metadata|
-    metadata[:browser] = true
+    metadata[:browser] = true unless metadata.key?(:browser)
   end
 
   config.define_derived_metadata(type: :system) do |metadata|
-    metadata[:browser] = true
+    metadata[:browser] = true unless metadata.key?(:browser)
   end
 
   config.define_derived_metadata(type: :feature) do |metadata|
-    metadata[:browser] = true
+    metadata[:browser] = true unless metadata.key?(:browser)
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Admin Dashboard' do
+RSpec.describe 'Admin Dashboard', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users
+
+  before do
+    driven_by(:rack_test)
+  end
 
   context 'when user is an administrator' do
     it 'displays key system metrics' do

--- a/spec/system/authorization/admin_access_spec.rb
+++ b/spec/system/authorization/admin_access_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Admin Access Authorization' do
+RSpec.describe 'Admin Access Authorization', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:admin) { users(:admin) }

--- a/spec/system/authorization/carer_access_spec.rb
+++ b/spec/system/authorization/carer_access_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Carer Access Authorization' do
+RSpec.describe 'Carer Access Authorization', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users, :carer_relationships
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:carer) { users(:carer) }

--- a/spec/system/authorization/clinician_access_spec.rb
+++ b/spec/system/authorization/clinician_access_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Clinician Access Authorization' do
+RSpec.describe 'Clinician Access Authorization', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:doctor) { users(:doctor) }

--- a/spec/system/authorization/dashboard_authorization_spec.rb
+++ b/spec/system/authorization/dashboard_authorization_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Dashboard Authorization' do
+RSpec.describe 'Dashboard Authorization', browser: false do
   fixtures :all
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:admin) { users(:admin) }

--- a/spec/system/authorization/medication_takes_authorization_spec.rb
+++ b/spec/system/authorization/medication_takes_authorization_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Medication Takes Authorization' do
+RSpec.describe 'Medication Takes Authorization', browser: false do
   fixtures :all
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:admin) { users(:admin) }

--- a/spec/system/authorization/person_medicines_authorization_spec.rb
+++ b/spec/system/authorization/person_medicines_authorization_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Person Medicines Authorization' do
+RSpec.describe 'Person Medicines Authorization', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users, :medicines, :carer_relationships
 
   before do
-    driven_by(:playwright)
+    driven_by(:rack_test)
   end
 
   let(:admin) { users(:admin) }

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Home' do
+RSpec.describe 'Home', browser: false do
   fixtures :accounts, :account_otp_keys, :people, :users, :medicines, :dosages, :prescriptions
+
+  before do
+    driven_by(:rack_test)
+  end
 
   it 'loads the dashboard as the home page for a signed-in user' do
     # Sign in the user from fixtures

--- a/spec/system/two_factor_soft_enforcement_spec.rb
+++ b/spec/system/two_factor_soft_enforcement_spec.rb
@@ -3,8 +3,12 @@
 require 'rails_helper'
 
 # rubocop:disable Capybara/NegationMatcherAfterVisit
-RSpec.describe 'Two-Factor Soft Enforcement' do
+RSpec.describe 'Two-Factor Soft Enforcement', browser: false do
   fixtures :accounts, :people, :users
+
+  before do
+    driven_by(:rack_test)
+  end
 
   describe 'privileged users without 2FA' do
     it 'shows notice to administrator on profile page' do


### PR DESCRIPTION
- Move 2 pure-Ruby specs out of features/ into spec/config/ (passkey_config, otlp_exporter)

- Switch 14 system/feature specs from Playwright to rack_test driver

- Make browser metadata conditional in rails_helper so specs can opt out

- 901 examples, 0 failures - no regressions

- ~120 tests now run without launching Chromium