### PR TITLE
perf: reduce test suite runtime by 19%

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,7 +36,7 @@ tasks:
       - task: internal:run
         vars:
           ENVIRONMENT: test
-          COMMAND: 'bundle exec rspec --format documentation {{ .TEST_FILE | default "spec" }}'
+          COMMAND: 'bundle exec rspec --profile 20 --format documentation {{ .TEST_FILE | default "spec" }}'
           TEST_FILE: '{{ .TEST_FILE | default "spec" }}'
 
   status:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,6 +5,8 @@
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
+BCrypt::Engine.cost = BCrypt::Engine::MIN_COST
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/features/accessibility/heading_order_spec.rb
+++ b/spec/features/accessibility/heading_order_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Heading Order Accessibility', type: :system do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   let(:user) { users(:carer) }
   let(:admin_user) { users(:admin) }

--- a/spec/features/dashboard_authorization_spec.rb
+++ b/spec/features/dashboard_authorization_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Dashboard Authorization', type: :system do
-  fixtures :accounts, :account_otp_keys, :people, :users, :prescriptions, :medicines, :dosages, :carer_relationships
+  fixtures :accounts, :people, :users, :prescriptions, :medicines, :dosages, :carer_relationships
 
   describe 'viewing the dashboard' do
     context 'when signed in as an administrator' do

--- a/spec/features/person_medicines_spec.rb
+++ b/spec/features/person_medicines_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Person Medicines', type: :system do
-  fixtures :accounts, :account_otp_keys, :people, :medicines, :users, :person_medicines
+  fixtures :accounts, :people, :medicines, :users, :person_medicines
 
   let(:person) { people(:john) }
   let(:user) { users(:john) }

--- a/spec/fixtures/account_otp_keys.yml
+++ b/spec/fixtures/account_otp_keys.yml
@@ -9,33 +9,3 @@ damacus:
   key: JBSWY3DPEHPK3PXP
   num_failures: 0
   last_use: <%= Time.current %>
-
-test:
-  id: <%= ActiveRecord::FixtureSet.identify(:test) %>
-  key: JBSWY3DPEHPK3PXP
-  num_failures: 0
-  last_use: <%= Time.current %>
-
-john_doe:
-  id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  key: JBSWY3DPEHPK3PXP
-  num_failures: 0
-  last_use: <%= Time.current %>
-
-admin:
-  id: <%= ActiveRecord::FixtureSet.identify(:admin) %>
-  key: JBSWY3DPEHPK3PXP
-  num_failures: 0
-  last_use: <%= Time.current %>
-
-dr_jones:
-  id: <%= ActiveRecord::FixtureSet.identify(:dr_jones) %>
-  key: JBSWY3DPEHPK3PXP
-  num_failures: 0
-  last_use: <%= Time.current %>
-
-nurse_smith:
-  id: <%= ActiveRecord::FixtureSet.identify(:nurse_smith) %>
-  key: JBSWY3DPEHPK3PXP
-  num_failures: 0
-  last_use: <%= Time.current %>

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Dashboard' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   context 'when user is an administrator' do
     it 'displays key system metrics' do

--- a/spec/system/admin_invites_users_spec.rb
+++ b/spec/system/admin_invites_users_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin invites users' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   let(:admin) { users(:admin) }
 

--- a/spec/system/admin_manages_carer_relationships_spec.rb
+++ b/spec/system/admin_manages_carer_relationships_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminManagesCarerRelationships' do
-  fixtures :accounts, :account_otp_keys, :people, :users, :carer_relationships
+  fixtures :accounts, :people, :users, :carer_relationships
 
   let(:admin) { users(:admin) }
   let(:carer) { users(:carer) }

--- a/spec/system/admin_manages_users_spec.rb
+++ b/spec/system/admin_manages_users_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminManagesUsers' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   # Use the admin fixture instead of creating a duplicate user
   let(:admin) { users(:admin) }

--- a/spec/system/authorization/admin_access_spec.rb
+++ b/spec/system/authorization/admin_access_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Access Authorization' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   before do
     driven_by(:playwright)

--- a/spec/system/authorization/carer_access_spec.rb
+++ b/spec/system/authorization/carer_access_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Carer Access Authorization' do
-  fixtures :accounts, :account_otp_keys, :people, :users, :carer_relationships
+  fixtures :accounts, :people, :users, :carer_relationships
 
   before do
     driven_by(:playwright)

--- a/spec/system/authorization/clinician_access_spec.rb
+++ b/spec/system/authorization/clinician_access_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Clinician Access Authorization' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   before do
     driven_by(:playwright)

--- a/spec/system/authorization/person_medicines_authorization_spec.rb
+++ b/spec/system/authorization/person_medicines_authorization_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Person Medicines Authorization' do
-  fixtures :accounts, :account_otp_keys, :people, :users, :medicines, :carer_relationships
+  fixtures :accounts, :people, :users, :medicines, :carer_relationships
 
   before do
     driven_by(:playwright)

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Dashboard' do
-  fixtures :accounts, :account_otp_keys, :users, :medicines, :dosages, :prescriptions, :people
+  fixtures :accounts, :users, :medicines, :dosages, :prescriptions, :people
 
   it 'loads the dashboard for a signed-in user' do
     sign_in(users(:john))

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Home' do
-  fixtures :accounts, :account_otp_keys, :people, :users, :medicines, :dosages, :prescriptions
+  fixtures :accounts, :people, :users, :medicines, :dosages, :prescriptions
 
   it 'loads the dashboard as the home page for a signed-in user' do
     # Sign in the user from fixtures

--- a/spec/system/medicine_finder_spec.rb
+++ b/spec/system/medicine_finder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'MedicineFinder' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   let(:user) { users(:john) }
 

--- a/spec/system/medicines/new_medicine_layout_spec.rb
+++ b/spec/system/medicines/new_medicine_layout_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'MedicineNewLayout' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   before do
     driven_by(:rack_test)

--- a/spec/system/minor_role_spec.rb
+++ b/spec/system/minor_role_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Minor role in user form' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   let(:admin) { users(:admin) }
 

--- a/spec/system/navigation_spec.rb
+++ b/spec/system/navigation_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 # This system test verifies the main site navigation using the Capybara DSL.
 RSpec.describe 'Navigation' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   before do
     driven_by(:rack_test)

--- a/spec/system/people_spec.rb
+++ b/spec/system/people_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'People' do
-  fixtures :accounts, :account_otp_keys, :people, :users, :medicines, :dosages, :prescriptions
+  fixtures :accounts, :people, :users, :medicines, :dosages, :prescriptions
 
   let(:user) { users(:john) }
 

--- a/spec/system/prescriptions/dosage_selection_spec.rb
+++ b/spec/system/prescriptions/dosage_selection_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Prescription dosage selection' do
-  fixtures :accounts, :account_otp_keys, :users, :people, :medicines, :dosages
+  fixtures :accounts, :users, :people, :medicines, :dosages
 
   before do
     driven_by(:playwright)

--- a/spec/system/profile_editing_spec.rb
+++ b/spec/system/profile_editing_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Profile Editing' do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
 
   let(:account) { accounts(:damacus) }
   let(:person) { people(:damacus) }

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User Sessions', :js do
-  fixtures :accounts, :account_otp_keys, :people, :users
+  fixtures :accounts, :people, :users
   let(:user) { users(:jane) }
 
   describe 'login page' do


### PR DESCRIPTION
## Summary

Reduces test suite wall time from **2m 37s → 2m 08s** (~19% faster, 30 seconds saved) with 901 examples, 0 failures.

## Changes

### 1. Reduce BCrypt cost in test environment
Added `BCrypt::Engine.cost = BCrypt::Engine::MIN_COST` to `config/environments/test.rb`. MIN_COST (4) is ~256x faster than default cost 12.

### 2. Reduce fixture 2FA keys from 6 to 1
Only `authentication_spec.rb` AUTH-019 needs a pre-existing OTP key. Kept only `damacus`.

### 3. Remove `:account_otp_keys` from 21 spec fixture declarations
Eliminates unnecessary DB writes. Users without 2FA are now directly usable by LLMs and test helpers.

### 4. Bump `--profile` to 20
Better visibility into slow tests.

## Before/After

| Spec | Before | After | Change |
|---|---|---|---|
| SpecFixtureLoader | 3.40s | dropped out of top 20 | :tada: |
| Admin User Management Workflow | 1.73s | 1.22s | -29% |
| AdminManagesCarerRelationships | 0.66s | 0.49s | -26% |
| Prescription dosage selection | 1.27s | 0.97s | -24% |
| AuditLogs Rate Limiting | 0.98s | 0.82s | -16% |
| AdminManagesUsers | 0.70s | 0.59s | -16% |