### PR TITLE
feat(people): show dependent creation location

### DIFF
--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -8,14 +8,15 @@ module Components
       include Phlex::Rails::Helpers::TurboFrameTag
       include RubyUI
 
-      attr_reader :person, :title, :subtitle, :return_to, :is_modal
+      attr_reader :person, :title, :subtitle, :return_to, :is_modal, :assigned_location
 
-      def initialize(person:, title: nil, subtitle: nil, return_to: nil, is_modal: false)
+      def initialize(person:, is_modal: false, assigned_location: nil, **options)
         @person = person
-        @title = title || default_title
-        @subtitle = subtitle || default_subtitle
-        @return_to = return_to
+        @title = options[:title] || default_title
+        @subtitle = options[:subtitle] || default_subtitle
+        @return_to = options[:return_to]
         @is_modal = is_modal
+        @assigned_location = assigned_location
         super()
       end
 
@@ -59,8 +60,21 @@ module Components
         form_with(model: person, id: 'person_form', class: 'space-y-6') do |f|
           render_errors if person.errors.any?
           input(type: 'hidden', name: 'return_to', value: return_to) if return_to.present?
+          render_location_hint
           render_form_fields(f)
           render_actions(f)
+        end
+      end
+
+      def render_location_hint
+        return unless person.new_record?
+        return if assigned_location.blank?
+
+        Alert(class: 'border-primary/20 bg-primary/5 text-primary') do
+          AlertTitle { 'Location' }
+          AlertDescription do
+            plain "This person will be created at #{assigned_location.name}."
+          end
         end
       end
 

--- a/app/components/people/modal.rb
+++ b/app/components/people/modal.rb
@@ -7,9 +7,9 @@ module Components
       include Phlex::Rails::Helpers::TurboFrameTag
       include RubyUI
 
-      attr_reader :person, :title, :subtitle, :return_to
+      attr_reader :person, :title, :subtitle, :return_to, :assigned_location
 
-      def initialize(person:, title: nil, subtitle: nil, return_to: nil)
+      def initialize(person:, title: nil, subtitle: nil, return_to: nil, assigned_location: nil)
         @person = person
         @title = title || (person.new_record? ? 'New Person' : 'Edit Person')
         @subtitle = subtitle || (if person.new_record?
@@ -18,6 +18,7 @@ module Components
                                    "Update #{person.name}'s details"
                                  end)
         @return_to = return_to
+        @assigned_location = assigned_location
         super()
       end
 
@@ -30,7 +31,12 @@ module Components
                 DialogDescription { subtitle }
               end
               DialogMiddle do
-                render FormView.new(person: person, return_to: return_to, is_modal: true)
+                render FormView.new(
+                  person: person,
+                  return_to: return_to,
+                  is_modal: true,
+                  assigned_location: assigned_location
+                )
               end
             end
           end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -50,11 +50,12 @@ class PeopleController < ApplicationController
     @person = Person.new
     authorize @person
     is_modal = request.headers['Turbo-Frame'] == 'modal'
+    assigned_location = current_primary_location
 
     if is_modal
-      render Components::People::Modal.new(person: @person), layout: false
+      render Components::People::Modal.new(person: @person, assigned_location: assigned_location), layout: false
     else
-      render Components::People::FormView.new(person: @person)
+      render Components::People::FormView.new(person: @person, assigned_location: assigned_location)
     end
   end
 
@@ -98,12 +99,13 @@ class PeopleController < ApplicationController
       else
         @medications = [] # Needed if form uses it
         format.html do
-          render Components::People::FormView.new(person: @person), status: :unprocessable_content
+          render Components::People::FormView.new(person: @person, assigned_location: current_primary_location),
+                 status: :unprocessable_content
         end
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace(
             'modal',
-            Components::People::Modal.new(person: @person)
+            Components::People::Modal.new(person: @person, assigned_location: current_primary_location)
           ), status: :unprocessable_content
         end
       end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'People' do
         expect(response.body).to include('value="dependent_adult"')
         expect(response.body).not_to include('value="adult"')
       end
+
+      it 'shows the primary location where the dependent will be created' do
+        get new_person_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('This person will be created at Home.')
+      end
     end
 
     context 'when signed in as an admin' do


### PR DESCRIPTION
## Summary
- show the creator's primary location in the new person form so dependent creation makes the assignment explicit
- thread the assigned location hint through both the full-page and modal person form
- cover the new hint in the people request spec alongside the existing primary-location assignment behavior

## Testing
- task test TEST_FILE=spec/requests/people_spec.rb
- task rubocop

Fixes #867