### PR TITLE
feat(sec): sanitize medication finder service errors

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -145,12 +145,14 @@ class MedicationsController < ApplicationController
   def search
     authorize Medication, :finder?
     query = params[:q].to_s.strip
+    return render json: { results: [] } if query.blank?
+
     result = NhsDmd::Search.new.call(query)
 
     if result.success?
       render json: { results: result.results.map(&:to_h) }
     else
-      render json: { results: [], error: result.error }
+      render json: { results: [], error: 'Medication search is temporarily unavailable.' }, status: :service_unavailable
     end
   end
 

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -25,9 +25,7 @@ export default class extends Controller {
 
       const data = await response.json()
 
-      if (data.error === "not_configured") {
-        this.showNotConfigured()
-      } else if (data.error) {
+      if (data.error) {
         this.showError(data.error)
       } else {
         this.showResults(query, data.results)
@@ -59,15 +57,6 @@ export default class extends Controller {
     this.resultsTarget.innerHTML = `
       <div class="text-center py-12 text-slate-500">
         <p class="text-sm">Enter a medication name above to search the NHS dm+d database.</p>
-      </div>
-    `
-  }
-
-  showNotConfigured() {
-    this.resultsTarget.innerHTML = `
-      <div class="rounded-lg border border-amber-200 bg-amber-50 p-4" role="alert">
-        <p class="text-sm font-medium text-amber-800">Medication search not available</p>
-        <p class="text-sm text-amber-700 mt-1">NHS dm+d credentials are not configured. Ask your administrator to set <code>NHS_DMD_CLIENT_ID</code> and <code>NHS_DMD_CLIENT_SECRET</code>.</p>
       </div>
     `
   }

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe 'GET /medication-finder/search' do
         allow(NhsDmd::Search).to receive(:new).and_return(search)
       end
 
-      it 'returns 200 with an error message' do
+      it 'returns 503 with a generic error message' do
         get medication_finder_search_path(format: :json), params: { q: 'aspirin' }
 
         json = response.parsed_body
-        expect(response).to have_http_status(:ok)
-        expect(json['error']).to be_present
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['error']).to eq('Medication search is temporarily unavailable.')
       end
     end
 
@@ -92,12 +92,12 @@ RSpec.describe 'GET /medication-finder/search' do
         allow(NhsDmd::Search).to receive(:new).and_return(search)
       end
 
-      it 'returns 200 with a not_configured error' do
+      it 'returns 503 with a generic error message' do
         get medication_finder_search_path(format: :json), params: { q: 'aspirin' }
 
         json = response.parsed_body
-        expect(response).to have_http_status(:ok)
-        expect(json['error']).to eq('not_configured')
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['error']).to eq('Medication search is temporarily unavailable.')
       end
     end
 


### PR DESCRIPTION
## Summary
- stop returning raw NHS dm+d service and configuration errors from the medication finder JSON endpoint
- return a generic `503 Service Unavailable` response for backend lookup failures
- keep blank queries fast and harmless, and update request coverage for the hardened behavior

## Security Context
- Severity: MEDIUM
- Vulnerability: the medication finder endpoint echoed backend error strings directly to clients, including service/configuration state
- Impact: users could learn internal integration details and transient backend failure messages that should stay server-side
- Fix: replace raw error payloads with a generic message and remove the client-side branch that exposed configuration guidance
- Verification: `task test TEST_FILE=spec/requests/medications_search_spec.rb`; `task test`

## Notes
- `task rubocop` is currently blocked in this environment by the host Ruby/Bundler setup (`ruby 2.6` vs repo Bundler 4 lockfile), so lint could not be completed from this worktree.
