### PR TITLE
refactor: extract person show query

### DIFF
--- a/app/controllers/concerns/person_viewable.rb
+++ b/app/controllers/concerns/person_viewable.rb
@@ -6,28 +6,13 @@ module PersonViewable
   private
 
   def person_show_view(person)
-    schedules = person.schedules.includes(:medication, :dosage)
-    person_medications = person.person_medications.includes(:medication).ordered
-    today_start = Time.current.beginning_of_day
-
-    takes_by_schedule = MedicationTake
-                        .where(schedule_id: schedules.map(&:id), taken_at: today_start..)
-                        .order(taken_at: :desc)
-                        .group_by(&:schedule_id)
-
-    takes_by_person_medication = MedicationTake
-                                 .where(person_medication_id: person_medications.map(&:id), taken_at: today_start..)
-                                 .order(taken_at: :desc)
-                                 .group_by(&:person_medication_id)
+    show_data = PersonShowQuery.new(person: person).call
 
     Components::People::ShowView.new(
       person: person,
-      schedules: schedules,
-      person_medications: person_medications,
-      preloaded_takes: {
-        schedules: takes_by_schedule,
-        person_medications: takes_by_person_medication
-      },
+      schedules: show_data.schedules,
+      person_medications: show_data.person_medications,
+      preloaded_takes: show_data.preloaded_takes,
       current_user: current_user
     )
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -13,35 +13,15 @@ class PeopleController < ApplicationController
 
   def show
     authorize @person
-    schedules = @person.schedules.includes(:medication, :dosage)
-    person_medications = @person.person_medications.includes(:medication).ordered
+    show_data = PersonShowQuery.new(person: @person).call
     editing = params[:editing] == 'true'
-
-    today_start = Time.current.beginning_of_day
-    schedule_ids = schedules.map(&:id)
-    person_medication_ids = person_medications.map(&:id)
-
-    takes_by_schedule = MedicationTake
-                        .where(schedule_id: schedule_ids, taken_at: today_start..)
-                        .includes(:taken_from_location, :taken_from_medication)
-                        .order(taken_at: :desc)
-                        .group_by(&:schedule_id)
-
-    takes_by_person_medication = MedicationTake
-                                 .where(person_medication_id: person_medication_ids, taken_at: today_start..)
-                                 .includes(:taken_from_location, :taken_from_medication)
-                                 .order(taken_at: :desc)
-                                 .group_by(&:person_medication_id)
 
     render Components::People::ShowView.new(
       person: @person,
-      schedules: schedules,
-      person_medications: person_medications,
+      schedules: show_data.schedules,
+      person_medications: show_data.person_medications,
       editing: editing,
-      preloaded_takes: {
-        schedules: takes_by_schedule,
-        person_medications: takes_by_person_medication
-      },
+      preloaded_takes: show_data.preloaded_takes,
       current_user: current_user
     )
   end

--- a/app/services/person_show_query.rb
+++ b/app/services/person_show_query.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class PersonShowQuery
+  Result = Data.define(:person, :schedules, :person_medications, :preloaded_takes)
+
+  attr_reader :person
+
+  def initialize(person:)
+    @person = person
+  end
+
+  def call
+    schedules = person.schedules.includes(:medication, :dosage)
+    person_medications = person.person_medications.includes(:medication).ordered
+
+    Result.new(
+      person: person,
+      schedules: schedules,
+      person_medications: person_medications,
+      preloaded_takes: {
+        schedules: takes_by_schedule(schedules),
+        person_medications: takes_by_person_medication(person_medications)
+      }
+    )
+  end
+
+  private
+
+  def takes_by_schedule(schedules)
+    MedicationTake
+      .where(schedule_id: schedules.map(&:id), taken_at: today_range)
+      .includes(:taken_from_location, :taken_from_medication)
+      .order(taken_at: :desc)
+      .group_by(&:schedule_id)
+  end
+
+  def takes_by_person_medication(person_medications)
+    MedicationTake
+      .where(person_medication_id: person_medications.map(&:id), taken_at: today_range)
+      .includes(:taken_from_location, :taken_from_medication)
+      .order(taken_at: :desc)
+      .group_by(&:person_medication_id)
+  end
+
+  def today_range
+    Time.current.all_day
+  end
+end

--- a/spec/services/person_show_query_spec.rb
+++ b/spec/services/person_show_query_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonShowQuery do
+  describe '#call' do
+    it 'returns the person show read model for one person with only today takes grouped by source' do
+      person = create(:person)
+      other_person = create(:person)
+      show_data = create_show_data_for(person: person, other_person: other_person)
+
+      result = described_class.new(person: person).call
+
+      expect(result.person).to eq(person)
+      expect(result.schedules).to contain_exactly(show_data[:schedule])
+      expect(result.person_medications).to contain_exactly(show_data[:person_medication])
+      expect(result.preloaded_takes[:schedules]).to eq(
+        show_data[:schedule].id => [show_data[:todays_schedule_take]]
+      )
+      expect(result.preloaded_takes[:person_medications]).to eq(
+        show_data[:person_medication].id => [show_data[:todays_person_medication_take]]
+      )
+    end
+  end
+
+  def create_show_data_for(person:, other_person:)
+    schedule = create(:schedule, person: person)
+    other_schedule = create(:schedule, person: other_person)
+    person_medication = create(:person_medication, person: person)
+    other_person_medication = create(:person_medication, person: other_person)
+
+    todays_schedule_take = create_schedule_takes(schedule: schedule, other_schedule: other_schedule)
+    todays_person_medication_take = create_person_medication_takes(
+      person_medication: person_medication,
+      other_person_medication: other_person_medication
+    )
+
+    {
+      schedule: schedule,
+      person_medication: person_medication,
+      todays_schedule_take: todays_schedule_take,
+      todays_person_medication_take: todays_person_medication_take
+    }
+  end
+
+  def create_schedule_takes(schedule:, other_schedule:)
+    todays_schedule_take = create(:medication_take, :for_schedule, :today, schedule: schedule)
+    create(:medication_take, :for_schedule, taken_at: 2.days.ago, schedule: schedule)
+    create(:medication_take, :for_schedule, :today, schedule: other_schedule)
+    todays_schedule_take
+  end
+
+  def create_person_medication_takes(person_medication:, other_person_medication:)
+    todays_person_medication_take = create(
+      :medication_take,
+      :for_person_medication,
+      :today,
+      person_medication: person_medication
+    )
+    create(:medication_take, :for_person_medication, taken_at: 2.days.ago, person_medication: person_medication)
+    create(:medication_take, :for_person_medication, :today, person_medication: other_person_medication)
+    todays_person_medication_take
+  end
+end


### PR DESCRIPTION
## Summary
- extract the person show-page read model into PersonShowQuery
- route PeopleController and PersonViewable through the shared query object
- add focused coverage for schedules, person medications, and grouped today's takes

## Testing
- task test TEST_FILE=spec/services/person_show_query_spec.rb
- task test TEST_FILE=spec/requests/people_show_actions_turbo_spec.rb
- task test TEST_FILE=spec/requests/person_medications_reorder_spec.rb
- task test TEST_FILE=spec/requests/people_spec.rb
- task rubocop
- task test

Refs #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
