### PR TITLE
fix(a11y): announce form errors to screen readers

### DIFF
--- a/app/components/admin/users/form_view.rb
+++ b/app/components/admin/users/form_view.rb
@@ -91,9 +91,10 @@ module Components
               id: 'user_person_attributes_name',
               value: user.person&.name,
               required: true,
-              class: person_field_error_class(:name)
+              class: person_field_error_class(:name),
+              **person_field_error_attributes(:name, input_id: 'user_person_attributes_name')
             )
-            render_person_field_error(:name)
+            render_person_field_error(:name, input_id: 'user_person_attributes_name')
           end
         end
 
@@ -105,8 +106,10 @@ module Components
               name: 'user[person_attributes][date_of_birth]',
               id: 'user_person_attributes_date_of_birth',
               value: user.person&.date_of_birth&.to_s,
-              required: true
+              required: true,
+              **person_field_error_attributes(:date_of_birth, input_id: 'user_person_attributes_date_of_birth')
             )
+            render_person_field_error(:date_of_birth, input_id: 'user_person_attributes_date_of_birth')
           end
         end
 
@@ -145,9 +148,10 @@ module Components
               id: 'user_email_address',
               value: user.email_address,
               required: true,
-              class: field_error_class(user, :email_address)
+              class: field_error_class(user, :email_address),
+              **field_error_attributes(user, :email_address, input_id: 'user_email_address')
             )
-            render_field_error(user, :email_address)
+            render_field_error(user, :email_address, input_id: 'user_email_address')
           end
         end
 
@@ -166,9 +170,10 @@ module Components
               name: 'user[password]',
               id: 'user_password',
               required: user.new_record?,
-              class: field_error_class(user, :password)
+              class: field_error_class(user, :password),
+              **field_error_attributes(user, :password, input_id: 'user_password')
             )
-            render_field_error(user, :password)
+            render_field_error(user, :password, input_id: 'user_password')
           end
         end
 
@@ -217,11 +222,18 @@ module Components
           field_error_class(person, field)
         end
 
-        def render_person_field_error(field)
+        def person_field_error_attributes(field, input_id:)
+          person = user.person
+          return {} unless person
+
+          field_error_attributes(person, field, input_id: input_id)
+        end
+
+        def render_person_field_error(field, input_id:)
           person = user.person
           return unless person
 
-          render_field_error(person, field)
+          render_field_error(person, field, input_id: input_id)
         end
       end
     end

--- a/app/components/dosages/form.rb
+++ b/app/components/dosages/form.rb
@@ -63,7 +63,9 @@ module Components
               span(class: 'text-destructive ml-0.5') { ' *' }
             end
             Input(type: :number, name: 'dosage[amount]', id: 'dosage_amount',
-                  value: dosage.amount, step: 'any', min: '0', required: true)
+                  value: dosage.amount, step: 'any', min: '0', required: true,
+                  **field_error_attributes(dosage, :amount, input_id: 'dosage_amount'))
+            render_field_error(dosage, :amount, input_id: 'dosage_amount')
           end
 
           FormField do
@@ -74,7 +76,9 @@ module Components
             Input(type: :text, name: 'dosage[unit]', id: 'dosage_unit',
                   value: dosage.unit, required: true,
                   placeholder: 'mg, tablet, ml…',
-                  list: 'dosage_unit_list')
+                  list: 'dosage_unit_list',
+                  **field_error_attributes(dosage, :unit, input_id: 'dosage_unit'))
+            render_field_error(dosage, :unit, input_id: 'dosage_unit')
             datalist(id: 'dosage_unit_list') do
               Medication::DOSAGE_UNITS.each { |u| option(value: u) }
             end
@@ -91,7 +95,9 @@ module Components
           Input(type: :text, name: 'dosage[frequency]', id: 'dosage_frequency',
                 value: dosage.frequency, required: true,
                 placeholder: 'Once daily',
-                data: { 'frequency-suggestions-target': 'input' })
+                data: { 'frequency-suggestions-target': 'input' },
+                **field_error_attributes(dosage, :frequency, input_id: 'dosage_frequency'))
+          render_field_error(dosage, :frequency, input_id: 'dosage_frequency')
         end
 
         FormField(class: 'mt-4') do

--- a/app/components/form_helpers.rb
+++ b/app/components/form_helpers.rb
@@ -27,10 +27,24 @@ module Components
       model.errors[field].any? ? 'border-destructive focus-visible:ring-destructive' : ''
     end
 
-    def render_field_error(model, field)
+    def field_error_attributes(model, field, input_id: nil)
+      return {} unless model.errors[field].any?
+
+      attributes = { aria: { invalid: true } }
+      attributes[:aria][:describedby] = field_error_id(input_id) if input_id.present?
+      attributes
+    end
+
+    def render_field_error(model, field, input_id: nil)
       return unless model.errors[field].any?
 
-      FormFieldError { model.errors[field].first }
+      error_attributes = {}
+      error_attributes[:id] = field_error_id(input_id) if input_id.present?
+      FormFieldError(**error_attributes) { model.errors[field].first }
+    end
+
+    def field_error_id(input_id)
+      "#{input_id}_error"
     end
   end
 end

--- a/app/components/locations/form_view.rb
+++ b/app/components/locations/form_view.rb
@@ -99,9 +99,10 @@ module Components
             required: true,
             placeholder: t('forms.locations.name_placeholder'),
             class: 'rounded-2xl border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
-                   "focus:border-primary transition-all #{field_error_class(location, :name)}"
+                   "focus:border-primary transition-all #{field_error_class(location, :name)}",
+            **field_error_attributes(location, :name, input_id: 'location_name')
           )
-          render_field_error(location, :name)
+          render_field_error(location, :name, input_id: 'location_name')
         end
       end
 

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -172,9 +172,10 @@ module Components
             required: true,
             placeholder: t('forms.medications.name_placeholder'),
             class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
-                   "focus:border-primary transition-all #{field_error_class(medication, :name)}"
+                   "focus:border-primary transition-all #{field_error_class(medication, :name)}",
+            **field_error_attributes(medication, :name, input_id: 'medication_name')
           )
-          render_field_error(medication, :name)
+          render_field_error(medication, :name, input_id: 'medication_name')
         end
       end
 
@@ -263,9 +264,10 @@ module Components
             min: '1',
             placeholder: t('forms.medications.standard_dosage_placeholder', default: 'e.g., 500'),
             class: 'rounded-md border-slate-200 bg-white py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
-                   'focus:border-primary transition-all'
+                   'focus:border-primary transition-all',
+            **field_error_attributes(medication, :dosage_amount, input_id: 'medication_dosage_amount')
           )
-          render_field_error(medication, :dosage_amount)
+          render_field_error(medication, :dosage_amount, input_id: 'medication_dosage_amount')
         end
       end
 

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -111,9 +111,10 @@ module Components
             value: person.name,
             required: true,
             placeholder: t('forms.people.name_placeholder', default: 'e.g., Jane Doe'),
-            class: field_error_class(person, :name)
+            class: field_error_class(person, :name),
+            **field_error_attributes(person, :name, input_id: 'person_name')
           )
-          render_field_error(person, :name)
+          render_field_error(person, :name, input_id: 'person_name')
         end
       end
 
@@ -126,9 +127,10 @@ module Components
             id: 'person_email',
             value: person.email,
             placeholder: t('forms.people.email_placeholder', default: 'e.g., jane@example.com'),
-            class: field_error_class(person, :email)
+            class: field_error_class(person, :email),
+            **field_error_attributes(person, :email, input_id: 'person_email')
           )
-          render_field_error(person, :email)
+          render_field_error(person, :email, input_id: 'person_email')
         end
       end
 
@@ -141,9 +143,10 @@ module Components
             id: 'person_date_of_birth',
             value: person.date_of_birth&.to_s,
             required: true,
-            class: field_error_class(person, :date_of_birth)
+            class: field_error_class(person, :date_of_birth),
+            **field_error_attributes(person, :date_of_birth, input_id: 'person_date_of_birth')
           )
-          render_field_error(person, :date_of_birth)
+          render_field_error(person, :date_of_birth, input_id: 'person_date_of_birth')
         end
       end
 

--- a/app/components/ruby_ui/form/form_field_error.rb
+++ b/app/components/ruby_ui/form/form_field_error.rb
@@ -13,7 +13,8 @@ module RubyUI
         data: {
           ruby_ui__form_field_target: 'error'
         },
-        class: 'text-sm font-medium text-destructive'
+        class: 'text-sm font-medium text-destructive',
+        role: 'alert'
       }
     end
   end

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe 'Admin create and update turbo flows' do
            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
       expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('role="alert"')
+      expect(response.body).to include('id="user_email_address_error"')
+      expect(response.body).to include('aria-describedby="user_email_address_error"')
+      expect(response.body).to include('aria-invalid')
     end
   end
 

--- a/spec/requests/form_validation_feedback_spec.rb
+++ b/spec/requests/form_validation_feedback_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Form inline validation feedback' do
            params: { medication: { name: '', description: 'A test', dosage_amount: 10, dosage_unit: 'mg' } }
 
       expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('role="alert"')
       expect(response.body).to include('error')
     end
 
@@ -34,6 +35,16 @@ RSpec.describe 'Form inline validation feedback' do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('border-destructive')
+    end
+
+    it 'associates field errors with invalid inputs' do
+      post medications_path,
+           params: { medication: { name: '', description: 'A test', dosage_amount: 10, dosage_unit: 'mg' } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('id="medication_name_error"')
+      expect(response.body).to include('aria-invalid')
+      expect(response.body).to include('aria-describedby="medication_name_error"')
     end
 
     it 'rejects zero dosage amount' do

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -193,6 +193,10 @@ RSpec.describe 'People' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include('target="modal"')
       expect(response.body).to include('person_form')
+      expect(response.body).to include('role="alert"')
+      expect(response.body).to include('id="person_name_error"')
+      expect(response.body).to include('aria-describedby="person_name_error"')
+      expect(response.body).to include('aria-invalid')
     end
 
     it 'allows creating multiple dependents in sequence without email addresses' do


### PR DESCRIPTION
## Summary
- wire shared form helpers to expose stable error ids plus aria-invalid and aria-describedby on invalid fields
- make field-level error messages announce themselves with alert semantics
- cover both HTML and Turbo form failures so screen-reader error behavior stays consistent

Fixes #682

## Testing
- task test TEST_FILE=spec/requests/form_validation_feedback_spec.rb
- task test TEST_FILE=spec/requests/people_spec.rb
- task test TEST_FILE=spec/requests/admin_create_update_turbo_spec.rb
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
