### PR TITLE
style: 🎨 Palette: Add descriptive placeholders to People and Medications forms

### DIFF
--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -260,6 +260,7 @@ module Components
             value: medication.dosage_amount.to_i,
             step: 'any',
             min: '1',
+            placeholder: t('forms.medications.standard_dosage_placeholder', default: 'e.g., 500'),
             class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all'
           )
@@ -342,6 +343,7 @@ module Components
             id: 'medication_current_supply',
             value: medication.current_supply,
             min: '0',
+            placeholder: t('forms.medications.current_supply_placeholder', default: 'e.g., 30'),
             class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all'
           )
@@ -360,6 +362,7 @@ module Components
             id: 'medication_reorder_threshold',
             value: medication.reorder_threshold,
             min: '1',
+            placeholder: t('forms.medications.reorder_threshold_placeholder', default: 'e.g., 5'),
             class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all'
           )

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -96,6 +96,7 @@ module Components
             id: 'person_name',
             value: person.name,
             required: true,
+            placeholder: t('forms.people.name_placeholder', default: 'e.g., Jane Doe'),
             class: field_error_class(person, :name)
           )
           render_field_error(person, :name)
@@ -110,6 +111,7 @@ module Components
             name: 'person[email]',
             id: 'person_email',
             value: person.email,
+            placeholder: t('forms.people.email_placeholder', default: 'e.g., jane@example.com'),
             class: field_error_class(person, :email)
           )
           render_field_error(person, :email)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -559,6 +559,9 @@ cy:
       administration: "Gweinyddu"
       logout: "Allgofnodi"
   forms:
+    people:
+      name_placeholder: "e.g., Jane Doe"
+      email_placeholder: "e.g., jane@example.com"
     medications:
       inventory_management: "Rheoli Rhestr Eiddo"
       dosage_and_supply: "Dos a Chyflenwad"
@@ -580,6 +583,9 @@ cy:
       select_category: "Dewiswch gategori (dewisol)..."
       filter_categories: "Teipiwch i hidlo categorïau..."
       no_categories_found: "Ni chanfuwyd categorïau."
+      standard_dosage_placeholder: "e.g., 500"
+      current_supply_placeholder: "e.g., 30"
+      reorder_threshold_placeholder: "e.g., 5"
       validation_errors:
         one: "1 gwall wedi atal y meddyginiaeth hon rhag cael ei chadw:"
         other: "%{count} wall wedi atal y meddyginiaeth hon rhag cael ei chadw:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,6 +650,9 @@ en:
       administration: "Administration"
       sign_out: "Sign Out"
   forms:
+    people:
+      name_placeholder: "e.g., Jane Doe"
+      email_placeholder: "e.g., jane@example.com"
     medications:
       inventory_management: "Inventory Management"
       dosage_and_supply: "Dosage & Supply"
@@ -671,6 +674,9 @@ en:
       select_category: "Select a category (optional)..."
       filter_categories: "Type to filter categories..."
       no_categories_found: "No categories found."
+      standard_dosage_placeholder: "e.g., 500"
+      current_supply_placeholder: "e.g., 30"
+      reorder_threshold_placeholder: "e.g., 5"
       validation_errors:
         one: "1 error prevented this medication from being saved:"
         other: "%{count} errors prevented this medication from being saved:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -581,6 +581,9 @@ es:
       administration: "Administración"
       logout: "Cerrar sesión"
   forms:
+    people:
+      name_placeholder: "e.g., Jane Doe"
+      email_placeholder: "e.g., jane@example.com"
     medications:
       inventory_management: "Gestión de Inventario"
       dosage_and_supply: "Dosis y Suministro"
@@ -602,6 +605,9 @@ es:
       select_category: "Seleccione una categoría (opcional)..."
       filter_categories: "Escriba para filtrar categorías..."
       no_categories_found: "No se encontraron categorías."
+      standard_dosage_placeholder: "e.g., 500"
+      current_supply_placeholder: "e.g., 30"
+      reorder_threshold_placeholder: "e.g., 5"
       validation_errors:
         one: "1 error impidió que este medicamento se guardara:"
         other: "%{count} errores impidieron que este medicamento se guardara:"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -594,6 +594,9 @@ ga:
       administration: "Riarachán"
       sign_out: "Sínigh Amach"
   forms:
+    people:
+      name_placeholder: "e.g., Jane Doe"
+      email_placeholder: "e.g., jane@example.com"
     medications:
       inventory_management: "Bainistíocht Stoc"
       dosage_and_supply: "Dáileog & Soláthar"
@@ -615,6 +618,9 @@ ga:
       select_category: "Roghnaigh catagóir (roghnach)..."
       filter_categories: "Clóscríobh chun catagóirí a scagadh..."
       no_categories_found: "Níor aimsíodh catagóirí."
+      standard_dosage_placeholder: "e.g., 500"
+      current_supply_placeholder: "e.g., 30"
+      reorder_threshold_placeholder: "e.g., 5"
       validation_errors:
         one: "Chuir 1 earráid cosc ar an leigheas a shábháil:"
         other: "Chuir %{count} earráid cosc ar an leigheas a shábháil:"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -581,6 +581,9 @@ pt:
       administration: "Administração"
       logout: "Terminar sessão"
   forms:
+    people:
+      name_placeholder: "e.g., Jane Doe"
+      email_placeholder: "e.g., jane@example.com"
     medications:
       inventory_management: "Gestão de Inventário"
       dosage_and_supply: "Dosagem e Fornecimento"
@@ -602,6 +605,9 @@ pt:
       select_category: "Selecione uma categoria (opcional)..."
       filter_categories: "Escreva para filtrar categorias..."
       no_categories_found: "Nenhuma categoria encontrada."
+      standard_dosage_placeholder: "e.g., 500"
+      current_supply_placeholder: "e.g., 30"
+      reorder_threshold_placeholder: "e.g., 5"
       validation_errors:
         one: "1 erro impediu que este medicamento fosse guardado:"
         other: "%{count} erros impediram que este medicamento fosse guardado:"


### PR DESCRIPTION
💡 What: Added descriptive translation placeholders to inputs in `app/components/people/form_view.rb` and `app/components/medications/form_view.rb`. Added the localization strings to `config/locales/*.yml`.
🎯 Why: Form fields lacking placeholder attributes can cause user friction since it’s not immediately clear what expected format or type of data to provide, per `palette.md` conventions. Adding placeholder text helps guide users effectively.
📸 Before/After: Visual changes apply to `/people/new` and `/medications/new` inputs.
♿ Accessibility: Increased form context for better screen reader and visual cues without breaking existing locators by changing Aria labels.

---
*PR created automatically by Jules for task [7090765434139220671](https://jules.google.com/task/7090765434139220671) started by @damacus*