### PR TITLE
feat(schedules): require explicit dose selection

### DIFF
--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -95,6 +95,7 @@ module Components
           input(type: :hidden, name: 'schedule[medication_id]', value: schedule.medication_id)
           div(class: 'grid grid-cols-1 md:grid-cols-2 gap-6') do
             render_dosage_cards
+            render_details_intro
             render_frequency_field(nil)
             render_start_date_field(nil)
             render_end_date_field(nil)
@@ -163,29 +164,48 @@ module Components
             plain 'Dose'
             span(class: 'text-destructive ml-0.5') { ' *' }
           end
-          div(class: 'grid grid-cols-1 md:grid-cols-2 gap-3') do
-            schedule.medication.dosages.each do |dosage|
-              label(class: dosage_card_classes(dosage)) do
-                input(
-                  type: :radio,
-                  name: 'schedule[dosage_id]',
-                  id: "schedule_dosage_id_#{dosage.id}",
-                  value: dosage.id,
-                  checked: schedule.dosage_id == dosage.id,
-                  required: true,
-                  class: 'sr-only',
-                  data: {
-                    action: 'change->schedule-form#onDosageChange',
-                    frequency: dosage.frequency,
-                    default_max_daily_doses: dosage.default_max_daily_doses,
-                    default_min_hours_between_doses: dosage.default_min_hours_between_doses,
-                    default_dose_cycle: dosage.default_dose_cycle
-                  }
-                )
-                div(class: 'font-semibold text-slate-900') { "#{dosage.amount.to_f} #{dosage.unit}" }
-                div(class: 'text-sm text-slate-500') { dosage.description }
+          Text(size: '2', class: 'text-slate-500') { 'Choose one dose before entering schedule details.' }
+          if schedule.medication.dosages.any?
+            div(class: 'mt-3 grid grid-cols-1 md:grid-cols-2 gap-3') do
+              schedule.medication.dosages.each do |dosage|
+                label(class: dosage_card_classes(dosage)) do
+                  input(
+                    type: :radio,
+                    name: 'schedule[dosage_id]',
+                    id: "schedule_dosage_id_#{dosage.id}",
+                    value: dosage.id,
+                    checked: schedule.dosage_id == dosage.id,
+                    required: true,
+                    class: 'sr-only',
+                    data: {
+                      action: 'change->schedule-form#onDosageChange',
+                      frequency: dosage.frequency,
+                      default_max_daily_doses: dosage.default_max_daily_doses,
+                      default_min_hours_between_doses: dosage.default_min_hours_between_doses,
+                      default_dose_cycle: dosage.default_dose_cycle
+                    }
+                  )
+                  div(class: 'font-semibold text-slate-900') { "#{dosage.amount.to_f} #{dosage.unit}" }
+                  div(class: 'text-sm text-slate-500') { dosage.description }
+                end
               end
             end
+          else
+            div(
+              class: 'mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-950',
+              data: { testid: 'schedule-no-dosage-message' }
+            ) do
+              'No dose options are available for this medication. Add a dosage before creating a schedule.'
+            end
+          end
+        end
+      end
+
+      def render_details_intro
+        div(class: 'md:col-span-2 space-y-1') do
+          Heading(level: 2, size: '4', class: 'font-semibold') { 'Schedule details' }
+          Text(size: '2', class: 'text-slate-500') do
+            'Set timing and safety guidance after choosing a dose.'
           end
         end
       end
@@ -368,6 +388,7 @@ module Components
               type: :submit,
               variant: :primary,
               size: :md,
+              disabled: schedule.new_record? && schedule.dosage.blank?,
               data: { schedule_form_target: 'submit' }
             ) { schedule.new_record? ? 'Add Plan' : 'Update Plan' }
           end
@@ -380,7 +401,11 @@ module Components
 
       def dosage_card_classes(dosage)
         base = 'rounded-2xl border p-4 transition-colors cursor-pointer'
-        selected = schedule.dosage_id == dosage.id ? ' border-primary bg-primary/5' : ' border-slate-200 bg-white'
+        selected = if schedule.dosage_id == dosage.id
+                     ' border-primary bg-primary/5 ring-2 ring-primary/20'
+                   else
+                     ' border-slate-200 bg-white'
+                   end
         "#{base}#{selected}"
       end
     end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -59,9 +59,6 @@ class SchedulesController < ApplicationController
     @schedule = @person.schedules.build
     @schedule.medication_id = params[:medication_id] if params[:medication_id].present?
     @schedule.frequency = params[:frequency] if params[:frequency].present?
-    if @schedule.medication && @schedule.dosage.blank?
-      @schedule.dosage = @schedule.medication.default_dosage_for_person_type(@person.person_type)
-    end
     authorize @schedule
     @medications = policy_scope(Medication)
     render_schedule_form(

--- a/spec/system/schedules/dosage_selection_spec.rb
+++ b/spec/system/schedules/dosage_selection_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Schedule dosage selection' do
     select 'Ibuprofen', from: 'Medication'
 
     expect(page).to have_content('Change')
+    expect(page).to have_no_css('[name="schedule[dosage_id]"]:checked', visible: :hidden)
+    expect(page).to have_button('Add Plan', disabled: true)
     choose("schedule_dosage_id_#{dosages(:ibuprofen_adult).id}", allow_label_click: true)
 
     fill_in 'Frequency', with: 'Once daily'
@@ -36,5 +38,26 @@ RSpec.describe 'Schedule dosage selection' do
     click_button 'Add Plan'
 
     expect(page).to have_content('Schedule was successfully created.')
+  end
+
+  it 'shows a blocked dose step when the medication has no dosage choices' do
+    Medication.create!(
+      name: 'Dose-less medication',
+      location: locations(:home),
+      reorder_threshold: 0
+    )
+
+    login_as(admin)
+    visit person_path(person)
+
+    within '[data-testid="quick-actions"]' do
+      click_link 'Add Medication'
+    end
+    click_link 'Prescribed / Scheduled'
+
+    select 'Dose-less medication', from: 'Medication'
+
+    expect(page).to have_content('No dose options are available for this medication.')
+    expect(page).to have_button('Add Plan', disabled: true)
   end
 end


### PR DESCRIPTION
## Summary
- stop preselecting a default dose in the prescribed schedule flow
- require the user to explicitly choose a dose before the plan can be submitted
- show a blocked empty state when a medication has no dosage choices

## Testing
- task test TEST_FILE=spec/system/schedules/dosage_selection_spec.rb
- task test TEST_FILE=spec/system/schedules/add_schedule_modal_spec.rb
- task rubocop

Fixes #920