### PR TITLE
refactor: extract DashboardPresenter from IndexView god component

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -4,15 +4,10 @@ module Components
   module Dashboard
     # Dashboard index view component that renders the main dashboard page
     class IndexView < Components::Base
-      attr_reader :people, :active_prescriptions, :upcoming_prescriptions, :url_helpers, :current_user, :doses
+      attr_reader :presenter
 
-      def initialize(people:, active_prescriptions:, upcoming_prescriptions:, doses:, **options)
-        @people = people
-        @active_prescriptions = active_prescriptions
-        @upcoming_prescriptions = upcoming_prescriptions
-        @doses = doses
-        @url_helpers = options[:url_helpers]
-        @current_user = options[:current_user]
+      def initialize(presenter:)
+        @presenter = presenter
         super()
       end
 
@@ -26,6 +21,9 @@ module Components
       end
 
       private
+
+      delegate :people, :active_prescriptions, :upcoming_prescriptions, :url_helpers,
+               :current_user, :doses, to: :presenter
 
       def render_header
         div(class: 'flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-8') do

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,47 +6,11 @@ class DashboardController < ApplicationController
   def index
     authorize :dashboard, :index?
 
-    # Core data for stats and existing logic
-    @people = scoped_people
-    @active_prescriptions = scoped_prescriptions
-    @upcoming_prescriptions = @active_prescriptions.group_by(&:person)
-
-    # Chronological family doses for our new timeline
-    query = FamilyDashboard::ScheduleQuery.new(@people)
-    @doses = query.call
-
-    render Components::Dashboard::IndexView.new(
-      people: @people,
-      active_prescriptions: @active_prescriptions,
-      upcoming_prescriptions: @upcoming_prescriptions,
-      doses: @doses,
-      url_helpers: self,
-      current_user: current_user
+    presenter = DashboardPresenter.new(
+      current_user: current_user,
+      url_helpers: self
     )
-  end
 
-  private
-
-  def scoped_people
-    if full_access?
-      Person.includes(:user, prescriptions: :medicine).all
-    elsif current_user.carer?
-      current_user.person.patients.includes(:user, prescriptions: :medicine)
-    elsif current_user.parent?
-      current_user.person.patients.where(person_type: :minor)
-                  .includes(:user, prescriptions: :medicine)
-    else
-      Person.where(id: current_user.person.id)
-            .includes(:user, prescriptions: :medicine)
-    end
-  end
-
-  def scoped_prescriptions
-    Prescription.where(active: true, person_id: @people.select(:id))
-                .includes(person: :user, medicine: [])
-  end
-
-  def full_access?
-    current_user.administrator? || current_user.doctor? || current_user.nurse?
+    render Components::Dashboard::IndexView.new(presenter: presenter)
   end
 end

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Presenter for the dashboard view that encapsulates data preparation logic
+class DashboardPresenter
+  attr_reader :current_user, :url_helpers
+
+  def initialize(current_user:, url_helpers: nil)
+    @current_user = current_user
+    @url_helpers = url_helpers
+  end
+
+  def people
+    @people ||= load_people
+  end
+
+  def active_prescriptions
+    @active_prescriptions ||= Prescription.where(active: true, person_id: people.select(:id))
+                                          .includes(person: :user, medicine: [])
+  end
+
+  def upcoming_prescriptions
+    @upcoming_prescriptions ||= active_prescriptions.group_by(&:person)
+  end
+
+  def doses
+    @doses ||= FamilyDashboard::ScheduleQuery.new(people).call
+  end
+
+  private
+
+  def load_people
+    return Person.none if current_user.nil?
+
+    return all_people if full_access?
+    return carer_patients if carer?
+    return parent_minor_patients if parent?
+
+    own_person
+  end
+
+  def all_people
+    Person.includes(:user, prescriptions: :medicine).all
+  end
+
+  def carer_patients
+    current_user.person.patients.includes(:user, prescriptions: :medicine)
+  end
+
+  def parent_minor_patients
+    current_user.person.patients.where(person_type: :minor)
+                .includes(:user, prescriptions: :medicine)
+  end
+
+  def own_person
+    Person.where(id: current_user.person.id)
+          .includes(:user, prescriptions: :medicine)
+  end
+
+  def carer?
+    current_user.carer?
+  end
+
+  def parent?
+    current_user.parent?
+  end
+
+  def full_access?
+    current_user.administrator? || current_user.doctor? || current_user.nurse?
+  end
+end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -6,17 +6,11 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
   fixtures :accounts, :people, :users, :medicines, :dosages, :prescriptions, :person_medicines, :medication_takes
 
   subject(:dashboard_view) do
-    described_class.new(
-      people: people,
-      active_prescriptions: active_prescriptions,
-      upcoming_prescriptions: upcoming_prescriptions,
-      doses: []
-    )
+    described_class.new(presenter: presenter)
   end
 
-  let(:people) { Person.includes(:user, prescriptions: :medicine).all }
-  let(:active_prescriptions) { Prescription.where(active: true).includes(person: :user, medicine: []) }
-  let(:upcoming_prescriptions) { active_prescriptions.group_by(&:person) }
+  let(:admin_user) { users(:admin) }
+  let(:presenter) { DashboardPresenter.new(current_user: admin_user, url_helpers: controller) }
 
   it 'renders the dashboard title' do
     rendered = render_inline(dashboard_view)
@@ -31,12 +25,12 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
   describe 'stats display' do
     it 'renders people count' do
       rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include(people.count.to_s)
+      expect(rendered.text).to include(presenter.people.count.to_s)
     end
 
     it 'renders active prescriptions count' do
       rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include(active_prescriptions.count.to_s)
+      expect(rendered.text).to include(presenter.active_prescriptions.count.to_s)
     end
   end
 
@@ -55,22 +49,14 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
-  context 'when there are people but no prescriptions' do
-    let(:active_prescriptions) { [] }
-    let(:upcoming_prescriptions) { {} }
-
-    it 'renders the empty prescriptions message' do
-      rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include('No medications scheduled for today')
+  context 'when there are no active prescriptions or person medicines' do
+    before do
+      MedicationTake.delete_all
+      PersonMedicine.delete_all
+      Prescription.update_all(end_date: 1.year.ago) # rubocop:disable Rails/SkipsModelValidations
     end
-  end
 
-  context 'when there are no people' do
-    let(:people) { [] }
-    let(:active_prescriptions) { [] }
-    let(:upcoming_prescriptions) { {} }
-
-    it 'renders the empty prescriptions message' do
+    it 'renders the empty state message' do
       rendered = render_inline(dashboard_view)
       expect(rendered.text).to include('No medications scheduled for today')
     end

--- a/spec/presenters/dashboard_presenter_spec.rb
+++ b/spec/presenters/dashboard_presenter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DashboardPresenter do
+  fixtures :accounts, :people, :users, :medicines, :dosages, :prescriptions
+
+  let(:admin_user) { users(:admin) }
+  let(:carer_user) { users(:carer) }
+  let(:parent_user) { users(:parent) }
+  let(:minor_user) { users(:one) } # role: 5 (minor) - falls into else branch
+
+  describe '#people' do
+    context 'when user is an administrator' do
+      it 'returns all people' do
+        presenter = described_class.new(current_user: admin_user)
+        expect(presenter.people).to eq(Person.all)
+      end
+    end
+
+    context 'when user is a carer' do
+      it 'returns patients of the carer' do
+        presenter = described_class.new(current_user: carer_user)
+        expect(presenter.people).to eq(carer_user.person.patients)
+      end
+    end
+
+    context 'when user is a parent' do
+      it 'returns minor patients of the parent' do
+        presenter = described_class.new(current_user: parent_user)
+        expect(presenter.people).to eq(parent_user.person.patients.where(person_type: :minor))
+      end
+    end
+
+    context 'when user is a minor (no special access)' do
+      it 'returns only their own person record' do
+        presenter = described_class.new(current_user: minor_user)
+        expect(presenter.people).to eq(Person.where(id: minor_user.person.id))
+      end
+    end
+  end
+
+  describe '#active_prescriptions' do
+    it 'returns active prescriptions for scoped people' do
+      presenter = described_class.new(current_user: admin_user)
+      expect(presenter.active_prescriptions).to all(have_attributes(active: true))
+    end
+  end
+
+  describe '#upcoming_prescriptions' do
+    it 'groups prescriptions by person' do
+      presenter = described_class.new(current_user: admin_user)
+      expect(presenter.upcoming_prescriptions).to be_a(Hash)
+      expect(presenter.upcoming_prescriptions.keys).to all(be_a(Person))
+    end
+  end
+
+  describe '#doses' do
+    it 'delegates to FamilyDashboard::ScheduleQuery' do
+      presenter = described_class.new(current_user: admin_user)
+      expect(presenter.doses).to be_an(Array)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts data preparation logic from `Components::Dashboard::IndexView` into a dedicated `DashboardPresenter`, resolving the 'God Component' code smell (6 data dependencies).

## Changes

- **`app/presenters/dashboard_presenter.rb`** — New presenter encapsulating role-based people scoping, active prescription queries, prescription grouping, and dose scheduling via `FamilyDashboard::ScheduleQuery`
- **`app/controllers/dashboard_controller.rb`** — Simplified to create presenter and pass to view (removed 25 lines of data preparation)
- **`app/components/dashboard/index_view.rb`** — Now receives a single `presenter:` keyword and delegates data access
- **`spec/presenters/dashboard_presenter_spec.rb`** — Comprehensive tests for all presenter methods and role-based scoping
- **`spec/components/dashboard/index_view_spec.rb`** — Updated to use presenter-based constructor

## Design Decisions

- Presenter uses lazy-loading to avoid unnecessary queries
- `FamilyDashboard::ScheduleQuery` integrated into presenter (was previously called directly in controller)
- Used `.select(:id)` instead of `.pluck(:id)` for active_prescriptions subquery to avoid extra round-trip

## Testing

- 921 examples, 0 failures
- RuboCop clean (only pre-existing schema.rb offenses)

Closes: med-tracker-12tv