### PR TITLE
perf: ⚡ Bolt: prevent N+1 queries in default_dosage_for_person_type

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -162,8 +162,7 @@ class Medication < ApplicationRecord # :nodoc:
   def default_dosage_for_person_type(person_type)
     child_types = %w[minor dependent_adult]
 
-    # ⚡ Bolt Optimization: Use Enumerable#find on the potentially preloaded
-    # dosages association instead of find_by to avoid N+1 queries.
+
     if child_types.include?(person_type.to_s)
       dosages.find(&:default_for_children?) || dosages.first
     else

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -161,10 +161,13 @@ class Medication < ApplicationRecord # :nodoc:
 
   def default_dosage_for_person_type(person_type)
     child_types = %w[minor dependent_adult]
+
+    # ⚡ Bolt Optimization: Use Enumerable#find on the potentially preloaded
+    # dosages association instead of find_by to avoid N+1 queries.
     if child_types.include?(person_type.to_s)
-      dosages.find_by(default_for_children: true) || dosages.first
+      dosages.find(&:default_for_children?) || dosages.first
     else
-      dosages.find_by(default_for_adults: true) || dosages.first
+      dosages.find(&:default_for_adults?) || dosages.first
     end
   end
 

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -162,7 +162,8 @@ class Medication < ApplicationRecord # :nodoc:
   def default_dosage_for_person_type(person_type)
     child_types = %w[minor dependent_adult]
 
-
+    # ⚡ Bolt Optimization: Use Enumerable#find on the potentially preloaded
+    # dosages association instead of find_by to avoid N+1 queries.
     if child_types.include?(person_type.to_s)
       dosages.find(&:default_for_children?) || dosages.first
     else


### PR DESCRIPTION
💡 What: Replaced `find_by` with `find` (using `Enumerable#find` block) inside `Medication#default_dosage_for_person_type` to retrieve preloaded `dosages` records in-memory instead of triggering direct database queries.

🎯 Why: Calling `find_by` directly on an association circumvents eager-loading optimization and triggers a new SQL `SELECT` statement every time. When displaying lists containing `Medication` or resolving medication requirements where dosages are accessed, this causes severe N+1 queries.

📊 Impact: Significantly reduces database load when rendering collections of medications (e.g. lists or dashboard items). Transforms N+1 SQL queries per medication list rendering into 0 database hits (when `dosages` is eager-loaded), resulting in much faster and more efficient data retrieval.

🔬 Measurement: Verify using MiniProfiler or Rails server logs during dashboard/list loading. You should notice a reduction in `SELECT ... FROM "dosages" WHERE "dosages"."medication_id" = ? ...` queries executing per medication rendered.

---
*PR created automatically by Jules for task [7497582583391134490](https://jules.google.com/task/7497582583391134490) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
