### PR TITLE
fix(login): gracefully skip unavailable passkeys

### DIFF
--- a/app/views/rodauth/login_passkey_support.rb
+++ b/app/views/rodauth/login_passkey_support.rb
@@ -16,6 +16,8 @@ module Views
           passkey_error_message
           render_passkey_login_form(credential_options)
         end
+      rescue StandardError
+        nil
       end
 
       def render_passkey_login_form(credential_options)


### PR DESCRIPTION
## Summary

- **Gracefully skip the passkey block when WebAuthn setup data cannot be generated** — restore the `rescue StandardError` fallback in `LoginPasskeySupport#render_passkey_section` so the standard login form still renders even if passkey credential options fail.
- **Match the current test contract on `main`** — `Views::Rodauth::Login` is now expected to render normally while omitting `#webauthn-login-form` when `webauthn_credential_options_for_get` raises.
- **Keep the failure isolated to the optional passkey surface** — this does not change password login, OIDC login, or successful passkey behavior; it only ensures WebAuthn setup errors do not take down the whole login page.

## Why This Matters

The login page should treat passkeys as an enhancement, not a hard dependency for rendering the rest of the sign-in experience.

After rebasing onto the latest `main`, CI started failing because the component spec now explicitly requires graceful fallback when passkey credential generation is unavailable. Restoring that behavior keeps the page resilient while still allowing the passkey flow to appear whenever WebAuthn data is available.

## Test Plan

- [x] `task rubocop` — no offenses
- [ ] `task test`
  `task test` could not be run in this session because the local Docker daemon is unavailable (`failed to connect to the docker API at unix:///var/run/docker.sock`).
- [x] Confirm the CI failure points to `Views::Rodauth::Login renders login form even when passkey credential generation fails`
- [x] Restore the passkey-section fallback so the main login form still renders when WebAuthn setup raises

## Notes

- The only code change is in `app/views/rodauth/login_passkey_support.rb`.
- This PR now supersedes the earlier description and is aligned with the current branch contents after rebasing.
