### PR TITLE
refactor: extract controller query objects

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,7 +4,7 @@ class LocationsController < ApplicationController
   before_action :set_location, only: %i[show edit update destroy]
 
   def index
-    locations = policy_scope(Location).includes(:medications, :members, :location_memberships)
+    locations = locations_query.index
     render Components::Locations::IndexView.new(locations: locations)
   end
 
@@ -72,10 +72,14 @@ class LocationsController < ApplicationController
   private
 
   def set_location
-    @location = policy_scope(Location).includes(:medications, :members, :location_memberships).find(params[:id])
+    @location = locations_query.find(id: params[:id])
   end
 
   def location_params
     params.expect(location: %i[name description])
+  end
+
+  def locations_query
+    LocationsQuery.new(scope: policy_scope(Location))
   end
 end

--- a/app/controllers/medication_workflow_controller.rb
+++ b/app/controllers/medication_workflow_controller.rb
@@ -3,12 +3,18 @@
 class MedicationWorkflowController < ApplicationController
   def index
     authorize Person, :index?
-    # Preload user person and patients to avoid N+1 in policy checks
-    current_user.person&.patients&.load
-
-    people = policy_scope(Person).order(:name)
-    people = people.select { |person| policy(person).add_medication? }
+    people = medication_workflow_people_query.call
 
     render Components::MedicationWorkflow::PersonSelection.new(people: people, medication_id: params[:medication_id])
+  end
+
+  private
+
+  def medication_workflow_people_query
+    @medication_workflow_people_query ||= MedicationWorkflowPeopleQuery.new(
+      people_scope: policy_scope(Person),
+      preload_person: current_user&.person,
+      can_add_medication: ->(person) { policy(person).add_medication? }
+    )
   end
 end

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -12,8 +12,10 @@ class PersonMedicationsController < ApplicationController
   def new
     authorize PersonMedication
     @person_medication = @person.person_medications.build
-    @person_medication.medication_id = params[:medication_id] if medication_in_scope?(params[:medication_id])
-    @medications = available_medications
+    if medication_options_query.include?(params[:medication_id])
+      @person_medication.medication_id = params[:medication_id]
+    end
+    @medications = medication_options_query.call
 
     is_modal = request.headers['Turbo-Frame'] == 'modal'
     back_path = modal_back_path(@person)
@@ -34,7 +36,7 @@ class PersonMedicationsController < ApplicationController
 
   def edit
     authorize @person_medication
-    @medications = available_medications
+    @medications = medication_options_query.call
 
     is_modal = request.headers['Turbo-Frame'] == 'modal'
 
@@ -55,7 +57,7 @@ class PersonMedicationsController < ApplicationController
   def create
     @person_medication = @person.person_medications.build(person_medication_params)
     authorize @person_medication
-    @medications = available_medications
+    @medications = medication_options_query.call
 
     if explicit_dose_submitted? && @person_medication.save
       respond_to do |format|
@@ -82,7 +84,7 @@ class PersonMedicationsController < ApplicationController
 
   def update
     authorize @person_medication
-    @medications = available_medications
+    @medications = medication_options_query.call
 
     if @person_medication.update(person_medication_update_params)
       respond_to do |format|
@@ -179,12 +181,8 @@ class PersonMedicationsController < ApplicationController
     params.expect(person_medication: %i[dose_amount dose_unit notes max_daily_doses min_hours_between_doses dose_cycle])
   end
 
-  def available_medications
-    policy_scope(Medication).order(:name)
-  end
-
-  def medication_in_scope?(medication_id)
-    available_medications.exists?(id: medication_id)
+  def medication_options_query
+    @medication_options_query ||= MedicationOptionsQuery.new(scope: policy_scope(Medication))
   end
 
   def explicit_dose_submitted?

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -60,7 +60,7 @@ class SchedulesController < ApplicationController
     @schedule.medication_id = params[:medication_id] if params[:medication_id].present?
     @schedule.frequency = params[:frequency] if params[:frequency].present?
     authorize @schedule
-    @medications = policy_scope(Medication)
+    @medications = medication_options_query.call
     render_schedule_form(
       schedule: @schedule,
       medications: @medications,
@@ -71,7 +71,7 @@ class SchedulesController < ApplicationController
 
   def edit
     authorize @schedule
-    @medications = policy_scope(Medication)
+    @medications = medication_options_query.call
     render_schedule_form(
       schedule: @schedule,
       medications: @medications,
@@ -83,7 +83,7 @@ class SchedulesController < ApplicationController
   def create
     @schedule = @person.schedules.build(schedule_params)
     authorize @schedule
-    @medications = policy_scope(Medication)
+    @medications = medication_options_query.call
 
     if @schedule.save
       respond_to do |format|
@@ -99,6 +99,7 @@ class SchedulesController < ApplicationController
         end
       end
     else
+      @medications = medication_options_query.call
       render_schedule_form(
         schedule: @schedule,
         medications: @medications,
@@ -123,7 +124,7 @@ class SchedulesController < ApplicationController
         end
       end
     else
-      @medications = policy_scope(Medication)
+      @medications = medication_options_query.call
       render_schedule_form(
         schedule: @schedule,
         medications: @medications,
@@ -192,5 +193,9 @@ class SchedulesController < ApplicationController
       people_scope: policy_scope(Person),
       medications_scope: policy_scope(Medication)
     )
+  end
+
+  def medication_options_query
+    @medication_options_query ||= MedicationOptionsQuery.new(scope: policy_scope(Medication))
   end
 end

--- a/app/services/locations_query.rb
+++ b/app/services/locations_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class LocationsQuery
+  attr_reader :scope
+
+  def initialize(scope:)
+    @scope = scope
+  end
+
+  def index
+    scoped_locations
+  end
+
+  def find(id:)
+    scoped_locations.find(id)
+  end
+
+  private
+
+  def scoped_locations
+    scope.includes(:medications, :members, :location_memberships)
+  end
+end

--- a/app/services/medication_options_query.rb
+++ b/app/services/medication_options_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class MedicationOptionsQuery
+  attr_reader :scope
+
+  def initialize(scope:)
+    @scope = scope
+  end
+
+  def call
+    scope.order(:name)
+  end
+
+  def include?(medication_id)
+    return false if medication_id.blank?
+
+    call.exists?(id: medication_id)
+  end
+end

--- a/app/services/medication_workflow_people_query.rb
+++ b/app/services/medication_workflow_people_query.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MedicationWorkflowPeopleQuery
+  attr_reader :people_scope, :preload_person, :can_add_medication
+
+  def initialize(people_scope:, preload_person:, can_add_medication:)
+    @people_scope = people_scope
+    @preload_person = preload_person
+    @can_add_medication = can_add_medication
+  end
+
+  def call
+    preload_person&.patients&.load
+
+    people_scope.order(:name).select { |person| can_add_medication.call(person) }
+  end
+end

--- a/spec/requests/medication_workflow_spec.rb
+++ b/spec/requests/medication_workflow_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medication workflow' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :carer_relationships
+
+  let(:admin_user) { users(:admin) }
+  let(:adult_patient_user) { users(:adult_patient) }
+
+  describe 'GET /add_medication' do
+    it 'shows all addable people for an administrator' do
+      sign_in(admin_user)
+
+      get add_medication_path, params: { medication_id: medications(:paracetamol).id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(people(:john).name)
+      expect(response.body).to include(people(:adult_patient_person).name)
+    end
+
+    it 'shows only policy-allowed people for a patient user' do
+      sign_in(adult_patient_user)
+
+      get add_medication_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(people(:adult_patient_person).name)
+      expect(response.body).not_to include(people(:john).name)
+    end
+  end
+end

--- a/spec/services/locations_query_spec.rb
+++ b/spec/services/locations_query_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocationsQuery do
+  fixtures :locations
+
+  describe '#index' do
+    it 'returns only locations from the passed scope with the existing preloads' do
+      result = described_class.new(scope: Location.where(id: [locations(:home).id])).index
+
+      expect(result).to contain_exactly(locations(:home))
+      expect(result.first.association(:medications)).to be_loaded
+      expect(result.first.association(:members)).to be_loaded
+      expect(result.first.association(:location_memberships)).to be_loaded
+    end
+  end
+
+  describe '#find' do
+    it 'resolves records within the passed scope with the existing preloads' do
+      result = described_class.new(scope: Location.where(id: [locations(:home).id])).find(id: locations(:home).id)
+
+      expect(result).to eq(locations(:home))
+      expect(result.association(:medications)).to be_loaded
+      expect(result.association(:members)).to be_loaded
+      expect(result.association(:location_memberships)).to be_loaded
+    end
+
+    it 'raises when the id is outside the passed scope' do
+      query = described_class.new(scope: Location.where(id: [locations(:home).id]))
+
+      expect do
+        query.find(id: locations(:school).id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/services/medication_options_query_spec.rb
+++ b/spec/services/medication_options_query_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationOptionsQuery do
+  describe '#call' do
+    it 'returns medications in name order' do
+      zeta_medication = create(:medication, name: 'Zeta Medication')
+      alpha_medication = create(:medication, name: 'Alpha Medication')
+
+      result = described_class.new(
+        scope: Medication.where(id: [zeta_medication.id, alpha_medication.id])
+      ).call
+
+      expect(result.map(&:name)).to eq(['Alpha Medication', 'Zeta Medication'])
+    end
+
+    it 'respects the passed scope boundary' do
+      included_medication = create(:medication)
+      create(:medication)
+
+      result = described_class.new(scope: Medication.where(id: included_medication.id)).call
+
+      expect(result).to contain_exactly(included_medication)
+    end
+  end
+
+  describe '#include?' do
+    it 'returns true only for medication ids inside the passed scope' do
+      included_medication = create(:medication)
+      excluded_medication = create(:medication)
+
+      query = described_class.new(scope: Medication.where(id: included_medication.id))
+
+      expect(query).to include(included_medication.id)
+      expect(query).not_to include(excluded_medication.id)
+    end
+  end
+end

--- a/spec/services/medication_workflow_people_query_spec.rb
+++ b/spec/services/medication_workflow_people_query_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationWorkflowPeopleQuery do
+  describe '#call' do
+    it 'returns people in name order filtered by the injected predicate' do
+      beta_person = create(:person, name: 'Beta Person')
+      alpha_person = create(:person, name: 'Alpha Person')
+      gamma_person = create(:person, name: 'Gamma Person')
+
+      result = described_class.new(
+        people_scope: Person.where(id: [beta_person.id, alpha_person.id, gamma_person.id]),
+        preload_person: nil,
+        can_add_medication: ->(person) { person.name != 'Gamma Person' }
+      ).call
+
+      expect(result.map(&:name)).to eq(['Alpha Person', 'Beta Person'])
+    end
+
+    it 'respects the passed scope boundary' do
+      included_person = create(:person)
+      create(:person)
+
+      result = described_class.new(
+        people_scope: Person.where(id: included_person.id),
+        preload_person: nil,
+        can_add_medication: ->(_person) { true }
+      ).call
+
+      expect(result).to contain_exactly(included_person)
+    end
+
+    it 'preloads patients when a preload person is provided' do
+      patients = instance_double(ActiveRecord::Associations::CollectionProxy)
+      preload_person = instance_double(Person, patients: patients)
+
+      allow(patients).to receive(:load)
+
+      described_class.new(
+        people_scope: Person.none,
+        preload_person: preload_person,
+        can_add_medication: ->(_person) { true }
+      ).call
+
+      expect(patients).to have_received(:load)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract medication workflow people selection into a dedicated query object
- share medication option loading across person medication and schedule forms
- move location preload relations into a dedicated query object

## Testing
- task test TEST_FILE=spec/services/medication_workflow_people_query_spec.rb
- task test TEST_FILE=spec/services/medication_options_query_spec.rb
- task test TEST_FILE=spec/services/locations_query_spec.rb
- task test TEST_FILE=spec/requests/medication_workflow_spec.rb
- task test TEST_FILE=spec/requests/person_medications_policy_scope_spec.rb
- task test TEST_FILE=spec/requests/schedules_spec.rb
- task test TEST_FILE=spec/requests/schedules_workflow_spec.rb
- task test TEST_FILE=spec/requests/locations_spec.rb
- task test TEST_FILE=spec/system/schedules/workflow_spec.rb
- task test TEST_FILE=spec/requests/medications_schedule_discoverability_spec.rb
- task rubocop
- task test

Refs #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
