### PR TITLE
perf: ⚡ Bolt: Replace `.exists?` with `.any?` to leverage preloaded associations

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -70,7 +70,10 @@ class Medication < ApplicationRecord # :nodoc:
 
   def sync_dosages
     return unless persisted? && switched_to_single_dose_mode?
-    return if schedules.exists?
+
+    # ⚡ Bolt Optimization: Use `.any?` instead of `.exists?`
+    # This avoids a redundant COUNT/EXISTS query if `schedules` is already loaded in memory
+    return if schedules.any?
 
     # When switching to single-dose mode (dosage_amount is set),
     # remove all orphaned multi-dose records to prevent data pollution.
@@ -169,7 +172,10 @@ class Medication < ApplicationRecord # :nodoc:
 
   def single_dose_switch_requires_no_schedules
     return unless switching_to_single_dose_mode?
-    return unless schedules.exists?
+
+    # ⚡ Bolt Optimization: Use `.any?` instead of `.exists?`
+    # This avoids a redundant COUNT/EXISTS query if `schedules` is already loaded in memory
+    return unless schedules.any?
 
     errors.add(:dosage_amount,
                'cannot switch to a single standard dose while schedules still use dose options')

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -130,7 +130,9 @@ class Person < ApplicationRecord
 
   def active_carer_relationship?
     carer_relationships.any? { |r| r.active? || r.active.nil? } ||
-      active_carer_relationships.exists?
+      # ⚡ Bolt Optimization: Use `.any?` instead of `.exists?`
+      # This avoids a redundant query if `active_carer_relationships` is already loaded in memory
+      active_carer_relationships.any?
   end
 
   def must_have_at_least_one_location


### PR DESCRIPTION
### 💡 What
This optimization replaces `.exists?` with `.any?` when checking for the presence of records in ActiveRecord associations (`schedules` and `active_carer_relationships`).

### 🎯 Why
In ActiveRecord, calling `.exists?` will **always** trigger a new database query (e.g., `SELECT 1 ... LIMIT 1`), even if the association has already been fully loaded into memory during the request. By using `.any?`, ActiveRecord will first check if the array is already preloaded in memory, bypassing the database entirely if so. If it hasn't been loaded, it efficiently falls back to the same `EXISTS` SQL query.

### 📊 Impact
- Eliminates redundant database queries during model validations and state checks (e.g., `sync_dosages`, `single_dose_switch_requires_no_schedules`, `active_carer_relationship?`) when those associations have already been loaded in the current transaction or view cycle.
- Improves overall request latency by reducing DB roundtrips.

### 🔬 Measurement
To verify the improvement, inspect the Rails server logs or run a local benchmark during a person profile load or medication update. You should observe a reduction in `COUNT` or `EXISTS` queries for the targeted associations compared to the `main` branch.

---
*PR created automatically by Jules for task [14462858765550156511](https://jules.google.com/task/14462858765550156511) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
