### PR TITLE
style: 🎨 Palette: Add aria-label to icon-only buttons in medications index

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Component icon-only `aria-label` conventions
+**Learning:** Found multiple icon-only components across the Ruby UI layout using `span.sr-only`, but icon-only buttons implemented using `Button` or `Link` components should simply accept the `aria_label:` prop. Ensure it exists.
+**Action:** When working with `<Button>` or `<Link>`, default to setting `aria_label` directly on the component rather than nesting an `sr-only` span.

--- a/app/components/medications/index_view.rb
+++ b/app/components/medications/index_view.rb
@@ -202,7 +202,8 @@ module Components
             href: edit_medication_path(medication, return_to: medications_path),
             variant: :outline,
             size: :sm,
-            class: 'rounded-xl w-10 h-10 p-0 border-slate-100 bg-white hover:bg-slate-50 text-slate-400'
+            class: 'rounded-xl w-10 h-10 p-0 border-slate-100 bg-white hover:bg-slate-50 text-slate-400',
+            aria_label: t('medications.index.edit', default: 'Edit medication')
           ) do
             render Icons::Pencil.new(size: 16)
           end
@@ -229,7 +230,8 @@ module Components
         AlertDialog do
           AlertDialogTrigger do
             Button(variant: :ghost, size: :sm,
-                   class: 'rounded-xl w-10 h-10 p-0 text-slate-300 hover:text-destructive hover:bg-destructive/5') do
+                   class: 'rounded-xl w-10 h-10 p-0 text-slate-300 hover:text-destructive hover:bg-destructive/5',
+                   aria_label: t('medications.index.delete', default: 'Delete medication')) do
               render Icons::Trash.new(size: 18)
             end
           end


### PR DESCRIPTION
💡 **What:** Added `aria_label` props to the 'Edit' and 'Delete' icon-only `<Link>` and `<Button>` components in `app/components/medications/index_view.rb`.
🎯 **Why:** To improve accessibility by providing clear, descriptive labels for screen reader users when navigating the medication index view, as the buttons only visually contain icons.
♿ **Accessibility:** Screen readers will now correctly announce 'Edit medication' and 'Delete medication' instead of reading unlabelled or non-descriptive elements.

---
*PR created automatically by Jules for task [13958469533354444945](https://jules.google.com/task/13958469533354444945) started by @damacus*