### PR TITLE
fix: allow parent/carer dependent creation entry points

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -54,12 +54,14 @@ module Components
             end
           end
           div(class: 'flex gap-3') do
-            render RubyUI::Link.new(
-              href: new_person_path,
-              variant: :outline,
-              size: :lg
-            ) do
-              t('dashboard.quick_actions.add_person')
+            if can_create_person?
+              render RubyUI::Link.new(
+                href: new_person_path,
+                variant: :outline,
+                size: :lg
+              ) do
+                t('dashboard.quick_actions.add_person')
+              end
             end
             render RubyUI::Link.new(
               href: new_medication_path,
@@ -243,6 +245,12 @@ module Components
         when 12..17 then 'dashboard.greeting_afternoon'
         else 'dashboard.greeting_evening'
         end
+      end
+
+      def can_create_person?
+        return false unless view_context.respond_to?(:policy)
+
+        view_context.policy(Person.new).new?
       end
     end
   end

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -126,15 +126,15 @@ module Components
             SelectInput(
               name: 'person[person_type]',
               id: 'person_person_type',
-              value: person.person_type
+              value: selected_person_type
             )
             SelectTrigger do
               SelectValue(placeholder: 'Select person type') do
-                person.person_type&.humanize || 'Select person type'
+                selected_person_type&.humanize || 'Select person type'
               end
             end
             SelectContent do
-              Person.person_types.each_key do |type|
+              available_person_types.each do |type|
                 SelectItem(value: type) { type.humanize }
               end
             end
@@ -190,6 +190,22 @@ module Components
             person.new_record? ? 'Create Person' : 'Update Person'
           end
         end
+      end
+
+      def available_person_types
+        @available_person_types ||= begin
+          allowed_types = Person.person_types.keys.select do |type|
+            view_context.policy(Person.new(person_type: type)).create?
+          end
+          allowed_types.presence || Person.person_types.keys
+        end
+      end
+
+      def selected_person_type
+        return person.person_type if available_person_types.include?(person.person_type)
+        return available_person_types.first if person.new_record?
+
+        person.person_type
       end
     end
   end

--- a/app/components/people/index_view.rb
+++ b/app/components/people/index_view.rb
@@ -26,7 +26,7 @@ module Components
       def render_header
         div(class: 'flex justify-between items-center mb-8') do
           Heading(level: 1) { 'People' }
-          if view_context.policy(Person.new).create?
+          if view_context.policy(Person.new).new?
             Link(href: new_person_path, variant: :primary, data: { turbo_frame: 'modal' }) { 'New Person' }
           end
         end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -54,10 +54,14 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
   end
 
   describe 'quick actions' do
-    it 'renders Add Medication and Add Person links' do
+    it 'renders Add Medication link' do
       rendered = render_inline(dashboard_view)
       expect(rendered.text).to include('Add Medication')
-      expect(rendered.text).to include('Add Person')
+    end
+
+    it 'hides Add Person for admin users' do
+      rendered = render_inline(dashboard_view)
+      expect(rendered.text).not_to include('Add Person')
     end
   end
 

--- a/spec/system/authorization/carer_access_spec.rb
+++ b/spec/system/authorization/carer_access_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe 'Carer Access Authorization' do
   end
 
   describe 'managing people' do
-    it 'denies carers ability to create new people' do
+    it 'allows carers ability to create new dependents' do
       login_as(carer)
       visit people_path
 
       expect(page).to have_css('h1', text: 'People')
-      expect(page).to have_no_link('New Person')
+      expect(page).to have_link('New Person', href: new_person_path)
     end
 
     it 'denies carers ability to edit people' do

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -5,18 +5,25 @@ require 'rails_helper'
 RSpec.describe 'Home' do
   fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules
 
-  it 'loads the dashboard as the home page for a signed-in user' do
-    # Sign in the user from fixtures
+  it 'loads the dashboard for an admin and hides Add Person' do
     sign_in(users(:damacus))
 
-    # Visit the root path after signing in
     visit root_path
 
-    # Assert that the dashboard is shown
     aggregate_failures 'dashboard content' do
       expect(page).to have_content('Dashboard')
-      # Dashboard quick actions are visible on all viewports
       expect(page).to have_link('Add Medication', href: new_medication_path)
+      expect(page).to have_no_link('Add Person')
+    end
+  end
+
+  it 'loads the dashboard for a parent and shows Add Person' do
+    sign_in(users(:jane))
+
+    visit root_path
+
+    aggregate_failures 'dashboard content' do
+      expect(page).to have_content('Dashboard')
       expect(page).to have_link('Add Person', href: new_person_path)
     end
   end


### PR DESCRIPTION
## Problem
  Parents/carers should be able to add dependent people (children/dependent adults) from
  normal UI flows.

  The backend create rules were mostly in place, but UI entry points and form behavior were
  inconsistent.

  ## Solution
  This PR aligns entry points, form options, and test coverage with the intended dependent-
  creation behavior.

  ### Entry points
  - People index now checks `new?` (not `create?` on a blank record) to show `New Person`.
  - Dashboard `Add Person` quick action is policy-gated.

  ### Form behavior
  - Person type options are filtered to policy-allowed create types.
  - For parent/carer roles, this results in dependent-only options (`minor`,
  `dependent_adult`).
  - New records default to the first allowed option when needed.

  ### Safeguard behavior
  - Dependent person creation continues to create a `Person` record only (no login `User`
  record).

  ## Files changed
  - `app/components/people/index_view.rb`
  - `app/components/dashboard/index_view.rb`
  - `app/components/people/form_view.rb`
  - `spec/requests/people_spec.rb`
  - `spec/system/authorization/carer_access_spec.rb`
  - `spec/system/home_spec.rb`
  - `spec/components/dashboard/index_view_spec.rb`

  ## Validation
  Executed in this branch:
  - `task test TEST_FILE=spec/requests/people_spec.rb`
  - `task test TEST_FILE=spec/components/dashboard/index_view_spec.rb`
  - `task test TEST_FILE=spec/system/authorization/carer_access_spec.rb`
  - `task test TEST_FILE=spec/system/home_spec.rb`
  - `task test TEST_FILE=spec/system/authorization/clinician_access_spec.rb`

  Post-rebase sanity checks:
  - `task test TEST_FILE=spec/components/dashboard/index_view_spec.rb`
  - `task test TEST_FILE=spec/system/home_spec.rb`