### PR TITLE
feat(perf): Prevent N+1 queries on schedule and medication cards

### DIFF
--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -138,10 +138,7 @@ module Components
       end
 
       def render_takes_section
-        takes = todays_takes || person_medication.medication_takes
-                                                 .where(taken_at: Time.current.beginning_of_day..)
-                                                 .order(taken_at: :desc)
-                                                 .load
+        takes = todays_takes || fetch_todays_takes
 
         div(class: 'space-y-4 pt-2') do
           div(class: 'flex items-center justify-between') do
@@ -151,6 +148,20 @@ module Components
             render_dose_counter(takes) if person_medication.max_daily_doses.present?
           end
           render_todays_takes(takes)
+        end
+      end
+
+      def fetch_todays_takes
+        if person_medication.medication_takes.loaded?
+          person_medication.medication_takes
+                           .select { |t| t.taken_at >= Time.current.beginning_of_day }
+                           .sort_by(&:taken_at)
+                           .reverse
+        else
+          person_medication.medication_takes
+                           .where(taken_at: Time.current.beginning_of_day..)
+                           .order(taken_at: :desc)
+                           .load
         end
       end
 

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -153,7 +153,11 @@ module Components
             end
             if schedule.max_daily_doses.present?
               takes_count = todays_takes&.count ||
-                            schedule.medication_takes.where(taken_at: Time.current.beginning_of_day..).count
+                            if schedule.medication_takes.loaded?
+                              schedule.medication_takes.count { |t| t.taken_at >= Time.current.beginning_of_day }
+                            else
+                              schedule.medication_takes.where(taken_at: Time.current.beginning_of_day..).count
+                            end
               Badge(variant: :outline, class: 'rounded-full text-[10px]') do
                 "#{takes_count}/#{schedule.max_daily_doses}"
               end
@@ -164,9 +168,7 @@ module Components
       end
 
       def render_todays_takes
-        takes = todays_takes || schedule.medication_takes
-                                        .where(taken_at: Time.current.beginning_of_day..)
-                                        .order(taken_at: :desc)
+        takes = todays_takes || fetch_todays_takes
 
         if takes.any?
           div(class: 'grid grid-cols-1 gap-2') do
@@ -178,6 +180,19 @@ module Components
           Text(size: '2', weight: 'medium', class: 'italic text-slate-300 px-1') do
             t('schedules.card.no_doses_today')
           end
+        end
+      end
+
+      def fetch_todays_takes
+        if schedule.medication_takes.loaded?
+          schedule.medication_takes
+                  .select { |t| t.taken_at >= Time.current.beginning_of_day }
+                  .sort_by(&:taken_at)
+                  .reverse
+        else
+          schedule.medication_takes
+                  .where(taken_at: Time.current.beginning_of_day..)
+                  .order(taken_at: :desc)
         end
       end
 


### PR DESCRIPTION
💡 **What**: Replaced database-level `.where` and `.order` queries with in-memory Ruby Enumerable methods (`.select`, `.count`, `.sort_by`) in `app/components/schedules/card.rb` and `app/components/person_medications/card.rb` when the `medication_takes` association is already loaded.

🎯 **Why**: When rendering lists of cards, calling `.where` or `.order` on an association forces ActiveRecord to ignore any preloaded data and issue a new query to the database. This creates an N+1 query issue. By checking `.loaded?` and using in-memory methods, we prevent these redundant database calls.

📊 **Impact**: Reduces N+1 database queries on views that render multiple schedule or medication cards.

🔬 **Measurement**: Inspect the Rails logs or APM when loading a dashboard or schedule view. The number of database queries should be significantly reduced compared to before the optimization.

---
*PR created automatically by Jules for task [13201881396847704103](https://jules.google.com/task/13201881396847704103) started by @damacus*