### PR TITLE
feat: block child signup paths and cover parent OTC limits

### DIFF
--- a/app/components/admin/invitations/index_view.rb
+++ b/app/components/admin/invitations/index_view.rb
@@ -5,6 +5,7 @@ module Components
     module Invitations
       class IndexView < Components::Base
         include Phlex::Rails::Helpers::FormWith
+        include Phlex::Rails::Helpers::Pluralize
         include Components::FormHelpers
 
         def initialize(invitation: Invitation.new)
@@ -62,6 +63,7 @@ module Components
               type: :email,
               name: 'invitation[email]',
               id: 'invitation_email',
+              value: @invitation.email,
               required: true,
               class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 ' \
                      'focus:ring-primary/10 focus:border-primary transition-all'
@@ -76,8 +78,8 @@ module Components
               'Role'
             end
             select(name: 'invitation[role]', id: 'invitation_role', class: select_classes, required: true) do
-              User.roles.each_key do |role|
-                option(value: role) { role.titleize }
+              Invitation.assignable_roles.each_key do |role|
+                option(value: role, selected: @invitation.role == role) { role.titleize }
               end
             end
           end
@@ -88,6 +90,21 @@ module Components
             Button(type: :submit, variant: :primary, size: :lg,
                    class: 'px-8 rounded-2xl shadow-lg shadow-primary/20') do
               'Send invitation'
+            end
+          end
+        end
+
+        def render_errors
+          render RubyUI::Alert.new(variant: :destructive, class: 'mb-6') do
+            div do
+              Heading(level: 2, size: '3', class: 'font-semibold mb-2') do
+                plain "#{pluralize(@invitation.errors.count, 'error')} prevented this invitation from being saved:"
+              end
+              ul(class: 'my-2 ml-6 list-disc [&>li]:mt-1') do
+                @invitation.errors.full_messages.each do |message|
+                  li { message }
+                end
+              end
             end
           end
         end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,7 +5,7 @@ class InvitationsController < ApplicationController
   layout false
 
   def accept
-    @invitation = Invitation.pending.find_by(token: params[:token])
+    @invitation = Invitation.pending.where.not(role: Invitation.roles[:minor]).find_by(token: params[:token])
 
     unless @invitation
       render plain: 'This invitation link is invalid or has expired.', status: :not_found

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -240,14 +240,18 @@ class RodauthMain < Rodauth::Rails::Auth
       throw_error_status(422, 'date_of_birth', 'must be present') if date_of_birth_str.blank?
 
       begin
-        Date.parse(date_of_birth_str)
+        date_of_birth = Date.parse(date_of_birth_str)
       rescue ArgumentError, TypeError
         throw_error_status(422, 'date_of_birth', 'must be a valid date')
       end
 
+      if Person.new(date_of_birth: date_of_birth).age < 18
+        throw_error_status(422, 'date_of_birth', 'Children must be added by a parent or carer.')
+      end
+
       # Validate invitation token if present and lock down email
       if (token = param_or_nil('invitation_token'))
-        @invitation = Invitation.pending.find_by(token: token)
+        @invitation = Invitation.pending.where.not(role: Invitation.roles[:minor]).find_by(token: token)
         throw_error_status(422, 'invitation_token', 'is invalid or expired') unless @invitation
         request.params[login_param] = @invitation.email
       end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -8,10 +8,15 @@ class Invitation < ApplicationRecord
                     format: { with: URI::MailTo::EMAIL_REGEXP },
                     uniqueness: { case_sensitive: false, conditions: -> { pending } }
   validates :role, presence: true
+  validate :role_cannot_be_minor
 
   enum :role, { administrator: 0, doctor: 1, nurse: 2, carer: 3, parent: 4, minor: 5 }, validate: true
 
   scope :pending, -> { where(accepted_at: nil).where('expires_at > ?', Time.current) }
+
+  def self.assignable_roles
+    roles.except('minor')
+  end
 
   def expired?
     return false if expires_at.nil?
@@ -31,5 +36,9 @@ class Invitation < ApplicationRecord
 
   def set_expires_at
     self.expires_at ||= 7.days.from_now
+  end
+
+  def role_cannot_be_minor
+    errors.add(:role, 'Children must be added by a parent or carer.') if minor?
   end
 end

--- a/spec/features/authentication/signup_verification_spec.rb
+++ b/spec/features/authentication/signup_verification_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Signup verification email', type: :system do
   let(:new_user_password) { 'Password123!' }
 
   before do
+    driven_by(:rack_test)
     ActionMailer::Base.deliveries.clear
   end
 

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'User Signup', type: :system do
   describe 'creating a new account' do
     before do
+      driven_by(:rack_test)
       User.administrator.destroy_all
     end
 
@@ -149,20 +150,20 @@ RSpec.describe 'User Signup', type: :system do
       expect(person&.person_type).to eq('adult')
     end
 
-    it 'sets person_type based on age (minor for under 18)' do
+    it 'rejects under-18 signup' do
       visit create_account_path
 
-      # Set date of birth to make user 15 years old
       fill_in 'Name', with: 'Minor User'
       fill_in 'Date of birth', with: 15.years.ago.to_date.to_s
       fill_in 'Email', with: 'minor@example.com'
       fill_in 'Password', with: 'SecureP@ssword123!'
       fill_in 'Confirm Password', with: 'SecureP@ssword123!'
 
-      click_button 'Create Account'
+      expect do
+        click_button 'Create Account'
+      end.not_to change(Account, :count)
 
-      person = Account.find_by(email: 'minor@example.com')&.person
-      expect(person&.person_type).to eq('minor')
+      expect(page).to have_content('Children must be added by a parent or carer.')
     end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe Invitation do
     it { is_expected.to validate_presence_of(:role) }
     it { is_expected.to allow_value('test@example.com').for(:email) }
     it { is_expected.not_to allow_value('invalid-email').for(:email) }
+
+    it 'does not allow minor invitations' do
+      invitation = build(:invitation, role: :minor)
+
+      expect(invitation).not_to be_valid
+      expect(invitation.errors[:role]).to include('Children must be added by a parent or carer.')
+    end
   end
 
   describe 'enums' do
@@ -16,6 +23,12 @@ RSpec.describe Invitation do
     it 'defines role enum' do
       expect(invitation).to define_enum_for(:role)
         .with_values(administrator: 0, doctor: 1, nurse: 2, carer: 3, parent: 4, minor: 5)
+    end
+  end
+
+  describe '.assignable_roles' do
+    it 'excludes minor' do
+      expect(described_class.assignable_roles.keys).not_to include('minor')
     end
   end
 

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe 'Admin create and update turbo flows' do
       expect(response.body).to include('target="admin_invitations"')
       expect(response.body).to include('target="flash"')
     end
+
+    it 'returns unprocessable content when inviting a minor' do
+      post admin_invitations_path,
+           params: { invitation: { email: 'minor.user@example.com', role: 'minor' } },
+           headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Children must be added by a parent or carer.')
+    end
   end
 
   describe 'POST /admin/users' do

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Invitations' do
+  describe 'GET /invitations/accept' do
+    it 'rejects existing minor invitation tokens' do
+      invitation = Invitation.new(email: 'child.invite@example.com', role: :minor)
+      invitation.save!(validate: false)
+
+      get accept_invitation_path(token: invitation.token)
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include('This invitation link is invalid or has expired.')
+    end
+  end
+end

--- a/spec/system/admin_invites_users_spec.rb
+++ b/spec/system/admin_invites_users_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe 'Admin invites users' do
     expect(email.to).to eq(['invited_parent@example.com'])
   end
 
+  it 'does not offer Minor in the invitation role selector' do
+    login_as(admin)
+
+    visit admin_root_path
+    click_link 'Invitations'
+
+    expect(page).to have_no_select('Role', with_options: ['Minor'])
+  end
+
   it 'allows an invitee to accept an invitation' do
     login_as(admin)
 
@@ -64,5 +73,31 @@ RSpec.describe 'Admin invites users' do
       expect(page).to have_content('Invited Parent')
       expect(page).to have_content('Parent')
     end
+  end
+
+  it 'rejects under-18 invited signup' do
+    login_as(admin)
+
+    visit admin_root_path
+    click_link 'Invitations'
+
+    fill_in 'Email', with: 'invited_child@example.com'
+    select 'Parent', from: 'Role'
+    click_button 'Send invitation'
+
+    invitation_url = ActionMailer::Base.deliveries.last.body.encoded.match(%r{https?://\S+})[0]
+    uri = URI.parse(invitation_url)
+    visit [uri.path, uri.query].compact.join('?')
+
+    fill_in 'Name', with: 'Invited Child'
+    fill_in 'Date of birth', with: 10.years.ago.to_date.to_s
+    fill_in 'Password', with: 'SecureP@ssword123!'
+    fill_in 'Confirm Password', with: 'SecureP@ssword123!'
+
+    expect do
+      click_button 'Create Account'
+    end.not_to change(Account, :count)
+
+    expect(page).to have_content('Children must be added by a parent or carer.')
   end
 end

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'Person medication workflow' do
   fixtures :accounts, :people, :locations, :medications, :users, :person_medications
 
   let(:person) { people(:child_user_person) }
-  let(:admin) { users(:admin) }
+  let(:parent) { users(:parent) }
 
   before do
     driven_by(:playwright)
-    login_as(admin)
+    login_as(parent)
   end
 
-  it 'walks through the as-needed workflow before submission' do
+  it 'lets a parent create and administer an as-needed medication for a linked child until the daily limit is hit' do
     visit person_path(person)
 
     within '[data-testid="quick-actions"]' do
@@ -52,11 +52,27 @@ RSpec.describe 'Person medication workflow' do
     expect(page).to have_button('Add Medication')
 
     fill_in 'person_medication_notes', with: 'Workflow test'
-    fill_in 'person_medication_max_daily_doses', with: '2'
+    fill_in 'person_medication_max_daily_doses', with: '1'
 
     click_button 'Add Medication'
 
     expect(page).to have_content('Medication added successfully')
     expect(page).to have_content('Workflow test')
+
+    created_person_medication = person.person_medications.order(:id).last
+
+    within("#person_medication_#{created_person_medication.id}") do
+      expect(page).to have_button('💊 Give')
+      click_button '💊 Give'
+    end
+
+    expect(page).to have_content('Medication taken successfully')
+
+    within("#person_medication_#{created_person_medication.id}") do
+      expect(page).to have_text(/today's doses/i)
+      expect(page).to have_text(/2\.5ml/i)
+      expect(page).to have_button('💊 Give', disabled: true)
+      expect(page).to have_content('1/1')
+    end
   end
 end


### PR DESCRIPTION
## Summary
- fix #676 by reusing the existing PRN workflow for a parent managing a linked child through creation, administration, and daily-limit lockout
- block child account creation through invitation and create-account flows while keeping admin-created minor users supported
- remove the minor role from admin invitation UI and reject existing minor invitation tokens

## Testing
- task test TEST_FILE=spec/system/person_medication_workflow_spec.rb
- task test TEST_FILE=spec/system/authorization/person_medications_authorization_spec.rb
- task test TEST_FILE=spec/models/invitation_spec.rb
- task test TEST_FILE=spec/requests/invitations_spec.rb
- task test TEST_FILE=spec/requests/admin_create_update_turbo_spec.rb
- task test TEST_FILE=spec/system/admin_invites_users_spec.rb
- task test TEST_FILE=spec/features/signup_spec.rb
- task test TEST_FILE=spec/features/authentication/signup_verification_spec.rb
- task test TEST_FILE=spec/features/authentication/invite_only_signup_spec.rb
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
