### PR TITLE
perf: ⚡ Bolt: Prevent N+1 query in Medication consumption estimate

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -120,7 +120,10 @@ class Medication < ApplicationRecord # :nodoc:
   def estimated_daily_consumption
     return @estimated_daily_consumption if defined?(@estimated_daily_consumption)
 
-    schedule_rate = schedules.active.sum do |schedule|
+    # ⚡ Bolt Optimization: Use Enumerable#select instead of ActiveRecord#active
+    # to filter schedules in-memory. This prevents N+1 queries when calculating
+    # daily consumption for a collection of eager-loaded medications.
+    schedule_rate = schedules.select(&:active?).sum do |schedule|
       next 0.0 if schedule.max_daily_doses.blank?
 
       schedule.max_daily_doses.to_f / (schedule.cycle_period / 1.day)


### PR DESCRIPTION
💡 **What**: Replaced the database-bound `schedules.active.sum` call with the in-memory `schedules.select(&:active?).sum` inside `Medication#estimated_daily_consumption`. Added a comment explaining the optimization.

🎯 **Why**: When `estimated_daily_consumption` is calculated in a loop on eager-loaded medication records (e.g., when determining if forecasting is available for many medications), calling the `.active` scope triggered an N+1 database query. Filtering the already-loaded collection in-memory eliminates these redundant queries.

📊 **Impact**: Prevents one database query per medication when calculating daily consumption, substantially reducing database load and response times for views presenting medication inventories or forecasts.

🔬 **Measurement**: Verify that accessing medication dashboards or running scripts that batch process `forecast_available?` for `PersonMedication` records do not exhibit `SELECT "schedules".* FROM "schedules" WHERE "schedules"."medication_id" = ?` queries in the server logs.

---
*PR created automatically by Jules for task [17134394830177961261](https://jules.google.com/task/17134394830177961261) started by @damacus*