### PR TITLE
test: 🧪 [improve Invitation.assignable_roles coverage]

### DIFF
--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -27,8 +27,15 @@ RSpec.describe Invitation do
   end
 
   describe '.assignable_roles' do
-    it 'excludes minor' do
-      expect(described_class.assignable_roles.keys).not_to include('minor')
+    it 'returns all roles except minor' do
+      expected_roles = {
+        'administrator' => 0,
+        'doctor' => 1,
+        'nurse' => 2,
+        'carer' => 3,
+        'parent' => 4
+      }
+      expect(described_class.assignable_roles).to eq(expected_roles)
     end
   end
 


### PR DESCRIPTION
🎯 **Why**
The public class method `Invitation.assignable_roles` was severely under-tested. The previous test only verified that the key 'minor' was excluded, but didn't verify that the method actually returned the expected mapping of all other roles (administrator, doctor, nurse, carer, parent).

📊 **Coverage**
Added a comprehensive assertion for `.assignable_roles` that evaluates the exact Hash object returned by the enum subset mapping.

✨ **Result**
Improved testing confidence. `Invitation.assignable_roles` is now fully covered to ensure exactly the 5 assignable roles and their correct enum integers are returned.

---
*PR created automatically by Jules for task [16741683521357570071](https://jules.google.com/task/16741683521357570071) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
