### PR TITLE
refactor: Refactor medication view renderers

### DIFF
--- a/app/components/medications/dose_history_component.rb
+++ b/app/components/medications/dose_history_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class DoseHistoryComponent < Components::Base
+      include Phlex::Rails::Helpers::TurboFrameTag
+
+      attr_reader :medication
+
+      def initialize(medication:)
+        @medication = medication
+        super()
+      end
+
+      def view_template
+        Card(class: 'p-6') do
+          div(class: 'flex items-center justify-between mb-4') do
+            Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.dosages_heading') }
+            if can_manage?
+              Link(
+                href: view_context.new_medication_dosage_path(medication),
+                variant: :outline,
+                size: :sm,
+                data: { turbo_frame: 'modal' }
+              ) { t('medications.show.add_dosage') }
+            end
+          end
+
+          turbo_frame_tag 'modal'
+
+          if dosages.any?
+            div(class: 'space-y-3') do
+              dosages.each do |dosage|
+                render_dosage_row(dosage)
+              end
+            end
+          else
+            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.no_dosages') }
+          end
+        end
+      end
+
+      private
+
+      def dosages
+        @dosages ||= medication.dosages.sort_by(&:amount)
+      end
+
+      def can_manage?
+        @can_manage ||= begin
+          view_context.policy(medication).update?
+        rescue StandardError
+          false
+        end
+      end
+
+      def render_dosage_row(dosage)
+        div(class: 'flex items-start justify-between gap-3 rounded-lg border border-border p-3') do
+          div(class: 'space-y-1') do
+            render_dosage_summary(dosage)
+            render_dosage_scheduling_hint(dosage)
+          end
+
+          if can_manage?
+            div(class: 'flex gap-2 flex-none') do
+              Link(
+                href: view_context.edit_medication_dosage_path(medication, dosage),
+                variant: :ghost,
+                size: :sm,
+                data: { turbo_frame: 'modal' }
+              ) { t('medications.show.edit_dosage') }
+            end
+          end
+        end
+      end
+
+      def render_dosage_summary(dosage)
+        div(class: 'flex items-center gap-2 flex-wrap') do
+          span(class: 'font-semibold text-sm') { "#{dosage.amount.to_f} #{dosage.unit}" }
+          span(class: 'text-muted-foreground text-sm') { dosage.frequency }
+          if dosage.default_for_adults?
+            Badge(variant: :outline, class: 'text-xs') { t('dosages.form.default_for_adults') }
+          end
+          if dosage.default_for_children?
+            Badge(variant: :secondary, class: 'text-xs') { t('medications.show.children') }
+          end
+        end
+      end
+
+      def render_dosage_scheduling_hint(dosage)
+        return unless dosage.default_max_daily_doses || dosage.default_min_hours_between_doses
+
+        div(class: 'text-xs text-muted-foreground') do
+          parts = []
+          if dosage.default_max_daily_doses
+            parts << t('medications.show.max_per_cycle', count: dosage.default_max_daily_doses)
+          end
+          if dosage.default_min_hours_between_doses
+            parts << t('medications.show.min_hours_apart', hours: dosage.default_min_hours_between_doses)
+          end
+          plain parts.join(' · ')
+        end
+      end
+    end
+  end
+end

--- a/app/components/medications/index_view.rb
+++ b/app/components/medications/index_view.rb
@@ -3,7 +3,6 @@
 module Components
   module Medications
     class IndexView < Components::Base
-      include Phlex::Rails::Helpers::FormWith
       include Phlex::Rails::Helpers::TurboFrameTag
 
       attr_reader :medications, :current_category, :categories, :locations, :current_location_id, :wizard_variant
@@ -65,116 +64,12 @@ module Components
       end
 
       def render_filters_section
-        return if locations.empty? && categories.empty?
-
-        div(class: 'mb-12 grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl') do
-          form_with(url: medications_path, method: :get, class: 'contents', data: { controller: 'form-submit' }) do
-            render_location_filter if locations.any?
-            render_category_filter if categories.any?
-          end
-        end
-      end
-
-      def render_location_filter
-        div(class: 'space-y-2') do
-          render RubyUI::FormFieldLabel.new(
-            for: 'inventory_location_trigger',
-            class: 'text-[10px] font-black uppercase tracking-widest text-muted-foreground ml-1'
-          ) { t('medications.show.location') }
-          render RubyUI::Combobox.new(class: 'w-full') do
-            render RubyUI::ComboboxTrigger.new(
-              placeholder: current_location_name || t('medications.index.all_locations', default: 'All locations')
-            )
-
-            render RubyUI::ComboboxPopover.new do
-              render RubyUI::ComboboxSearchInput.new(
-                placeholder: t('medications.index.search_locations', default: 'Filter locations')
-              )
-
-              render RubyUI::ComboboxList.new do
-                render RubyUI::ComboboxEmptyState.new do
-                  t('medications.index.no_locations_found', default: 'No locations found')
-                end
-
-                render RubyUI::ComboboxItem.new do
-                  render RubyUI::ComboboxRadio.new(
-                    name: 'location_id',
-                    value: '',
-                    checked: current_location_id.blank?,
-                    data: { action: 'change->form-submit#submitForm' }
-                  )
-                  span { t('medications.index.all_locations', default: 'All locations') }
-                end
-
-                locations.each do |location|
-                  render RubyUI::ComboboxItem.new do
-                    render RubyUI::ComboboxRadio.new(
-                      name: 'location_id',
-                      value: location.id,
-                      checked: current_location_id == location.id,
-                      data: { action: 'change->form-submit#submitForm' }
-                    )
-                    span { location.name }
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-
-      def render_category_filter
-        div(class: 'space-y-2') do
-          render RubyUI::FormFieldLabel.new(
-            for: 'inventory_category_trigger',
-            class: 'text-[10px] font-black uppercase tracking-widest text-muted-foreground ml-1'
-          ) { 'Category' }
-          render RubyUI::Combobox.new(class: 'w-full') do
-            render RubyUI::ComboboxTrigger.new(
-              placeholder: current_category.presence || t('medications.index.all')
-            )
-
-            render RubyUI::ComboboxPopover.new do
-              render RubyUI::ComboboxSearchInput.new(
-                placeholder: t('forms.medications.filter_categories')
-              )
-
-              render RubyUI::ComboboxList.new do
-                render RubyUI::ComboboxEmptyState.new do
-                  t('forms.medications.no_categories_found')
-                end
-
-                render RubyUI::ComboboxItem.new do
-                  render RubyUI::ComboboxRadio.new(
-                    name: 'category',
-                    value: '',
-                    checked: current_category.blank?,
-                    data: { action: 'change->form-submit#submitForm' }
-                  )
-                  span { t('medications.index.all') }
-                end
-
-                categories.each do |category|
-                  render RubyUI::ComboboxItem.new do
-                    render RubyUI::ComboboxRadio.new(
-                      name: 'category',
-                      value: category,
-                      checked: current_category == category,
-                      data: { action: 'change->form-submit#submitForm' }
-                    )
-                    span { category }
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-
-      def current_location_name
-        return nil if current_location_id.blank?
-
-        locations.find { |location| location.id == current_location_id }&.name
+        render Components::Medications::SearchComponent.new(
+          current_category: current_category,
+          categories: categories,
+          locations: locations,
+          current_location_id: current_location_id
+        )
       end
 
       def inventory_query_params
@@ -189,157 +84,26 @@ module Components
       end
 
       def render_medications_grid
-        div(class: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8', id: 'medications') do
-          medications.each do |medication|
-            render_medication_card(medication)
-          end
-        end
-      end
-
-      def render_medication_card(medication)
-        Card(
-          id: "medication_#{medication.id}",
-          class: 'h-full flex flex-col border-none shadow-[0_8px_30px_rgb(0,0,0,0.04)] bg-surface-container-lowest ' \
-                 'rounded-[2.5rem] transition-all duration-300 hover:scale-[1.02] hover:shadow-xl ' \
-                 'group overflow-hidden'
-        ) do
-          CardHeader(class: 'pb-4 pt-8 px-8') do
-            div(class: 'flex justify-between items-start mb-4') do
-              render_medication_icon
-              status_badge(medication)
-            end
-            div(class: 'space-y-2') do
-              Heading(level: 2, size: '5', class: 'font-bold tracking-tight') { medication.name }
-              Badge(variant: :outline, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
+        if medications.any?
+          div(class: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8', id: 'medications') do
+            medications.each do |medication|
+              render Components::Medications::ListItemComponent.new(
+                medication: medication,
+                inventory_query_params: inventory_query_params,
+                can_manage: manageable_medication?(medication)
+              )
             end
           end
-
-          CardContent(class: 'flex-grow space-y-6 px-8 pb-4') do
-            if medication.description.present?
-              Text(size: '2', class: 'text-muted-foreground line-clamp-2 leading-relaxed') { medication.description }
-            end
-
-            div(class: 'pt-4 border-t border-border space-y-4') do
-              render_supply_bar(medication)
-            end
-          end
-
-          CardFooter(class: 'px-8 pb-8 pt-2 mt-auto') do
-            render_medication_actions(medication)
-          end
-        end
-      end
-
-      def status_badge(medication)
-        if medication.reorder_ordered?
-          Badge(variant: :default) { t('medications.reorder_statuses.ordered') }
-        elsif medication.reorder_received?
-          Badge(variant: :success) { t('medications.reorder_statuses.received') }
-        elsif medication.out_of_stock?
-          Badge(variant: :destructive) { t('dashboard.statuses.out_of_stock') }
-        elsif medication.low_stock?
-          Badge(variant: :warning) { t('medications.show.low_stock_alert') }
         else
-          Badge(variant: :success) { t('medications.index.in_stock', default: 'In Stock') }
+          render Components::Shared::EmptyState.new(
+            title: t('medications.index.empty_title'),
+            description: t('medications.index.empty_description')
+          )
         end
       end
 
-      def render_supply_bar(medication)
-        percentage = medication.supply_percentage
-        bar_color = medication.low_stock? ? 'bg-destructive' : 'bg-primary'
-
-        div(class: 'space-y-2') do
-          div(
-            class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
-                   'tracking-widest text-muted-foreground'
-          ) do
-            span { t('medications.index.inventory_level') }
-            span { pluralize(medication.current_supply, 'unit') }
-          end
-          div(class: 'h-1.5 w-full bg-surface-container-low rounded-full overflow-hidden') do
-            div(class: "h-full #{bar_color} rounded-full transition-all duration-1000", style: "width: #{percentage}%")
-          end
-        end
-      end
-
-      def render_medication_icon
-        div(
-          class: 'w-12 h-12 rounded-2xl bg-surface-container-low flex items-center ' \
-                 'justify-center text-muted-foreground ' \
-                 'group-hover:text-primary group-hover:bg-primary/5 transition-all'
-        ) do
-          render Icons::Pill.new(size: 24)
-        end
-      end
-
-      def render_medication_actions(medication)
-        div(class: 'flex items-center gap-2 w-full') do
-          Link(
-            href: medication_path(medication),
-            variant: :outline,
-            size: :sm,
-            class: 'flex-1 rounded-xl py-5 border-border bg-surface-container-lowest ' \
-                   'hover:bg-surface-container-low text-muted-foreground'
-          ) do
-            t('medications.index.view')
-          end
-          Link(
-            href: edit_medication_path(medication, return_to: medications_path(inventory_query_params)),
-            variant: :outline,
-            size: :sm,
-            class: 'rounded-xl w-10 h-10 p-0 border-border bg-surface-container-lowest ' \
-                   'hover:bg-surface-container-low text-muted-foreground',
-            aria_label: t('medications.index.edit', default: 'Edit medication')
-          ) do
-            render Icons::Pencil.new(size: 16)
-          end
-          if view_context.policy(medication).update?
-            refill_classes = if medication.reorder_received?
-                               'flex items-center justify-center rounded-xl w-10 h-10 p-0'
-                             else
-                               'flex items-center justify-center rounded-xl w-10 h-10 p-0 ' \
-                                 'border-border bg-surface-container-lowest ' \
-                                 'hover:bg-surface-container-low text-muted-foreground'
-                             end
-
-            render Components::Medications::RefillModal.new(
-              medication: medication,
-              button_variant: medication.reorder_received? ? :primary : :outline,
-              button_class: refill_classes,
-              icon_only: true
-            )
-          end
-          render_delete_dialog(medication)
-        end
-      end
-
-      def render_delete_dialog(medication)
-        AlertDialog do
-          AlertDialogTrigger do
-            Button(variant: :ghost, size: :sm,
-                   class: 'rounded-xl w-10 h-10 p-0 text-muted-foreground ' \
-                          'hover:text-destructive hover:bg-destructive/5',
-                   aria_label: t('medications.index.delete', default: 'Delete medication')) do
-              render Icons::Trash.new(size: 18)
-            end
-          end
-          AlertDialogContent(class: 'rounded-[2rem] border-none shadow-2xl') do
-            AlertDialogHeader do
-              AlertDialogTitle { t('medications.index.delete_dialog.title') }
-              AlertDialogDescription do
-                t('medications.index.delete_dialog.confirm', name: medication.name)
-              end
-            end
-            AlertDialogFooter do
-              AlertDialogCancel(class: 'rounded-xl') { t('medications.index.delete_dialog.cancel') }
-              form_with(url: medication_path(medication), method: :delete, class: 'inline') do
-                Button(variant: :destructive, type: :submit, class: 'rounded-xl shadow-lg shadow-destructive/20') do
-                  t('medications.index.delete_dialog.submit')
-                end
-              end
-            end
-          end
-        end
+      def manageable_medication?(medication)
+        view_context.policy(medication).update?
       end
     end
   end

--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class ListItemComponent < Components::Base
+      include Phlex::Rails::Helpers::FormWith
+
+      attr_reader :medication, :inventory_query_params, :can_manage
+
+      def initialize(medication:, inventory_query_params: {}, can_manage: false)
+        @medication = medication
+        @inventory_query_params = inventory_query_params
+        @can_manage = can_manage
+        super()
+      end
+
+      def view_template
+        Card(
+          id: "medication_#{medication.id}",
+          class: 'h-full flex flex-col border-none shadow-[0_8px_30px_rgb(0,0,0,0.04)] bg-surface-container-lowest ' \
+                 'rounded-[2.5rem] transition-all duration-300 hover:scale-[1.02] hover:shadow-xl ' \
+                 'group overflow-hidden'
+        ) do
+          CardHeader(class: 'pb-4 pt-8 px-8') do
+            div(class: 'flex justify-between items-start mb-4') do
+              render_medication_icon
+              render_status_badge
+            end
+            div(class: 'space-y-2') do
+              Heading(level: 2, size: '5', class: 'font-bold tracking-tight') { medication.name }
+              Badge(variant: :outline, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
+            end
+          end
+
+          CardContent(class: 'flex-grow space-y-6 px-8 pb-4') do
+            if medication.description.present?
+              Text(size: '2', class: 'text-muted-foreground line-clamp-2 leading-relaxed') { medication.description }
+            end
+
+            div(class: 'pt-4 border-t border-border space-y-4') do
+              render_supply_bar
+            end
+          end
+
+          CardFooter(class: 'px-8 pb-8 pt-2 mt-auto') do
+            render_actions
+          end
+        end
+      end
+
+      private
+
+      def render_status_badge
+        if medication.reorder_ordered?
+          Badge(variant: :default) { t('medications.reorder_statuses.ordered') }
+        elsif medication.reorder_received?
+          Badge(variant: :success) { t('medications.reorder_statuses.received') }
+        elsif medication.out_of_stock?
+          Badge(variant: :destructive) { t('dashboard.statuses.out_of_stock') }
+        elsif medication.low_stock?
+          Badge(variant: :warning) { t('medications.show.low_stock_alert') }
+        else
+          Badge(variant: :success) { t('medications.index.in_stock', default: 'In Stock') }
+        end
+      end
+
+      def render_supply_bar
+        percentage = medication.supply_percentage
+        bar_color = medication.low_stock? ? 'bg-destructive' : 'bg-primary'
+
+        div(class: 'space-y-2') do
+          div(
+            class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
+                   'tracking-widest text-muted-foreground'
+          ) do
+            span { t('medications.index.inventory_level') }
+            span { pluralize(medication.current_supply, 'unit') }
+          end
+          div(class: 'h-1.5 w-full bg-surface-container-low rounded-full overflow-hidden') do
+            div(class: "h-full #{bar_color} rounded-full transition-all duration-1000", style: "width: #{percentage}%")
+          end
+        end
+      end
+
+      def render_medication_icon
+        div(
+          class: 'w-12 h-12 rounded-2xl bg-surface-container-low flex items-center ' \
+                 'justify-center text-muted-foreground ' \
+                 'group-hover:text-primary group-hover:bg-primary/5 transition-all'
+        ) do
+          render Icons::Pill.new(size: 24)
+        end
+      end
+
+      def render_actions
+        div(class: 'flex items-center gap-2 w-full') do
+          Link(
+            href: medication_path(medication),
+            variant: :outline,
+            size: :sm,
+            class: 'flex-1 rounded-xl py-5 border-border bg-surface-container-lowest ' \
+                   'hover:bg-surface-container-low text-muted-foreground'
+          ) do
+            t('medications.index.view')
+          end
+          Link(
+            href: edit_medication_path(medication, return_to: medications_path(inventory_query_params)),
+            variant: :outline,
+            size: :sm,
+            class: 'rounded-xl w-10 h-10 p-0 border-border bg-surface-container-lowest ' \
+                   'hover:bg-surface-container-low text-muted-foreground',
+            aria_label: t('medications.index.edit', default: 'Edit medication')
+          ) do
+            render Icons::Pencil.new(size: 16)
+          end
+          if can_manage
+            refill_classes = if medication.reorder_received?
+                               'flex items-center justify-center rounded-xl w-10 h-10 p-0'
+                             else
+                               'flex items-center justify-center rounded-xl w-10 h-10 p-0 ' \
+                                 'border-border bg-surface-container-lowest ' \
+                                 'hover:bg-surface-container-low text-muted-foreground'
+                             end
+
+            render Components::Medications::RefillModal.new(
+              medication: medication,
+              button_variant: medication.reorder_received? ? :primary : :outline,
+              button_class: refill_classes,
+              icon_only: true
+            )
+          end
+          render_delete_dialog
+        end
+      end
+
+      def render_delete_dialog
+        AlertDialog do
+          AlertDialogTrigger do
+            Button(variant: :ghost, size: :sm,
+                   class: 'rounded-xl w-10 h-10 p-0 text-muted-foreground ' \
+                          'hover:text-destructive hover:bg-destructive/5',
+                   aria_label: t('medications.index.delete', default: 'Delete medication')) do
+              render Icons::Trash.new(size: 18)
+            end
+          end
+          AlertDialogContent(class: 'rounded-[2rem] border-none shadow-2xl') do
+            AlertDialogHeader do
+              AlertDialogTitle { t('medications.index.delete_dialog.title') }
+              AlertDialogDescription do
+                t('medications.index.delete_dialog.confirm', name: medication.name)
+              end
+            end
+            AlertDialogFooter do
+              AlertDialogCancel(class: 'rounded-xl') { t('medications.index.delete_dialog.cancel') }
+              form_with(url: medication_path(medication), method: :delete, class: 'inline') do
+                Button(variant: :destructive, type: :submit, class: 'rounded-xl shadow-lg shadow-destructive/20') do
+                  t('medications.index.delete_dialog.submit')
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/medications/search_component.rb
+++ b/app/components/medications/search_component.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class SearchComponent < Components::Base
+      include Phlex::Rails::Helpers::FormWith
+
+      attr_reader :current_category, :categories, :locations, :current_location_id
+
+      def initialize(current_category: nil, categories: [], locations: [], current_location_id: nil)
+        @current_category = current_category
+        @categories = categories
+        @locations = locations
+        @current_location_id = current_location_id
+        super()
+      end
+
+      def view_template
+        return if locations.empty? && categories.empty?
+
+        div(class: 'mb-12 grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl') do
+          form_with(url: medications_path, method: :get, class: 'contents', data: { controller: 'form-submit' }) do
+            render_location_filter if locations.any?
+            render_category_filter if categories.any?
+          end
+        end
+      end
+
+      private
+
+      def render_location_filter
+        div(class: 'space-y-2') do
+          render RubyUI::FormFieldLabel.new(
+            for: 'inventory_location_trigger',
+            class: 'text-[10px] font-black uppercase tracking-widest text-muted-foreground ml-1'
+          ) { t('medications.show.location') }
+          render RubyUI::Combobox.new(class: 'w-full') do
+            render RubyUI::ComboboxTrigger.new(
+              placeholder: current_location_name || t('medications.index.all_locations', default: 'All locations')
+            )
+
+            render RubyUI::ComboboxPopover.new do
+              render RubyUI::ComboboxSearchInput.new(
+                placeholder: t('medications.index.search_locations', default: 'Filter locations')
+              )
+
+              render RubyUI::ComboboxList.new do
+                render RubyUI::ComboboxEmptyState.new do
+                  t('medications.index.no_locations_found', default: 'No locations found')
+                end
+
+                render RubyUI::ComboboxItem.new do
+                  render RubyUI::ComboboxRadio.new(
+                    name: 'location_id',
+                    value: '',
+                    checked: current_location_id.blank?,
+                    data: { action: 'change->form-submit#submitForm' }
+                  )
+                  span { t('medications.index.all_locations', default: 'All locations') }
+                end
+
+                locations.each do |location|
+                  render RubyUI::ComboboxItem.new do
+                    render RubyUI::ComboboxRadio.new(
+                      name: 'location_id',
+                      value: location.id,
+                      checked: current_location_id == location.id,
+                      data: { action: 'change->form-submit#submitForm' }
+                    )
+                    span { location.name }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def render_category_filter
+        div(class: 'space-y-2') do
+          render RubyUI::FormFieldLabel.new(
+            for: 'inventory_category_trigger',
+            class: 'text-[10px] font-black uppercase tracking-widest text-muted-foreground ml-1'
+          ) { 'Category' }
+          render RubyUI::Combobox.new(class: 'w-full') do
+            render RubyUI::ComboboxTrigger.new(
+              placeholder: current_category.presence || t('medications.index.all')
+            )
+
+            render RubyUI::ComboboxPopover.new do
+              render RubyUI::ComboboxSearchInput.new(
+                placeholder: t('forms.medications.filter_categories')
+              )
+
+              render RubyUI::ComboboxList.new do
+                render RubyUI::ComboboxEmptyState.new do
+                  t('forms.medications.no_categories_found')
+                end
+
+                render RubyUI::ComboboxItem.new do
+                  render RubyUI::ComboboxRadio.new(
+                    name: 'category',
+                    value: '',
+                    checked: current_category.blank?,
+                    data: { action: 'change->form-submit#submitForm' }
+                  )
+                  span { t('medications.index.all') }
+                end
+
+                categories.each do |category|
+                  render RubyUI::ComboboxItem.new do
+                    render RubyUI::ComboboxRadio.new(
+                      name: 'category',
+                      value: category,
+                      checked: current_category == category,
+                      data: { action: 'change->form-submit#submitForm' }
+                    )
+                    span { category }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def current_location_name
+        return nil if current_location_id.blank?
+
+        locations.find { |location| location.id == current_location_id }&.name
+      end
+    end
+  end
+end

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -96,44 +96,11 @@ module Components
       end
 
       def render_warnings_section
-        div(class: 'space-y-4') do
-          div(class: 'flex items-center gap-2') do
-            render Icons::AlertCircle.new(size: 20, class: 'text-on-error-container')
-            Heading(level: 2, size: '5', class: 'font-bold tracking-tight text-on-error-container') do
-              t('medications.show.safety_warnings')
-            end
-          end
-          Card(class: 'bg-error-container border-error/20 p-8') do
-            Text(size: '3', class: 'text-on-error-container leading-relaxed font-medium') { medication.warnings }
-          end
-        end
+        render Components::Medications::WarningsComponent.new(medication: medication)
       end
 
       def render_dosage_card
-        Card(class: 'p-8 space-y-6') do
-          Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.standard_dosage') }
-
-          if dosage_specified?
-            div(class: 'flex items-center gap-4') do
-              div(
-                class: 'w-12 h-12 rounded-2xl bg-secondary-container flex items-center justify-center ' \
-                       'text-on-secondary-container shadow-sm'
-              ) do
-                render Icons::CheckCircle.new(size: 24)
-              end
-              div do
-                span(class: 'text-3xl font-black text-foreground') { medication.dosage_amount.to_s }
-                span(class: 'text-lg font-bold text-muted-foreground ml-1') { medication.dosage_unit }
-              end
-            end
-          else
-            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.no_dosage') }
-          end
-
-          div(class: 'pt-4 border-t border-surface-container-low') do
-            overview_item(t('medications.show.reorder_at_label'), pluralize(medication.reorder_threshold, 'unit'), Icons::Settings)
-          end
-        end
+        render Components::Medications::StandardDosageComponent.new(medication: medication)
       end
 
       def render_actions_card
@@ -204,107 +171,8 @@ module Components
         )
       end
 
-      def overview_item(label, value, icon_class)
-        div(class: 'flex items-center gap-4 group') do
-          div(
-            class: 'w-10 h-10 rounded-xl bg-surface-container-low flex items-center justify-center ' \
-                   'text-muted-foreground ' \
-                   'group-hover:bg-primary/5 group-hover:text-primary transition-colors'
-          ) do
-            render icon_class.new(size: 20)
-          end
-          div do
-            Text(size: '1', weight: 'black', class: 'uppercase tracking-widest text-muted-foreground') { label }
-            Text(size: '2', weight: 'semibold') { value }
-          end
-        end
-      end
-
       def render_dosages_section
-        dosages = medication.dosages.sort_by(&:amount)
-        can_manage = begin
-          view_context.policy(medication).update?
-        rescue StandardError
-          false
-        end
-
-        Card(class: 'p-6') do
-          div(class: 'flex items-center justify-between mb-4') do
-            Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.dosages_heading') }
-            if can_manage
-              Link(
-                href: view_context.new_medication_dosage_path(medication),
-                variant: :outline,
-                size: :sm,
-                data: { turbo_frame: 'modal' }
-              ) { t('medications.show.add_dosage') }
-            end
-          end
-
-          turbo_frame_tag 'modal'
-
-          if dosages.any?
-            div(class: 'space-y-3') do
-              dosages.each do |dosage|
-                render_dosage_row(dosage, can_manage)
-              end
-            end
-          else
-            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.no_dosages') }
-          end
-        end
-      end
-
-      def render_dosage_row(dosage, can_manage)
-        div(class: 'flex items-start justify-between gap-3 rounded-lg border border-border p-3') do
-          div(class: 'space-y-1') do
-            render_dosage_summary(dosage)
-            render_dosage_scheduling_hint(dosage)
-          end
-
-          if can_manage
-            div(class: 'flex gap-2 flex-none') do
-              Link(
-                href: view_context.edit_medication_dosage_path(medication, dosage),
-                variant: :ghost,
-                size: :sm,
-                data: { turbo_frame: 'modal' }
-              ) { t('medications.show.edit_dosage') }
-            end
-          end
-        end
-      end
-
-      def render_dosage_summary(dosage)
-        div(class: 'flex items-center gap-2 flex-wrap') do
-          span(class: 'font-semibold text-sm') { "#{dosage.amount.to_f} #{dosage.unit}" }
-          span(class: 'text-muted-foreground text-sm') { dosage.frequency }
-          if dosage.default_for_adults?
-            Badge(variant: :outline, class: 'text-xs') { t('dosages.form.default_for_adults') }
-          end
-          if dosage.default_for_children?
-            Badge(variant: :secondary, class: 'text-xs') { t('medications.show.children') }
-          end
-        end
-      end
-
-      def render_dosage_scheduling_hint(dosage)
-        return unless dosage.default_max_daily_doses || dosage.default_min_hours_between_doses
-
-        div(class: 'text-xs text-muted-foreground') do
-          parts = []
-          if dosage.default_max_daily_doses
-            parts << t('medications.show.max_per_cycle', count: dosage.default_max_daily_doses)
-          end
-          if dosage.default_min_hours_between_doses
-            parts << t('medications.show.min_hours_apart', hours: dosage.default_min_hours_between_doses)
-          end
-          plain parts.join(' · ')
-        end
-      end
-
-      def dosage_specified?
-        medication.dosage_amount.present? && medication.dosage_unit.present?
+        render Components::Medications::DoseHistoryComponent.new(medication: medication)
       end
     end
   end

--- a/app/components/medications/standard_dosage_component.rb
+++ b/app/components/medications/standard_dosage_component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class StandardDosageComponent < Components::Base
+      attr_reader :medication
+
+      def initialize(medication:)
+        @medication = medication
+        super()
+      end
+
+      def view_template
+        Card(class: 'p-8 space-y-6') do
+          Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.standard_dosage') }
+
+          if dosage_specified?
+            div(class: 'flex items-center gap-4') do
+              div(
+                class: 'w-12 h-12 rounded-2xl bg-secondary-container flex items-center justify-center ' \
+                       'text-on-secondary-container shadow-sm'
+              ) do
+                render Icons::CheckCircle.new(size: 24)
+              end
+              div do
+                span(class: 'text-3xl font-black text-foreground') { medication.dosage_amount.to_s }
+                span(class: 'text-lg font-bold text-muted-foreground ml-1') { medication.dosage_unit }
+              end
+            end
+          else
+            Text(size: '2', class: 'text-muted-foreground italic') { t('medications.show.no_dosage') }
+          end
+
+          div(class: 'pt-4 border-t border-surface-container-low') do
+            render_overview_item(
+              t('medications.show.reorder_at_label'),
+              pluralize(medication.reorder_threshold, 'unit')
+            )
+          end
+        end
+      end
+
+      private
+
+      def dosage_specified?
+        medication.dosage_amount.present? && medication.dosage_unit.present?
+      end
+
+      def render_overview_item(label, value)
+        div(class: 'flex items-center gap-4 group') do
+          div(
+            class: 'w-10 h-10 rounded-xl bg-surface-container-low flex items-center justify-center ' \
+                   'text-muted-foreground ' \
+                   'group-hover:bg-primary/5 group-hover:text-primary transition-colors'
+          ) do
+            render Icons::Settings.new(size: 20)
+          end
+          div do
+            Text(size: '1', weight: 'black', class: 'uppercase tracking-widest text-muted-foreground') { label }
+            Text(size: '2', weight: 'semibold') { value }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/medications/warnings_component.rb
+++ b/app/components/medications/warnings_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class WarningsComponent < Components::Base
+      attr_reader :medication
+
+      def initialize(medication:)
+        @medication = medication
+        super()
+      end
+
+      def view_template
+        div(class: 'space-y-4') do
+          div(class: 'flex items-center gap-2') do
+            render Icons::AlertCircle.new(size: 20, class: 'text-on-error-container')
+            Heading(level: 2, size: '5', class: 'font-bold tracking-tight text-on-error-container') do
+              t('medications.show.safety_warnings')
+            end
+          end
+          Card(class: 'bg-error-container border-error/20 p-8') do
+            Text(size: '3', class: 'text-on-error-container leading-relaxed font-medium') { medication.warnings }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/shared/empty_state.rb
+++ b/app/components/shared/empty_state.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Components
+  module Shared
+    class EmptyState < Components::Base
+      attr_reader :title, :description, :icon
+
+      def initialize(title:, description:, icon: :pill)
+        @title = title
+        @description = description
+        @icon = icon
+        super()
+      end
+
+      def view_template
+        Card(
+          class: 'p-10 text-center rounded-[2.5rem] border border-dashed border-border ' \
+                 'bg-surface-container-lowest'
+        ) do
+          div(
+            class: 'w-16 h-16 rounded-full bg-surface-container-low flex items-center justify-center ' \
+                   'text-muted-foreground mx-auto mb-5'
+          ) do
+            render_icon
+          end
+          Heading(level: 2, size: '5', class: 'font-bold tracking-tight mb-2') { title }
+          Text(size: '3', class: 'text-muted-foreground max-w-md mx-auto') { description }
+        end
+      end
+
+      private
+
+      def render_icon
+        case icon
+        when :search
+          render Icons::Search.new(size: 28)
+        else
+          render Icons::Pill.new(size: 28)
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -480,6 +480,8 @@ en:
       your_inventory: "Your Inventory"
       title: "Medications"
       add_medication: "Add Medication"
+      empty_title: "No medications yet"
+      empty_description: "Add your first medication to start tracking inventory and dosage."
       all: "All"
       view: "View"
       inventory_level: "Inventory Level"

--- a/spec/components/medications/dose_history_component_spec.rb
+++ b/spec/components/medications/dose_history_component_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::DoseHistoryComponent, type: :component do
+  let(:medication) { create(:medication) }
+
+  it 'renders dosage rows in ascending amount order' do
+    create(:dosage, medication: medication, amount: 10, unit: 'ml', frequency: 'Twice daily')
+    create(:dosage, medication: medication, amount: 5, unit: 'ml', frequency: 'Once daily')
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('Dosages')
+    expect(rendered.text.index('5.0 ml')).to be < rendered.text.index('10.0 ml')
+    expect(rendered.text).to include('Once daily')
+    expect(rendered.text).to include('Twice daily')
+  end
+
+  it 'renders the empty state when there are no dosages' do
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('No dosages')
+  end
+end

--- a/spec/components/medications/index_view_spec.rb
+++ b/spec/components/medications/index_view_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::IndexView, type: :component do
+  fixtures :accounts, :people, :users
+
+  def render_view(**args)
+    view_context_helper = view_context
+    policy_stub = Struct.new(:create?, :update?).new(true, true)
+    admin = users(:admin)
+
+    view_context_helper.singleton_class.define_method(:policy) { |_record| policy_stub }
+    view_context_helper.singleton_class.define_method(:current_user) { admin }
+    view_context_helper.singleton_class.define_method(:pundit_user) { admin }
+
+    html = view_context_helper.render(described_class.new(**args))
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  it 'renders the empty state when there are no medications' do
+    rendered = render_view(medications: [])
+
+    expect(rendered.text).to include('No medications yet')
+    expect(rendered.text).to include('Add Medication')
+  end
+end

--- a/spec/components/medications/list_item_component_spec.rb
+++ b/spec/components/medications/list_item_component_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::ListItemComponent, type: :component do
+  let(:medication) do
+    create(:medication,
+           name: 'Paracetamol',
+           description: 'Pain relief',
+           current_supply: 50,
+           reorder_threshold: 10)
+  end
+
+  it 'renders the medication details and primary actions' do
+    rendered = render_inline(described_class.new(
+                               medication: medication,
+                               inventory_query_params: { category: 'Vitamin' },
+                               can_manage: true
+                             ))
+
+    expect(rendered.text).to include('Paracetamol')
+    expect(rendered.text).to include('Pain relief')
+    expect(rendered.text).to include('Inventory Level')
+    expect(rendered.text).to include('50 units')
+    expect(rendered.css("a[href='/medications/#{medication.id}']")).to be_present
+  end
+
+  it 'omits the refill action when the medication cannot be managed' do
+    rendered = render_inline(described_class.new(
+                               medication: medication,
+                               inventory_query_params: {},
+                               can_manage: false
+                             ))
+
+    expect(rendered.text).not_to include('Refill Inventory')
+  end
+end

--- a/spec/components/medications/search_component_spec.rb
+++ b/spec/components/medications/search_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::SearchComponent, type: :component do
+  let(:home) { create(:location, name: 'Search Home') }
+  let(:school) { create(:location, name: 'Search School') }
+
+  it 'renders category and location filters with the current selections' do
+    rendered = render_inline(described_class.new(
+                               current_category: 'Vitamin',
+                               categories: %w[Analgesic Vitamin],
+                               locations: [home, school],
+                               current_location_id: school.id
+                             ))
+
+    expect(rendered.css("input[type='radio'][name='category'][value='Vitamin'][checked]")).to be_present
+    expect(rendered.css("input[type='radio'][name='location_id'][value='#{school.id}'][checked]")).to be_present
+    expect(rendered.text).to include('Category')
+    expect(rendered.text).to include('Location')
+  end
+
+  it 'does not render anything when no filters are available' do
+    rendered = render_inline(described_class.new(categories: [], locations: []))
+
+    expect(rendered.text.strip).to eq('')
+  end
+end

--- a/spec/components/medications/standard_dosage_component_spec.rb
+++ b/spec/components/medications/standard_dosage_component_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::StandardDosageComponent, type: :component do
+  it 'renders the medication standard dosage and reorder threshold' do
+    medication = create(:medication, dosage_amount: 500, dosage_unit: 'mg', reorder_threshold: 10)
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('Dose')
+    expect(rendered.text).to include('500')
+    expect(rendered.text).to include('mg')
+    expect(rendered.text).to include('Reorder At')
+    expect(rendered.text).to include('10 units')
+  end
+
+  it 'renders the empty dosage copy when dosage is not specified' do
+    medication = create(:medication, dosage_amount: nil, dosage_unit: nil)
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('No standard dosage specified.')
+  end
+end

--- a/spec/components/medications/warnings_component_spec.rb
+++ b/spec/components/medications/warnings_component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::WarningsComponent, type: :component do
+  it 'renders safety warnings when present' do
+    medication = create(:medication, warnings: 'Take with food')
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('Safety Warnings')
+    expect(rendered.text).to include('Take with food')
+  end
+end

--- a/spec/components/shared/empty_state_spec.rb
+++ b/spec/components/shared/empty_state_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Shared::EmptyState, type: :component do
+  it 'renders the title and description' do
+    rendered = render_inline(described_class.new(
+                               title: 'No medications yet',
+                               description: 'Add your first medication to get started.'
+                             ))
+
+    expect(rendered.text).to include('No medications yet')
+    expect(rendered.text).to include('Add your first medication to get started.')
+  end
+end


### PR DESCRIPTION
## Summary
- extract medication view renderer components from `ShowView` and `IndexView`
- add focused component specs for the new renderer seams and a reusable shared empty state
- keep the top-level medication views as composition roots with behavior preserved

## Changes
- extract `WarningsComponent`, `DoseHistoryComponent`, and `StandardDosageComponent` from the medication show flow
- extract `SearchComponent` and `ListItemComponent` from the medications index flow
- add `Components::Shared::EmptyState` and use it for the medications index empty branch
- add localized empty-state copy for the medications index

## Verification
- `task rubocop`
- `task test`

Refs #1049
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
