### PR TITLE
style: 🎨 Palette: Add aria-label to sidebar logout button

### DIFF
--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -114,7 +114,8 @@ module Components
             button(
               type: 'submit',
               class: 'w-full flex items-center justify-center md:justify-start gap-4 px-4 py-3 rounded-2xl ' \
-                     'text-muted-foreground hover:text-destructive hover:bg-destructive/5 transition-all group'
+                     'text-muted-foreground hover:text-destructive hover:bg-destructive/5 transition-all group',
+              aria_label: t('layouts.sidebar.sign_out')
             ) do
               div(class: 'group-hover:scale-110 transition-transform flex items-center justify-center') do
                 render Icons::LogOut.new(size: 24)


### PR DESCRIPTION
💡 What: Added an `aria_label` property to the logout button in the `Sidebar` ViewComponent.
🎯 Why: On mobile devices, the textual content of the logout button is hidden using Tailwind classes (`md:block`), turning it into an icon-only button. Without an accessible name, screen readers cannot properly announce the action, creating an accessibility issue.
♿ Accessibility: Ensures that screen reader users can navigate to and understand the purpose of the sign-out button regardless of the viewport size or whether the text label is visibly rendered.

---
*PR created automatically by Jules for task [17179801644250511690](https://jules.google.com/task/17179801644250511690) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
