### PR TITLE
fix: MedicationTakePolicy handles person_medicine-based takes

### DIFF
--- a/spec/policies/medication_take_policy_spec.rb
+++ b/spec/policies/medication_take_policy_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe MedicationTakePolicy do
 
         it { is_expected.not_to permit_action(:create) }
       end
+
+      context 'with assigned patient person_medicine take' do
+        let(:person_medicine) do
+          PersonMedicine.new(person: people(:child_user_person), medicine: medicines(:vitamin_d))
+        end
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
+
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context 'with non-assigned patient person_medicine take' do
+        let(:person_medicine) { person_medicines(:john_vitamin_d) }
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
+
+        it { is_expected.not_to permit_action(:create) }
+      end
     end
 
     context 'when user is a parent' do
@@ -73,6 +89,22 @@ RSpec.describe MedicationTakePolicy do
 
         it { is_expected.not_to permit_action(:create) }
       end
+
+      context 'with minor child person_medicine take' do
+        let(:person_medicine) do
+          PersonMedicine.new(person: people(:child_user_person), medicine: medicines(:vitamin_d))
+        end
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
+
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context 'with non-child person_medicine take' do
+        let(:person_medicine) { person_medicines(:john_vitamin_d) }
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
+
+        it { is_expected.not_to permit_action(:create) }
+      end
     end
 
     context 'when user is an adult patient' do
@@ -88,6 +120,22 @@ RSpec.describe MedicationTakePolicy do
       context 'with another patient prescription' do
         let(:prescription) { prescriptions(:child_prescription) }
         let(:medication_take) { prescription.medication_takes.build }
+
+        it { is_expected.not_to permit_action(:create) }
+      end
+
+      context 'with their own person_medicine take' do
+        let(:person_medicine) do
+          PersonMedicine.new(person: people(:adult_patient_person), medicine: medicines(:vitamin_c))
+        end
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
+
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context 'with someone else person_medicine take' do
+        let(:person_medicine) { person_medicines(:john_vitamin_d) }
+        let(:medication_take) { person_medicine.medication_takes.build(taken_at: Time.current) }
 
         it { is_expected.not_to permit_action(:create) }
       end
@@ -138,38 +186,59 @@ RSpec.describe MedicationTakePolicy do
       context 'when user is a carer' do
         let(:user) { carer_user }
 
-        it 'returns medication takes for assigned patients only' do
-          scope = described_class::Scope.new(user, MedicationTake.all).resolve
+        it 'returns medication takes for assigned patients only, including person_medicine takes' do
           patient_ids = user.person.patient_ids
-          expected_takes = MedicationTake.joins(:prescription)
-                                         .where(prescriptions: { person_id: patient_ids })
+          pm = create(:person_medicine, person: people(:child_user_person), medicine: medicines(:aspirin))
+          pm_take = create(:medication_take, :for_person_medicine, person_medicine: pm)
 
-          expect(scope.pluck(:id).sort).to eq(expected_takes.pluck(:id).sort)
+          scope = described_class::Scope.new(user, MedicationTake.all).resolve
+          prescription_takes = MedicationTake.joins(:prescription)
+                                             .where(prescriptions: { person_id: patient_ids })
+          person_medicine_takes = MedicationTake.joins(:person_medicine)
+                                                .where(person_medicines: { person_id: patient_ids })
+          expected_ids = (prescription_takes.pluck(:id) + person_medicine_takes.pluck(:id)).uniq.sort
+
+          expect(scope.pluck(:id).sort).to eq(expected_ids)
+          expect(scope.pluck(:id)).to include(pm_take.id)
         end
       end
 
       context 'when user is a parent' do
         let(:user) { parent_user }
 
-        it 'returns medication takes for their minor children only' do
-          scope = described_class::Scope.new(user, MedicationTake.all).resolve
-          child_ids = Person.where(id: user.person.patient_ids, person_type: :child).pluck(:id)
-          expected_takes = MedicationTake.joins(:prescription)
-                                         .where(prescriptions: { person_id: child_ids })
+        it 'returns medication takes for their minor children only, including person_medicine takes' do
+          child_ids = Person.where(id: user.person.patient_ids, person_type: :minor).pluck(:id)
+          pm = create(:person_medicine, person: people(:child_user_person), medicine: medicines(:aspirin))
+          pm_take = create(:medication_take, :for_person_medicine, person_medicine: pm)
 
-          expect(scope.pluck(:id).sort).to eq(expected_takes.pluck(:id).sort)
+          scope = described_class::Scope.new(user, MedicationTake.all).resolve
+          prescription_takes = MedicationTake.joins(:prescription)
+                                             .where(prescriptions: { person_id: child_ids })
+          person_medicine_takes = MedicationTake.joins(:person_medicine)
+                                                .where(person_medicines: { person_id: child_ids })
+          expected_ids = (prescription_takes.pluck(:id) + person_medicine_takes.pluck(:id)).uniq.sort
+
+          expect(scope.pluck(:id).sort).to eq(expected_ids)
+          expect(scope.pluck(:id)).to include(pm_take.id)
         end
       end
 
       context 'when user is an adult patient' do
         let(:user) { adult_patient_user }
 
-        it 'returns only their own medication takes' do
-          scope = described_class::Scope.new(user, MedicationTake.all).resolve
-          expected_takes = MedicationTake.joins(:prescription)
-                                         .where(prescriptions: { person_id: user.person.id })
+        it 'returns only their own medication takes, including person_medicine takes' do
+          pm = create(:person_medicine, person: people(:adult_patient_person), medicine: medicines(:aspirin))
+          pm_take = create(:medication_take, :for_person_medicine, person_medicine: pm)
 
-          expect(scope.pluck(:id).sort).to eq(expected_takes.pluck(:id).sort)
+          scope = described_class::Scope.new(user, MedicationTake.all).resolve
+          prescription_takes = MedicationTake.joins(:prescription)
+                                             .where(prescriptions: { person_id: user.person.id })
+          person_medicine_takes = MedicationTake.joins(:person_medicine)
+                                                .where(person_medicines: { person_id: user.person.id })
+          expected_ids = (prescription_takes.pluck(:id) + person_medicine_takes.pluck(:id)).uniq.sort
+
+          expect(scope.pluck(:id).sort).to eq(expected_ids)
+          expect(scope.pluck(:id)).to include(pm_take.id)
         end
       end
 


### PR DESCRIPTION
## Problem

`MedicationTakePolicy` only handled prescription-based `MedicationTake` records. When a take had only a `person_medicine` (and no `prescription`), three things broke:

1. **`adult_with_own_prescription?`** called `record.prescription.person_id` → `NoMethodError` when `prescription` is nil
2. **`person_id_for_authorization`** had the same crash
3. **`Scope#carer_parent_scope` / `own_takes_scope`** used `joins(:prescription)` so person_medicine-based takes were never returned

## Fix

- Rename `adult_with_own_prescription?` → `adult_with_own_medicine?` and use `record.person&.id` (the model already implements `#person` to return from either source)
- Fix `person_id_for_authorization` to use `record.person&.id`
- Fix both scope methods to `left_joins(:prescription, :person_medicine)` with an `OR` condition so takes from either source are included

## Tests

Added 6 new `create?` test cases covering carer, parent, and adult patient accessing person_medicine-based takes (both permitted and denied scenarios).

Updated 3 existing `Scope#resolve` tests (carer, parent, adult patient) to verify person_medicine takes are included, using inline FactoryBot creates to avoid fixture collisions.

Closes: med-tracker-6sni