### PR TITLE
test: 🧪 add location assignment and validation tests for MedicationTake

### DIFF
--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -200,6 +200,40 @@ RSpec.describe MedicationTake do
         expect(take.errors[:taken_from_medication]).to include('must match the assigned medication')
       end
     end
+
+    context 'when the selected location does not match the medication location' do
+      it 'assigns the medication location if none is provided' do
+        alternate_location = Location.create!(name: 'Assignment Loc')
+        alternate_medication = create_matching_medication(medication: medication, location: alternate_location)
+
+        take = MedicationTake.new(
+          schedule: schedule,
+          taken_at: Time.current,
+          amount_ml: 10.0,
+          taken_from_medication: alternate_medication
+        )
+
+        take.valid?
+        expect(take.taken_from_location).to eq(alternate_location)
+      end
+
+      it 'is invalid if an incorrect location is explicitly provided' do
+        alternate_location = Location.create!(name: 'Correct Loc')
+        wrong_location = Location.create!(name: 'Wrong Loc')
+        alternate_medication = create_matching_medication(medication: medication, location: alternate_location)
+
+        take = MedicationTake.new(
+          schedule: schedule,
+          taken_at: Time.current,
+          amount_ml: 10.0,
+          taken_from_medication: alternate_medication,
+          taken_from_location: wrong_location
+        )
+
+        expect(take).not_to be_valid
+        expect(take.errors[:taken_from_location]).to include('must match the selected medication location')
+      end
+    end
   end
 
   describe 'versioning' do # rubocop:disable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
This PR adds test coverage for the `assign_taken_from_location` method and the `taken_from_location_matches_medication` validation in the `MedicationTake` model.

### 🎯 Why
The `assign_taken_from_location` method is responsible for ensuring that a medication take is correctly associated with a physical location, defaulting to the medication's primary location if none is provided. Ensuring this logic is robust is critical for audit trail accuracy.

### 📊 Coverage
- **Happy Path**: Verified that `taken_from_location` is automatically populated from the associated `taken_from_medication` during validation if it was originally nil.
- **Error Path**: Verified that providing a `taken_from_location` that does not match the `taken_from_medication.location` triggers a validation error, preventing inconsistent data entry.

### ✨ Result
Increased test coverage for `MedicationTake`, ensuring that the location tracking logic is verified and protected against future regressions.

---
*PR created automatically by Jules for task [17998625004575700290](https://jules.google.com/task/17998625004575700290) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
