### PR TITLE
feat: make dashboard greeting time-aware with i18n support

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -42,7 +42,7 @@ module Components
             end
             Heading(level: 1, size: '8', class: 'font-extrabold tracking-tight') do
               if current_user.person&.name.present?
-                t('dashboard.greeting', name: current_user.person.name.split.first)
+                t(greeting_key, name: current_user.person.name.split.first)
               else
                 t('dashboard.title')
               end
@@ -211,6 +211,14 @@ module Components
               style: "width: #{percentage}%"
             )
           end
+        end
+      end
+
+      def greeting_key
+        case Time.current.hour
+        when 5..11 then 'dashboard.greeting_morning'
+        when 12..17 then 'dashboard.greeting_afternoon'
+        else 'dashboard.greeting_evening'
         end
       end
     end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -303,6 +303,9 @@ cy:
         other: "%{count} wall wedi atal y meddyginiaeth hon rhag cael ei chadw:"
   dashboard:
     title: "Bwrdd Rheoli Teulu"
+    greeting_morning: "Bore da, %{name}"
+    greeting_afternoon: "Prynhawn da, %{name}"
+    greeting_evening: "Noswaith dda, %{name}"
     subtitle: "Amserlen meddyginiaeth eich teulu am heddiw."
     todays_schedule: "Amserlen Heddiw"
     medication_schedule: "Amserlen Meddyginiaeth"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,7 +361,9 @@ en:
         other: "%{count} errors prevented this medicine from being saved:"
   dashboard:
     title: "Family Dashboard"
-    greeting: "Good morning, %{name}"
+    greeting_morning: "Good morning, %{name}"
+    greeting_afternoon: "Good afternoon, %{name}"
+    greeting_evening: "Good evening, %{name}"
     subtitle: "Your family's medication schedule for today."
     todays_schedule: "Today's Schedule"
     medication_schedule: "Medication Schedule"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -302,6 +302,9 @@ es:
         other: "%{count} errores impidieron que este medicamento se guardara:"
   dashboard:
     title: "Panel Familiar"
+    greeting_morning: "Buenos días, %{name}"
+    greeting_afternoon: "Buenas tardes, %{name}"
+    greeting_evening: "Buenas noches, %{name}"
     subtitle: "El horario de medicamentos de su familia para hoy."
     todays_schedule: "Horario de Hoy"
     medication_schedule: "Horario de Medicamentos"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -361,7 +361,9 @@ ga:
         other: "Chuir %{count} earráid cosc ar an leigheas a shábháil:"
   dashboard:
     title: "Dashboard an Teaghlaigh"
-    greeting: "Maidin mhaith, %{name}"
+    greeting_morning: "Maidin mhaith, %{name}"
+    greeting_afternoon: "Tráthnóna maith, %{name}"
+    greeting_evening: "Oíche mhaith, %{name}"
     subtitle: "Sceideal leigheasanna do theaghlaigh inniu."
     todays_schedule: "Sceideal an Lae Innuit"
     medication_schedule: "Sceideal Leigheasanna"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -302,6 +302,9 @@ pt:
         other: "%{count} erros impediram que este medicamento fosse guardado:"
   dashboard:
     title: "Painel Familiar"
+    greeting_morning: "Bom dia, %{name}"
+    greeting_afternoon: "Boa tarde, %{name}"
+    greeting_evening: "Boa noite, %{name}"
     subtitle: "O horário de medicamentos da sua família para hoje."
     todays_schedule: "Horário de Hoje"
     medication_schedule: "Horário de Medicamentos"

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -13,9 +13,27 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
   let(:admin_user) { users(:admin) }
   let(:presenter) { DashboardPresenter.new(current_user: admin_user) }
 
-  it 'renders the dashboard title' do
-    rendered = render_inline(dashboard_view)
-    expect(rendered.text).to include('Good morning')
+  describe 'greetings' do
+    it 'renders Good morning in the morning' do
+      travel_to Time.zone.parse('2026-02-25 09:00:00') do
+        rendered = render_inline(dashboard_view)
+        expect(rendered.text).to include('Good morning')
+      end
+    end
+
+    it 'renders Good afternoon in the afternoon' do
+      travel_to Time.zone.parse('2026-02-25 15:00:00') do
+        rendered = render_inline(dashboard_view)
+        expect(rendered.text).to include('Good afternoon')
+      end
+    end
+
+    it 'renders Good evening in the evening' do
+      travel_to Time.zone.parse('2026-02-25 20:00:00') do
+        rendered = render_inline(dashboard_view)
+        expect(rendered.text).to include('Good evening')
+      end
+    end
   end
 
   it 'renders the schedule heading' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,6 +87,9 @@ RSpec.configure do |config|
 
   # Include FactoryBot syntax methods
   config.include FactoryBot::Syntax::Methods
+
+  # Include ActiveSupport TimeHelpers for travel_to
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 # Include Pundit matchers for policy specs after RSpec is configured


### PR DESCRIPTION
This PR updates the dashboard greeting to be time-of-day aware (morning, afternoon, evening) and adds translations for all supported languages. It also includes unit tests for the greeting logic.