### PR TITLE
fix: mark OIDC accounts as verified to prevent hijacking (OIDC-SEC-011)

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -170,6 +170,7 @@ class RodauthMain < Rodauth::Rails::Auth
                         uid_field: 'sub',
                         discovery: true,
                         issuer: oidc_issuer,
+                        verify_account_login_status: :verified,
                         client_options: {
                           identifier: oidc_client_id,
                           secret: oidc_client_secret,

--- a/spec/security/oidc_security_spec.rb
+++ b/spec/security/oidc_security_spec.rb
@@ -79,6 +79,13 @@ RSpec.describe 'OIDC Security' do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  describe 'OIDC-SEC-011: Account hijacking prevention via email verification' do
+    it 'marks OIDC accounts as verified to prevent hijacking' do
+      rodauth_file = Rails.root.join('app/misc/rodauth_main.rb').read
+      expect(rodauth_file).to include('verify_account_login_status: :verified')
+    end
+  end
+
   describe 'OIDC-SEC-012: Session fixation prevention' do
     it 'has active_sessions feature enabled for session management' do
       rodauth_file = Rails.root.join('app/misc/rodauth_main.rb').read


### PR DESCRIPTION
## Summary

Fixes OIDC-SEC-011 by ensuring OIDC accounts are marked as verified to prevent account hijacking attacks.

## Problem

OIDC accounts were being created without email verification status. Since the OIDC provider has already verified the email, these accounts should be marked as verified to prevent hijacking attacks where someone could use another person's email.

## Solution

Add `verify_account_login_status: :verified` to the omniauth_provider configuration. This tells Rodauth to mark OIDC accounts as verified since the OIDC provider has already performed email verification.

## Test Results

673 examples, 0 failures

Closes: med-tracker-6wh