### PR TITLE
fix: chain docker build from release-please workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,13 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "Git tag name for release (e.g. v1.0.0)"
+        required: false
+        type: string
+        default: ""
 
 env:
   REGISTRY: ghcr.io
@@ -21,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -58,11 +67,11 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.tag_name || '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag_name || '' }}
             type=sha,format=long
-            type=raw,value=beta,enable=${{ github.ref_type != 'tag' && github.ref_name == 'main' }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=beta,enable=${{ inputs.tag_name == '' && github.ref_type != 'tag' && github.ref_name == 'main' }}
+            type=raw,value=latest,enable=${{ inputs.tag_name != '' || github.ref_type == 'tag' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:
@@ -22,3 +23,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  docker:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
Events created by GITHUB_TOKEN don't trigger other workflows. When release-please creates a tag, the push event is suppressed, so docker-publish's tags trigger never fires.

Fix by making docker-publish.yml a reusable workflow (workflow_call) and calling it from release-please when releases_created is true. The tag_name is passed as input so docker/metadata-action can generate proper semver tags via the value parameter.
