### PR TITLE
perf: ⚡ Bolt: Optimize schedule existence check on Medication

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -68,7 +68,7 @@ class Medication < ApplicationRecord # :nodoc:
 
   def sync_dosages
     return unless persisted? && switched_to_single_dose_mode?
-    return if schedules.exists?
+    return if schedules.loaded? ? schedules.to_a.any? : schedules.exists?
 
     # When switching to single-dose mode (dosage_amount is set),
     # remove all orphaned multi-dose records to prevent data pollution.
@@ -130,7 +130,9 @@ class Medication < ApplicationRecord # :nodoc:
       schedule.max_daily_doses.to_f / (schedule.cycle_period / 1.day)
     end
 
-    pm_rate = person_medications.sum do |pm|
+    # ⚡ Bolt Optimization: Use .to_a.sum instead of .sum to evaluate
+    # in-memory and prevent N+1 queries for preloaded person_medications.
+    pm_rate = person_medications.to_a.sum do |pm|
       next 0.0 if pm.max_daily_doses.blank?
 
       pm.max_daily_doses.to_f
@@ -183,7 +185,7 @@ class Medication < ApplicationRecord # :nodoc:
 
   def single_dose_switch_requires_no_schedules
     return unless switching_to_single_dose_mode?
-    return unless schedules.exists?
+    return unless schedules.loaded? ? schedules.to_a.any? : schedules.exists?
 
     errors.add(:dosage_amount,
                'cannot switch to a single standard dose while schedules still use dose options')


### PR DESCRIPTION
💡 **What**: Changed `schedules.exists?` to `schedules.loaded? ? schedules.to_a.any? : schedules.exists?` inside `sync_dosages` and `single_dose_switch_requires_no_schedules`. Note: We used `.loaded? ? .to_a.any? : .exists?` because previous system instructions indicated that just using `.any?` or `.exists?` alone could trigger an N+1 condition when preloading due to specific Rails nuances.
🎯 **Why**: When checking if `schedules` exist for a medication that is already preloaded in memory, calling `.exists?` forces a new database query.
📊 **Impact**: Saves one database query per loaded medication in memory when verifying schedule existence or performing single dose switches.
🔬 **Measurement**: Watch SQL logs when running operations like `Medication#sync_dosages` on a batch of pre-loaded `medications` using `.includes(:schedules)`.

---
*PR created automatically by Jules for task [6761018438297184413](https://jules.google.com/task/6761018438297184413) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
