### PR TITLE
refactor: extract location queries

### DIFF
--- a/app/controllers/concerns/inventory_location_filterable.rb
+++ b/app/controllers/concerns/inventory_location_filterable.rb
@@ -6,11 +6,7 @@ module InventoryLocationFilterable
   private
 
   def accessible_inventory_locations(medications)
-    Location.joins(:medications)
-            .merge(medications.except(:includes))
-            .distinct
-            .order(:name)
-            .to_a
+    InventoryLocationsQuery.new(medications_scope: medications).call
   end
 
   def resolved_inventory_location_id(locations)

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -35,7 +35,7 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def new
     @medication = Medication.new
-    @medication.location_id ||= current_primary_location&.id
+    @medication.location_id ||= primary_location&.id
     authorize @medication
 
     render wizard_wrapper_class.new(
@@ -58,7 +58,7 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def create
     @medication = Medication.new(medication_params)
-    @medication.location_id ||= current_primary_location&.id
+    @medication.location_id ||= primary_location&.id
     authorize @medication
 
     if @medication.save
@@ -193,10 +193,8 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
     policy_scope(Location).order(:name)
   end
 
-  def current_primary_location
-    return nil unless current_user&.person
-
-    current_user.person.location_memberships.order(:id).first&.location
+  def primary_location
+    PrimaryLocationQuery.new(person: current_user&.person).call
   end
 
   def medication_params

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -30,7 +30,7 @@ class PeopleController < ApplicationController
     @person = Person.new
     authorize @person
     is_modal = request.headers['Turbo-Frame'] == 'modal'
-    assigned_location = current_primary_location
+    assigned_location = primary_location
 
     if is_modal
       render Components::People::Modal.new(person: @person, assigned_location: assigned_location), layout: false
@@ -55,7 +55,7 @@ class PeopleController < ApplicationController
   def create
     @person = Person.new(person_params)
     authorize @person
-    @person.primary_location = current_primary_location
+    @person.primary_location = primary_location
 
     if current_user.parent? || current_user.carer?
       @person.carer_relationships.build(
@@ -78,13 +78,13 @@ class PeopleController < ApplicationController
         end
       else
         format.html do
-          render Components::People::FormView.new(person: @person, assigned_location: current_primary_location),
+          render Components::People::FormView.new(person: @person, assigned_location: primary_location),
                  status: :unprocessable_content
         end
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace(
             'modal',
-            Components::People::Modal.new(person: @person, assigned_location: current_primary_location)
+            Components::People::Modal.new(person: @person, assigned_location: primary_location)
           ), status: :unprocessable_content
         end
       end
@@ -154,9 +154,7 @@ class PeopleController < ApplicationController
     params.expect(person: %i[name date_of_birth email person_type has_capacity])
   end
 
-  def current_primary_location
-    return nil unless current_user&.person
-
-    current_user.person.location_memberships.order(:id).first&.location
+  def primary_location
+    PrimaryLocationQuery.new(person: current_user&.person).call
   end
 end

--- a/app/services/inventory_locations_query.rb
+++ b/app/services/inventory_locations_query.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class InventoryLocationsQuery
+  attr_reader :medications_scope
+
+  def initialize(medications_scope:)
+    @medications_scope = medications_scope
+  end
+
+  def call
+    Location.joins(:medications)
+            .merge(medications_scope.except(:includes))
+            .distinct
+            .order(:name)
+            .to_a
+  end
+end

--- a/app/services/primary_location_query.rb
+++ b/app/services/primary_location_query.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PrimaryLocationQuery
+  attr_reader :person
+
+  def initialize(person:)
+    @person = person
+  end
+
+  def call
+    return nil unless person
+
+    person.location_memberships.order(:id).first&.location
+  end
+end

--- a/spec/services/inventory_locations_query_spec.rb
+++ b/spec/services/inventory_locations_query_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InventoryLocationsQuery do
+  describe '#call' do
+    it 'returns distinct locations for medications in the passed scope ordered by name' do
+      alpha_location = create(:location, name: 'Alpha')
+      beta_location = create(:location, name: 'Beta')
+      gamma_location = create(:location, name: 'Gamma')
+
+      first_alpha_medication = create(:medication, location: alpha_location)
+      second_alpha_medication = create(:medication, location: alpha_location)
+      beta_medication = create(:medication, location: beta_location)
+      create(:medication, location: gamma_location)
+      medication_ids = [beta_medication.id, second_alpha_medication.id, first_alpha_medication.id]
+
+      result = described_class.new(
+        medications_scope: Medication.where(id: medication_ids).includes(:location)
+      ).call
+
+      expect(result).to eq([alpha_location, beta_location])
+    end
+
+    it 'respects the passed medication scope boundary' do
+      included_location = create(:location)
+      excluded_location = create(:location)
+      included_medication = create(:medication, location: included_location)
+      create(:medication, location: excluded_location)
+
+      result = described_class.new(
+        medications_scope: Medication.where(id: included_medication.id)
+      ).call
+
+      expect(result).to contain_exactly(included_location)
+    end
+  end
+end

--- a/spec/services/primary_location_query_spec.rb
+++ b/spec/services/primary_location_query_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PrimaryLocationQuery do
+  describe '#call' do
+    it 'returns nil when person is nil' do
+      expect(described_class.new(person: nil).call).to be_nil
+    end
+
+    it 'returns nil when the person has no location memberships' do
+      person = create(:person)
+      person.location_memberships.delete_all
+
+      expect(described_class.new(person: person).call).to be_nil
+    end
+
+    it 'returns the location from the earliest membership by id' do
+      person = create(:person)
+      person.location_memberships.delete_all
+      first_location = create(:location, name: 'First')
+      second_location = create(:location, name: 'Second')
+
+      create(:location_membership, person: person, location: first_location)
+      create(:location_membership, person: person, location: second_location)
+
+      expect(described_class.new(person: person).call).to eq(first_location)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract inventory location filtering into a dedicated query object
- extract primary location lookup into a reusable query object
- remove duplicated controller and concern query logic while preserving behavior

## Testing
- task test TEST_FILE=spec/services/inventory_locations_query_spec.rb
- task test TEST_FILE=spec/services/primary_location_query_spec.rb
- task test TEST_FILE=spec/requests/medications_category_filter_spec.rb
- task test TEST_FILE=spec/requests/people_spec.rb
- task test TEST_FILE=spec/system/medications/new_medication_layout_spec.rb
- task rubocop
- task test

Refs #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
