### PR TITLE
refactor: introduce dose constraints value object

### DIFF
--- a/app/domain/dose_timing_policy.rb
+++ b/app/domain/dose_timing_policy.rb
@@ -1,28 +1,25 @@
 # frozen_string_literal: true
 
 class DoseTimingPolicy
-  def initialize(takes:, max_daily_doses: nil, min_hours_between_doses: nil, dose_cycle: 'daily')
+  def initialize(takes:, dose_constraints:, dose_cycle: 'daily')
     @takes = takes
-    @max_daily_doses = max_daily_doses
-    @min_hours_between_doses = min_hours_between_doses
+    @dose_constraints = dose_constraints
     @cycle = DoseCycle.new(dose_cycle)
   end
 
-  def restrictions?
-    @max_daily_doses.present? || @min_hours_between_doses.present?
-  end
+  delegate :restrictions?, to: :@dose_constraints
 
   def can_take_at?(check_time = Time.current)
     return true unless restrictions?
 
-    !would_violate_restrictions?(check_time)
+    @dose_constraints.satisfied_by?(takes: @takes, check_time: check_time, cycle: @cycle)
   end
 
   def next_available_time
     return nil unless restrictions?
     return Time.current if can_take_at?
 
-    calculate_next_available_time
+    @dose_constraints.next_available_time(takes: @takes, cycle: @cycle, now: Time.current)
   end
 
   def time_until_next_dose
@@ -44,52 +41,4 @@ class DoseTimingPolicy
 
     hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
   end
-
-  private
-
-  def would_violate_restrictions?(check_time)
-    would_exceed_max_doses?(check_time) || would_violate_min_hours?(check_time)
-  end
-
-  def would_exceed_max_doses?(check_time)
-    return false if @max_daily_doses.blank?
-
-    range = cycle_range(check_time)
-    doses_in_cycle = @takes.count { |take| range.cover?(take.taken_at) }
-
-    doses_in_cycle >= @max_daily_doses
-  end
-
-  def would_violate_min_hours?(check_time)
-    return false if @min_hours_between_doses.blank?
-
-    last_take = @takes.select { |t| t.taken_at < check_time }.max_by(&:taken_at)
-    return false if last_take.blank?
-
-    hours_since_last = (check_time - last_take.taken_at) / 1.hour
-    hours_since_last < @min_hours_between_doses
-  end
-
-  def calculate_next_available_time
-    [next_time_from_min_hours, next_time_from_max_doses].compact.max
-  end
-
-  def next_time_from_min_hours
-    return nil if @min_hours_between_doses.blank?
-
-    last_take = @takes.max_by(&:taken_at)
-    return nil unless last_take
-
-    last_take.taken_at + @min_hours_between_doses.hours
-  end
-
-  def next_time_from_max_doses
-    return nil if @max_daily_doses.blank?
-    return nil unless would_exceed_max_doses?(Time.current)
-
-    next_cycle_reset_time(Time.current)
-  end
-
-  def cycle_range(time) = @cycle.range_for(time)
-  def next_cycle_reset_time(time) = @cycle.next_reset_time(time)
 end

--- a/app/models/concerns/timing_restrictions.rb
+++ b/app/models/concerns/timing_restrictions.rb
@@ -3,6 +3,15 @@
 module TimingRestrictions
   extend ActiveSupport::Concern
 
+  def dose_constraints
+    return @dose_constraints if defined?(@dose_constraints)
+
+    @dose_constraints = DoseConstraints.new(
+      max_daily_doses: max_daily_doses,
+      min_hours_between_doses: min_hours_between_doses
+    )
+  end
+
   def timing_policy
     return @timing_policy if defined?(@timing_policy)
 
@@ -14,20 +23,20 @@ module TimingRestrictions
             end
     @timing_policy = DoseTimingPolicy.new(
       takes: takes,
-      max_daily_doses: max_daily_doses,
-      min_hours_between_doses: min_hours_between_doses,
+      dose_constraints: dose_constraints,
       dose_cycle: cycle
     )
   end
 
   def reload(*)
     remove_instance_variable(:@timing_policy) if defined?(@timing_policy)
+    remove_instance_variable(:@dose_constraints) if defined?(@dose_constraints)
     super
   end
 
-  def timing_restrictions?
-    max_daily_doses.present? || min_hours_between_doses.present?
-  end
+  delegate :restrictions?, to: :dose_constraints, prefix: false
+
+  alias timing_restrictions? restrictions?
 
   def can_take_now?
     return true unless timing_restrictions?

--- a/app/models/dose_constraints.rb
+++ b/app/models/dose_constraints.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class DoseConstraints
+  attr_reader :max_daily_doses, :min_hours_between_doses
+
+  def initialize(max_daily_doses:, min_hours_between_doses:)
+    @max_daily_doses = normalize(max_daily_doses)
+    @min_hours_between_doses = normalize(min_hours_between_doses)
+  end
+
+  def restrictions?
+    daily_limit? || interval_limit?
+  end
+
+  def daily_limit?
+    max_daily_doses.present?
+  end
+
+  def interval_limit?
+    min_hours_between_doses.present?
+  end
+
+  def would_exceed_daily_limit?(takes:, cycle:, check_time: Time.current)
+    return false unless daily_limit?
+
+    range = cycle.range_for(check_time)
+    doses_in_cycle = takes.count { |take| range.cover?(take.taken_at) }
+
+    doses_in_cycle >= max_daily_doses
+  end
+
+  def would_violate_interval?(takes:, check_time:)
+    return false unless interval_limit?
+
+    last_take = takes.select { |take| take.taken_at < check_time }.max_by(&:taken_at)
+    return false unless last_take
+
+    hours_since_last = (check_time - last_take.taken_at) / 1.hour
+    hours_since_last < min_hours_between_doses
+  end
+
+  def satisfied_by?(takes:, check_time:, cycle:)
+    return true unless restrictions?
+
+    !would_exceed_daily_limit?(takes: takes, cycle: cycle, check_time: check_time) &&
+      !would_violate_interval?(takes: takes, check_time: check_time)
+  end
+
+  def next_available_time(takes:, cycle:, now:)
+    return nil unless restrictions?
+    return now if satisfied_by?(takes: takes, check_time: now, cycle: cycle)
+
+    [
+      next_time_from_interval_limit(takes: takes),
+      next_time_from_daily_limit(takes: takes, cycle: cycle, now: now)
+    ].compact.max
+  end
+
+  private
+
+  def normalize(value)
+    value.presence
+  end
+
+  def next_time_from_interval_limit(takes:)
+    return nil unless interval_limit?
+
+    last_take = takes.max_by(&:taken_at)
+    return nil unless last_take
+
+    last_take.taken_at + min_hours_between_doses.hours
+  end
+
+  def next_time_from_daily_limit(takes:, cycle:, now:)
+    return nil unless daily_limit?
+    return nil unless would_exceed_daily_limit?(takes: takes, cycle: cycle, check_time: now)
+
+    cycle.next_reset_time(now)
+  end
+end

--- a/spec/domain/dose_timing_policy_spec.rb
+++ b/spec/domain/dose_timing_policy_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe DoseTimingPolicy do
   def policy(takes: [], max_daily_doses: nil, min_hours_between_doses: nil, dose_cycle: 'daily')
     described_class.new(
       takes: takes,
-      max_daily_doses: max_daily_doses,
-      min_hours_between_doses: min_hours_between_doses,
+      dose_constraints: DoseConstraints.new(
+        max_daily_doses: max_daily_doses,
+        min_hours_between_doses: min_hours_between_doses
+      ),
       dose_cycle: dose_cycle
     )
   end

--- a/spec/models/dose_constraints_spec.rb
+++ b/spec/models/dose_constraints_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DoseConstraints do
+  let(:now) { Time.current }
+  let(:daily_cycle) { DoseCycle.new('daily') }
+
+  def constraints(max_daily_doses: nil, min_hours_between_doses: nil)
+    described_class.new(
+      max_daily_doses: max_daily_doses,
+      min_hours_between_doses: min_hours_between_doses
+    )
+  end
+
+  def fake_take(taken_at:)
+    instance_double(MedicationTake, taken_at: taken_at)
+  end
+
+  describe '#restrictions?' do
+    it 'returns false when no restrictions are set' do
+      expect(constraints.restrictions?).to be false
+    end
+
+    it 'returns false when values are blank' do
+      expect(described_class.new(max_daily_doses: '', min_hours_between_doses: nil).restrictions?).to be false
+    end
+
+    it 'returns true when the daily limit is present' do
+      expect(constraints(max_daily_doses: 2).restrictions?).to be true
+    end
+
+    it 'returns true when the interval limit is present' do
+      expect(constraints(min_hours_between_doses: 4).restrictions?).to be true
+    end
+  end
+
+  describe '#daily_limit?' do
+    it 'returns true when max_daily_doses is present' do
+      expect(constraints(max_daily_doses: 2).daily_limit?).to be true
+    end
+
+    it 'returns false when max_daily_doses is blank' do
+      expect(described_class.new(max_daily_doses: '', min_hours_between_doses: nil).daily_limit?).to be false
+    end
+  end
+
+  describe '#interval_limit?' do
+    it 'returns true when min_hours_between_doses is present' do
+      expect(constraints(min_hours_between_doses: 4).interval_limit?).to be true
+    end
+
+    it 'returns false when min_hours_between_doses is blank' do
+      expect(described_class.new(max_daily_doses: nil, min_hours_between_doses: '').interval_limit?).to be false
+    end
+  end
+
+  describe '#would_exceed_daily_limit?' do
+    it 'returns false when there is no daily limit' do
+      expect(constraints.would_exceed_daily_limit?(takes: [], cycle: daily_cycle)).to be false
+    end
+
+    it 'returns true when doses in cycle meet the daily limit' do
+      take = fake_take(taken_at: now.beginning_of_day + 2.hours)
+
+      expect(constraints(max_daily_doses: 1).would_exceed_daily_limit?(takes: [take], cycle: daily_cycle)).to be true
+    end
+
+    it 'ignores doses outside the current cycle' do
+      yesterday_take = fake_take(taken_at: 1.day.ago.beginning_of_day + 2.hours)
+
+      expect(
+        constraints(max_daily_doses: 1).would_exceed_daily_limit?(takes: [yesterday_take], cycle: daily_cycle)
+      ).to be false
+    end
+  end
+
+  describe '#would_violate_interval?' do
+    it 'returns false when there is no interval limit' do
+      expect(constraints.would_violate_interval?(takes: [], check_time: now)).to be false
+    end
+
+    it 'returns true when the latest prior take is inside the interval window' do
+      take = fake_take(taken_at: 2.hours.ago)
+
+      expect(constraints(min_hours_between_doses: 4).would_violate_interval?(takes: [take], check_time: now)).to be true
+    end
+
+    it 'returns false when the latest prior take is outside the interval window' do
+      take = fake_take(taken_at: 5.hours.ago)
+
+      expect(
+        constraints(min_hours_between_doses: 4).would_violate_interval?(takes: [take], check_time: now)
+      ).to be false
+    end
+
+    it 'ignores takes after the check time' do
+      take = fake_take(taken_at: 30.minutes.from_now)
+
+      expect(
+        constraints(min_hours_between_doses: 4).would_violate_interval?(takes: [take], check_time: now)
+      ).to be false
+    end
+  end
+
+  describe '#satisfied_by?' do
+    it 'returns true when there are no constraints' do
+      expect(constraints.satisfied_by?(takes: [], check_time: now, cycle: daily_cycle)).to be true
+    end
+
+    it 'returns false when the daily limit would be exceeded' do
+      take = fake_take(taken_at: now.beginning_of_day + 1.hour)
+
+      expect(
+        constraints(max_daily_doses: 1).satisfied_by?(takes: [take], check_time: now, cycle: daily_cycle)
+      ).to be false
+    end
+
+    it 'returns false when the interval limit would be violated' do
+      take = fake_take(taken_at: 2.hours.ago)
+
+      expect(
+        constraints(min_hours_between_doses: 4).satisfied_by?(takes: [take], check_time: now, cycle: daily_cycle)
+      ).to be false
+    end
+
+    it 'returns true when both constraints are satisfied' do
+      take = fake_take(taken_at: 5.hours.ago)
+
+      expect(
+        constraints(max_daily_doses: 2, min_hours_between_doses: 4).satisfied_by?(
+          takes: [take],
+          check_time: now,
+          cycle: daily_cycle
+        )
+      ).to be true
+    end
+  end
+
+  describe '#next_available_time' do
+    it 'returns nil when there are no constraints' do
+      expect(constraints.next_available_time(takes: [], cycle: daily_cycle, now: now)).to be_nil
+    end
+
+    it 'returns now when constrained but currently satisfied' do
+      expect(
+        constraints(max_daily_doses: 3).next_available_time(takes: [], cycle: daily_cycle, now: now)
+      ).to be_within(1.second).of(now)
+    end
+
+    it 'returns the next cycle reset when blocked by the daily limit' do
+      take = fake_take(taken_at: now.beginning_of_day + 8.hours)
+
+      expect(
+        constraints(max_daily_doses: 1).next_available_time(takes: [take], cycle: daily_cycle, now: now)
+      ).to be_within(1.second).of(now.end_of_day + 1.second)
+    end
+
+    it 'returns the interval expiry when blocked by the interval limit' do
+      take = fake_take(taken_at: 2.hours.ago)
+      expected = take.taken_at + 4.hours
+
+      expect(
+        constraints(min_hours_between_doses: 4).next_available_time(takes: [take], cycle: daily_cycle, now: now)
+      ).to be_within(1.second).of(expected)
+    end
+
+    it 'returns the later blocker when both constraints apply' do
+      take = fake_take(taken_at: now.beginning_of_day + 22.hours)
+      expected = take.taken_at + 4.hours
+
+      expect(
+        constraints(max_daily_doses: 1, min_hours_between_doses: 4).next_available_time(
+          takes: [take],
+          cycle: daily_cycle,
+          now: now
+        )
+      ).to be_within(1.second).of(expected)
+    end
+  end
+end

--- a/spec/models/person_medication_spec.rb
+++ b/spec/models/person_medication_spec.rb
@@ -3,6 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe PersonMedication do
+  describe '#dose_constraints' do
+    let(:person_medication) { create(:person_medication, max_daily_doses: 3, min_hours_between_doses: 4) }
+
+    it 'returns a value object built from the persisted timing fields' do
+      expect(person_medication.dose_constraints).to have_attributes(
+        max_daily_doses: 3,
+        min_hours_between_doses: 4
+      )
+    end
+  end
+
+  describe '#timing_restrictions?' do
+    it 'delegates to dose_constraints' do
+      person_medication = create(:person_medication, max_daily_doses: 1)
+
+      expect(person_medication.timing_restrictions?).to be true
+    end
+  end
+
   describe 'dose validations' do
     it 'requires a resolvable dose for new records' do
       medication = create(:medication, dosage_amount: nil, dosage_unit: nil)

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -5,6 +5,27 @@ require 'rails_helper'
 RSpec.describe Schedule do
   fixtures :accounts, :schedules, :people, :locations, :medications, :dosages
 
+  describe '#dose_constraints' do
+    let(:schedule) do
+      create(:schedule, max_daily_doses: 3, min_hours_between_doses: 4)
+    end
+
+    it 'returns a value object built from the persisted timing fields' do
+      expect(schedule.dose_constraints).to have_attributes(
+        max_daily_doses: 3,
+        min_hours_between_doses: 4
+      )
+    end
+  end
+
+  describe '#timing_restrictions?' do
+    it 'delegates to dose_constraints' do
+      schedule = create(:schedule, max_daily_doses: 1)
+
+      expect(schedule.timing_restrictions?).to be true
+    end
+  end
+
   describe 'active flag' do
     let(:schedule) { schedules(:john_paracetamol) }
 


### PR DESCRIPTION
## Summary
- introduce `DoseConstraints` as the domain object for dose timing rules
- refactor `DoseTimingPolicy` to delegate timing evaluation to the new value object
- expose `dose_constraints` through `TimingRestrictions` and add focused model/domain specs

## Testing
- task rubocop
- task test

Refs #1034
Enables #1035
Leaves #1046 open due to remaining terminology drift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
