### PR TITLE
feat: 🎨 Palette: [Add descriptive placeholders to location forms]

### DIFF
--- a/app/components/locations/form_view.rb
+++ b/app/components/locations/form_view.rb
@@ -97,7 +97,7 @@ module Components
             id: 'location_name',
             value: location.name,
             required: true,
-            placeholder: 'e.g. Home, School, Grandma\'s House',
+            placeholder: t('forms.locations.name_placeholder'),
             class: 'rounded-2xl border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
                    "focus:border-primary transition-all #{field_error_class(location, :name)}"
           )
@@ -115,7 +115,7 @@ module Components
             name: 'location[description]',
             id: 'location_description',
             rows: 3,
-            placeholder: 'Describe this location...',
+            placeholder: t('forms.locations.description_placeholder'),
             class: 'rounded-2xl border-slate-200 bg-white p-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all resize-none'
           ) { location.description }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -570,6 +570,9 @@ cy:
       administration: "Gweinyddu"
       logout: "Allgofnodi"
   forms:
+    locations:
+      name_placeholder: "e.e. Cartref, Ysgol, Tŷ Mam-gu"
+      description_placeholder: "Disgrifiwch y lleoliad hwn..."
     people:
       name_placeholder: "e.g., Jane Doe"
       email_placeholder: "e.g., jane@example.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -662,6 +662,9 @@ en:
       administration: "Administration"
       sign_out: "Sign Out"
   forms:
+    locations:
+      name_placeholder: "e.g. Home, School, Grandma's House"
+      description_placeholder: "Describe this location..."
     people:
       name_placeholder: "e.g., Jane Doe"
       email_placeholder: "e.g., jane@example.com"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -592,6 +592,9 @@ es:
       administration: "Administración"
       logout: "Cerrar sesión"
   forms:
+    locations:
+      name_placeholder: "p. ej. Casa, Escuela, Casa de la Abuela"
+      description_placeholder: "Describe esta ubicación..."
     people:
       name_placeholder: "e.g., Jane Doe"
       email_placeholder: "e.g., jane@example.com"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -606,6 +606,9 @@ ga:
       administration: "Riarachán"
       sign_out: "Sínigh Amach"
   forms:
+    locations:
+      name_placeholder: "m.sh. Baile, Scoil, Teach na Mamó"
+      description_placeholder: "Déan cur síos ar an suíomh seo..."
     people:
       name_placeholder: "e.g., Jane Doe"
       email_placeholder: "e.g., jane@example.com"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -592,6 +592,9 @@ pt:
       administration: "Administração"
       logout: "Terminar sessão"
   forms:
+    locations:
+      name_placeholder: "p. ex. Casa, Escola, Casa da Avó"
+      description_placeholder: "Descreva esta localização..."
     people:
       name_placeholder: "e.g., Jane Doe"
       email_placeholder: "e.g., jane@example.com"


### PR DESCRIPTION
💡 What: Replaced hardcoded 'Describe this location...' and 'e.g. Home, School...' text in `app/components/locations/form_view.rb` with correctly translated `name_placeholder` and `description_placeholder` keys across `en.yml`, `cy.yml`, `es.yml`, `ga.yml`, and `pt.yml`.
🎯 Why: Form fields lacking placeholders can cause user friction. Descriptve placeholders guide users without cluttering the UI with additional helper text. Hardcoded text also breaks internationalization.
♿ Accessibility: Ensures localization works correctly across all supported languages.

---
*PR created automatically by Jules for task [12691673499364715794](https://jules.google.com/task/12691673499364715794) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
