### PR TITLE
fix: 🛡️ Sentinel: [HIGH] Fix IDOR vulnerabilities in admin controllers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-09 - Insecure Direct Object Reference (IDOR) via Direct Model Find
+**Vulnerability:** Controller actions using `Model.find(params[:id])` directly without scoping to the current user's authorized records.
+**Learning:** Even with Pundit `authorize @record` checks later, fetching records without `policy_scope` can expose existence of records and potentially lead to authorization bypasses if policies are misconfigured. It also triggers `ActiveRecord::RecordNotFound` instead of `Pundit::NotAuthorizedError`, standardizing 404 responses for unauthorized access, preventing information disclosure.
+**Prevention:** Always use `policy_scope(Model).find(params[:id])` pattern in controller actions to enforce scope-based authorization at the database query level.

--- a/app/controllers/admin/carer_relationships_controller.rb
+++ b/app/controllers/admin/carer_relationships_controller.rb
@@ -86,7 +86,7 @@ module Admin
     end
 
     def destroy
-      @relationship = CarerRelationship.find(params[:id])
+      @relationship = policy_scope(CarerRelationship).find(params[:id])
       authorize @relationship
 
       @relationship.deactivate!
@@ -100,7 +100,7 @@ module Admin
     end
 
     def activate
-      @relationship = CarerRelationship.find(params[:id])
+      @relationship = policy_scope(CarerRelationship).find(params[:id])
       authorize @relationship
 
       @relationship.activate!

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,7 +22,7 @@ module Admin
     end
 
     def edit
-      @user = User.find(params[:id])
+      @user = policy_scope(User).find(params[:id])
       authorize @user
       render Components::Admin::Users::FormView.new(user: @user)
     end
@@ -53,7 +53,7 @@ module Admin
     end
 
     def update
-      @user = User.find(params[:id])
+      @user = policy_scope(User).find(params[:id])
       authorize @user
 
       respond_to do |format|
@@ -72,7 +72,7 @@ module Admin
     end
 
     def destroy
-      @user = User.find(params[:id])
+      @user = policy_scope(User).find(params[:id])
       authorize @user
 
       respond_to do |format|
@@ -95,7 +95,7 @@ module Admin
     end
 
     def activate
-      @user = User.find(params[:id])
+      @user = policy_scope(User).find(params[:id])
       authorize @user
 
       @user.activate!
@@ -109,7 +109,7 @@ module Admin
     end
 
     def verify
-      @user = User.find(params[:id])
+      @user = policy_scope(User).find(params[:id])
       authorize @user
 
       account = @user.person&.account


### PR DESCRIPTION
Addresses Insecure Direct Object Reference (IDOR) vulnerabilities in the Admin::UsersController and Admin::CarerRelationshipsController.

🚨 Severity: HIGH
💡 Vulnerability: Direct model lookup via `Model.find(params[:id])` without applying Pundit `policy_scope` before the `authorize` check.
🎯 Impact: Attackers could potentially determine the existence of unauthorized records by observing whether a 403 Forbidden or 404 Not Found error is returned, leading to information disclosure.
🔧 Fix: Wrapped all `find` calls with `policy_scope(Model).find(params[:id])`. This ensures that unauthorized requests trigger an `ActiveRecord::RecordNotFound` exception (which renders a 404 page), obfuscating the existence of records the user doesn't have access to.
✅ Verification: Code logic visually verified. (Local test suite skipped due to Docker pull rate limit constraints on the runner environment).
📝 Log: Added a new entry to `.jules/sentinel.md` documenting this pattern.

---
*PR created automatically by Jules for task [7959636757156051278](https://jules.google.com/task/7959636757156051278) started by @damacus*