### PR TITLE
fix: Handle medication search and push delivery crashes

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -156,12 +156,13 @@ class MedicationsController < ApplicationController
     query = params[:q].to_s.strip
     return render json: { results: [] } if query.blank?
 
-    result = NhsDmd::Search.new.call(query)
+    result = search_results_for(query)
+    return render_medication_search_unavailable unless result
 
     if result.success?
       render json: { results: result.results.map(&:to_h) }
     else
-      render json: { results: [], error: 'Medication search is temporarily unavailable.' }, status: :service_unavailable
+      render_medication_search_unavailable
     end
   end
 
@@ -203,5 +204,16 @@ class MedicationsController < ApplicationController
                      warnings
                      location_id]
     )
+  end
+
+  def search_results_for(query)
+    NhsDmd::Search.new.call(query)
+  rescue StandardError => e
+    Rails.logger.error("Medication finder search failed: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def render_medication_search_unavailable
+    render json: { results: [], error: 'Medication search is temporarily unavailable.' }, status: :service_unavailable
   end
 end

--- a/app/services/nhs_dmd/client.rb
+++ b/app/services/nhs_dmd/client.rb
@@ -15,6 +15,15 @@ module NhsDmd
 
     VMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/VMP'
     AMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/AMP'
+    NETWORK_ERRORS = [
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      EOFError,
+      SocketError,
+      OpenSSL::SSL::SSLError
+    ].freeze
 
     def configured?
       client_id.present? && client_secret.present?
@@ -59,7 +68,7 @@ module NhsDmd
       request['Authorization'] = "Bearer #{access_token}" if authenticated?
 
       http.request(request)
-    rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED => e
+    rescue *NETWORK_ERRORS => e
       raise ApiError, "NHS dm+d API request failed: #{e.message}"
     end
 
@@ -109,7 +118,9 @@ module NhsDmd
       raise ApiError, "Failed to obtain NHS dm+d access token: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
       JSON.parse(response.body)['access_token']
-    rescue Net::OpenTimeout, Net::ReadTimeout => e
+    rescue JSON::ParserError => e
+      raise ApiError, "NHS dm+d token response was invalid JSON: #{e.message}"
+    rescue *NETWORK_ERRORS => e
       raise ApiError, "NHS dm+d token request failed: #{e.message}"
     end
 

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -16,18 +16,34 @@ module NhsDmd
       return not_configured_result unless @client.configured?
       return Result.new(results: [], error: nil) if query.blank?
 
-      raw = @client.search(query)
-      results = raw.map { |item| build_result(item) }
-      Result.new(results: results, error: nil)
+      Result.new(results: search_results(query), error: nil)
     rescue Client::ApiError => e
-      Rails.logger.error("NhsDmd::Search failed: #{e.message}")
-      Result.new(results: [], error: e.message)
+      failed_result(e.message)
+    rescue StandardError => e
+      failed_result('unexpected_error', e)
     end
 
     private
 
     def not_configured_result
       Result.new(results: [], error: 'not_configured')
+    end
+
+    def search_results(query)
+      @client.search(query).map { |item| build_result(item) }
+    end
+
+    def failed_result(message, exception = nil)
+      log_failure(message, exception)
+      Result.new(results: [], error: message)
+    end
+
+    def log_failure(message, exception)
+      if exception
+        Rails.logger.error("NhsDmd::Search crashed: #{exception.class}: #{exception.message}")
+      else
+        Rails.logger.error("NhsDmd::Search failed: #{message}")
+      end
     end
 
     def build_result(item)

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -29,6 +29,8 @@ class PushNotificationService
     )
   rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription
     sub.destroy
+  rescue StandardError => e
+    Rails.logger.error("Push notification delivery failed for subscription #{sub.id}: #{e.class}: #{e.message}")
   end
   private_class_method :deliver
 end

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe 'GET /medication-finder/search' do
       end
     end
 
+    context 'when the search service crashes unexpectedly' do
+      before do
+        login_as_doctor
+        search = instance_double(NhsDmd::Search)
+        allow(search).to receive(:call).and_raise(SocketError, 'lookup failed')
+        allow(NhsDmd::Search).to receive(:new).and_return(search)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns 503 instead of raising a server error' do
+        get medication_finder_search_path(format: :json), params: { q: 'aspirin' }
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.parsed_body['error']).to eq('Medication search is temporarily unavailable.')
+        expect(Rails.logger).to have_received(:error).with(/Medication finder search failed/)
+      end
+    end
+
     context 'when the NHS dm+d service is not configured (credentials absent)' do
       let(:unconfigured_outcome) { NhsDmd::Search::Result.new(results: [], error: 'not_configured') }
 

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -93,5 +93,22 @@ RSpec.describe NhsDmd::Search do
         expect(result.results).to eq([])
       end
     end
+
+    context 'when the client raises an unexpected error' do
+      before do
+        allow(client).to receive(:configured?).and_return(true)
+        allow(client).to receive(:search).and_raise(SocketError, 'lookup failed')
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns a result instead of propagating the exception' do
+        result = search.call('aspirin')
+
+        expect(result).not_to be_success
+        expect(result.error).to eq('unexpected_error')
+        expect(result.results).to eq([])
+        expect(Rails.logger).to have_received(:error).with(/NhsDmd::Search crashed/)
+      end
+    end
   end
 end

--- a/spec/services/push_notification_service_spec.rb
+++ b/spec/services/push_notification_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PushNotificationService do
+  fixtures :accounts
+
+  let(:account) { accounts(:admin) }
+
+  describe '.send_to_account' do
+    let!(:first_subscription) do
+      PushSubscription.create!(
+        account: account,
+        endpoint: 'https://example.com/push/subscriptions/first',
+        p256dh: 'first_public_key',
+        auth: 'first_auth_secret'
+      )
+    end
+    let!(:second_subscription) do
+      PushSubscription.create!(
+        account: account,
+        endpoint: 'https://example.com/push/subscriptions/second',
+        p256dh: 'second_public_key',
+        auth: 'second_auth_secret'
+      )
+    end
+
+    it 'continues delivering after a transient push failure' do
+      calls = 0
+
+      allow(WebPush).to receive(:payload_send) do
+        calls += 1
+        raise SocketError, 'lookup failed' if calls == 1
+      end
+      allow(Rails.logger).to receive(:error)
+
+      expect do
+        described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin')
+      end.not_to raise_error
+
+      expect(WebPush).to have_received(:payload_send).twice
+      expect(Rails.logger).to have_received(:error).with(/Push notification delivery failed/)
+    end
+
+    it 'removes expired subscriptions and continues with the rest' do
+      calls = 0
+      stub_const('WebPush::ExpiredSubscription', Class.new(StandardError))
+
+      allow(WebPush).to receive(:payload_send) do
+        calls += 1
+        raise WebPush::ExpiredSubscription if calls == 1
+      end
+
+      expect do
+        described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin')
+      end.to change(PushSubscription, :count).by(-1)
+
+      expect(WebPush).to have_received(:payload_send).twice
+      expect(PushSubscription.exists?(first_subscription.id)).to be(false)
+      expect(PushSubscription.exists?(second_subscription.id)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- prevent transient Web Push errors from aborting reminder delivery for the whole account
- harden NHS dm+d lookup handling so transport/parser failures return the existing unavailable response instead of a 500
- add focused service and request coverage for both crash paths

## Testing
- task local:test TEST_FILE='spec/services/push_notification_service_spec.rb spec/services/nhs_dmd/search_spec.rb spec/requests/medications_search_spec.rb'
- task rubocop