### PR TITLE
fix: stabilise flaky audit_logs rate limiting spec with freeze_time

### DIFF
--- a/spec/requests/admin/audit_logs_rate_limiting_spec.rb
+++ b/spec/requests/admin/audit_logs_rate_limiting_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::AuditLogs Rate Limiting' do
-  # skip 'FLAKY TEST'
+  include ActiveSupport::Testing::TimeHelpers
+
   fixtures :all
 
   let(:admin) { users(:admin) }
@@ -23,6 +24,7 @@ RSpec.describe 'Admin::AuditLogs Rate Limiting' do
   end
 
   before do
+    freeze_time
     sign_in(admin)
   end
 


### PR DESCRIPTION
Rack::Attack computes throttle window keys from Time.now.to_i / period. When a slow CI runner took ~50s to dispatch 100 rack-test requests, the wall clock could cross a 60-second boundary mid-test, resetting the counter and causing the 101st request to return 200 instead of 429.

Fix by including ActiveSupport::Testing::TimeHelpers and calling freeze_time in a before hook, ensuring all requests in an example share the same throttle window.

