### PR TITLE
fix(🎨 Palette): Add ARIA labels to icon-only buttons in schedules and locations

### DIFF
--- a/app/components/locations/index_view.rb
+++ b/app/components/locations/index_view.rb
@@ -118,7 +118,8 @@ module Components
             href: edit_location_path(location, return_to: locations_path),
             variant: :outline,
             size: :sm,
-            class: 'rounded-xl w-10 h-10 p-0 border-slate-100 bg-white hover:bg-slate-50 text-slate-400'
+            class: 'rounded-xl w-10 h-10 p-0 border-slate-100 bg-white hover:bg-slate-50 text-slate-400',
+            aria_label: t('locations.index.edit', default: 'Edit location')
           ) do
             render Icons::Pencil.new(size: 16)
           end
@@ -130,7 +131,8 @@ module Components
         AlertDialog do
           AlertDialogTrigger do
             Button(variant: :ghost, size: :sm,
-                   class: 'rounded-xl w-10 h-10 p-0 text-slate-300 hover:text-destructive hover:bg-destructive/5') do
+                   class: 'rounded-xl w-10 h-10 p-0 text-slate-300 hover:text-destructive hover:bg-destructive/5',
+                   aria_label: t('locations.index.delete', default: 'Delete location')) do
               render Icons::Trash.new(size: 18)
             end
           end

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -157,7 +157,8 @@ module Components
               variant: :ghost,
               size: :sm,
               class: 'opacity-0 group-hover:opacity-100 transition-opacity text-slate-300 ' \
-                     'hover:text-destructive h-8 w-8 p-0'
+                     'hover:text-destructive h-8 w-8 p-0',
+              aria_label: t('locations.show.remove_member.aria_label', default: 'Remove member')
             ) do
               render Icons::X.new(size: 14)
             end
@@ -193,7 +194,8 @@ module Components
                 href: edit_location_path(location, return_to: location_path(location)),
                 variant: :ghost,
                 size: :sm,
-                class: 'text-slate-400 hover:text-primary h-8 w-8 p-0 flex items-center justify-center'
+                class: 'text-slate-400 hover:text-primary h-8 w-8 p-0 flex items-center justify-center',
+                aria_label: t('locations.show.edit_details', default: 'Edit location details')
               ) do
                 render Icons::Pencil.new(size: 16)
               end
@@ -216,7 +218,8 @@ module Components
             Button(
               variant: :ghost,
               size: :sm,
-              class: 'w-8 h-8 p-0 rounded-full bg-slate-50 text-slate-400 hover:text-primary hover:bg-primary/5'
+              class: 'w-8 h-8 p-0 rounded-full bg-slate-50 text-slate-400 hover:text-primary hover:bg-primary/5',
+              aria_label: t('locations.show.add_member.aria_label', default: 'Add member')
             ) do
               render Icons::Plus.new(size: 16)
             end

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -260,6 +260,7 @@ module Components
               variant: :outline,
               class: 'w-12 h-12 p-0 rounded-xl border-slate-100 flex items-center justify-center ' \
                      'text-slate-400 hover:text-slate-600',
+              aria_label: t('schedules.card.edit', default: 'Edit schedule'),
               data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" }
             ) do
               render Icons::Pencil.new(size: 20)
@@ -274,6 +275,7 @@ module Components
           AlertDialogTrigger do
             Button(variant: :ghost,
                    class: 'w-12 h-12 p-0 rounded-xl text-slate-300 hover:text-destructive hover:bg-destructive/5',
+                   aria_label: t('schedules.card.delete', default: 'Delete schedule'),
                    data: { testid: "delete-schedule-#{schedule.id}" }) do
               render Icons::Trash.new(size: 20)
             end


### PR DESCRIPTION
💡 What: Added `aria_label` properties to icon-only buttons (edit, delete, add member, remove member) in schedule and location views.
🎯 Why: To improve accessibility for screen readers on icon-only interactive elements.
♿ Accessibility: Ensures that interactive elements provide an accessible name for assistive technologies.

---
*PR created automatically by Jules for task [17389125105149315786](https://jules.google.com/task/17389125105149315786) started by @damacus*