### PR TITLE
perf: ⚡ Bolt: optimize reports controller daily compliance n+1 query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2026-03-07 - Cache Timing Restriction State Per Card Render
 **Learning:** MedTracker medication cards can evaluate the same timing restriction logic multiple times in one render path: once for countdown visibility, again for the disabled button state, and again for disabled-label copy. On cooldown states this multiplies `can_take_now?` work across every visible card.
 **Action:** In card components that render medication actions, cache `can_take_now?`, out-of-stock state, and blocked reason per render using instance variables guarded with `instance_variable_defined?`. That keeps cooldown/out-of-stock renders to a single timing evaluation while preserving behavior.
+
+## 2026-03-08 - Avoid Redundant Subqueries When Array is Materialized Immediately Afterwards
+**Learning:** In `reports_controller.rb`, extracting `Schedule.where(person_id: person_ids).select(:id)` as a subquery constraint for `MedicationTake` forced an extra database subquery, even though the exact filtered subset of active `schedules` was materialized into an array on the very next line via `.to_a`.
+**Action:** Order ActiveRecord relation evaluations logically to maximize reuse. If a collection must be materialized into a Ruby array anyway, compute it first, and then map its IDs (`schedules.map(&:id)`) to constrain subsequent queries instead of duplicating the database effort with a subquery.

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -36,13 +36,13 @@ class ReportsController < ApplicationController
     person_ids = people.map(&:id)
 
     # Pre-fetch takes and schedules to avoid N+1
-    takes = MedicationTake.where(schedule_id: Schedule.where(person_id: person_ids).select(:id))
-                          .where(taken_at: start_date.beginning_of_day..end_date.end_of_day)
-                          .group_by { |t| t.taken_at.to_date }
-
     schedules = Schedule.where(person_id: person_ids)
                         .where('start_date <= ? AND (end_date IS NULL OR end_date >= ?)', end_date, start_date)
                         .to_a
+
+    takes = MedicationTake.where(schedule_id: schedules.map(&:id))
+                          .where(taken_at: start_date.beginning_of_day..end_date.end_of_day)
+                          .group_by { |t| t.taken_at.to_date }
 
     (start_date..end_date).map do |date|
       active_schedules = schedules.select do |p|


### PR DESCRIPTION
💡 What: Reorders the `schedules` fetch to occur before the `takes` query inside `calculate_daily_compliance` in `ReportsController`. Swaps out `Schedule.where(person_id: person_ids).select(:id)` with the `schedules.map(&:id)` extracted from the materialized active schedules array.

🎯 Why: To eliminate an unnecessary database subquery. The old code triggered an implicit subquery requesting *all* medication schedules for a person, even though immediately afterward we load the strictly valid date-ranged `schedules` array into memory via `.to_a`. By resolving the `schedules` array first, we can simply pass `.map(&:id)` to correctly and explicitly bind the `MedicationTake` scope without additional database subquerying.

📊 Impact: Reduces SQL evaluation load and memory usage by removing the overhead of evaluating unbounded schedules within the `WHERE IN ()` subquery.

🔬 Measurement: View SQL trace execution times during report generation and notice the subquery string replaced by a tightly constrained `IN (1, 2, 3)` parameter array.

---
*PR created automatically by Jules for task [2743716073527790549](https://jules.google.com/task/2743716073527790549) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
