### PR TITLE
feat: 🎨 Palette: [Add placeholders to complex form inputs]

### DIFF
--- a/app/components/dosages/form.rb
+++ b/app/components/dosages/form.rb
@@ -137,6 +137,7 @@ module Components
             FormFieldLabel(for: 'dosage_default_max_daily_doses') { 'Max doses / cycle' }
             Input(type: :number, name: 'dosage[default_max_daily_doses]',
                   id: 'dosage_default_max_daily_doses',
+                  placeholder: 'e.g., 4',
                   value: dosage.default_max_daily_doses, min: 1)
           end
 
@@ -144,6 +145,7 @@ module Components
             FormFieldLabel(for: 'dosage_default_min_hours_between_doses') { 'Min hours apart' }
             Input(type: :number, name: 'dosage[default_min_hours_between_doses]',
                   id: 'dosage_default_min_hours_between_doses',
+                  placeholder: 'e.g., 6',
                   value: dosage.default_min_hours_between_doses, min: 0, step: '0.5')
           end
 

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -124,7 +124,10 @@ module Components
           render RubyUI::FormFieldLabel.new(
             for: 'medication_location_id_trigger',
             class: 'text-[10px] font-black uppercase tracking-widest text-slate-400 ml-1'
-          ) { t('medications.show.location') }
+          ) do
+            plain t('medications.show.location')
+            span(class: 'text-destructive ml-0.5') { ' *' }
+          end
           render RubyUI::Combobox.new(class: 'w-full') do
             render RubyUI::ComboboxTrigger.new(
               placeholder: selected_location_name || t('forms.medications.select_location'),
@@ -163,7 +166,10 @@ module Components
           render RubyUI::FormFieldLabel.new(
             for: 'medication_name',
             class: 'text-[10px] font-black uppercase tracking-widest text-slate-400 ml-1'
-          ) { t('forms.medications.name') }
+          ) do
+            plain t('forms.medications.name')
+            span(class: 'text-destructive ml-0.5') { ' *' }
+          end
           render RubyUI::Input.new(
             type: :text,
             name: 'medication[name]',

--- a/app/components/medications/wizard/field_helpers.rb
+++ b/app/components/medications/wizard/field_helpers.rb
@@ -13,7 +13,10 @@ module Components
             render RubyUI::FormFieldLabel.new(
               for: 'medication_location_id_trigger',
               class: 'text-[10px] font-black uppercase tracking-widest text-slate-400 ml-1'
-            ) { t('medications.show.location') }
+            ) do
+              plain t('medications.show.location')
+              span(class: 'text-destructive ml-0.5') { ' *' }
+            end
             render RubyUI::Combobox.new(class: 'w-full') do
               render RubyUI::ComboboxTrigger.new(
                 placeholder: selected_location_name || t('forms.medications.select_location'),
@@ -52,7 +55,10 @@ module Components
             render RubyUI::FormFieldLabel.new(
               for: 'medication_name',
               class: 'text-[10px] font-black uppercase tracking-widest text-slate-400 ml-1'
-            ) { t('forms.medications.name') }
+            ) do
+              plain t('forms.medications.name')
+              span(class: 'text-destructive ml-0.5') { ' *' }
+            end
             render RubyUI::Input.new(
               type: :text,
               name: 'medication[name]',

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -319,6 +319,7 @@ module Components
             name: 'schedule[max_daily_doses]',
             id: 'schedule_max_daily_doses',
             value: schedule.max_daily_doses,
+            placeholder: 'e.g., 4',
             min: 1,
             data: { schedule_form_target: 'maxDosesInput', action: 'input->schedule-form#generateFrequency' }
           )
@@ -334,6 +335,7 @@ module Components
             name: 'schedule[min_hours_between_doses]',
             id: 'schedule_min_hours_between_doses',
             value: schedule.min_hours_between_doses,
+            placeholder: 'e.g., 6',
             min: 0,
             step: '0.5',
             data: { schedule_form_target: 'minHoursInput', action: 'input->schedule-form#generateFrequency' }


### PR DESCRIPTION
💡 What: Added informative placeholder text (`e.g., 4`, `e.g., 6`) to the default scheduling configuration fields in `Dosages::Form` and `Schedules::Form`. Also added explicit red asterisks (`*`) to the `Name` and `Location` labels in the medication creation wizard.
🎯 Why: Empty numeric inputs for frequency constraints often confuse users regarding expected values. Placeholder examples reduce cognitive load. Highlighting required fields explicitly prevents submission errors.
📸 Before/After: Visual changes add placeholders in existing inputs and an asterisk to required field labels.
♿ Accessibility: No changes to ARIA. Existing `.sr-only` strings were retained for correct screen reader announcement per project rules.

---
*PR created automatically by Jules for task [985066795642943835](https://jules.google.com/task/985066795642943835) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
