### PR TITLE
refactor: extract medication timeline query

### DIFF
--- a/app/controllers/concerns/timeline_refreshable.rb
+++ b/app/controllers/concerns/timeline_refreshable.rb
@@ -45,29 +45,20 @@ module TimelineRefreshable
   end
 
   def other_timeline_streams(taken_source, medication)
+    related_sources = MedicationTimelineQuery.new(medication: medication, excluding: taken_source).call
     streams = []
 
-    other_schedules(taken_source, medication).each do |p|
+    related_sources.schedules.each do |p|
       stream = replace_timeline_item(p)
       streams << stream if stream
     end
 
-    other_pms(taken_source, medication).each do |pm|
+    related_sources.person_medications.each do |pm|
       stream = replace_timeline_item(pm)
       streams << stream if stream
     end
 
     streams
-  end
-
-  def other_schedules(taken_source, medication)
-    scope = Schedule.where(active: true).where(medication: medication).includes(:person, :medication, :dosage)
-    taken_source.is_a?(Schedule) ? scope.where.not(id: taken_source.id) : scope
-  end
-
-  def other_pms(taken_source, medication)
-    scope = PersonMedication.where(medication: medication).includes(:person, :medication)
-    taken_source.is_a?(PersonMedication) ? scope.where.not(id: taken_source.id) : scope
   end
 
   def replace_timeline_item(source)

--- a/app/services/medication_timeline_query.rb
+++ b/app/services/medication_timeline_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MedicationTimelineQuery
+  Result = Data.define(:schedules, :person_medications)
+
+  attr_reader :medication, :excluding
+
+  def initialize(medication:, excluding: nil)
+    @medication = medication
+    @excluding = excluding
+  end
+
+  def call
+    Result.new(
+      schedules: schedules,
+      person_medications: person_medications
+    )
+  end
+
+  private
+
+  def schedules
+    relation = Schedule.active.where(medication: medication).includes(:person, :medication, :dosage)
+    excluding.is_a?(Schedule) ? relation.where.not(id: excluding.id) : relation
+  end
+
+  def person_medications
+    relation = PersonMedication.where(medication: medication).includes(:person, :medication)
+    excluding.is_a?(PersonMedication) ? relation.where.not(id: excluding.id) : relation
+  end
+end

--- a/spec/services/medication_timeline_query_spec.rb
+++ b/spec/services/medication_timeline_query_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationTimelineQuery do
+  describe '#call' do
+    it 'returns related timeline sources for one medication and excludes the passed source' do
+      medication = create(:medication)
+      other_medication = create(:medication)
+      timeline_data = create_timeline_data_for(medication: medication, other_medication: other_medication)
+
+      result = described_class.new(medication: medication, excluding: timeline_data[:schedule]).call
+
+      expect(result.schedules).to contain_exactly(timeline_data[:other_schedule])
+      expect(result.person_medications).to contain_exactly(timeline_data[:person_medication])
+    end
+  end
+
+  def create_timeline_data_for(medication:, other_medication:)
+    schedule = create(:schedule, medication: medication)
+    other_schedule = create(:schedule, medication: medication)
+    create(:schedule, :expired, medication: medication)
+    create(:schedule, medication: other_medication)
+    person_medication = create(:person_medication, medication: medication)
+    create(:person_medication, medication: other_medication)
+
+    {
+      schedule: schedule,
+      other_schedule: other_schedule,
+      person_medication: person_medication
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- extract shared medication timeline source lookups into MedicationTimelineQuery
- remove Active Record query construction from TimelineRefreshable
- add focused query-object coverage and keep timeline refresh behavior unchanged

## Testing
- task test TEST_FILE=spec/services/medication_timeline_query_spec.rb
- task test TEST_FILE=spec/requests/timeline_refresh_spec.rb
- task rubocop
- task test

Refs #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
