### PR TITLE
fix: align admin locale branches

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,9 +1,24 @@
 ---
 cy:
   hello: "Helo byd"
+  ruby_ui:
+    common:
+      close: "Cau"
+      navigation_menu: "Dewislen llywio"
+      more: "Mwy"
+    calendar:
+      previous_month: "Mynd i'r mis blaenorol"
+      next_month: "Mynd i'r mis nesaf"
   activerecord:
     attributes:
       invitation:
+        roles:
+          admin: "Gweinyddu"
+          clinician: "Clinigwr"
+          carer: "Gofalwr"
+          parent: "Rhiant"
+          self: "Hunan"
+      user:
         roles:
           admin: "Gweinyddu"
           clinician: "Clinigwr"
@@ -181,6 +196,23 @@ cy:
       resent: "Ailanfonwyd y gwahoddiad"
       cannot_resend_accepted: "Ni ellir ailanfon gwahoddiadau sydd wedi'u derbyn"
       resend_failed: "Ni ellid ailanfon y gwahoddiad hwn. Mae'n bosibl bod gwahoddiad sy'n aros am yr e-bost hwn eisoes yn bodoli."
+      index:
+        title: "Gwahoddiadau"
+        subtitle: "Gwahoddwch ddefnyddwyr newydd i ymuno â MedTracker."
+        recent: "Gwahoddiadau diweddar"
+        resend: "Ail-anfon"
+        form:
+          email: "E-bost"
+          role: "Rôl"
+          submit: "Anfon gwahoddiad"
+        status:
+          accepted: "Wedi'i dderbyn"
+          expired: "Wedi dod i ben"
+          pending: "Yn aros"
+        metadata:
+          accepted: "Wedi'i dderbyn %{time} yn ôl"
+          expired: "Daeth i ben %{time} yn ôl"
+          expires: "Yn dod i ben mewn %{time}"
     carer_relationships:
       created: "Crëwyd perthynas gofalwr yn llwyddiannus."
       deactivated: "Mae perthynas gofalwr wedi'i ddadactifadu."
@@ -212,12 +244,51 @@ cy:
           results: "canlyniad"
     users:
       unauthorized: "Nid oes gennych awdurdod i gyflawni'r weithred hon."
+      missing_account: "Nid oes gan y defnyddiwr gyfrif i'w ddilysu."
+      form:
+        subtitle: "Llenwch y manylion isod i greu cyfrif defnyddiwr newydd."
+        create_title: "Creu defnyddiwr newydd"
+        edit_title: "Golygu defnyddiwr"
+        name: "Enw"
+        date_of_birth: "Dyddiad geni"
+        locations: "Lleoliadau"
+        email_address: "Cyfeiriad e-bost"
+        password: "Cyfrinair"
+        password_confirmation: "Cadarnhad cyfrinair"
+        role: "Rôl"
+        select_role: "Dewis rôl"
+        cancel: "Canslo"
+        create_submit: "Creu defnyddiwr"
+        update_submit: "Diweddaru defnyddiwr"
+      search:
+        search: "Chwilio"
+        search_placeholder: "Chwilio yn ôl enw neu e-bost..."
+        role: "Rôl"
+        all_roles: "Pob rôl"
+        status: "Statws"
+        all: "Pawb"
+        clear: "Clirio"
+      table:
+        activation: "Actifadu"
+        verification: "Dilysu"
+        actions: "Gweithredoedd"
+      pagination:
+        label: "Tudalennu"
+        showing: "Yn dangos"
+        to: "i"
+        of: "o"
+        results: "canlyniadau"
+        previous: "Blaenorol"
+        next: "Nesaf"
       user_row:
         edit: "Golygu"
         active: "Actif"
         inactive: "Anactif"
+        soft_deleted: "Wedi'i ddileu'n feddal"
         deactivate: "Dadactifadu"
         activate: "Actifadu"
+        verify: "Dilysu"
+        verified: "Wedi'i ddilysu"
         deactivate_dialog:
           title: "Dadactifadu Cyfrif Defnyddiwr"
           confirm: "Ydych chi'n sicr eich bod am ddadactifadu cyfrif %{name}? Ni fyddant yn gallu mewngofnodi mwyach."
@@ -236,6 +307,7 @@ cy:
           clear_filters: "Clirio hidlwyr"
         table:
           timestamp: "Amser"
+          activity: "Gweithgarwch"
           record_type: "Math o Gofnod"
           event: "Digwyddiad"
           user: "Defnyddiwr"
@@ -271,9 +343,39 @@ cy:
         new_state_create: "Cyflwr y cofnod pan gafodd ei greu"
         new_state_update: "Cyflwr y cofnod ar ôl y newid hwn"
         new_state_other: "Cyflwr cyfredol y cofnod"
+        changes: "Newidiadau maes"
+        field: "Maes"
+        previous: "Gwerth blaenorol"
+        new: "Gwerth newydd"
+        record: "Cofnod"
+        view_title: "Manylyn archwilio"
+        view_subtitle: "Manylion a gofnodwyd ar gyfer y digwyddiad hwn"
+        snapshot: "Ciplun gwrthrych"
+        snapshot_description: "Cyflwr llawn y cofnod ar y foment hon"
+        no_data: "Nid oes data wedi'i gofnodi ar gyfer y fersiwn hon"
+    dashboard:
+      title: "Dangosfwrdd gweinyddol"
+      metrics:
+        total_users: "Cyfanswm defnyddwyr"
+        active_users: "Defnyddwyr gweithredol"
+        recent_signups: "Cofrestriadau diweddar"
+        total_people: "Cyfanswm pobl"
+        active_schedules: "Amserlenni gweithredol"
+        no_carers: "Dim gofalwyr"
+      quick_actions:
+        title: "Camau cyflym"
+        manage_users_title: "Rheoli defnyddwyr"
+        manage_users_description: "Gweld a rheoli cyfrifon defnyddwyr"
+        invitations_title: "Gwahoddiadau"
+        invitations_description: "Gwahodd defnyddwyr newydd i ymuno"
+        manage_people_title: "Rheoli pobl"
+        manage_people_description: "Gweld a rheoli cofnodion pobl"
+        audit_trail_title: "Llwybr archwilio"
+        audit_trail_description: "Gweld logiau archwilio'r system"
 
   authentication:
     login_required: "Mewngofnodwch i barhau"
+    session_expired: "Daeth eich sesiwn i ben. Mewngofnodwch eto."
     two_factor_required: "Er mwy o ddiogelwch, gosodwch ddilysu dau ffactor ar gyfer eich cyfrif."
 
   invitation_mailer:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,9 +1,24 @@
 ---
 es:
   hello: "Hola mundo"
+  ruby_ui:
+    common:
+      close: "Cerrar"
+      navigation_menu: "Menú de navegación"
+      more: "Más"
+    calendar:
+      previous_month: "Ir al mes anterior"
+      next_month: "Ir al mes siguiente"
   activerecord:
     attributes:
       invitation:
+        roles:
+          admin: "Administrador"
+          clinician: "Clínico"
+          carer: "Cuidador"
+          parent: "Padre/Madre"
+          self: "Mismo"
+      user:
         roles:
           admin: "Administrador"
           clinician: "Clínico"
@@ -181,6 +196,23 @@ es:
       resent: "Invitación reenviada"
       cannot_resend_accepted: "Las invitaciones aceptadas no se pueden reenviar"
       resend_failed: "No se pudo reenviar esta invitación. Es posible que ya exista una invitación pendiente para este correo electrónico."
+      index:
+        title: "Invitaciones"
+        subtitle: "Invita a nuevos usuarios a unirse a MedTracker."
+        recent: "Invitaciones recientes"
+        resend: "Reenviar"
+        form:
+          email: "Correo electrónico"
+          role: "Rol"
+          submit: "Enviar invitación"
+        status:
+          accepted: "Aceptada"
+          expired: "Caducada"
+          pending: "Pendiente"
+        metadata:
+          accepted: "Aceptada hace %{time}"
+          expired: "Caducó hace %{time}"
+          expires: "Caduca dentro de %{time}"
     carer_relationships:
       created: "La relación de cuidador se creó correctamente."
       deactivated: "La relación de cuidador ha sido desactivada."
@@ -212,12 +244,50 @@ es:
           results: "resultados"
     users:
       unauthorized: "No está autorizado para realizar esta acción."
+      form:
+        subtitle: "Rellena los datos a continuación para crear una nueva cuenta de usuario."
+        create_title: "Crear nuevo usuario"
+        edit_title: "Editar usuario"
+        name: "Nombre"
+        date_of_birth: "Fecha de nacimiento"
+        locations: "Ubicaciones"
+        email_address: "Dirección de correo electrónico"
+        password: "Contraseña"
+        password_confirmation: "Confirmación de contraseña"
+        role: "Rol"
+        select_role: "Selecciona un rol"
+        cancel: "Cancelar"
+        create_submit: "Crear usuario"
+        update_submit: "Actualizar usuario"
+      search:
+        search: "Buscar"
+        search_placeholder: "Buscar por nombre o correo electrónico..."
+        role: "Rol"
+        all_roles: "Todos los roles"
+        status: "Estado"
+        all: "Todos"
+        clear: "Limpiar"
+      table:
+        activation: "Activación"
+        verification: "Verificación"
+        actions: "Acciones"
+      pagination:
+        label: "Paginación"
+        showing: "Mostrando"
+        to: "a"
+        of: "de"
+        results: "resultados"
+        previous: "Anterior"
+        next: "Siguiente"
       user_row:
         edit: "Editar"
         active: "Activo"
         inactive: "Inactivo"
+        soft_deleted: "Eliminado lógicamente"
         deactivate: "Desactivar"
         activate: "Activar"
+        verify: "Verificar"
+        verified: "Verificado"
         deactivate_dialog:
           title: "Desactivar Cuenta de Usuario"
           confirm: "¿Está seguro de que desea desactivar la cuenta de %{name}? Ya no podrán iniciar sesión."
@@ -236,6 +306,7 @@ es:
           clear_filters: "Limpiar filtros"
         table:
           timestamp: "Marca de Tiempo"
+          activity: "Actividad"
           record_type: "Tipo de Registro"
           event: "Evento"
           user: "Usuario"
@@ -271,9 +342,39 @@ es:
         new_state_create: "El estado del registro cuando fue creado"
         new_state_update: "El estado del registro después de este cambio"
         new_state_other: "El estado actual del registro"
+        changes: "Cambios en los campos"
+        field: "Campo"
+        previous: "Valor anterior"
+        new: "Valor nuevo"
+        record: "Registro"
+        view_title: "Detalle de auditoría"
+        view_subtitle: "Detalles registrados para este evento"
+        snapshot: "Instantánea del objeto"
+        snapshot_description: "El estado completo del registro en este momento"
+        no_data: "No hay datos registrados para esta versión"
+    dashboard:
+      title: "Panel de administración"
+      metrics:
+        total_users: "Usuarios totales"
+        active_users: "Usuarios activos"
+        recent_signups: "Registros recientes"
+        total_people: "Personas totales"
+        active_schedules: "Planes activos"
+        no_carers: "Sin cuidadores"
+      quick_actions:
+        title: "Acciones rápidas"
+        manage_users_title: "Gestionar usuarios"
+        manage_users_description: "Ver y gestionar cuentas de usuario"
+        invitations_title: "Invitaciones"
+        invitations_description: "Invitar a nuevos usuarios a unirse"
+        manage_people_title: "Gestionar personas"
+        manage_people_description: "Ver y gestionar registros de personas"
+        audit_trail_title: "Registro de auditoría"
+        audit_trail_description: "Ver los registros de auditoría del sistema"
 
   authentication:
     login_required: "Por favor, inicie sesión para continuar"
+    session_expired: "Tu sesión ha caducado. Vuelve a iniciar sesión."
     two_factor_required: "Para mayor seguridad, configure la autenticación de dos factores para su cuenta."
 
   invitation_mailer:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1,6 +1,30 @@
 ---
 ga:
   hello: "Dia dhuit an domhan"
+  ruby_ui:
+    common:
+      close: "Dún"
+      navigation_menu: "Roghchlár nascleanúna"
+      more: "Tuilleadh"
+    calendar:
+      previous_month: "Téigh go dtí an mhí roimhe seo"
+      next_month: "Téigh go dtí an mhí seo chugainn"
+  activerecord:
+    attributes:
+      invitation:
+        roles:
+          admin: "Riarthóir"
+          clinician: "Cliniceoir"
+          carer: "Cúramóir"
+          parent: "Tuismitheoir"
+          self: "Féin"
+      user:
+        roles:
+          admin: "Riarthóir"
+          clinician: "Cliniceoir"
+          carer: "Cúramóir"
+          parent: "Tuismitheoir"
+          self: "Féin"
   app:
     name: "MedTracker"
 
@@ -10,6 +34,23 @@ ga:
       resent: "Cuireadh athsheolta"
       cannot_resend_accepted: "Ní féidir cuirí a nglactar leo a athsheoladh"
       resend_failed: "Níorbh fhéidir an cuireadh seo a athsheoladh. Seans go bhfuil cuireadh ar feitheamh don ríomhphost seo ann cheana féin."
+      index:
+        title: "Cuirí"
+        subtitle: "Tabhair cuireadh d'úsáideoirí nua páirt a ghlacadh i MedTracker."
+        recent: "Cuirí le déanaí"
+        resend: "Athsheol"
+        form:
+          email: "Ríomhphost"
+          role: "Ról"
+          submit: "Seol cuireadh"
+        status:
+          accepted: "Glactha"
+          expired: "Imithe in éag"
+          pending: "Ar feitheamh"
+        metadata:
+          accepted: "Glactha %{time} ó shin"
+          expired: "D'imigh sé in éag %{time} ó shin"
+          expires: "Rachaidh sé in éag i gceann %{time}"
     carer_relationships:
       created: "Cruthaíodh an caidreamh cúramóra go rathúil."
       deactivated: "Díghníomhaíodh an caidreamh cúramóra."
@@ -42,6 +83,41 @@ ga:
     users:
       unauthorized: "Níl údarás agat an gníomh seo a dhéanamh."
       missing_account: "Níl cuntas ag an úsáideoir le fíorú."
+      form:
+        subtitle: "Líon isteach na sonraí thíos chun cuntas úsáideora nua a chruthú."
+        create_title: "Cruthaigh úsáideoir nua"
+        edit_title: "Cuir úsáideoir in eagar"
+        name: "Ainm"
+        date_of_birth: "Dáta breithe"
+        locations: "Suíomhanna"
+        email_address: "Seoladh ríomhphoist"
+        password: "Focal faire"
+        password_confirmation: "Deimhniú focail faire"
+        role: "Ról"
+        select_role: "Roghnaigh ról"
+        cancel: "Cealaigh"
+        create_submit: "Cruthaigh úsáideoir"
+        update_submit: "Nuashonraigh úsáideoir"
+      search:
+        search: "Cuardaigh"
+        search_placeholder: "Cuardaigh de réir ainm nó ríomhphoist..."
+        role: "Ról"
+        all_roles: "Gach ról"
+        status: "Stádas"
+        all: "Gach ceann"
+        clear: "Glan"
+      table:
+        activation: "Gníomhachtú"
+        verification: "Fíorú"
+        actions: "Gníomhartha"
+      pagination:
+        label: "Leathanaigh"
+        showing: "Ag taispeáint"
+        to: "go"
+        of: "as"
+        results: "torthaí"
+        previous: "Roimhe Seo"
+        next: "Ar Aghaidh"
       user_row:
         edit: "Cuir in eagar"
         active: "Gníomhach"
@@ -69,6 +145,7 @@ ga:
           clear_filters: "Glan scagairí"
         table:
           timestamp: "Stamp Ama"
+          activity: "Gníomhaíocht"
           record_type: "Cineál Taifid"
           event: "Imeacht"
           user: "Úsáideoir"
@@ -104,9 +181,39 @@ ga:
         new_state_create: "Stáid na taifid nuair a cruthaíodh í"
         new_state_update: "Stáid na taifid tar éis an athraithe seo"
         new_state_other: "Stáid reatha na taifid"
+        changes: "Athruithe réimse"
+        field: "Réimse"
+        previous: "Luach roimhe seo"
+        new: "Luach nua"
+        record: "Taifead"
+        view_title: "Mionsonra iniúchta"
+        view_subtitle: "Sonraí a taifeadadh don imeacht seo"
+        snapshot: "Léargas ar an réad"
+        snapshot_description: "Staid iomlán an taifid ag an bpointe ama seo"
+        no_data: "Níl aon sonraí taifeadta don leagan seo"
+    dashboard:
+      title: "Painéal riarthóra"
+      metrics:
+        total_users: "Líon iomlán úsáideoirí"
+        active_users: "Úsáideoirí gníomhacha"
+        recent_signups: "Clárúcháin le déanaí"
+        total_people: "Líon iomlán daoine"
+        active_schedules: "Sceidil ghníomhacha"
+        no_carers: "Gan chúramóirí"
+      quick_actions:
+        title: "Gníomhartha tapa"
+        manage_users_title: "Bainistigh úsáideoirí"
+        manage_users_description: "Féach agus bainistigh cuntais úsáideoirí"
+        invitations_title: "Cuirí"
+        invitations_description: "Tabhair cuireadh d'úsáideoirí nua páirt a ghlacadh"
+        manage_people_title: "Bainistigh daoine"
+        manage_people_description: "Féach agus bainistigh taifid daoine"
+        audit_trail_title: "Conair iniúchta"
+        audit_trail_description: "Féach logaí iniúchta an chórais"
 
   authentication:
     login_required: "Logáil isteach le leanúint"
+    session_expired: "D'éag do sheisiún. Sínigh isteach arís."
     two_factor_required: "Le haghaidh slándála fheabhsaithe, socraigh fíorú dhá fhachtar do chuntas."
 
   invitation_mailer:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,9 +1,24 @@
 ---
 pt:
   hello: "Olá mundo"
+  ruby_ui:
+    common:
+      close: "Fechar"
+      navigation_menu: "Menu de navegação"
+      more: "Mais"
+    calendar:
+      previous_month: "Ir para o mês anterior"
+      next_month: "Ir para o mês seguinte"
   activerecord:
     attributes:
       invitation:
+        roles:
+          admin: "Administrador"
+          clinician: "Clínico"
+          carer: "Cuidador"
+          parent: "Pai/Mãe"
+          self: "Próprio"
+      user:
         roles:
           admin: "Administrador"
           clinician: "Clínico"
@@ -181,6 +196,23 @@ pt:
       resent: "Convite reenviado"
       cannot_resend_accepted: "Convites aceitos não podem ser reenviados"
       resend_failed: "Este convite não pôde ser reenviado. Já pode existir um convite pendente para este e-mail."
+      index:
+        title: "Convites"
+        subtitle: "Convide novos utilizadores para aderirem ao MedTracker."
+        recent: "Convites recentes"
+        resend: "Reenviar"
+        form:
+          email: "Email"
+          role: "Função"
+          submit: "Enviar convite"
+        status:
+          accepted: "Aceite"
+          expired: "Expirado"
+          pending: "Pendente"
+        metadata:
+          accepted: "Aceite há %{time}"
+          expired: "Expirou há %{time}"
+          expires: "Expira dentro de %{time}"
     carer_relationships:
       created: "A relação de cuidador foi criada com sucesso."
       deactivated: "A relação de cuidador foi desativada."
@@ -212,12 +244,50 @@ pt:
           results: "resultados"
     users:
       unauthorized: "Não está autorizado a realizar esta ação."
+      form:
+        subtitle: "Preencha os dados abaixo para criar uma nova conta de utilizador."
+        create_title: "Criar novo utilizador"
+        edit_title: "Editar utilizador"
+        name: "Nome"
+        date_of_birth: "Data de nascimento"
+        locations: "Localizações"
+        email_address: "Endereço de email"
+        password: "Palavra-passe"
+        password_confirmation: "Confirmação da palavra-passe"
+        role: "Função"
+        select_role: "Selecione uma função"
+        cancel: "Cancelar"
+        create_submit: "Criar utilizador"
+        update_submit: "Atualizar utilizador"
+      search:
+        search: "Pesquisar"
+        search_placeholder: "Pesquisar por nome ou email..."
+        role: "Função"
+        all_roles: "Todas as funções"
+        status: "Estado"
+        all: "Todos"
+        clear: "Limpar"
+      table:
+        activation: "Ativação"
+        verification: "Verificação"
+        actions: "Ações"
+      pagination:
+        label: "Paginação"
+        showing: "A mostrar"
+        to: "a"
+        of: "de"
+        results: "resultados"
+        previous: "Anterior"
+        next: "Seguinte"
       user_row:
         edit: "Editar"
         active: "Ativo"
         inactive: "Inativo"
+        soft_deleted: "Eliminado logicamente"
         deactivate: "Desativar"
         activate: "Ativar"
+        verify: "Verificar"
+        verified: "Verificado"
         deactivate_dialog:
           title: "Desativar Conta de Utilizador"
           confirm: "Tem certeza de que deseja desativar a conta de %{name}? Eles não poderão mais iniciar sessão."
@@ -236,6 +306,7 @@ pt:
           clear_filters: "Limpar filtros"
         table:
           timestamp: "Data/Hora"
+          activity: "Atividade"
           record_type: "Tipo de Registo"
           event: "Evento"
           user: "Utilizador"
@@ -271,9 +342,39 @@ pt:
         new_state_create: "O estado do registo quando foi criado"
         new_state_update: "O estado do registo após esta alteração"
         new_state_other: "O estado atual do registo"
+        changes: "Alterações aos campos"
+        field: "Campo"
+        previous: "Valor anterior"
+        new: "Novo valor"
+        record: "Registo"
+        view_title: "Detalhe de auditoria"
+        view_subtitle: "Detalhes registados para este evento"
+        snapshot: "Instantâneo do objeto"
+        snapshot_description: "O estado completo do registo neste momento"
+        no_data: "Não existem dados registados para esta versão"
+    dashboard:
+      title: "Painel de administração"
+      metrics:
+        total_users: "Total de utilizadores"
+        active_users: "Utilizadores ativos"
+        recent_signups: "Registos recentes"
+        total_people: "Total de pessoas"
+        active_schedules: "Planos ativos"
+        no_carers: "Sem cuidadores"
+      quick_actions:
+        title: "Ações rápidas"
+        manage_users_title: "Gerir utilizadores"
+        manage_users_description: "Ver e gerir contas de utilizador"
+        invitations_title: "Convites"
+        invitations_description: "Convidar novos utilizadores a aderir"
+        manage_people_title: "Gerir pessoas"
+        manage_people_description: "Ver e gerir registos de pessoas"
+        audit_trail_title: "Registo de auditoria"
+        audit_trail_description: "Ver os registos de auditoria do sistema"
 
   authentication:
     login_required: "Por favor, inicie sessão para continuar"
+    session_expired: "A sua sessão expirou. Inicie sessão novamente."
     two_factor_required: "Para maior segurança, configure a autenticação de dois fatores para a sua conta."
 
   invitation_mailer:

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Person Medications', type: :system do
       expect(page).to have_content('Choose the dose')
       # Wait for the async fetch to populate the select options
       expect(page).to have_css('#person_medication_dose_option option', text: '500 mg', visible: :all)
-      select '500 mg', from: 'person_medication_dose_option'
+      select '500 mg', from: 'Dose'
       click_button 'Next'
 
       expect(page).to have_content('Add optional guidance')


### PR DESCRIPTION
Summary:
- backfill shared admin/auth locale branches across Welsh, Spanish, Irish, and Portuguese locale files
- add the missing RubyUI calendar/common and user role translations used by those flows
- stabilize the as-needed person medication Playwright spec by selecting the dose via the visible label

Verification:
- task rubocop
- task test

Notes:
- leaves unrelated local deletions in .jules/palette.md and CLAUDE.md untouched
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
