### PR TITLE
perf: ⚡ fix N+1 query in locations medications

### DIFF
--- a/app/components/locations/index_view.rb
+++ b/app/components/locations/index_view.rb
@@ -72,7 +72,7 @@ module Components
               Text(size: '2', class: 'text-slate-400 line-clamp-2 leading-relaxed') { location.description }
             end
 
-            if location.members.any?
+            if location.members.present?
               div(class: 'pt-4 border-t border-slate-100') do
                 Text(size: '1', weight: 'black', class: 'uppercase tracking-widest text-slate-500 mb-2 block') do
                   t('locations.index.members')

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -72,7 +72,7 @@ module Components
             Heading(level: 2, size: '5', class: 'font-bold tracking-tight') { t('locations.show.medications_heading') }
           end
 
-          if location.medications.any?
+          if location.medications.present?
             div(class: 'grid grid-cols-1 md:grid-cols-2 gap-4') do
               location.medications.each do |medication|
                 render_medication_card(medication)
@@ -126,7 +126,7 @@ module Components
             render_add_member_dialog if view_context.policy(location).update?
           end
 
-          if location.members.any?
+          if location.members.present?
             div(class: 'space-y-3') do
               location.members.each do |member|
                 div(class: 'flex items-center justify-between group') do
@@ -138,7 +138,7 @@ module Components
                   end
 
                   if view_context.policy(location).update?
-                    membership = location.location_memberships.find_by(person: member)
+                    membership = location.location_memberships.find { |lm| lm.person_id == member.id }
                     render_remove_member_dialog(member, membership)
                   end
                 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,7 +4,7 @@ class LocationsController < ApplicationController
   before_action :set_location, only: %i[show edit update destroy]
 
   def index
-    locations = policy_scope(Location).includes(:medications, :members)
+    locations = policy_scope(Location).includes(:medications, :members, :location_memberships)
     render Components::Locations::IndexView.new(locations: locations)
   end
 
@@ -72,7 +72,7 @@ class LocationsController < ApplicationController
   private
 
   def set_location
-    @location = policy_scope(Location).includes(:medications, :members).find(params[:id])
+    @location = policy_scope(Location).includes(:medications, :members, :location_memberships).find(params[:id])
   end
 
   def location_params


### PR DESCRIPTION
## 💡 What
- Edited `app/controllers/locations_controller.rb` to update the `includes` in `set_location` to `.includes(:medications, :members, :location_memberships)`.
- Replaced `.any?` with `.present?` in view components to avoid COUNT queries.
- Changed `find_by` to `.find { ... }` in the view to fix an N+1 query.

## 🎯 Why
Iterating over `location.medications` without proper eager loading in the controller leads to N+1 queries. Eager loading can be applied at the controller level. Calling `.any?` on an association without loading it or with `includes`, it often executes a COUNT query in the database.

## 📊 Measured Improvement
I am unable to run the full test suite and make a performance measure due to a Docker pull rate limit error. However, the changes I made are very localized and correctly address the issue described.

---
*PR created automatically by Jules for task [11224578837350667074](https://jules.google.com/task/11224578837350667074) started by @damacus*