### PR TITLE
fix: resolve 422 error on TOTP auth behind reverse proxy

### DIFF
--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -17,6 +17,10 @@ class RodauthApp < Rodauth::Rails::App
     end
 
     r.rodauth # route rodauth requests
+  rescue ActionController::InvalidAuthenticityToken
+    r.session.clear
+    flash[:alert] = I18n.t('authentication.session_expired', default: 'Your session expired. Please sign in again.')
+    r.redirect rodauth.login_path
 
     # ==> Authenticating requests
     # Call `rodauth.require_account` for requests that you want to

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,11 +30,10 @@ Rails.application.configure do
   config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # Can be disabled via RAILS_FORCE_SSL=false for local Docker testing
-  config.force_ssl = ENV.fetch('RAILS_FORCE_SSL', 'true') == 'true'
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with ECS-formatted JSON logs for production observability.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## Summary

- **`config/environments/production.rb`**: Hardcode `force_ssl = true` (remove the `RAILS_FORCE_SSL` env var override) so session cookies are always marked `secure: true` and HSTS is emitted. Enable the `/up` health check exclusion from the SSL redirect so liveness/readiness probes work when Traefik + `assume_ssl` are both active.
- **`app/misc/rodauth_app.rb`**: Rescue `ActionController::InvalidAuthenticityToken` in the Roda route block so CSRF failures on Rodauth routes (login, OTP, etc.) redirect to the login page with a "session expired" message instead of rendering the generic `public/422.html`.

### Root cause

The deployment was setting `RAILS_FORCE_SSL: "false"`, which disabled `ActionDispatch::SSL`. Without it, session cookies lack the `secure` flag, which can cause session inconsistencies after Rodauth resets the session for session-fixation protection during login. When the CSRF token from the OTP form no longer matched the (reset) session, the `InvalidAuthenticityToken` exception was raised inside Roda middleware — outside the scope of ApplicationController's `rescue_from` handler — so Rails fell back to rendering `public/422.html`.

### Deployment action required

Remove `RAILS_FORCE_SSL: "false"` from the helmrelease in home-ops (`kubernetes/apps/home/med-tracker/app/helmrelease.yaml`). `force_ssl` is now unconditionally `true` in `production.rb`, so the env var is no longer read.

## Test plan

- [ ] Deploy and attempt login with TOTP — should complete successfully
- [ ] Verify `/up` health check still returns 200 (not redirected)
- [ ] Simulate expired session on a Rodauth route — should redirect to login with "session expired" flash, not 422
- [ ] All 1377 existing tests pass