### PR TITLE
perf: reuse schedule card data during render

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-03-05 - Manually Preloading Associations in Query Objects
 **Learning:** When a query object (like `ScheduleQuery`) preloads records into a hash or separate collection, child models with custom logic (like `TimingRestrictions`) will still hit the database if they access the association and don't know it's already "preloaded". Even if you have the data, the model's `association.loaded?` check will return false.
 **Action:** In query objects that perform bulk fetching, manually associate the child records with their parents using `source.association(:association_name).loaded!` and `source.association(:association_name).target.concat(preloaded_records)`. This ensures that downstream logic using the association (like `.count { ... }` on the loaded collection) avoids triggering new SQL queries.
+
+## 2026-03-05 - Materialize Shared Card Data Once Per Render
+**Learning:** In MedTracker card components, showing both a "today's doses" badge and the corresponding take list can accidentally trigger duplicate `medication_takes` work in the same render: one query for the count and another for the rows, plus repeated boolean checks if memoization uses `||=` for falsey values.
+**Action:** When a card needs the same association for multiple UI elements, materialize it once into an array and reuse it for counts and rendering. For per-render boolean/nil memoization, prefer `instance_variable_defined?` guards over `||=` so blocked/out-of-stock states cache correctly.

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -33,9 +33,9 @@ module Components
       private
 
       def status_top_border_class
-        if schedule.out_of_stock?
+        if out_of_stock?
           'border-t-rose-500'
-        elsif !schedule.can_take_now?
+        elsif !can_take_now?
           'border-t-amber-500'
         else
           'border-t-primary'
@@ -62,9 +62,9 @@ module Components
       end
 
       def status_badge
-        return if schedule.out_of_stock?
+        return if out_of_stock?
 
-        if schedule.can_take_now?
+        if can_take_now?
           Badge(variant: :success, class: 'rounded-full text-[10px] py-0.5') { t('schedules.card.ready_now') }
         else
           Badge(variant: :warning, class: 'rounded-full text-[10px] py-0.5') { t('schedules.card.waiting') }
@@ -76,7 +76,7 @@ module Components
           div(class: 'pt-4 border-t border-slate-50 space-y-4') do
             render_date_details
             render_notes if schedule.notes.present?
-            render_countdown_notice if !schedule.can_take_now? && schedule.countdown_display
+            render_countdown_notice if !can_take_now? && schedule.countdown_display
             render_takes_section
           end
         end
@@ -152,14 +152,8 @@ module Components
               t('schedules.card.todays_doses')
             end
             if schedule.max_daily_doses.present?
-              takes_count = todays_takes&.count ||
-                            if schedule.medication_takes.loaded?
-                              schedule.medication_takes.count { |t| t.taken_at >= Time.current.beginning_of_day }
-                            else
-                              schedule.medication_takes.where(taken_at: Time.current.beginning_of_day..).count
-                            end
               Badge(variant: :outline, class: 'rounded-full text-[10px]') do
-                "#{takes_count}/#{schedule.max_daily_doses}"
+                "#{todays_takes_count}/#{schedule.max_daily_doses}"
               end
             end
           end
@@ -168,7 +162,7 @@ module Components
       end
 
       def render_todays_takes
-        takes = todays_takes || fetch_todays_takes
+        takes = resolved_todays_takes
 
         if takes.any?
           div(class: 'grid grid-cols-1 gap-2') do
@@ -196,6 +190,46 @@ module Components
         end
       end
 
+      # Cache these per-render so the card doesn't rescan or requery the same data
+      # for the status badge, disabled button, dose count badge, and take history.
+      def out_of_stock?
+        return @out_of_stock if instance_variable_defined?(:@out_of_stock)
+
+        @out_of_stock = schedule.out_of_stock?
+      end
+
+      def can_take_now?
+        return @can_take_now if instance_variable_defined?(:@can_take_now)
+
+        @can_take_now = schedule.can_take_now?
+      end
+
+      def can_administer?
+        return @can_administer if instance_variable_defined?(:@can_administer)
+
+        @can_administer = !out_of_stock? && can_take_now?
+      end
+
+      def blocked_reason
+        return @blocked_reason if instance_variable_defined?(:@blocked_reason)
+
+        @blocked_reason = if out_of_stock?
+                            :out_of_stock
+                          else
+                            (can_take_now? ? nil : :cooldown)
+                          end
+      end
+
+      def resolved_todays_takes
+        return @resolved_todays_takes if instance_variable_defined?(:@resolved_todays_takes)
+
+        @resolved_todays_takes = (todays_takes || fetch_todays_takes).to_a
+      end
+
+      def todays_takes_count
+        @todays_takes_count ||= resolved_todays_takes.size
+      end
+
       def render_take_item(take)
         div(
           class: 'flex items-center justify-between p-3 rounded-xl bg-slate-50/50 group/item transition-colors ' \
@@ -212,7 +246,7 @@ module Components
       end
 
       def render_take_medication_button
-        if invalid_dose_configured? || !schedule.can_administer?
+        if invalid_dose_configured? || !can_administer?
           render_disabled_button_with_reason
         else
           form_with(
@@ -239,8 +273,7 @@ module Components
         label = if invalid_dose_configured?
                   t('schedules.card.invalid_dose')
                 else
-                  reason = schedule.administration_blocked_reason
-                  reason == :out_of_stock ? t('schedules.card.out_of_stock') : take_label('schedules')
+                  blocked_reason == :out_of_stock ? t('schedules.card.out_of_stock') : take_label('schedules')
                 end
         render Button.new(
           variant: :secondary,

--- a/spec/components/schedules/card_todays_takes_spec.rb
+++ b/spec/components/schedules/card_todays_takes_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe Components::Schedules::Card, type: :component do
     Nokogiri::HTML::DocumentFragment.parse(html)
   end
 
+  def count_medication_take_queries(&)
+    query_count = 0
+
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+      next unless sql.include?('"medication_takes"')
+
+      query_count += 1
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    query_count
+  end
+
   describe 'pre-loaded todays_takes' do
     let(:take) { MedicationTake.create!(schedule: schedule, taken_at: Time.current, amount_ml: 400) }
 
@@ -43,6 +58,24 @@ RSpec.describe Components::Schedules::Card, type: :component do
       take
       rendered = render_card
       expect(rendered.text).to include('400mg')
+    end
+
+    it 'reuses one medication_takes load for the dose badge and list' do
+      schedule.update!(max_daily_doses: 4)
+      allow(schedule).to receive_messages(out_of_stock?: false, can_take_now?: true)
+
+      take
+
+      expect(count_medication_take_queries { render_card }).to eq(1)
+    end
+
+    it 'memoizes schedule availability checks for the render' do
+      allow(schedule).to receive_messages(out_of_stock?: false, can_take_now?: true)
+
+      render_card
+
+      expect(schedule).to have_received(:out_of_stock?).once
+      expect(schedule).to have_received(:can_take_now?).once
     end
   end
 end

--- a/spec/components/views/profiles/theme_picker_card_spec.rb
+++ b/spec/components/views/profiles/theme_picker_card_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Views::Profiles::ThemePickerCard, type: :component do
     buttons = rendered.css('button[data-theme]')
 
     expect(buttons).not_to be_empty
-    expect(buttons.map { |button| button['type'] }).to all(eq('button'))
-    expect(buttons.map { |button| button['aria-pressed'] }).to all(eq('false'))
+    expect(buttons.pluck('type')).to all(eq('button'))
+    expect(buttons.pluck('aria-pressed')).to all(eq('false'))
   end
 end


### PR DESCRIPTION
## 💡 What
- Cache per-render schedule state inside the schedule card so the same render does not repeatedly recompute `out_of_stock?`, `can_take_now?`, or disabled-button state.
- Materialize `todays_takes` once and reuse that array for both the daily dose badge and the rendered take history.
- Add component specs that verify the card now performs a single `medication_takes` query for the badge/list path and only evaluates availability once per render.

## 🎯 Why
The schedule card was doing duplicate work on a hot UI path:
- rendering both the daily dose badge and the take list could trigger a count query and then a second fetch for the same `medication_takes`
- the same render could ask the schedule about availability multiple times

On pages with many schedule cards, that adds avoidable database work and repeated association scans.

## 📊 Impact
- Reduces `medication_takes` database work for the schedule card badge/list path from 2 queries to 1 when `todays_takes` is not preloaded.
- Reduces repeated availability evaluation in a single card render from multiple calls to 1 cached result.
- Expected result: less per-card database and Ruby work on schedule-heavy pages, especially person and dashboard views that render many cards.

## 🔬 Measurement
- Added a component spec that counts SQL against `medication_takes` and verifies one query is issued when rendering the badge and list together.
- Added a component spec that verifies `out_of_stock?` and `can_take_now?` are each evaluated once per render.
- Verified with `task test TEST_FILE=spec/components/schedules/card_todays_takes_spec.rb` and full `task test`.

## Notes
- `task rubocop` is currently blocked in this worktree because the host Ruby is missing the Bundler version required by `Gemfile.lock` (`bundler 4.0.3`).
