### PR TITLE
refactor: extract schedule queries

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -14,14 +14,15 @@ class SchedulesController < ApplicationController
 
   def index
     authorize Schedule.new(person: schedule_index_person), :index?
-    schedules = policy_scope(Schedule).active.includes(:person, :medication, :dosage).order(:start_date, :id)
+    schedules = SchedulesIndexQuery.new(scope: policy_scope(Schedule)).call
     render Components::Schedules::IndexView.new(schedules: schedules)
   end
 
   def workflow
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
-    @people = policy_scope(Person).order(:name)
-    @medications = policy_scope(Medication).includes(:location).order(:name)
+    workflow_options = schedule_workflow_query.options
+    @people = workflow_options.people
+    @medications = workflow_options.medications
     @selected_person_id = params[:person_id]
     @selected_medication_id = params[:medication_id]
     @schedule_type = params[:schedule_type]
@@ -39,17 +40,16 @@ class SchedulesController < ApplicationController
 
   def start_workflow
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
-    people = policy_scope(Person)
-    medications = policy_scope(Medication)
-
-    person = people.find(params.require(:person_id))
-    medication = medications.find(params.require(:medication_id))
+    selection = schedule_workflow_query.selection(
+      person_id: params.require(:person_id),
+      medication_id: params.require(:medication_id)
+    )
     frequency = params[:frequency].to_s
     schedule_type = params[:schedule_type].to_s
 
     redirect_to new_person_schedule_path(
-      person,
-      medication_id: medication.id,
+      selection.person,
+      medication_id: selection.medication.id,
       frequency: frequency,
       schedule_type: schedule_type
     )
@@ -185,5 +185,12 @@ class SchedulesController < ApplicationController
   def set_person
     @person = policy_scope(Person).find(params[:person_id])
     authorize @person, :show?
+  end
+
+  def schedule_workflow_query
+    @schedule_workflow_query ||= ScheduleWorkflowQuery.new(
+      people_scope: policy_scope(Person),
+      medications_scope: policy_scope(Medication)
+    )
   end
 end

--- a/app/services/schedule_workflow_query.rb
+++ b/app/services/schedule_workflow_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ScheduleWorkflowQuery
+  Options = Data.define(:people, :medications)
+  Selection = Data.define(:person, :medication)
+
+  attr_reader :people_scope, :medications_scope
+
+  def initialize(people_scope:, medications_scope:)
+    @people_scope = people_scope
+    @medications_scope = medications_scope
+  end
+
+  def options
+    Options.new(
+      people: people_scope.order(:name),
+      medications: medications_scope.includes(:location).order(:name)
+    )
+  end
+
+  def selection(person_id:, medication_id:)
+    Selection.new(
+      person: people_scope.find(person_id),
+      medication: medications_scope.find(medication_id)
+    )
+  end
+end

--- a/app/services/schedules_index_query.rb
+++ b/app/services/schedules_index_query.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SchedulesIndexQuery
+  attr_reader :scope
+
+  def initialize(scope:)
+    @scope = scope
+  end
+
+  def call
+    scope.active.includes(:person, :medication, :dosage).order(:start_date, :id)
+  end
+end

--- a/spec/services/schedule_workflow_query_spec.rb
+++ b/spec/services/schedule_workflow_query_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScheduleWorkflowQuery do
+  describe '#options' do
+    it 'returns people and medications in name order' do
+      beta_person = create(:person, name: 'Beta Person')
+      alpha_person = create(:person, name: 'Alpha Person')
+      zeta_medication = create(:medication, name: 'Zeta Medication')
+      alpha_medication = create(:medication, name: 'Alpha Medication')
+
+      result = described_class.new(
+        people_scope: Person.where(id: [beta_person.id, alpha_person.id]),
+        medications_scope: Medication.where(id: [zeta_medication.id, alpha_medication.id])
+      ).options
+
+      expect(result.people.map(&:name)).to eq(['Alpha Person', 'Beta Person'])
+      expect(result.medications.map(&:name)).to eq(['Alpha Medication', 'Zeta Medication'])
+      expect(result.medications.first.association(:location)).to be_loaded
+    end
+  end
+
+  describe '#selection' do
+    it 'resolves the selected records from the provided scopes only' do
+      allowed_person = create(:person)
+      allowed_medication = create(:medication)
+      create(:person)
+      create(:medication)
+
+      result = described_class.new(
+        people_scope: Person.where(id: allowed_person.id),
+        medications_scope: Medication.where(id: allowed_medication.id)
+      ).selection(person_id: allowed_person.id, medication_id: allowed_medication.id)
+
+      expect(result.person).to eq(allowed_person)
+      expect(result.medication).to eq(allowed_medication)
+    end
+
+    it 'raises when the selected person is outside the provided scope' do
+      out_of_scope_person = create(:person)
+      medication = create(:medication)
+
+      query = described_class.new(
+        people_scope: Person.none,
+        medications_scope: Medication.where(id: medication.id)
+      )
+
+      expect do
+        query.selection(person_id: out_of_scope_person.id, medication_id: medication.id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises when the selected medication is outside the provided scope' do
+      person = create(:person)
+      out_of_scope_medication = create(:medication)
+
+      query = described_class.new(
+        people_scope: Person.where(id: person.id),
+        medications_scope: Medication.none
+      )
+
+      expect do
+        query.selection(person_id: person.id, medication_id: out_of_scope_medication.id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/services/schedules_index_query_spec.rb
+++ b/spec/services/schedules_index_query_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SchedulesIndexQuery do
+  describe '#call' do
+    it 'returns only active schedules ordered by start_date then id' do
+      later_schedule = create(:schedule, start_date: Date.new(2026, 4, 2))
+      first_same_day = create(:schedule, start_date: Date.new(2026, 4, 1))
+      second_same_day = create(:schedule, start_date: Date.new(2026, 4, 1))
+      expired_schedule = create(:schedule, :expired)
+      schedule_ids = [later_schedule.id, first_same_day.id, second_same_day.id]
+
+      result = described_class.new(scope: Schedule.where(id: schedule_ids)).call
+
+      expect(result).to eq([first_same_day, second_same_day, later_schedule])
+      expect(result.map(&:id)).not_to include(expired_schedule.id)
+      expect(result.first.association(:person)).to be_loaded
+      expect(result.first.association(:medication)).to be_loaded
+      expect(result.first.association(:dosage)).to be_loaded
+    end
+
+    it 'respects the passed scope boundary' do
+      included_schedule = create(:schedule)
+      create(:schedule)
+
+      result = described_class.new(scope: Schedule.where(id: included_schedule.id)).call
+
+      expect(result).to contain_exactly(included_schedule)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract workflow option and selection lookups into ScheduleWorkflowQuery
- extract the schedules index relation into SchedulesIndexQuery
- remove inline schedule query construction from SchedulesController while preserving behavior

## Testing
- task test TEST_FILE=spec/services/schedule_workflow_query_spec.rb
- task test TEST_FILE=spec/services/schedules_index_query_spec.rb
- task test TEST_FILE=spec/requests/schedules_workflow_spec.rb
- task test TEST_FILE=spec/requests/schedules_spec.rb
- task test TEST_FILE=spec/system/schedules/workflow_spec.rb
- task rubocop
- task test

Refs #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
