### PR TITLE
refactor: extract medication supply card

### DIFF
--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -4,7 +4,6 @@ module Components
   module Medications
     class ShowView < Components::Base
       include Phlex::Rails::Helpers::TurboFrameTag
-      include Phlex::Rails::Helpers::TimeAgoInWords
 
       attr_reader :medication, :notice
 
@@ -27,7 +26,7 @@ module Components
             end
 
             div(class: 'space-y-8') do
-              render_stock_card
+              render Components::Medications::SupplyStatusCard.new(medication: medication)
               render_dosage_card
               render_actions_card
             end
@@ -106,87 +105,6 @@ module Components
           end
           Card(class: 'bg-error-container border-error/20 p-8') do
             Text(size: '3', class: 'text-on-error-container leading-relaxed font-medium') { medication.warnings }
-          end
-        end
-      end
-
-      def render_stock_card
-        Card(class: 'p-8 space-y-6 overflow-hidden relative') do
-          Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.inventory_status') }
-
-          current = medication.current_supply || 0
-          percentage = medication.supply_percentage
-
-          div(class: 'space-y-4') do
-            div(class: 'flex items-baseline gap-2') do
-              stock_count_class = if medication.low_stock?
-                                    'text-5xl font-black text-on-error-container'
-                                  else
-                                    'text-5xl font-black text-primary'
-                                  end
-
-              span(class: stock_count_class) do
-                current.to_s
-              end
-              Text(size: '2', weight: 'bold', class: 'text-muted-foreground') do
-                current == 1 ? 'unit remaining' : 'units remaining'
-              end
-            end
-
-            div(class: 'space-y-2') do
-              div(class: 'h-2 w-full bg-surface-container-low rounded-full overflow-hidden') do
-                div(class: "h-full #{medication.low_stock? ? 'bg-error' : 'bg-primary'} rounded-full",
-                    style: "width: #{percentage}%")
-              end
-              div(
-                class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
-                       'tracking-widest text-muted-foreground'
-              ) do
-                span { t('medications.show.supply_level') }
-                span { t('medications.show.reorder_at', threshold: medication.reorder_threshold) }
-              end
-            end
-
-            if medication.low_stock?
-              div(class: 'pt-2 space-y-2') do
-                Badge(variant: :destructive, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
-                  t('medications.show.low_stock_alert')
-                end
-
-                render_reorder_status_badge if medication.reorder_status.present?
-              end
-            end
-
-            render_forecast_section
-          end
-        end
-      end
-
-      def render_forecast_section
-        if medication.forecast_available?
-          div(class: 'pt-4 border-t border-surface-container-low space-y-2') do
-            if medication.days_until_low_stock&.positive?
-              forecast_item(t('medications.show.forecast.low_in_days', days: medication.days_until_low_stock), :warning)
-            end
-            if medication.days_until_out_of_stock&.positive?
-              forecast_item(t('medications.show.forecast.empty_in_days', days: medication.days_until_out_of_stock),
-                            :destructive)
-            end
-          end
-        else
-          div(class: 'pt-4 border-t border-surface-container-low') do
-            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.forecast_unavailable') }
-          end
-        end
-      end
-
-      def forecast_item(message, variant)
-        text_class = variant == :destructive ? 'text-on-error-container' : 'text-on-warning-container'
-
-        div(class: 'flex items-center gap-2') do
-          render Icons::AlertCircle.new(size: 14, class: text_class)
-          Text(size: '2', weight: 'medium', class: text_class) do
-            message
           end
         end
       end
@@ -284,34 +202,6 @@ module Components
           button_class: button_class,
           button_label: is_received ? t('medications.show.complete_refill') : t('medications.show.refill_inventory')
         )
-      end
-
-      def render_reorder_status_badge
-        variant = case medication.reorder_status.to_sym
-                  when :ordered then :default
-                  when :received then :success
-                  else :outline
-                  end
-
-        div(class: 'flex flex-col gap-1') do
-          Badge(variant: variant, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
-            t("medications.reorder_statuses.#{medication.reorder_status}")
-          end
-
-          timestamp = if medication.reorder_received?
-                        medication.reordered_at
-                      elsif medication.reorder_ordered?
-                        medication.ordered_at
-                      end
-
-          if timestamp
-            Text(size: '1', class: 'text-center text-muted-foreground font-medium') do
-              status_text = t("medications.reorder_statuses.#{medication.reorder_status}")
-              time_ago = time_ago_in_words(timestamp)
-              "#{status_text} #{time_ago} ago"
-            end
-          end
-        end
       end
 
       def overview_item(label, value, icon_class)

--- a/app/components/medications/supply_status_card.rb
+++ b/app/components/medications/supply_status_card.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class SupplyStatusCard < Components::Base
+      include Phlex::Rails::Helpers::TimeAgoInWords
+
+      attr_reader :medication
+
+      def initialize(medication:)
+        @medication = medication
+        super()
+      end
+
+      def view_template
+        Card(class: 'p-8 space-y-6 overflow-hidden relative') do
+          Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.inventory_status') }
+
+          current = medication.current_supply || 0
+          percentage = medication.supply_percentage
+
+          div(class: 'space-y-4') do
+            div(class: 'flex items-baseline gap-2') do
+              stock_count_class = if medication.low_stock?
+                                    'text-5xl font-black text-on-error-container'
+                                  else
+                                    'text-5xl font-black text-primary'
+                                  end
+
+              span(class: stock_count_class) do
+                current.to_s
+              end
+              Text(size: '2', weight: 'bold', class: 'text-muted-foreground') do
+                current == 1 ? 'unit remaining' : 'units remaining'
+              end
+            end
+
+            div(class: 'space-y-2') do
+              div(class: 'h-2 w-full bg-surface-container-low rounded-full overflow-hidden') do
+                div(class: "h-full #{medication.low_stock? ? 'bg-error' : 'bg-primary'} rounded-full",
+                    style: "width: #{percentage}%")
+              end
+              div(
+                class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
+                       'tracking-widest text-muted-foreground'
+              ) do
+                span { t('medications.show.supply_level') }
+                span { t('medications.show.reorder_at', threshold: medication.reorder_threshold) }
+              end
+            end
+
+            if medication.low_stock?
+              div(class: 'pt-2 space-y-2') do
+                Badge(variant: :destructive, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
+                  t('medications.show.low_stock_alert')
+                end
+
+                render_reorder_status_badge if medication.reorder_status.present?
+              end
+            end
+
+            render_forecast_section
+          end
+        end
+      end
+
+      private
+
+      def render_forecast_section
+        if medication.forecast_available?
+          div(class: 'pt-4 border-t border-surface-container-low space-y-2') do
+            if medication.days_until_low_stock&.positive?
+              forecast_item(t('medications.show.forecast.low_in_days', days: medication.days_until_low_stock), :warning)
+            end
+            if medication.days_until_out_of_stock&.positive?
+              forecast_item(t('medications.show.forecast.empty_in_days', days: medication.days_until_out_of_stock),
+                            :destructive)
+            end
+          end
+        else
+          div(class: 'pt-4 border-t border-surface-container-low') do
+            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.forecast_unavailable') }
+          end
+        end
+      end
+
+      def forecast_item(message, variant)
+        text_class = variant == :destructive ? 'text-on-error-container' : 'text-on-warning-container'
+
+        div(class: 'flex items-center gap-2') do
+          render Icons::AlertCircle.new(size: 14, class: text_class)
+          Text(size: '2', weight: 'medium', class: text_class) do
+            message
+          end
+        end
+      end
+
+      def render_reorder_status_badge
+        variant = case medication.reorder_status.to_sym
+                  when :ordered then :default
+                  when :received then :success
+                  else :outline
+                  end
+
+        div(class: 'flex flex-col gap-1') do
+          Badge(variant: variant, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
+            t("medications.reorder_statuses.#{medication.reorder_status}")
+          end
+
+          timestamp = if medication.reorder_received?
+                        medication.reordered_at
+                      elsif medication.reorder_ordered?
+                        medication.ordered_at
+                      end
+
+          if timestamp
+            Text(size: '1', class: 'text-center text-muted-foreground font-medium') do
+              status_text = t("medications.reorder_statuses.#{medication.reorder_status}")
+              time_ago = time_ago_in_words(timestamp)
+              "#{status_text} #{time_ago} ago"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/medications/supply_status_card_spec.rb
+++ b/spec/components/medications/supply_status_card_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::SupplyStatusCard, type: :component do
+  let(:medication) { create(:medication, name: 'Paracetamol', current_supply: 50) }
+
+  it 'renders the inventory status heading' do
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('Inventory Status')
+  end
+
+  context 'when forecast is available' do
+    it 'renders the out-of-stock forecast' do
+      medication_with_schedule = create(:medication, name: 'Paracetamol', current_supply: 50)
+      dosage = create(:dosage, medication: medication_with_schedule)
+      create(:schedule, medication: medication_with_schedule, dosage: dosage, max_daily_doses: 10,
+                        dose_cycle: :daily)
+
+      rendered = render_inline(described_class.new(medication: medication_with_schedule))
+
+      expect(rendered.text).to include('Supply will be empty in 5 days')
+    end
+
+    it 'renders the low-stock forecast' do
+      medication_with_schedule = create(:medication, name: 'Paracetamol', current_supply: 50)
+      dosage = create(:dosage, medication: medication_with_schedule)
+      create(:schedule, medication: medication_with_schedule, dosage: dosage, max_daily_doses: 10,
+                        dose_cycle: :daily)
+
+      rendered = render_inline(described_class.new(medication: medication_with_schedule))
+
+      expect(rendered.text).to include('Supply will be low in 4 days')
+    end
+  end
+
+  context 'when forecast is not available' do
+    it 'renders the fallback message' do
+      rendered = render_inline(described_class.new(medication: medication))
+
+      expect(rendered.text).to include('Forecast unavailable')
+    end
+  end
+
+  context 'when reorder status is present' do
+    it 'renders the reorder status badge and timestamp' do
+      medication.update!(
+        current_supply: 5,
+        supply_at_last_restock: 50,
+        reorder_status: :ordered,
+        ordered_at: 2.hours.ago
+      )
+
+      rendered = render_inline(described_class.new(medication: medication))
+
+      expect(rendered.text).to include('Ordered')
+      expect(rendered.text).to match(/Ordered .* ago/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract the medication supply and forecast UI from `Components::Medications::ShowView`
- add `Components::Medications::SupplyStatusCard` to own stock, reorder status, and forecast rendering
- add focused component coverage for the new supply status card

## Verification
- `task test TEST_FILE=spec/components/medications/supply_status_card_spec.rb`
- `task test TEST_FILE=spec/components/medications/show_view_spec.rb`
- `task rubocop`
- `task test`

Refs #1049
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
