### PR TITLE
feat(ui): add compact metric card for dashboard right rail

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -22,6 +22,7 @@ module Components
               render_health_insights
             end
             div(class: 'space-y-8') do
+              render_right_rail_next_dose
               render_schedules_section
               render_supply_levels
             end
@@ -165,6 +166,16 @@ module Components
             upcoming_doses.each { |dose| upcoming_dose_item(dose) }
           end
         end
+      end
+
+      def render_right_rail_next_dose
+        render Components::Shared::MetricCard.new(
+          title: t('dashboard.stats.next_dose'),
+          value: next_dose_value,
+          icon_type: 'clock',
+          layout: :compact,
+          testid: 'dashboard-right-rail-next-dose'
+        )
       end
 
       def upcoming_dose_item(dose)

--- a/app/components/shared/metric_card.rb
+++ b/app/components/shared/metric_card.rb
@@ -3,7 +3,7 @@
 module Components
   module Shared
     class MetricCard < Components::Base
-      attr_reader :title, :value, :icon_type, :href, :badge, :testid, :variant, :value_data_attr
+      attr_reader :title, :value, :icon_type, :href, :badge, :testid, :variant, :value_data_attr, :layout
 
       def initialize(title:, value:, icon_type:, **options)
         @title = title
@@ -14,6 +14,7 @@ module Components
         @testid = options.fetch(:testid, nil)
         @variant = options.fetch(:variant, :default).to_sym
         @value_data_attr = options.fetch(:value_data_attr, {}) || {}
+        @layout = options.fetch(:layout, :default).to_sym
         super()
       end
 
@@ -37,26 +38,31 @@ module Components
 
       def render_card(as_link: false)
         Card(
-          class: "#{border_class} h-full min-h-[9.5rem] sm:min-h-[10rem] " \
-                 "shadow-sm #{background_class} backdrop-blur-sm " \
-                 'transition-all duration-300 md:hover:scale-[1.02] md:hover:shadow-xl md:hover:shadow-primary/5 ' \
+          class: "#{border_class} h-full #{min_height_class} " \
+                 "shadow-sm #{background_class} backdrop-blur-sm #{hover_class} " \
                  "#{cursor_class} group",
           data: testid.present? && !as_link ? { testid: testid } : nil
         ) do
-          CardContent(class: 'p-6 h-full flex flex-col') do
-            div(class: 'flex items-center justify-between gap-2 mb-2 min-w-0') do
+          CardContent(class: "#{content_padding_class} h-full flex flex-col") do
+            div(class: "flex items-center justify-between gap-2 #{header_margin_class} min-w-0") do
               Text(
                 size: '1', weight: 'muted',
-                class: 'uppercase font-black tracking-widest group-hover:text-primary transition-colors truncate'
+                class: "uppercase font-black tracking-widest truncate #{title_class}"
               ) do
                 title
               end
-              div(class: "p-2 rounded-lg flex-shrink-0 #{icon_bg_class} #{value_color_class} transition-colors") do
-                render_icon(size: 16)
+              div(
+                class: "#{icon_padding_class} rounded-lg flex-shrink-0 " \
+                       "#{icon_bg_class} #{value_color_class} transition-colors"
+              ) do
+                render_icon(size: icon_size)
               end
             end
             div(class: 'mt-auto flex flex-col items-start gap-2') do
-              span(class: "text-3xl font-black tracking-tight #{value_color_class}", data: value_data_attr) do
+              span(
+                class: "#{value_size_class} font-black tracking-tight #{value_color_class}",
+                data: value_data_attr
+              ) do
                 value.to_s
               end
               if badge.present?
@@ -72,8 +78,46 @@ module Components
         end
       end
 
+      def compact?
+        layout == :compact
+      end
+
       def cursor_class
         href.present? ? 'cursor-pointer' : 'cursor-default'
+      end
+
+      def min_height_class
+        compact? ? 'min-h-[7rem]' : 'min-h-[9.5rem] sm:min-h-[10rem]'
+      end
+
+      def hover_class
+        return '' if compact?
+
+        'transition-all duration-300 md:hover:scale-[1.02] md:hover:shadow-xl md:hover:shadow-primary/5'
+      end
+
+      def content_padding_class
+        compact? ? 'p-4' : 'p-6'
+      end
+
+      def header_margin_class
+        compact? ? 'mb-3' : 'mb-2'
+      end
+
+      def title_class
+        compact? ? 'text-[0.7rem]' : 'group-hover:text-primary transition-colors'
+      end
+
+      def icon_padding_class
+        compact? ? 'p-1.5' : 'p-2'
+      end
+
+      def icon_size
+        compact? ? 14 : 16
+      end
+
+      def value_size_class
+        compact? ? 'text-2xl' : 'text-3xl'
       end
 
       def background_class

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -103,6 +103,18 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(dashboard_view)
       expect(rendered.text).to include('Stock Inventory')
     end
+
+    it 'renders a compact Next Dose card in the right rail' do
+      rendered = render_inline(dashboard_view)
+      expected_value = presenter.next_dose_time&.strftime('%H:%M') || I18n.t('dashboard.stats.no_upcoming_doses')
+
+      compact_card = rendered.at_css('[data-testid="dashboard-right-rail-next-dose"]')
+
+      expect(compact_card).to be_present
+      expect(compact_card.text).to include('Next Dose')
+      expect(compact_card.text).to include(expected_value)
+      expect(compact_card.to_html).to include('min-h-[7rem]')
+    end
   end
 
   context 'when there are no active schedules or person medications' do

--- a/spec/components/shared/metric_card_spec.rb
+++ b/spec/components/shared/metric_card_spec.rb
@@ -55,4 +55,16 @@ RSpec.describe Components::Shared::MetricCard, type: :component do
 
     expect(rendered.css('[data-metric-value="10"]')).to be_present
   end
+
+  it 'renders compact layout classes when requested' do
+    rendered = render_inline(
+      described_class.new(title: 'Next Dose', value: '14:47', icon_type: 'clock', layout: :compact)
+    )
+    html = rendered.to_html
+
+    expect(html).to include('min-h-[7rem]')
+    expect(html).to include('p-4')
+    expect(html).to include('text-2xl')
+    expect(html).not_to include('md:hover:scale-[1.02]')
+  end
 end


### PR DESCRIPTION
## Summary
- add an opt-in compact layout to the shared metric card
- render a single compact Next Dose card in the dashboard right rail
- cover the new layout and dashboard usage with component specs
