### PR TITLE
fix: complete soft-delete account flow

### DIFF
--- a/app/components/admin/users/search_form.rb
+++ b/app/components/admin/users/search_form.rb
@@ -80,6 +80,7 @@ module Components
                 option(value: '', selected: search_params[:status].blank?) { 'All' }
                 option(value: 'active', selected: search_params[:status] == 'active') { 'Active' }
                 option(value: 'inactive', selected: search_params[:status] == 'inactive') { 'Inactive' }
+                option(value: 'soft_deleted', selected: search_params[:status] == 'soft_deleted') { 'Soft deleted' }
               end
             end
           end

--- a/app/components/admin/users/user_row.rb
+++ b/app/components/admin/users/user_row.rb
@@ -16,7 +16,7 @@ module Components
         end
 
         def view_template
-          row_class = user.active? ? '' : 'opacity-60'
+          row_class = user.active? && !user.soft_deleted? ? '' : 'opacity-60'
           render RubyUI::TableRow.new(id: "user_#{user.id}", class: row_class, data: { user_id: user.id }) do
             render RubyUI::TableCell.new(class: 'font-medium') { user.name }
             render(RubyUI::TableCell.new { user.email_address })
@@ -40,7 +40,9 @@ module Components
         private
 
         def render_status_badge
-          if user.active?
+          if user.soft_deleted?
+            render RubyUI::Badge.new(variant: :secondary) { t('admin.users.user_row.soft_deleted') }
+          elsif user.active?
             render RubyUI::Badge.new(variant: :success) { t('admin.users.user_row.active') }
           else
             render RubyUI::Badge.new(variant: :destructive) { t('admin.users.user_row.inactive') }
@@ -48,6 +50,8 @@ module Components
         end
 
         def render_activation_button
+          return if user.soft_deleted?
+
           is_current_user = user == current_user
 
           if user.active?
@@ -76,6 +80,7 @@ module Components
         end
 
         def render_verification_button
+          return render_soft_deleted_button if user.soft_deleted?
           return render_verified_button if user.person&.account&.verified?
 
           form_with(
@@ -98,6 +103,15 @@ module Components
             size: :sm,
             disabled: true
           ) { t('admin.users.user_row.verified') }
+        end
+
+        def render_soft_deleted_button
+          Button(
+            type: :button,
+            variant: :outline,
+            size: :sm,
+            disabled: true
+          ) { t('admin.users.user_row.soft_deleted') }
         end
 
         def render_deactivate_dialog

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -187,6 +187,7 @@ module Admin
       case params[:status]
       when 'active' then scope.active
       when 'inactive' then scope.inactive
+      when 'soft_deleted' then scope.left_joins(person: :account).where(accounts: { id: nil }).or(scope.left_joins(person: :account).where(accounts: { status: Account.statuses[:closed] }))
       else scope
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,11 @@ class User < ApplicationRecord
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
 
+  def soft_deleted?
+    account = person&.account
+    person.present? && (account.nil? || account.closed?)
+  end
+
   delegate :name, :date_of_birth, :age, to: :person, allow_nil: true
 
   def deactivate!

--- a/app/views/profiles/close_account_dialog.rb
+++ b/app/views/profiles/close_account_dialog.rb
@@ -47,10 +47,34 @@ module Views
       def render_dialog_footer
         render AlertDialogFooter.new do
           render(AlertDialogCancel.new { t('profiles.close_account.cancel_button') })
-          render AlertDialogAction.new(
-            data: { turbo_method: :delete, turbo_confirm: false },
-            href: '/close-account'
-          ) { t('profiles.close_account.confirm_button') }
+          render_close_account_form
+        end
+      end
+
+      def render_close_account_form
+        render RubyUI::Form.new(action: view_context.rodauth.close_account_path, method: :post, class: 'space-y-3') do
+          render_close_account_hidden_fields
+          render_close_account_password_field
+          render Button.new(type: :submit, variant: :destructive, class: 'w-full') { t('profiles.close_account.confirm_button') }
+        end
+      end
+
+      def render_close_account_hidden_fields
+        additional_tags = view_context.rodauth.close_account_additional_form_tags
+        safe(additional_tags) if additional_tags.present?
+        input(type: 'hidden', name: 'authenticity_token', value: view_context.form_authenticity_token)
+      end
+
+      def render_close_account_password_field
+        render RubyUI::FormField.new do
+          render RubyUI::FormFieldLabel.new(for: 'close-account-password') { t('rodauth.views.change_login.password_label') }
+          render RubyUI::Input.new(
+            type: :password,
+            name: view_context.rodauth.password_param,
+            id: 'close-account-password',
+            required: true,
+            autocomplete: 'current-password'
+          )
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         edit: "Edit"
         active: "Active"
         inactive: "Inactive"
+        soft_deleted: "Soft deleted"
         deactivate: "Deactivate"
         activate: "Activate"
         verify: "Verify"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -38,6 +38,7 @@ ga:
         edit: "Cuir in eagar"
         active: "Gníomhach"
         inactive: "Neamhghníomhach"
+        soft_deleted: "Scriosta go bog"
         deactivate: "Díghníomhachtú"
         activate: "Gníomhachtú"
         verify: "Fíoraigh"

--- a/spec/components/admin/users/search_form_spec.rb
+++ b/spec/components/admin/users/search_form_spec.rb
@@ -64,13 +64,13 @@ RSpec.describe Components::Admin::Users::SearchForm, type: :component do
   end
 
   describe 'status filter' do
-    it 'renders active and inactive status options' do
+    it 'renders active, inactive, and soft deleted status options' do
       rendered = render_inline(described_class.new)
 
       status_select = rendered.css('select[name="status"]').first
       options = status_select.css('option').map(&:text)
 
-      expect(options).to include('All', 'Active', 'Inactive')
+      expect(options).to include('All', 'Active', 'Inactive', 'Soft deleted')
     end
 
     it 'pre-selects the current status filter' do
@@ -79,6 +79,14 @@ RSpec.describe Components::Admin::Users::SearchForm, type: :component do
       status_select = rendered.css('select[name="status"]').first
       selected = status_select.css('option[selected]')
       expect(selected.first['value']).to eq('active')
+    end
+
+    it 'pre-selects the soft deleted status filter' do
+      rendered = render_inline(described_class.new(search_params: { status: 'soft_deleted' }))
+
+      status_select = rendered.css('select[name="status"]').first
+      selected = status_select.css('option[selected]')
+      expect(selected.first['value']).to eq('soft_deleted')
     end
   end
 

--- a/spec/requests/admin_users_index_spec.rb
+++ b/spec/requests/admin_users_index_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin users index' do
+  fixtures :accounts, :people, :users
+
+  let(:admin) { users(:admin) }
+  let(:soft_deleted_user) do
+    account = Account.create!(
+      email: 'soft.deleted@example.com',
+      password_hash: RodauthApp.rodauth.allocate.password_hash('password'),
+      status: :closed
+    )
+    person = Person.create!(
+      name: 'Soft Deleted User',
+      date_of_birth: '1990-01-01',
+      account: account
+    )
+    person.update!(account: nil)
+    User.create!(
+      person: person,
+      email_address: 'soft.deleted@example.com',
+      role: :parent,
+      active: true
+    )
+  end
+
+  before do
+    sign_in(admin)
+    soft_deleted_user
+  end
+
+  it 'shows soft deleted users to administrators' do
+    get admin_users_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(soft_deleted_user.email_address)
+    expect(response.body).to include('Soft deleted')
+  end
+
+  it 'filters the list to soft deleted users' do
+    get admin_users_path, params: { status: 'soft_deleted' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(soft_deleted_user.email_address)
+    expect(response.body).not_to include(users(:jane).email_address)
+  end
+end

--- a/spec/requests/close_account_spec.rb
+++ b/spec/requests/close_account_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Close account' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:jane) }
+  let!(:account) { user.person.account }
+
+  before do
+    sign_in(user)
+  end
+
+  it 'soft deletes the account and blocks future login' do
+    post '/close-account', params: { password: 'password' }
+
+    expect(response).to redirect_to('/')
+    expect(account.reload).to be_closed
+    expect(user.person.reload.account).to be_nil
+
+    get dashboard_path
+    expect(response).to redirect_to(login_path)
+
+    post login_path, params: { email: account.email, password: 'password' }
+
+    expect(session[:account_id]).to be_nil
+    expect(response.body).to match(/closed|invalid|error/i)
+  end
+end

--- a/spec/system/profile_editing_spec.rb
+++ b/spec/system/profile_editing_spec.rb
@@ -73,5 +73,26 @@ RSpec.describe 'Profile Editing' do
       # Dialog should close and we're still on profile page
       expect(page).to have_content('My Profile')
     end
+
+    it 'closes the account and prevents future login' do
+      expect(page).to have_css('[data-ruby-ui--alert-dialog-target="content"]', visible: :hidden, wait: 5)
+
+      click_button 'Close Account'
+      expect(page).to have_content('Are you absolutely sure?', wait: 10)
+
+      fill_in 'Password', with: 'password'
+      click_button 'Yes, delete my account'
+
+      expect(page).to have_current_path('/login')
+      expect(account.reload).to be_closed
+      expect(person.reload.account).to be_nil
+
+      fill_in 'Email address', with: account.email
+      fill_in 'Password', with: 'password'
+      click_button 'Sign In to Dashboard'
+
+      expect(page).to have_no_current_path('/dashboard')
+      expect(page).to have_content(/closed|invalid|error/i)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- complete the profile close-account dialog by submitting the password Rodauth requires
- surface soft-deleted users in admin user management with an explicit filter and badge
- add request and system coverage for account closure, admin visibility, and blocked re-login

Fixes #689

## Validation
- task test TEST_FILE=spec/requests/admin_users_index_spec.rb
- task test TEST_FILE=spec/requests/close_account_spec.rb
- task test TEST_FILE=spec/system/profile_editing_spec.rb
- task test TEST_FILE=spec/components/admin/users/search_form_spec.rb
- task rubocop
- task test (currently has one unrelated existing failure in spec/features/person_medications_spec.rb:19)
