### PR TITLE
perf: ⚡ Bolt: avoid N+1 EXISTS query in location show view any? call

### DIFF
--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -235,7 +235,9 @@ module Components
             end
 
             DialogMiddle do
-              if available_people.any?
+              # ⚡ Bolt Optimization: Use .to_a.any? instead of .any? to materialize the relation
+              # into an array in memory. This prevents an extra COUNT/EXISTS query before iterating.
+              if available_people.to_a.any?
                 form_with(url: location_location_memberships_path(location), method: :post, class: 'space-y-4') do
                   div(class: 'space-y-2') do
                     label(for: 'location_membership_person_id', class: 'text-sm font-medium') do


### PR DESCRIPTION
💡 **What:** 
Replaced `if available_people.any?` with `if available_people.to_a.any?` in `app/components/locations/show_view.rb`. Added an explanatory Bolt comment.

🎯 **Why:**
`available_people` is an ActiveRecord relation (`Person.where.not(...)`) evaluated multiple times. Calling `.any?` directly on an unloaded relation executes a `COUNT` or `EXISTS` database query. A moment later, when `.each` is called inside the form, a separate `SELECT *` query is executed. Materializing it once via `.to_a.any?` avoids the initial redundant database lookup.

📊 **Impact:**
Removes one duplicate `SELECT 1 AS one FROM "people"...` or `COUNT(*)` query per render of the location show view modal dialog.

🔬 **Measurement:**
Load the Location Show view where members can be added. Check database logs to verify `COUNT` or `EXISTS` queries on the `people` table are no longer present, leaving just the single `SELECT` query.

---
*PR created automatically by Jules for task [17494943713734949406](https://jules.google.com/task/17494943713734949406) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
