### PR TITLE
test: 🧪 Add PushSubscription model specs

### DIFF
--- a/spec/models/push_subscription_spec.rb
+++ b/spec/models/push_subscription_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PushSubscription do
+  describe 'associations' do
+    it { is_expected.to belong_to(:account) }
+  end
+
+  describe 'validations' do
+    subject do
+      described_class.new(
+        account_id: 1,
+        endpoint: 'https://example.com/push',
+        p256dh: 'p256dh_key',
+        auth: 'auth_key'
+      )
+    end
+
+    it { is_expected.to validate_presence_of(:endpoint) }
+
+    # We use a dummy subject in memory to avoid uniqueness DB insertion requirements
+    # that usually require building and saving an account object.
+    it { is_expected.to validate_uniqueness_of(:endpoint) }
+
+    it { is_expected.to validate_presence_of(:p256dh) }
+    it { is_expected.to validate_presence_of(:auth) }
+  end
+
+  describe '#to_webpush_params' do
+    it 'returns a hash with endpoint, p256dh, and auth keys' do
+      subscription = described_class.new(
+        endpoint: 'https://example.com/push',
+        p256dh: 'p256dh_key',
+        auth: 'auth_key'
+      )
+
+      expect(subscription.to_webpush_params).to eq(
+        endpoint: 'https://example.com/push',
+        p256dh: 'p256dh_key',
+        auth: 'auth_key'
+      )
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing specs for `PushSubscription` model validations, associations, and methods.
📊 **Coverage:** What scenarios are now tested: `endpoint` presence and uniqueness, `p256dh` and `auth` presence validations, `account` association, and the `#to_webpush_params` expected hash output.
✨ **Result:** The improvement in test coverage: Full coverage of the existing model.

---
*PR created automatically by Jules for task [1193485108238496051](https://jules.google.com/task/1193485108238496051) started by @damacus*