### PR TITLE
fix: tagging strategy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
 			"package-name": "med-tracker",
 			"changelog-path": "CHANGELOG.md",
 			"version-file": "lib/med_tracker/version.rb",
+			"include-component-in-tag": false,
 			"prerelease": true,
 			"initial-version": "0.1.0"
 		}


### PR DESCRIPTION
This PR updates the release-please configuration to use standard `v*` tags. This ensures semver compatibility for Renovate.