### PR TITLE
feat: add authentication translations for es, cy, and pt

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,6 +6,13 @@ cy:
     users:
       unauthorized: "Nid oes gennych awdurdod i gyflawni'r weithred hon."
 
+  authentication:
+    login_required: "Mewngofnodwch i barhau"
+    two_factor_required: "Er mwy o ddiogelwch, gosodwch ddilysu dau ffactor ar gyfer eich cyfrif."
+
+  invitation_mailer:
+    subject: "Gwahoddiad i ymuno â MedTracker"
+
   medicines:
     created: "Crëwyd y feddyginiaeth yn llwyddiannus."
     updated: "Diweddarwyd y feddyginiaeth yn llwyddiannus."
@@ -79,3 +86,7 @@ cy:
     deactivated: "Mae cyfrif y defnyddiwr wedi'i ddadactifadu."
     activated: "Mae cyfrif y defnyddiwr wedi'i actifadu."
     cannot_deactivate_self: "Ni allwch ddadactifadu eich cyfrif eich hun."
+
+  webauthn:
+    passkey_removed: "Allwedd mynediad wedi'i dynnu'n llwyddiannus"
+    passkey_registered: "Allwedd mynediad wedi'i chofrestru'n llwyddiannus"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,6 +6,13 @@ es:
     users:
       unauthorized: "No está autorizado para realizar esta acción."
 
+  authentication:
+    login_required: "Por favor, inicie sesión para continuar"
+    two_factor_required: "Para mayor seguridad, configure la autenticación de dos factores para su cuenta."
+
+  invitation_mailer:
+    subject: "Invitación para unirse a MedTracker"
+
   medicines:
     created: "Medicamento creado correctamente."
     updated: "Medicamento actualizado correctamente."
@@ -79,3 +86,7 @@ es:
     deactivated: "Cuenta de usuario desactivada."
     activated: "Cuenta de usuario activada."
     cannot_deactivate_self: "No puede desactivar su propia cuenta."
+
+  webauthn:
+    passkey_removed: "Clave de acceso eliminada correctamente"
+    passkey_registered: "Clave de acceso registrada correctamente"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -6,6 +6,13 @@ pt:
     users:
       unauthorized: "Não está autorizado a realizar esta ação."
 
+  authentication:
+    login_required: "Por favor, inicie sessão para continuar"
+    two_factor_required: "Para maior segurança, configure a autenticação de dois fatores para a sua conta."
+
+  invitation_mailer:
+    subject: "Convite para aderir ao MedTracker"
+
   medicines:
     created: "Medicamento criado com sucesso."
     updated: "Medicamento atualizado com sucesso."
@@ -79,3 +86,7 @@ pt:
     deactivated: "Conta de utilizador desativada."
     activated: "Conta de utilizador ativada."
     cannot_deactivate_self: "Não pode desativar a sua própria conta."
+
+  webauthn:
+    passkey_removed: "Chave de acesso removida com sucesso"
+    passkey_registered: "Chave de acesso registada com sucesso"


### PR DESCRIPTION
## Summary
- Add missing authentication-related translations to Spanish (es), Welsh (cy), and Portuguese (pt) locales
- Improves i18n coverage for security-critical features across all supported languages

## Changes
Added the following translations to Spanish, Welsh, and Portuguese:
- `authentication.login_required` - Login prompt message
- `authentication.two_factor_required` - 2FA setup prompt
- `invitation_mailer.subject` - Email subject for invitations
- `webauthn.passkey_removed` - Passkey removal success message
- `webauthn.passkey_registered` - Passkey registration success message

## Test plan
- [x] All existing tests pass (901 examples, 0 failures)
- [x] Translation files follow existing structure and formatting
- [x] Rubocop linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)