### PR TITLE
fix: 🎨 Palette: Correct aria-label attribute on Reports page button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-03-14 - Initialize Palette Journal
+
+## 2024-03-14 - Fix Aria Label in Class String Bug
+**Learning:** Found an instance where an `aria-label` attribute was mistakenly placed inside the `class` string parameter (e.g., `class: '... aria-label: "Text"'`) in a Phlex view, preventing the attribute from actually being rendered by the browser as an accessible name.
+**Action:** When adding or verifying `aria-label`s in Phlex views, be sure they are passed as distinct keyword arguments rather than trailing text inside the `class` string.

--- a/app/views/reports/index.rb
+++ b/app/views/reports/index.rb
@@ -42,7 +42,7 @@ module Views
               label(for: 'end_date', class: 'text-xs font-bold uppercase tracking-wider text-muted-foreground') { 'To' }
               input(type: 'date', name: 'end_date', id: 'end_date', value: @end_date, class: 'form-input rounded-lg border-border bg-background text-sm text-foreground focus:border-primary focus:ring-primary')
             end
-            button(type: 'submit', class: 'mt-5 rounded-lg bg-primary p-2 text-primary-foreground transition-colors hover:opacity-90 aria-label: "Apply date filters"') do
+            button(type: 'submit', class: 'mt-5 rounded-lg bg-primary p-2 text-primary-foreground transition-colors hover:opacity-90', 'aria-label': 'Apply date filters') do
               render Icons::ChevronRight.new(size: 20)
             end
           end


### PR DESCRIPTION
💡 What: Moved the `aria-label` for the "Apply date filters" button on the Reports page out of the `class` string parameter and into its own keyword argument attribute.
🎯 Why: The aria-label was previously embedded inside the class string (e.g. `class: '... aria-label: "Text"'`), preventing the browser and screen readers from actually reading the button's accessible name.
📸 Before/After: Accessibility tooling will now correctly parse "Apply date filters" rather than attempting to read the chevron icon alone.
♿ Accessibility: The icon-only submit button on the Reports page is now properly labeled for screen readers.

---
*PR created automatically by Jules for task [13524269048388877725](https://jules.google.com/task/13524269048388877725) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
