### PR TITLE
fix(ui): require explicit as-needed dose selection

### DIFF
--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -57,7 +57,7 @@ class PersonMedicationsController < ApplicationController
     authorize @person_medication
     @medications = available_medications
 
-    if @person_medication.save
+    if explicit_dose_submitted? && @person_medication.save
       respond_to do |format|
         format.html { redirect_to person_path(@person), notice: t('person_medications.created') }
         format.turbo_stream do
@@ -71,6 +71,8 @@ class PersonMedicationsController < ApplicationController
         end
       end
     else
+      add_explicit_dose_errors unless explicit_dose_submitted?
+
       respond_to do |format|
         format.html { render Components::PersonMedications::FormView.new(person_medication: @person_medication, person: @person, medications: @medications), status: :unprocessable_content }
         format.turbo_stream { render turbo_stream: turbo_stream.replace('modal', Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.new_title', person: @person.name))), status: :unprocessable_content }
@@ -214,5 +216,15 @@ class PersonMedicationsController < ApplicationController
 
   def available_medications
     Medication.order(:name)
+  end
+
+  def explicit_dose_submitted?
+    params.dig(:person_medication, :dose_amount).present? &&
+      params.dig(:person_medication, :dose_unit).present?
+  end
+
+  def add_explicit_dose_errors
+    @person_medication.errors.add(:dose_amount, :blank) if @person_medication.errors[:dose_amount].blank?
+    @person_medication.errors.add(:dose_unit, :blank) if @person_medication.errors[:dose_unit].blank?
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -411,7 +411,7 @@ cy:
       add_first_schedule: "Ychwanegu Presgripsiwn Cyntaf"
       my_medications_heading: "Fy Meddyginiaethau"
       no_medications: "Dim meddyginiaethau wedi'u hychwanegu eto."
-      medications_hint: "Ychwanegwch fitaminau, atchwanegion, neu feddyginiaethau dros y cownter yma."
+      medications_hint: "Ychwanegwch feddyginiaethau a gymerir yn ôl yr angen yma."
       add_first_medication: "Ychwanegu Meddyginiaeth Gyntaf"
     form:
       edit_heading: "Golygu Person"
@@ -426,7 +426,7 @@ cy:
     medication_taken: "Cymerwyd y feddyginiaeth yn llwyddiannus."
     modal:
       new_title: "Ychwanegu Meddyginiaeth ar gyfer %{person}"
-      subtitle: "Ychwanegu fitamin, atodiad, neu feddyginiaeth dros y cownter"
+      subtitle: "Ychwanegu meddyginiaeth yn ôl yr angen"
     card:
       notes: "📝 Nodiadau: "
       timing_restrictions: "⏱️ Cyfyngiadau Amseru:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,7 +434,7 @@ en:
       add_first_schedule: "Add First Schedule"
       my_medications_heading: "My Medications"
       no_medications: "No medications added yet."
-      medications_hint: "Add vitamins, supplements, or over-the-counter medications here."
+      medications_hint: "Add medications that are taken as needed here."
       add_first_medication: "Add First Medication"
       no_any_medications: "No medications yet."
       add_first_any_medication: "Add Medication"
@@ -466,7 +466,7 @@ en:
     modal:
       new_title: "Add Medication for %{person}"
       edit_title: "Edit Medication for %{person}"
-      subtitle: "Add a medication that is taken as needed"
+      subtitle: "Add an as-needed medication"
     card:
       notes: "📝 Notes: "
       timing_restrictions: "⏱️ Timing Restrictions:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -411,7 +411,7 @@ es:
       add_first_schedule: "Agregar Primera Receta"
       my_medications_heading: "Mis Medicamentos"
       no_medications: "Sin medicamentos aún."
-      medications_hint: "Agregue vitaminas, suplementos o medicamentos de venta libre aquí."
+      medications_hint: "Agregue aquí medicamentos que se toman según sea necesario."
       add_first_medication: "Agregar Primer Medicamento"
     form:
       edit_heading: "Editar Persona"
@@ -426,7 +426,7 @@ es:
     medication_taken: "Medicamento tomado correctamente."
     modal:
       new_title: "Agregar Medicamento para %{person}"
-      subtitle: "Agregar una vitamina, suplemento o medicamento sin receta"
+      subtitle: "Agregar un medicamento según sea necesario"
     card:
       notes: "📝 Notas: "
       timing_restrictions: "⏱️ Restricciones de Tiempo:"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -401,7 +401,7 @@ ga:
       add_first_schedule: "Cuir an Chéad Oideas Leigheasanna Leis"
       my_medications_heading: "Mo Leigheasanna"
       no_medications: "Níl aon leigheasanna curtha leis fós."
-      medications_hint: "Cuir vitimíní, forlíontáin, nó leigheasanna os cionn an chuntair anseo."
+      medications_hint: "Cuir leigheasanna a thógtar de réir mar is gá anseo."
       add_first_medication: "Cuir an Chéad Leigheas Leis"
     overview:
       title: "Forbhreathnú Próifíle"
@@ -428,7 +428,7 @@ ga:
     medication_taken: "Tógadh an leigheas go rathúil."
     modal:
       new_title: "Cuir Leigheas Leis do %{person}"
-      subtitle: "Cuir vitimín, forlíonadh, nó cógas gan oideas leis"
+      subtitle: "Cuir leigheas de réir mar is gá leis"
     card:
       notes: "📝 Nótaí: "
       timing_restrictions: "⏱️ Srian Amanna:"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -411,7 +411,7 @@ pt:
       add_first_schedule: "Adicionar Primeira Receita"
       my_medications_heading: "Os Meus Medicamentos"
       no_medications: "Sem medicamentos ainda."
-      medications_hint: "Adicione vitaminas, suplementos ou medicamentos de venda livre aqui."
+      medications_hint: "Adicione aqui medicamentos que são tomados conforme necessário."
       add_first_medication: "Adicionar Primeiro Medicamento"
     form:
       edit_heading: "Editar Pessoa"
@@ -426,7 +426,7 @@ pt:
     medication_taken: "Medicamento tomado com sucesso."
     modal:
       new_title: "Adicionar Medicamento para %{person}"
-      subtitle: "Adicionar uma vitamina, suplemento ou medicamento sem receita"
+      subtitle: "Adicionar um medicamento conforme necessário"
     card:
       notes: "📝 Notas: "
       timing_restrictions: "⏱️ Restrições de Tempo:"

--- a/spec/requests/person_medications_policy_scope_spec.rb
+++ b/spec/requests/person_medications_policy_scope_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe 'PersonMedicationsController medication options' do
         expect(response.body).to include('Add Medication for')
         expect(response.body).to include('Choose a medication')
       end
+
+      it 'requires an explicit dose selection before creating the medication' do
+        post person_person_medications_path(adult_patient_person),
+             params: {
+               person_medication: {
+                 medication_id: medications(:vitamin_d).id,
+                 notes: 'No dose selected'
+               }
+             }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('Dose amount can&#39;t be blank')
+        expect(response.body).to include('Dose unit can&#39;t be blank')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- require person medication create requests to submit an explicit dose instead of falling back to the medication default
- update as-needed copy so the person medication flow no longer uses OTC wording in the person UI
- add request coverage for the missing-dose create path while keeping the workflow system path green

## Testing
- task test TEST_FILE=spec/requests/person_medications_policy_scope_spec.rb
- task test TEST_FILE=spec/system/person_medication_workflow_spec.rb
- task rubocop

Fixes #919