### PR TITLE
refactor: add medication domain objects

### DIFF
--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -51,13 +51,15 @@ module Components
       private
 
       def render_status_badge
+        supply_level = medication.supply_level
+
         if medication.reorder_ordered?
           Badge(variant: :default) { t('medications.reorder_statuses.ordered') }
         elsif medication.reorder_received?
           Badge(variant: :success) { t('medications.reorder_statuses.received') }
-        elsif medication.out_of_stock?
+        elsif supply_level.out_of_stock?
           Badge(variant: :destructive) { t('dashboard.statuses.out_of_stock') }
-        elsif medication.low_stock?
+        elsif supply_level.low_stock?
           Badge(variant: :warning) { t('medications.show.low_stock_alert') }
         else
           Badge(variant: :success) { t('medications.index.in_stock', default: 'In Stock') }
@@ -65,8 +67,8 @@ module Components
       end
 
       def render_supply_bar
-        percentage = medication.supply_percentage
-        bar_color = medication.low_stock? ? 'bg-destructive' : 'bg-primary'
+        supply_level = medication.supply_level
+        bar_color = supply_level.low_stock? ? 'bg-destructive' : 'bg-primary'
 
         div(class: 'space-y-2') do
           div(
@@ -74,10 +76,11 @@ module Components
                    'tracking-widest text-muted-foreground'
           ) do
             span { t('medications.index.inventory_level') }
-            span { pluralize(medication.current_supply, 'unit') }
+            span { pluralize(supply_level.current, 'unit') }
           end
           div(class: 'h-1.5 w-full bg-surface-container-low rounded-full overflow-hidden') do
-            div(class: "h-full #{bar_color} rounded-full transition-all duration-1000", style: "width: #{percentage}%")
+            div(class: "h-full #{bar_color} rounded-full transition-all duration-1000",
+                style: "width: #{supply_level.percentage}%")
           end
         end
       end

--- a/app/components/medications/supply_status_card.rb
+++ b/app/components/medications/supply_status_card.rb
@@ -16,29 +16,28 @@ module Components
         Card(class: 'p-8 space-y-6 overflow-hidden relative') do
           Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.inventory_status') }
 
-          current = medication.current_supply || 0
-          percentage = medication.supply_percentage
+          supply_level = medication.supply_level
 
           div(class: 'space-y-4') do
             div(class: 'flex items-baseline gap-2') do
-              stock_count_class = if medication.low_stock?
+              stock_count_class = if supply_level.low_stock?
                                     'text-5xl font-black text-on-error-container'
                                   else
                                     'text-5xl font-black text-primary'
                                   end
 
               span(class: stock_count_class) do
-                current.to_s
+                supply_level.current.to_s
               end
               Text(size: '2', weight: 'bold', class: 'text-muted-foreground') do
-                current == 1 ? 'unit remaining' : 'units remaining'
+                supply_level.current == 1 ? 'unit remaining' : 'units remaining'
               end
             end
 
             div(class: 'space-y-2') do
               div(class: 'h-2 w-full bg-surface-container-low rounded-full overflow-hidden') do
-                div(class: "h-full #{medication.low_stock? ? 'bg-error' : 'bg-primary'} rounded-full",
-                    style: "width: #{percentage}%")
+                div(class: "h-full #{supply_level.low_stock? ? 'bg-error' : 'bg-primary'} rounded-full",
+                    style: "width: #{supply_level.percentage}%")
               end
               div(
                 class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
@@ -49,7 +48,7 @@ module Components
               end
             end
 
-            if medication.low_stock?
+            if supply_level.low_stock?
               div(class: 'pt-2 space-y-2') do
                 Badge(variant: :destructive, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
                   t('medications.show.low_stock_alert')

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -8,18 +8,20 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def index
     @current_category = params[:category]
-    medications = policy_scope(Medication).includes(:location)
-    locations = accessible_inventory_locations(medications)
+    base_scope = policy_scope(Medication).includes(:location)
+    locations = accessible_inventory_locations(base_scope)
     @current_location_id = resolved_inventory_location_id(locations)
 
-    medications = medications.where(location_id: @current_location_id) if @current_location_id.present?
-    categories = medications.where.not(category: [nil, '']).distinct.order(:category).pluck(:category)
-    medications = medications.where(category: @current_category) if @current_category.present?
+    medication_query = MedicationQuery.new(
+      scope: base_scope,
+      category: @current_category,
+      location_id: @current_location_id
+    )
 
     render Components::Medications::IndexView.new(
-      medications: medications,
+      medications: medication_query.call,
       current_category: @current_category,
-      categories: categories,
+      categories: medication_query.categories,
       locations: locations,
       current_location_id: @current_location_id,
       wizard_variant: current_user.wizard_variant

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -66,6 +66,8 @@ class Medication < ApplicationRecord # :nodoc:
   validates :supply_at_last_restock, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :reorder_threshold, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  delegate :low_stock?, :out_of_stock?, to: :supply_level
+
   def sync_dosages
     return unless persisted? && switched_to_single_dose_mode?
     return if schedules.exists?
@@ -99,23 +101,7 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   def supply_percentage
-    current = current_supply || 0
-    denominator = supply_at_last_restock || [reorder_threshold, 1].max
-    return 0 if denominator <= 0
-
-    [current.to_f / denominator * 100, 100].min.round
-  end
-
-  def low_stock?
-    return false if current_supply.nil?
-
-    current_supply <= reorder_threshold
-  end
-
-  def out_of_stock?
-    return false if current_supply.nil?
-
-    current_supply <= 0
+    supply_level.percentage
   end
 
   def estimated_daily_consumption
@@ -140,24 +126,15 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   def forecast_available?
-    current_supply.present? && estimated_daily_consumption.positive?
+    supply_level.forecast_available?(daily_consumption: estimated_daily_consumption)
   end
 
   def days_until_out_of_stock
-    return nil unless forecast_available?
-    return 0 if out_of_stock?
-
-    (current_supply.to_f / estimated_daily_consumption).ceil
+    supply_level.days_until_out_of_stock(daily_consumption: estimated_daily_consumption)
   end
 
   def days_until_low_stock
-    return nil unless forecast_available?
-    return 0 if low_stock?
-
-    surplus = current_supply - reorder_threshold
-    return 0 if surplus <= 0
-
-    (surplus.to_f / estimated_daily_consumption).ceil
+    supply_level.days_until_low_stock(daily_consumption: estimated_daily_consumption)
   end
 
   def default_dosage_for_person_type(person_type)
@@ -178,6 +155,14 @@ class Medication < ApplicationRecord # :nodoc:
   def low_stock_date
     days = days_until_low_stock
     days ? Time.zone.today + days.days : nil
+  end
+
+  def supply_level
+    SupplyLevel.new(
+      current: current_supply,
+      reorder_threshold: reorder_threshold,
+      last_restock: supply_at_last_restock
+    )
   end
 
   private

--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class SupplyLevel
+  attr_reader :raw_current, :reorder_threshold, :last_restock
+
+  def initialize(current:, reorder_threshold:, last_restock:)
+    @raw_current = current
+    @reorder_threshold = reorder_threshold.to_i
+    @last_restock = last_restock
+  end
+
+  def current
+    raw_current || 0
+  end
+
+  def tracked?
+    !raw_current.nil?
+  end
+
+  def percentage
+    denominator = last_restock || [reorder_threshold, 1].max
+    return 0 if denominator <= 0
+
+    [(current.to_f / denominator * 100), 100].min.round
+  end
+
+  def low_stock?
+    return false unless tracked?
+
+    current <= reorder_threshold
+  end
+
+  def out_of_stock?
+    return false unless tracked?
+
+    current <= 0
+  end
+
+  def days_until_low_stock(daily_consumption:)
+    return nil unless forecast_available?(daily_consumption:)
+    return 0 if low_stock?
+
+    surplus = current - reorder_threshold
+    return 0 if surplus <= 0
+
+    (surplus.to_f / daily_consumption).ceil
+  end
+
+  def days_until_out_of_stock(daily_consumption:)
+    return nil unless forecast_available?(daily_consumption:)
+    return 0 if out_of_stock?
+
+    (current.to_f / daily_consumption).ceil
+  end
+
+  def forecast_available?(daily_consumption:)
+    tracked? && daily_consumption.to_f.positive?
+  end
+end

--- a/app/services/medication_query.rb
+++ b/app/services/medication_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class MedicationQuery
+  attr_reader :scope, :category, :location_id
+
+  def initialize(scope:, category: nil, location_id: nil)
+    @scope = scope
+    @category = category.presence
+    @location_id = location_id.presence
+  end
+
+  def call
+    filtered_scope.order(:name)
+  end
+
+  def categories
+    location_filtered_scope.where.not(category: [nil, '']).distinct.order(:category).pluck(:category)
+  end
+
+  private
+
+  def filtered_scope
+    relation = location_filtered_scope
+    relation = relation.where(category: category) if category.present?
+    relation
+  end
+
+  def location_filtered_scope
+    return scope if location_id.blank?
+
+    scope.where(location_id: location_id)
+  end
+end

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,6 +16,8 @@ for timing and daily-dose safety, while preserving an auditable history.
 Domain logic is enforced on the server. UI forms and pages render server-sent
 HTML and use Turbo Streams for updates.
 
+Phlex components are composition roots and rendering units, not the home of core medication business rules. New UI code should consume server-side domain objects and query objects rather than re-implementing supply, filtering, or administration logic inline.
+
 ## Core domain entities
 
 - `Person`: demographic and care-capacity record for an individual

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,6 +2,8 @@
 
 This glossary defines MedTracker's core domain language so model names, UI copy, and business rules stay consistent.
 
+UI components and presenters must use these domain terms and consume server-side domain objects rather than inventing parallel terminology.
+
 ## Medication inventory terms
 
 ### Remaining Supply (`medications.current_supply`)
@@ -11,6 +13,7 @@ The number of dispensable units left **right now**.
 - Decrements by 1 each time a dose is recorded.
 - Drives low/out-of-stock logic.
 - Should be shown in patient/carer-facing quantity displays.
+- Prefer **Remaining Supply** or **units remaining** in new UI copy over generic **Stock** where the meaning is "what is left now".
 
 ### Supply at Last Restock (`medications.supply_at_last_restock`)
 
@@ -25,6 +28,36 @@ The value of `current_supply` immediately after the most recent restock.
 The level at or below which a medication is considered low stock.
 
 - `low_stock?` is true when `remaining_supply <= reorder_threshold`.
+
+## Medication administration terms
+
+### Medication
+
+The aggregate root for dosage options, supply attributes, and administration sources.
+
+- `Medication` remains the canonical term in code for this aggregate.
+- Do not introduce parallel model names for the same concept in this pass.
+
+### Schedule
+
+A time-based medication regimen tied to a person.
+
+- Schedules remain distinct from ad-hoc medications.
+- A `Schedule` is one source of medication administration.
+
+### PersonMedication
+
+An ad-hoc medication assignment outside the scheduled regimen flow.
+
+- `PersonMedication` remains distinct from `Schedule`.
+- It is the second source of medication administration.
+
+### MedicationTake
+
+The persisted dose record for a single administration event.
+
+- `MedicationTake` remains the canonical persistence term in this pass.
+- UI copy may use "dose" or "administration" where clearer for users, but code should not introduce a second model name.
 
 ## Usage guidance
 

--- a/spec/models/supply_level_spec.rb
+++ b/spec/models/supply_level_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SupplyLevel do
+  describe '#current' do
+    it 'returns zero when current supply is nil' do
+      supply_level = described_class.new(current: nil, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.current).to eq(0)
+    end
+  end
+
+  describe '#percentage' do
+    it 'uses supply at last restock as the denominator when present' do
+      supply_level = described_class.new(current: 40, reorder_threshold: 10, last_restock: 80)
+
+      expect(supply_level.percentage).to eq(50)
+    end
+
+    it 'falls back to reorder threshold when last restock is nil' do
+      supply_level = described_class.new(current: 40, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.percentage).to eq(100)
+    end
+
+    it 'caps percentage at 100' do
+      supply_level = described_class.new(current: 100, reorder_threshold: 10, last_restock: 80)
+
+      expect(supply_level.percentage).to eq(100)
+    end
+  end
+
+  describe '#low_stock?' do
+    it 'returns true when current supply meets the reorder threshold' do
+      supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level).to be_low_stock
+    end
+  end
+
+  describe '#out_of_stock?' do
+    it 'returns false when current supply is nil' do
+      supply_level = described_class.new(current: nil, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level).not_to be_out_of_stock
+    end
+  end
+
+  describe '#days_until_low_stock' do
+    it 'returns nil when daily consumption is not positive' do
+      supply_level = described_class.new(current: 50, reorder_threshold: 10, last_restock: 80)
+
+      expect(supply_level.days_until_low_stock(daily_consumption: 0)).to be_nil
+    end
+
+    it 'returns zero when already low stock' do
+      supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.days_until_low_stock(daily_consumption: 2)).to eq(0)
+    end
+  end
+
+  describe '#days_until_out_of_stock' do
+    it 'returns nil when current supply is nil' do
+      supply_level = described_class.new(current: nil, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.days_until_out_of_stock(daily_consumption: 2)).to be_nil
+    end
+
+    it 'rounds up fractional days remaining' do
+      supply_level = described_class.new(current: 5, reorder_threshold: 1, last_restock: 10)
+
+      expect(supply_level.days_until_out_of_stock(daily_consumption: 2)).to eq(3)
+    end
+  end
+end

--- a/spec/services/medication_query_spec.rb
+++ b/spec/services/medication_query_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationQuery do
+  fixtures :locations, :medications
+
+  let(:scope) { Medication.includes(:location) }
+
+  before do
+    Medication.create!(
+      name: 'School Only Medicine',
+      location: locations(:school),
+      category: 'Analgesic',
+      dosage_amount: 500,
+      dosage_unit: 'mg',
+      current_supply: 10,
+      reorder_threshold: 1
+    )
+  end
+
+  it 'returns all medications when no filters are provided' do
+    results = described_class.new(scope: scope).call
+
+    expect(results.map(&:name)).to include('Paracetamol', 'Vitamin D', 'School Only Medicine')
+  end
+
+  it 'filters by category' do
+    results = described_class.new(scope: scope, category: 'Vitamin').call
+
+    expect(results.map(&:name)).to contain_exactly('Vitamin C', 'Vitamin D')
+  end
+
+  it 'filters by location' do
+    results = described_class.new(scope: scope, location_id: locations(:school).id).call
+
+    expect(results.map(&:name)).to contain_exactly('School Only Medicine')
+  end
+
+  it 'combines category and location filters' do
+    school_vitamin = Medication.create!(
+      name: 'School Vitamin',
+      location: locations(:school),
+      category: 'Vitamin',
+      dosage_amount: 250,
+      dosage_unit: 'mg',
+      current_supply: 12,
+      reorder_threshold: 2
+    )
+
+    results = described_class.new(
+      scope: scope,
+      category: 'Vitamin',
+      location_id: locations(:school).id
+    ).call
+
+    expect(results).to contain_exactly(school_vitamin)
+  end
+
+  it 'returns categories for the filtered scope in sorted order' do
+    categories = described_class.new(scope: scope, location_id: locations(:school).id).categories
+
+    expect(categories).to eq(%w[Analgesic])
+  end
+end


### PR DESCRIPTION
## Summary
- introduce medication-slice domain objects for supply state and inventory filtering
- move medication index query composition out of the controller and into a dedicated query object
- align glossary and architecture docs so medication UI code consumes domain objects instead of re-implementing supply logic

## Changes
- add `SupplyLevel` as the canonical value object for medication inventory state
- add `MedicationQuery` for medication index filtering, category derivation, and ordering
- delegate medication supply calculations through `Medication#supply_level` while preserving the existing public model methods
- update medication supply renderers to consume `supply_level`
- document the medication vocabulary and the rule that Phlex renderers should consume domain/query objects

## Verification
- `task rubocop`
- `task test`

Refs #1033
Refs #1045
Refs #1046
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
