### PR TITLE
fix: Clear the PWA cache for end users

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,14 +1,62 @@
 // Add a service worker for processing Web Push notifications:
 
+const CACHE_VERSION = 'v2'
+const STATIC_CACHE = `medtracker-static-${CACHE_VERSION}`
+const PRECACHE_URLS = [
+  '/',
+  '/manifest.webmanifest'
+]
+
 // The install event is fired when the service worker is first installed
 self.addEventListener('install', function(event) {
+    event.waitUntil(
+      Promise.all([
+        self.skipWaiting(),
+        caches.open(STATIC_CACHE).then((cache) => cache.addAll(PRECACHE_URLS))
+      ])
+    )
     console.log('Service Worker installed');
   });
 
 // The activate event is fired after the install event when the service worker is actually controlling the page
 self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => Promise.all([
+      self.clients.claim(),
+      ...cacheNames
+        .filter((cacheName) => cacheName !== STATIC_CACHE)
+        .map((cacheName) => caches.delete(cacheName))
+    ]))
+  )
   console.log('Service Worker activated');
 });
+
+self.addEventListener('fetch', function(event) {
+  if (event.request.method !== 'GET') {
+    return
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse
+      }
+
+      return fetch(event.request).then((response) => {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
+          return response
+        }
+
+        const responseToCache = response.clone()
+        caches.open(STATIC_CACHE).then((cache) => {
+          cache.put(event.request, responseToCache)
+        })
+
+        return response
+      }).catch(() => cachedResponse)
+    })
+  )
+})
 
 // The push event is fired when a push notification is received
 self.addEventListener("push", async (event) => {

--- a/spec/requests/pwa_spec.rb
+++ b/spec/requests/pwa_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe 'PWA' do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq('text/javascript')
       expect(response.body).to include('self.addEventListener')
+      expect(response.body).to include("const CACHE_VERSION = 'v2'")
+      expect(response.body).to include('self.skipWaiting()')
+      expect(response.body).to include('self.clients.claim()')
     end
   end
 


### PR DESCRIPTION
## Summary
- bump the PWA cache version so existing installed clients drop stale cached responses
- activate the new service worker immediately and claim open clients so users get the refresh without manual cache clearing
- cover the served service worker response with a request spec

Closes #865