### PR TITLE
fix: refine medication dose editor

### DIFF
--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -75,17 +75,17 @@ module Components
         link_to path,
                 class: 'flex items-center gap-4 px-4 py-3 rounded-shape-full transition-all group no-underline ' \
                        "#{if is_active
-                            'bg-secondary-container text-on-secondary-container'
+                            'bg-sidebar-accent text-sidebar-accent-foreground shadow-sm'
                           else
                             'text-muted-foreground hover:text-foreground hover:bg-accent/60'
                           end}" do
           div(
             class: 'flex items-center justify-center ' \
-                   "#{is_active ? 'text-on-secondary-container' : 'group-hover:scale-110 transition-transform'}"
+                   "#{is_active ? 'text-sidebar-accent-foreground' : 'group-hover:scale-110 transition-transform'}"
           ) do
             render icon_class.new(size: 24)
           end
-          span(class: "hidden md:block font-bold text-sm #{'text-on-secondary-container' if is_active}") { label }
+          span(class: "hidden md:block font-bold text-sm #{'text-sidebar-accent-foreground' if is_active}") { label }
         end
       end
 

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -476,7 +476,7 @@ module Components
           id: "medication_dosage_records_attributes_#{index}_frequency",
           value: dosage.frequency,
           placeholder: 'Every morning',
-          required: true,
+          required: dosage_row_requires_input?(dosage),
           data: { 'frequency-suggestions-target': 'input' },
           **field_error_attributes(
             dosage,
@@ -549,7 +549,7 @@ module Components
             value: dosage.amount&.to_s,
             step: 'any',
             min: '0',
-            required: true,
+            required: dosage_row_requires_input?(dosage),
             **field_error_attributes(dosage, :amount, input_id: "medication_dosage_records_attributes_#{index}_amount")
           )
           render_field_error(dosage, :amount, input_id: "medication_dosage_records_attributes_#{index}_amount")
@@ -593,7 +593,7 @@ module Components
             id: "medication_dosage_records_attributes_#{index}_#{field}",
             value: config[:value]&.to_s,
             min: config.fetch(:min),
-            required: true,
+            required: dosage_row_requires_input?(dosage),
             data: { 'frequency-suggestions-target': config.fetch(:target) }
           }
           options[:step] = config[:step] if config[:step]
@@ -618,9 +618,10 @@ module Components
             name: dosage_field_name(index, 'default_dose_cycle'),
             id: "medication_dosage_records_attributes_#{index}_default_dose_cycle",
             class: 'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm',
-            required: true,
+            required: dosage_row_requires_input?(dosage),
             data: { 'frequency-suggestions-target': 'doseCycle' }
           ) do
+            option(value: '', selected: dosage.default_dose_cycle.blank?) { 'Select cycle' }
             MedicationDosage::DOSE_CYCLE_OPTIONS.each do |label, value|
               option(value: value, selected: dosage.default_dose_cycle == value) { label }
             end
@@ -648,6 +649,29 @@ module Components
 
       def dosage_field_name(index, field)
         "medication[dosage_records_attributes][#{index}][#{field}]"
+      end
+
+      def dosage_row_requires_input?(dosage)
+        return true if dosage.persisted? || dosage.errors.any?
+
+        dosage_row_values(dosage).any?(&:present?) || dosage_row_default_flags(dosage).any?
+      end
+
+      def dosage_row_values(dosage)
+        [
+          dosage.amount,
+          dosage.frequency,
+          dosage.description,
+          dosage.default_max_daily_doses,
+          dosage.default_min_hours_between_doses
+        ]
+      end
+
+      def dosage_row_default_flags(dosage)
+        [
+          dosage.default_for_adults?,
+          dosage.default_for_children?
+        ]
       end
 
       def render_current_supply_field

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -7,6 +7,22 @@ module Components
       include Phlex::Rails::Helpers::Pluralize
       include Wizard::FieldHelpers
 
+      FREQUENCY_TEMPLATES = [
+        { label: 'Every morning', frequency: 'Every morning', max_doses: '1', min_hours: '24', dose_cycle: 'daily' },
+        { label: 'Every evening', frequency: 'Every evening', max_doses: '1', min_hours: '24', dose_cycle: 'daily' },
+        { label: 'Twice daily', frequency: 'Twice daily', max_doses: '2', min_hours: '12', dose_cycle: 'daily' },
+        {
+          label: 'Three times daily',
+          frequency: 'Three times daily',
+          max_doses: '3',
+          min_hours: '8',
+          dose_cycle: 'daily'
+        },
+        { label: 'Every 4 hours', frequency: 'Every 4 hours', max_doses: '6', min_hours: '4', dose_cycle: 'daily' },
+        { label: 'Every 4-6 hours', frequency: 'Every 4-6 hours', max_doses: '6', min_hours: '4', dose_cycle: 'daily' },
+        { label: 'Once weekly', frequency: 'Once weekly', max_doses: '1', min_hours: '168', dose_cycle: 'weekly' }
+      ].freeze
+
       attr_reader :medication, :title, :subtitle, :locations, :return_to
 
       def initialize(medication:, title:, subtitle: nil, locations: [], return_to: nil)
@@ -350,7 +366,7 @@ module Components
       end
 
       def render_dosage_options_section
-        div(class: 'space-y-6') do
+        div(class: 'space-y-6', data: { controller: 'dosage-options' }) do
           Heading(level: 3, size: '4', class: 'font-bold text-foreground') { 'Dose Options' }
           Text(size: '2', class: 'text-muted-foreground') do
             'Manage all medication-owned dose options here. Schedules copy these values when they are created.'
@@ -372,94 +388,152 @@ module Components
       end
 
       def render_dosage_option_fields(dosage, index)
-        div(class: 'rounded-2xl border border-border bg-surface-container-low p-6 space-y-4') do
+        div(
+          class: 'rounded-3xl border border-border/70 bg-white p-6 shadow-sm space-y-4',
+          data: { 'dosage-options-target': 'option' }
+        ) do
           input(type: :hidden, name: dosage_field_name(index, 'id'), value: dosage.id) if dosage.persisted?
+          input(
+            type: :hidden,
+            name: dosage_field_name(index, '_destroy'),
+            value: '0',
+            data: { 'dosage-options-target': 'destroyField' }
+          )
 
-          div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-4') do
-            render_dosage_option_amount_field(dosage, index)
-            render_dosage_option_unit_field(dosage, index)
-          end
-
-          div(class: 'space-y-2', data: { controller: 'frequency-suggestions' }) do
-            render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_frequency") do
-              'Frequency label'
+          div(
+            class: 'space-y-4',
+            data: {
+              'dosage-options-target': 'editor',
+              controller: 'frequency-suggestions'
+            }
+          ) do
+            div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-4') do
+              render_dosage_option_amount_field(dosage, index)
+              render_dosage_option_unit_field(dosage, index)
             end
-            div(class: 'flex flex-nowrap overflow-x-auto gap-1.5 mt-1 mb-2 pb-0.5 -mx-0.5 px-0.5') do
-              Components::Dosages::Form::FREQUENCY_SUGGESTIONS.each do |suggestion|
-                button(
-                  type: 'button',
-                  data: {
-                    action: 'click->frequency-suggestions#suggest',
-                    suggestion: suggestion
-                  },
-                  class: 'inline-flex shrink-0 items-center rounded-full border border-border ' \
-                         'bg-surface-container-lowest px-2.5 py-0.5 text-xs font-medium ' \
-                         'text-muted-foreground shadow-sm whitespace-nowrap hover:bg-accent ' \
-                         'hover:border-border cursor-pointer transition-colors'
-                ) { suggestion }
+
+            div(class: 'space-y-2') { render_frequency_field(dosage, index) }
+
+            div(class: 'space-y-2') do
+              render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_description") do
+                'Description / notes'
               end
+              render RubyUI::Input.new(
+                type: :text,
+                name: dosage_field_name(index, 'description'),
+                id: "medication_dosage_records_attributes_#{index}_description",
+                value: dosage.description,
+                placeholder: 'Optional'
+              )
             end
-            render RubyUI::Input.new(
-              type: :text,
-              name: dosage_field_name(index, 'frequency'),
-              id: "medication_dosage_records_attributes_#{index}_frequency",
-              value: dosage.frequency,
-              placeholder: 'Once daily',
-              data: { 'frequency-suggestions-target': 'input' }
-            )
-          end
 
-          div(class: 'space-y-2') do
-            render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_description") do
-              'Description / notes'
+            div(class: 'grid grid-cols-1 sm:grid-cols-3 gap-4') do
+              render_dosage_default_number_field(
+                dosage: dosage,
+                index: index,
+                config: {
+                  field: 'default_max_daily_doses',
+                  label: 'Max doses / cycle',
+                  value: dosage.default_max_daily_doses,
+                  min: '1',
+                  target: 'maxDoses'
+                }
+              )
+              render_dosage_default_number_field(
+                dosage: dosage,
+                index: index,
+                config: {
+                  field: 'default_min_hours_between_doses',
+                  label: 'Min hours apart',
+                  value: dosage.default_min_hours_between_doses,
+                  min: '0',
+                  step: '0.5',
+                  target: 'minHours'
+                }
+              )
+              render_dosage_default_cycle_field(dosage, index)
             end
-            render RubyUI::Input.new(
-              type: :text,
-              name: dosage_field_name(index, 'description'),
-              id: "medication_dosage_records_attributes_#{index}_description",
-              value: dosage.description,
-              placeholder: 'Optional'
-            )
-          end
 
-          div(class: 'grid grid-cols-1 sm:grid-cols-3 gap-4') do
-            render_dosage_default_number_field(
-              index: index,
-              config: {
-                field: 'default_max_daily_doses',
-                label: 'Max doses / cycle',
-                value: dosage.default_max_daily_doses,
-                min: '1'
-              }
-            )
-            render_dosage_default_number_field(
-              index: index,
-              config: {
-                field: 'default_min_hours_between_doses',
-                label: 'Min hours apart',
-                value: dosage.default_min_hours_between_doses,
-                min: '0',
-                step: '0.5'
-              }
-            )
-            render_dosage_default_cycle_field(dosage, index)
-          end
-
-          div(class: 'flex flex-wrap items-center gap-6') do
-            render_dosage_default_checkbox(dosage, index, 'default_for_adults', 'Default for adults')
-            render_dosage_default_checkbox(dosage, index, 'default_for_children', 'Default for children / dependents')
-            if dosage.persisted?
-              label(class: 'flex items-center gap-2 text-sm cursor-pointer text-destructive') do
-                input(
-                  type: 'checkbox',
-                  name: dosage_field_name(index, '_destroy'),
-                  value: '1',
-                  class: 'rounded border-input'
-                )
-                span { 'Remove this dose option' }
-              end
+            div(class: 'flex flex-wrap items-center gap-6') do
+              render_dosage_default_checkbox(dosage, index, 'default_for_adults', 'Default for adults')
+              render_dosage_default_checkbox(dosage, index, 'default_for_children', 'Default for children / dependents')
+              render_remove_dosage_option_button
             end
           end
+
+          render_removed_dosage_option_state
+        end
+      end
+
+      def render_frequency_field(dosage, index)
+        render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_frequency") do
+          'Frequency label'
+        end
+        render_frequency_template_buttons
+        render RubyUI::Input.new(
+          type: :text,
+          name: dosage_field_name(index, 'frequency'),
+          id: "medication_dosage_records_attributes_#{index}_frequency",
+          value: dosage.frequency,
+          placeholder: 'Every morning',
+          required: true,
+          data: { 'frequency-suggestions-target': 'input' },
+          **field_error_attributes(
+            dosage,
+            :frequency,
+            input_id: "medication_dosage_records_attributes_#{index}_frequency"
+          )
+        )
+        render_field_error(
+          dosage,
+          :frequency,
+          input_id: "medication_dosage_records_attributes_#{index}_frequency"
+        )
+      end
+
+      def render_frequency_template_buttons
+        div(class: 'flex flex-nowrap overflow-x-auto gap-1.5 mt-1 mb-2 pb-0.5 -mx-0.5 px-0.5') do
+          FREQUENCY_TEMPLATES.each do |template|
+            button(
+              type: 'button',
+              data: {
+                action: 'click->frequency-suggestions#suggest',
+                frequency: template.fetch(:label),
+                'frequency-suggestions-frequency-value': template.fetch(:frequency),
+                'frequency-suggestions-max-doses-value': template.fetch(:max_doses),
+                'frequency-suggestions-min-hours-value': template.fetch(:min_hours),
+                'frequency-suggestions-dose-cycle-value': template.fetch(:dose_cycle)
+              },
+              class: 'inline-flex shrink-0 items-center rounded-full border border-border/80 ' \
+                     'bg-white px-3 py-1 text-xs font-semibold text-foreground/80 shadow-sm ' \
+                     'whitespace-nowrap hover:bg-primary/5 hover:border-primary/30 ' \
+                     'cursor-pointer transition-colors'
+            ) { template.fetch(:label) }
+          end
+        end
+      end
+
+      def render_remove_dosage_option_button
+        button(
+          type: 'button',
+          class: 'inline-flex items-center gap-2 text-sm font-semibold text-destructive ' \
+                 'hover:text-destructive/80',
+          data: { action: 'click->dosage-options#remove' }
+        ) { 'Remove dose option' }
+      end
+
+      def render_removed_dosage_option_state
+        div(
+          class: 'hidden items-center justify-between gap-4 rounded-2xl border border-dashed ' \
+                 'border-destructive/30 bg-destructive/5 px-4 py-3',
+          data: { 'dosage-options-target': 'removedState' }
+        ) do
+          Text(size: '2', class: 'font-medium text-foreground') { 'Dose option removed' }
+          button(
+            type: 'button',
+            class: 'inline-flex items-center gap-2 text-sm font-semibold text-foreground hover:text-primary',
+            data: { action: 'click->dosage-options#undo' }
+          ) { 'Undo' }
         end
       end
 
@@ -474,31 +548,40 @@ module Components
             id: "medication_dosage_records_attributes_#{index}_amount",
             value: dosage.amount&.to_s,
             step: 'any',
-            min: '0'
+            min: '0',
+            required: true,
+            **field_error_attributes(dosage, :amount, input_id: "medication_dosage_records_attributes_#{index}_amount")
           )
+          render_field_error(dosage, :amount, input_id: "medication_dosage_records_attributes_#{index}_amount")
         end
       end
 
-      def render_dosage_option_unit_field(dosage, index)
+      def render_dosage_option_unit_field(_dosage, index)
         div(class: 'space-y-2') do
-          render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_unit") do
+          render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_display_unit") do
             'Unit'
           end
-          render RubyUI::Input.new(
-            type: :text,
+          input(
+            type: :hidden,
             name: dosage_field_name(index, 'unit'),
             id: "medication_dosage_records_attributes_#{index}_unit",
-            value: dosage.unit,
-            placeholder: 'mg, tablet, ml…',
-            list: "medication_dosage_unit_list_#{index}"
+            value: medication.dosage_unit
           )
-          datalist(id: "medication_dosage_unit_list_#{index}") do
-            Medication::DOSAGE_UNITS.each { |unit| option(value: unit) }
+          render RubyUI::Input.new(
+            type: :text,
+            id: "medication_dosage_records_attributes_#{index}_display_unit",
+            value: medication.dosage_unit,
+            disabled: true,
+            readonly: true,
+            class: 'rounded-md border-border bg-muted/70 text-muted-foreground py-4 px-4'
+          )
+          Text(size: '1', class: 'text-muted-foreground') do
+            'Matches the main dose unit'
           end
         end
       end
 
-      def render_dosage_default_number_field(index:, config:)
+      def render_dosage_default_number_field(dosage:, index:, config:)
         field = config.fetch(:field)
         div(class: 'space-y-2') do
           render RubyUI::FormFieldLabel.new(for: "medication_dosage_records_attributes_#{index}_#{field}") do
@@ -509,10 +592,20 @@ module Components
             name: dosage_field_name(index, field),
             id: "medication_dosage_records_attributes_#{index}_#{field}",
             value: config[:value]&.to_s,
-            min: config.fetch(:min)
+            min: config.fetch(:min),
+            required: true,
+            data: { 'frequency-suggestions-target': config.fetch(:target) }
           }
           options[:step] = config[:step] if config[:step]
+          options.merge!(
+            field_error_attributes(
+              dosage,
+              field,
+              input_id: "medication_dosage_records_attributes_#{index}_#{field}"
+            )
+          )
           render RubyUI::Input.new(**options)
+          render_field_error(dosage, field, input_id: "medication_dosage_records_attributes_#{index}_#{field}")
         end
       end
 
@@ -524,13 +617,19 @@ module Components
           select(
             name: dosage_field_name(index, 'default_dose_cycle'),
             id: "medication_dosage_records_attributes_#{index}_default_dose_cycle",
-            class: 'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm'
+            class: 'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm',
+            required: true,
+            data: { 'frequency-suggestions-target': 'doseCycle' }
           ) do
-            option(value: '') { '— none —' }
             MedicationDosage::DOSE_CYCLE_OPTIONS.each do |label, value|
               option(value: value, selected: dosage.default_dose_cycle == value) { label }
             end
           end
+          render_field_error(
+            dosage,
+            :default_dose_cycle,
+            input_id: "medication_dosage_records_attributes_#{index}_default_dose_cycle"
+          )
         end
       end
 

--- a/app/components/person_medications/form_fields.rb
+++ b/app/components/person_medications/form_fields.rb
@@ -81,7 +81,7 @@ module Components
 
       def render_selection_summary(show_dose: false)
         div(class: selection_summary_layout_classes(show_dose)) do
-          div(class: 'rounded-2xl border border-border bg-surface-container-low px-4 py-3') do
+          div(class: 'rounded-2xl border border-border/60 bg-white px-4 py-3 shadow-sm') do
             Text(
               size: '1', weight: 'medium',
               class: 'uppercase tracking-[0.2em] text-muted-foreground'
@@ -93,7 +93,7 @@ module Components
           end
 
           if show_dose
-            div(class: 'rounded-2xl border border-border bg-surface-container-low px-4 py-3') do
+            div(class: 'rounded-2xl border border-border/60 bg-white px-4 py-3 shadow-sm') do
               Text(
                 size: '1', weight: 'medium',
                 class: 'uppercase tracking-[0.2em] text-muted-foreground'

--- a/app/components/person_medications/modal.rb
+++ b/app/components/person_medications/modal.rb
@@ -25,8 +25,11 @@ module Components
       def view_template
         turbo_frame_tag 'modal' do
           Dialog(open: true) do
-            DialogContent(size: dialog_size) do
-              DialogHeader do
+            DialogContent(
+              size: dialog_size,
+              class: 'overflow-hidden border-border/50 bg-white shadow-[0_32px_90px_rgba(15,23,42,0.18)]'
+            ) do
+              DialogHeader(class: 'bg-gradient-to-b from-[#fffaf1] to-white px-8 pt-8 pb-4') do
                 if back_path
                   a(
                     href: back_path,
@@ -40,7 +43,7 @@ module Components
                 DialogTitle { title }
                 DialogDescription { t('person_medications.modal.subtitle') }
               end
-              DialogMiddle do
+              DialogMiddle(class: 'bg-[#fffdf8] px-8 pb-8 pt-4') do
                 render_form
               end
             end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -250,7 +250,10 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
       amount: @medication.dosage_amount,
       unit: @medication.dosage_unit,
       frequency: 'As directed',
-      default_for_adults: true
+      default_for_adults: true,
+      default_max_daily_doses: 1,
+      default_min_hours_between_doses: 24,
+      default_dose_cycle: :daily
     )
   end
 

--- a/app/javascript/controllers/dosage_options_controller.js
+++ b/app/javascript/controllers/dosage_options_controller.js
@@ -30,13 +30,40 @@ export default class extends Controller {
     event.preventDefault()
     const option = event.target.closest('[data-dosage-options-target="option"]')
     if (option) {
-      const destroyField = option.querySelector('input[name*="_destroy"]')
-      if (destroyField) {
-        destroyField.value = '1'
-        option.style.display = 'none'
-      } else {
-        option.remove()
-      }
+      this.toggleOption(option, true)
     }
+  }
+
+  undo(event) {
+    event.preventDefault()
+    const option = event.target.closest('[data-dosage-options-target="option"]')
+    if (option) {
+      this.toggleOption(option, false)
+    }
+  }
+
+  toggleOption(option, removed) {
+    const destroyField = option.querySelector('[data-dosage-options-target="destroyField"]')
+    const editor = option.querySelector('[data-dosage-options-target="editor"]')
+    const removedState = option.querySelector('[data-dosage-options-target="removedState"]')
+
+    if (destroyField) destroyField.value = removed ? '1' : '0'
+
+    this.toggleEditorControls(editor, removed)
+
+    if (editor) editor.classList.toggle('hidden', removed)
+    if (removedState) {
+      removedState.classList.toggle('hidden', !removed)
+      removedState.classList.toggle('flex', removed)
+    }
+  }
+
+  toggleEditorControls(editor, disabled) {
+    if (!editor) return
+
+    editor.querySelectorAll('input, select, textarea, button').forEach((element) => {
+      if (element.dataset.action?.includes('dosage-options#remove')) return
+      element.disabled = disabled
+    })
   }
 }

--- a/app/javascript/controllers/frequency_suggestions_controller.js
+++ b/app/javascript/controllers/frequency_suggestions_controller.js
@@ -1,13 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input"]
+  static targets = ["input", "maxDoses", "minHours", "doseCycle"]
 
   suggest(event) {
     event.preventDefault()
+
+    const template = event.currentTarget.dataset
+
     if (this.hasInputTarget) {
-      this.inputTarget.value = event.currentTarget.dataset.suggestion
+      this.inputTarget.value = template.frequencySuggestionsFrequencyValue || template.suggestion || ''
       this.inputTarget.focus()
     }
+    if (this.hasMaxDosesTarget) this.maxDosesTarget.value = template.frequencySuggestionsMaxDosesValue || ''
+    if (this.hasMinHoursTarget) this.minHoursTarget.value = template.frequencySuggestionsMinHoursValue || ''
+    if (this.hasDoseCycleTarget) this.doseCycleTarget.value = template.frequencySuggestionsDoseCycleValue || ''
   }
 }

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -52,7 +52,7 @@ class Medication < ApplicationRecord # :nodoc:
   has_many :schedules, dependent: :destroy
   has_many :person_medications, dependent: :destroy
 
-  accepts_nested_attributes_for :dosage_records, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :dosage_records, allow_destroy: true, reject_if: :blank_dosage_record_attributes?
 
   validate :single_dose_switch_requires_no_schedules
   validate :nested_dosage_records_are_valid
@@ -193,6 +193,15 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   private
+
+  def blank_dosage_record_attributes?(attributes)
+    ignored_keys = %w[id _destroy unit default_dose_cycle]
+    meaningful_attributes = attributes.except(*ignored_keys)
+
+    meaningful_attributes.values.all? do |value|
+      value.blank? || value == '0'
+    end
+  end
 
   def single_dose_switch_requires_no_schedules
     return unless switching_to_single_dose_mode?

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -65,7 +65,6 @@ class Medication < ApplicationRecord # :nodoc:
   validates :category, inclusion: { in: CATEGORIES }, allow_blank: true
   validates :dosage_amount, numericality: { greater_than: 0 }, allow_nil: true
   validates :dosage_unit, inclusion: { in: DOSAGE_UNITS }, allow_blank: true
-  validates_associated :dosage_records
   validates :current_supply, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :supply_at_last_restock, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :reorder_threshold, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -55,6 +55,7 @@ class Medication < ApplicationRecord # :nodoc:
   accepts_nested_attributes_for :dosage_records, allow_destroy: true, reject_if: :all_blank
 
   validate :single_dose_switch_requires_no_schedules
+  validate :nested_dosage_records_are_valid
   after_commit :sync_dosages, on: :update
 
   enum :reorder_status, { requested: 0, ordered: 1, received: 2 }, prefix: :reorder
@@ -64,6 +65,7 @@ class Medication < ApplicationRecord # :nodoc:
   validates :category, inclusion: { in: CATEGORIES }, allow_blank: true
   validates :dosage_amount, numericality: { greater_than: 0 }, allow_nil: true
   validates :dosage_unit, inclusion: { in: DOSAGE_UNITS }, allow_blank: true
+  validates_associated :dosage_records
   validates :current_supply, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :supply_at_last_restock, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :reorder_threshold, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -217,5 +219,15 @@ class Medication < ApplicationRecord # :nodoc:
 
     previous_amount, new_amount = change
     previous_amount.blank? && new_amount.present?
+  end
+
+  def nested_dosage_records_are_valid
+    dosage_records.reject(&:marked_for_destruction?).each do |dosage_record|
+      next if dosage_record.valid?
+
+      dosage_record.errors.full_messages.each do |message|
+        errors.add(:base, message)
+      end
+    end
   end
 end

--- a/app/models/medication_dosage_option.rb
+++ b/app/models/medication_dosage_option.rb
@@ -5,6 +5,7 @@ class MedicationDosageOption < ApplicationRecord
 
   belongs_to :medication
 
+  before_validation :align_unit_with_medication
   after_create :sync_medication_dosage
 
   enum :default_dose_cycle, { daily: 0, weekly: 1, monthly: 2 }, prefix: :default
@@ -15,11 +16,14 @@ class MedicationDosageOption < ApplicationRecord
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :unit, presence: true
   validates :frequency, presence: true
+  validates :default_max_daily_doses, presence: true, numericality: { greater_than: 0 }
+  validates :default_min_hours_between_doses, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :default_dose_cycle, presence: true
 
   def to_value
     MedicationDosage.new(
       amount: amount,
-      unit: unit,
+      unit: medication&.dosage_unit.presence || unit,
       frequency: frequency,
       description: description,
       default_for_adults: default_for_adults,
@@ -32,8 +36,12 @@ class MedicationDosageOption < ApplicationRecord
 
   private
 
+  def align_unit_with_medication
+    self.unit = medication&.dosage_unit.presence || unit
+  end
+
   def sync_medication_dosage
-    stmt = 'UPDATE medications SET dosage_amount = NULL, dosage_unit = NULL WHERE id = $1'
+    stmt = 'UPDATE medications SET dosage_amount = NULL WHERE id = $1'
     binds = [
       ActiveRecord::Relation::QueryAttribute.new('id', medication_id, ActiveRecord::Type::BigInteger.new)
     ]

--- a/spec/components/layouts/sidebar_spec.rb
+++ b/spec/components/layouts/sidebar_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe Components::Layouts::Sidebar, type: :component do
   let(:admin_user) { users(:admin) }
   let(:carer_user) { users(:carer) }
 
-  def render_sidebar(user: nil)
+  def render_sidebar(user: nil, path: '/')
     vc = view_context
     vc.singleton_class.define_method(:current_user) { user }
-    # Mock current_page?
-    allow(vc).to receive(:current_page?).and_return(false)
+    allow(vc.request).to receive(:path).and_return(path)
 
     html = vc.render(described_class.new(current_user: user))
     Nokogiri::HTML::DocumentFragment.parse(html)
@@ -46,6 +45,16 @@ RSpec.describe Components::Layouts::Sidebar, type: :component do
     it 'renders the sign out button' do
       rendered = render_sidebar(user: admin_user)
       expect(rendered.text).to include('Sign Out')
+    end
+
+    it 'uses a readable active state for the highlighted link' do
+      inventory_path = Rails.application.routes.url_helpers.medications_path
+      rendered = render_sidebar(user: admin_user, path: inventory_path)
+      inventory_link = rendered.at_css(%(a[href="#{inventory_path}"]))
+
+      expect(inventory_link['class']).to include('bg-sidebar-accent')
+      expect(inventory_link['class']).to include('text-sidebar-accent-foreground')
+      expect(inventory_link['class']).not_to include('text-on-secondary-container')
     end
   end
 

--- a/spec/components/medications/dose_history_component_spec.rb
+++ b/spec/components/medications/dose_history_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Components::Medications::DoseHistoryComponent, type: :component do
-  let(:medication) { create(:medication) }
+  let(:medication) { create(:medication, dosage_unit: 'ml') }
 
   it 'renders dosage rows in ascending amount order' do
     create(:dosage, medication: medication, amount: 10, unit: 'ml', frequency: 'Twice daily')

--- a/spec/components/medications/form_view_spec.rb
+++ b/spec/components/medications/form_view_spec.rb
@@ -3,6 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Components::Medications::FormView, type: :component do
+  def build_dose_option(medication, persisted: false, **overrides)
+    attributes = {
+      amount: 5,
+      unit: 'ml',
+      frequency: 'Once daily',
+      default_max_daily_doses: 1,
+      default_min_hours_between_doses: 24,
+      default_dose_cycle: :daily
+    }.merge(overrides)
+
+    persisted ? medication.dosage_records.create!(attributes) : medication.dosage_records.build(attributes)
+  end
+
   describe 'i18n translations' do
     it 'renders form with default locale translations' do
       medication = Medication.new(name: 'Test Medication')
@@ -79,27 +92,98 @@ RSpec.describe Components::Medications::FormView, type: :component do
   describe 'dose options management' do
     it 'renders nested medication-owned dosage fields' do
       medication = build(:medication)
-      medication.dosage_records.build(amount: 5, unit: 'ml', frequency: 'Once daily')
+      build_dose_option(medication)
 
       rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
       html = rendered.to_html
 
-      expect(html).to include('Dose Options')
-      expect(html).to include('Manage all medication-owned dose options here.')
-      expect(html).to include('name="medication[dosage_records_attributes][0][amount]"')
-      expect(html).to include('name="medication[dosage_records_attributes][0][unit]"')
-      expect(html).to include('name="medication[dosage_records_attributes][0][frequency]"')
+      expect(html).to include(
+        'Dose Options',
+        'Manage all medication-owned dose options here.',
+        'name="medication[dosage_records_attributes][0][amount]"',
+        'name="medication[dosage_records_attributes][0][unit]"',
+        'name="medication[dosage_records_attributes][0][frequency]"',
+        'Matches the main dose unit'
+      )
     end
 
     it 'renders frequency suggestions for medication-owned dosage fields' do
       medication = build(:medication)
-      medication.dosage_records.build(amount: 5, unit: 'ml', frequency: 'Once daily')
+      build_dose_option(medication)
 
       rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
       html = rendered.to_html
 
       expect(html).to match(/data-controller="[^"]*frequency-suggestions[^"]*"/)
-      expect(html).to include('data-action="click-&gt;frequency-suggestions#suggest"')
+      expect(html).to include(
+        'data-action="click-&gt;frequency-suggestions#suggest"',
+        'Every morning',
+        'Every evening',
+        'Once weekly'
+      )
+      expect(html).not_to include('As needed (PRN)')
+    end
+
+    it 'renders structured frequency template payloads for the suggestion chips' do
+      medication = build(:medication)
+      build_dose_option(medication)
+
+      rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
+
+      morning_chip = rendered.at_css("button[data-frequency='Every morning']")
+      expect(morning_chip).not_to be_nil
+      expect(morning_chip['data-frequency-suggestions-frequency-value']).to eq('Every morning')
+      expect(morning_chip['data-frequency-suggestions-max-doses-value']).to eq('1')
+      expect(morning_chip['data-frequency-suggestions-min-hours-value']).to eq('24')
+      expect(morning_chip['data-frequency-suggestions-dose-cycle-value']).to eq('daily')
+    end
+
+    it 'marks timing defaults as required fields' do
+      medication = build(:medication)
+      build_dose_option(medication)
+
+      rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
+
+      max_doses = rendered.at_css("input[name='medication[dosage_records_attributes][0][default_max_daily_doses]']")
+      min_hours = rendered.at_css(
+        "input[name='medication[dosage_records_attributes][0][default_min_hours_between_doses]']"
+      )
+      dose_cycle = rendered.at_css("select[name='medication[dosage_records_attributes][0][default_dose_cycle]']")
+
+      expect(max_doses.attribute('required')).not_to be_nil
+      expect(min_hours.attribute('required')).not_to be_nil
+      expect(dose_cycle.attribute('required')).not_to be_nil
+    end
+
+    it 'renders destructive remove controls instead of a checkbox' do
+      medication = create(:medication)
+      build_dose_option(medication, persisted: true)
+
+      rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
+      html = rendered.to_html
+
+      expect(html).to include('Remove dose option')
+      expect(html).to include('Undo')
+      expect(rendered.css("button[data-action='click->dosage-options#remove']")).to be_present
+      expect(rendered.css("button[data-action='click->dosage-options#undo']")).to be_present
+      expect(
+        rendered.css("input[type='checkbox'][name='medication[dosage_records_attributes][0][_destroy]']")
+      ).to be_empty
+    end
+
+    it 'greys out dose option units and keeps them aligned with the main medication unit' do
+      medication = build(:medication, dosage_unit: 'ml')
+      build_dose_option(medication, amount: 2.5, unit: 'mg', frequency: 'Every morning')
+
+      rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
+
+      hidden_unit = rendered.at_css("input[type='hidden'][name='medication[dosage_records_attributes][0][unit]']")
+      display_unit = rendered.at_css('#medication_dosage_records_attributes_0_display_unit')
+
+      expect(hidden_unit['value']).to eq('ml')
+      expect(display_unit['value']).to eq('ml')
+      expect(display_unit['disabled']).to eq('disabled')
+      expect(display_unit['class']).to include('bg-muted/70')
     end
   end
 end

--- a/spec/components/medications/form_view_spec.rb
+++ b/spec/components/medications/form_view_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Components::Medications::FormView, type: :component do
     persisted ? medication.dosage_records.create!(attributes) : medication.dosage_records.build(attributes)
   end
 
+  def dosage_row_field(rendered, index, field, tag: 'input')
+    rendered.at_css("#{tag}[name='medication[dosage_records_attributes][#{index}][#{field}]']")
+  end
+
   describe 'i18n translations' do
     it 'renders form with default locale translations' do
       medication = Medication.new(name: 'Test Medication')
@@ -153,6 +157,25 @@ RSpec.describe Components::Medications::FormView, type: :component do
       expect(max_doses.attribute('required')).not_to be_nil
       expect(min_hours.attribute('required')).not_to be_nil
       expect(dose_cycle.attribute('required')).not_to be_nil
+    end
+
+    it 'does not mark the auto-appended blank row as required' do
+      medication = create(:medication, dosage_unit: 'ml')
+      build_dose_option(medication, persisted: true, amount: 2.5, frequency: 'Every morning')
+
+      rendered = render_inline(described_class.new(medication: medication, title: 'Test Title'))
+
+      blank_row_fields = [
+        dosage_row_field(rendered, 1, 'amount'),
+        dosage_row_field(rendered, 1, 'frequency'),
+        dosage_row_field(rendered, 1, 'default_max_daily_doses'),
+        dosage_row_field(rendered, 1, 'default_min_hours_between_doses'),
+        dosage_row_field(rendered, 1, 'default_dose_cycle', tag: 'select')
+      ]
+
+      blank_row_fields.each do |field|
+        expect(field.attribute('required')).to be_nil
+      end
     end
 
     it 'renders destructive remove controls instead of a checkbox' do

--- a/spec/components/person_medications/modal_spec.rb
+++ b/spec/components/person_medications/modal_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::PersonMedications::Modal, type: :component do
+  it 'renders a brighter modal shell for the medication workflow' do
+    person = create(:person, name: 'Damacus User')
+    medication = create(:medication, name: 'Calpol')
+    person_medication = build(:person_medication, person: person, medication: medication)
+
+    rendered = render_inline(
+      described_class.new(
+        person_medication: person_medication,
+        person: person,
+        medications: [medication]
+      )
+    )
+
+    html = rendered.to_html
+
+    expect(html).to include('bg-white')
+    expect(html).to include('border-border/50')
+    expect(html).to include('shadow-[0_32px_90px_rgba(15,23,42,0.18)]')
+  end
+end

--- a/spec/factories/dosages.rb
+++ b/spec/factories/dosages.rb
@@ -7,5 +7,8 @@ FactoryBot.define do
     unit { 'mg' }
     frequency { 'As needed' }
     description { 'Standard dose' }
+    default_max_daily_doses { 1 }
+    default_min_hours_between_doses { 24 }
+    default_dose_cycle { :daily }
   end
 end

--- a/spec/fixtures/dosages.yml
+++ b/spec/fixtures/dosages.yml
@@ -5,6 +5,9 @@ paracetamol_adult:
   unit: mg
   description: Standard adult dose
   frequency: As needed
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 4
+  default_dose_cycle: daily
   medication: paracetamol
 
 paracetamol_light:
@@ -12,6 +15,9 @@ paracetamol_light:
   unit: mg
   description: Light adult dose
   frequency: As needed
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 4
+  default_dose_cycle: daily
   medication: paracetamol
 
 # Ibuprofen dosages
@@ -20,6 +26,9 @@ ibuprofen_adult:
   unit: mg
   description: Standard adult dose
   frequency: Every 6-8 hours
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 6
+  default_dose_cycle: daily
   medication: ibuprofen
 
 ibuprofen_light:
@@ -27,6 +36,9 @@ ibuprofen_light:
   unit: mg
   description: Light adult dose
   frequency: Every 6-8 hours
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 6
+  default_dose_cycle: daily
   medication: ibuprofen
 
 # Aspirin dosages
@@ -35,6 +47,9 @@ aspirin_adult:
   unit: mg
   description: Standard adult dose
   frequency: Once daily
+  default_max_daily_doses: 1
+  default_min_hours_between_doses: 24
+  default_dose_cycle: daily
   medication: aspirin
 
 aspirin_light:
@@ -42,6 +57,9 @@ aspirin_light:
   unit: mg
   description: Low dose for heart health
   frequency: Once daily
+  default_max_daily_doses: 1
+  default_min_hours_between_doses: 24
+  default_dose_cycle: daily
   medication: aspirin
 
 vitamin_d_daily:
@@ -49,6 +67,9 @@ vitamin_d_daily:
   unit: IU
   description: Daily Vitamin D supplement
   frequency: Once daily
+  default_max_daily_doses: 1
+  default_min_hours_between_doses: 24
+  default_dose_cycle: daily
   medication: vitamin_d
 
 # Calpol dosages
@@ -57,6 +78,9 @@ calpol_child:
   unit: ml
   description: Standard child dose
   frequency: Every 4-6 hours
+  default_max_daily_doses: 6
+  default_min_hours_between_doses: 4
+  default_dose_cycle: daily
   medication: calpol
 
 calpol_infant:
@@ -64,6 +88,9 @@ calpol_infant:
   unit: ml
   description: Standard infant dose
   frequency: Every 4-6 hours
+  default_max_daily_doses: 6
+  default_min_hours_between_doses: 4
+  default_dose_cycle: daily
   medication: calpol
 
 # Child dosages for paracetamol
@@ -72,6 +99,9 @@ paracetamol_child:
   unit: mg
   description: Standard child dose (6-12 years)
   frequency: Every 4-6 hours
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 4
+  default_dose_cycle: daily
   medication: paracetamol
 
 # Child dosages for ibuprofen
@@ -80,4 +110,7 @@ ibuprofen_child:
   unit: mg
   description: Standard child dose (6-12 years)
   frequency: Every 6-8 hours
+  default_max_daily_doses: 4
+  default_min_hours_between_doses: 6
+  default_dose_cycle: daily
   medication: ibuprofen

--- a/spec/models/dosage_spec.rb
+++ b/spec/models/dosage_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe Dosage do
   describe '#sync_medication_dosage' do
     let(:medication) { create(:medication, dosage_amount: 500, dosage_unit: 'mg') }
 
-    it 'clears standard dosage fields on the medication when a new dosage is created' do
+    it 'clears the standard dosage amount while preserving the medication unit' do
       expect do
         create(:dosage, medication: medication, amount: 10, unit: 'mg')
       end.to change { medication.reload.dosage_amount }.from(500).to(nil)
-                                                       .and change { medication.reload.dosage_unit }.from('mg').to(nil)
+      expect(medication.reload.dosage_unit).to eq('mg')
     end
   end
 end

--- a/spec/models/medication_dosage_option_spec.rb
+++ b/spec/models/medication_dosage_option_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationDosageOption do
+  describe 'timing defaults' do
+    it 'requires max doses, min hours apart, and dose cycle' do
+      dosage_option = build(
+        :dosage,
+        default_max_daily_doses: nil,
+        default_min_hours_between_doses: nil,
+        default_dose_cycle: nil
+      )
+
+      expect(dosage_option).not_to be_valid
+      expect(dosage_option.errors[:default_max_daily_doses]).to include("can't be blank")
+      expect(dosage_option.errors[:default_min_hours_between_doses]).to include("can't be blank")
+      expect(dosage_option.errors[:default_dose_cycle]).to include("can't be blank")
+    end
+  end
+
+  describe 'unit alignment' do
+    it 'follows the medication main unit' do
+      medication = build(:medication, dosage_unit: 'ml')
+      dosage_option = build(:dosage, medication: medication, unit: 'mg')
+
+      dosage_option.valid?
+
+      expect(dosage_option.unit).to eq('ml')
+    end
+  end
+end

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe Medication do
     )
   end
 
+  def blank_dosage_row_attributes
+    {
+      amount: '',
+      unit: 'ml',
+      frequency: '',
+      description: '',
+      default_max_daily_doses: '',
+      default_min_hours_between_doses: '',
+      default_dose_cycle: 'daily',
+      default_for_adults: '0',
+      default_for_children: '0',
+      _destroy: '0'
+    }
+  end
+
+  def create_persisted_dose_option(medication)
+    medication.dosage_records.create!(
+      amount: 2.5,
+      unit: 'ml',
+      frequency: 'Every morning',
+      default_max_daily_doses: 1,
+      default_min_hours_between_doses: 24,
+      default_dose_cycle: :daily
+    )
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.not_to validate_presence_of(:current_supply) }
@@ -56,6 +82,22 @@ RSpec.describe Medication do
     it { is_expected.to belong_to(:location) }
     it { is_expected.to have_many(:dosage_records).class_name('MedicationDosageOption').dependent(:destroy) }
     it { is_expected.to have_many(:schedules).dependent(:destroy) }
+  end
+
+  describe 'nested dosage records' do
+    it 'ignores untouched auto-appended dose option rows on update' do
+      medication = create(:medication, dosage_unit: 'ml')
+      create_persisted_dose_option(medication)
+
+      expect(
+        medication.update(
+          name: 'Updated medication',
+          dosage_records_attributes: { '0' => blank_dosage_row_attributes }
+        )
+      ).to be(true)
+
+      expect(medication.reload.dosage_records.count).to eq(1)
+    end
   end
 
   describe '#restock!' do

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -18,7 +18,17 @@ RSpec.describe MedicationTake do
     )
   end
 
-  let(:dosage) { Dosage.create!(medication: medication, amount: 10, unit: 'mg', frequency: 'daily') }
+  let(:dosage) do
+    Dosage.create!(
+      medication: medication,
+      amount: 10,
+      unit: 'mg',
+      frequency: 'daily',
+      default_max_daily_doses: 1,
+      default_min_hours_between_doses: 24,
+      default_dose_cycle: :daily
+    )
+  end
 
   let(:schedule) do
     Schedule.create!(
@@ -214,7 +224,15 @@ RSpec.describe MedicationTake do
         current_supply: 100,
         reorder_threshold: 10
       )
-      dosage = Dosage.create!(medication: medication, amount: 10, unit: 'mg', frequency: 'daily')
+      dosage = Dosage.create!(
+        medication: medication,
+        amount: 10,
+        unit: 'mg',
+        frequency: 'daily',
+        default_max_daily_doses: 1,
+        default_min_hours_between_doses: 24,
+        default_dose_cycle: :daily
+      )
 
       Schedule.create!(
         person: person,

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -102,7 +102,17 @@ RSpec.describe Schedule do
     let(:person) do
       Person.create!(name: 'Test Person', email: 'test-administer@example.com', date_of_birth: Date.new(1990, 1, 1))
     end
-    let(:dosage) { Dosage.create!(medication: medication, amount: 10, unit: 'mg', frequency: 'daily') }
+    let(:dosage) do
+      Dosage.create!(
+        medication: medication,
+        amount: 10,
+        unit: 'mg',
+        frequency: 'daily',
+        default_max_daily_doses: 1,
+        default_min_hours_between_doses: 24,
+        default_dose_cycle: :daily
+      )
+    end
     let(:schedule) do
       described_class.create!(
         person: person, medication: medication, dose_amount: dosage.amount, dose_unit: dosage.unit,
@@ -142,7 +152,17 @@ RSpec.describe Schedule do
     let(:person) do
       Person.create!(name: 'Test Person2', email: 'test-reason@example.com', date_of_birth: Date.new(1990, 1, 1))
     end
-    let(:dosage) { Dosage.create!(medication: medication, amount: 10, unit: 'mg', frequency: 'daily') }
+    let(:dosage) do
+      Dosage.create!(
+        medication: medication,
+        amount: 10,
+        unit: 'mg',
+        frequency: 'daily',
+        default_max_daily_doses: 1,
+        default_min_hours_between_doses: 24,
+        default_dose_cycle: :daily
+      )
+    end
     let(:schedule) do
       described_class.create!(
         person: person, medication: medication, dose_amount: dosage.amount, dose_unit: dosage.unit,
@@ -220,7 +240,17 @@ RSpec.describe Schedule do
 
   describe '#frequency vs #dose_cycle' do
     let(:medication) { medications(:paracetamol) }
-    let(:dosage) { Dosage.create!(medication: medication, amount: 10, unit: 'mg', frequency: 'daily') }
+    let(:dosage) do
+      Dosage.create!(
+        medication: medication,
+        amount: 10,
+        unit: 'mg',
+        frequency: 'daily',
+        default_max_daily_doses: 1,
+        default_min_hours_between_doses: 24,
+        default_dose_cycle: :daily
+      )
+    end
     let(:schedule) do
       described_class.create!(
         person: people(:john),

--- a/spec/requests/dosages_frequency_suggestions_spec.rb
+++ b/spec/requests/dosages_frequency_suggestions_spec.rb
@@ -13,12 +13,20 @@ RSpec.describe 'Medication dose option suggestions' do
     get edit_medication_path(medication)
 
     expect(response).to have_http_status(:ok)
-    expect(response.body).to include('Once daily')
-    expect(response.body).to include('Every 4–6 hours')
+    expect(response.body).to include('Twice daily')
+    expect(response.body).to include('Every 4-6 hours')
     expect(response.body).to include('Every morning')
-    expect(response.body).to include('As needed (PRN)')
+    expect(response.body).to include('Every evening')
+    expect(response.body).to include('Once weekly')
     expect(response.body).to include('name="medication[dosage_records_attributes][0][frequency]"')
     expect(response.body).to match(/data-controller="[^"]*frequency-suggestions[^"]*"/)
     expect(response.body).to include('data-action="click->frequency-suggestions#suggest"')
+    expect(response.body).to include('data-frequency-suggestions-frequency-value="Every morning"')
+    expect(response.body).to include('data-frequency-suggestions-max-doses-value="1"')
+    expect(response.body).to include('data-frequency-suggestions-min-hours-value="24"')
+    expect(response.body).to include('data-frequency-suggestions-dose-cycle-value="daily"')
+    expect(response.body).to include('Matches the main dose unit')
+    expect(response.body).to include('id="medication_dosage_records_attributes_0_display_unit"')
+    expect(response.body).to match(/id="medication_dosage_records_attributes_0_display_unit"[^>]*disabled/)
   end
 end

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -153,7 +153,15 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       let!(:schedule) do
         oos_medication = Medication.create!(name: 'OOS Med', current_supply: 0, reorder_threshold: 2,
                                             location: locations(:home))
-        Dosage.create!(medication: oos_medication, amount: 10, unit: 'mg', frequency: 'daily')
+        Dosage.create!(
+          medication: oos_medication,
+          amount: 10,
+          unit: 'mg',
+          frequency: 'daily',
+          default_max_daily_doses: 1,
+          default_min_hours_between_doses: 24,
+          default_dose_cycle: :daily
+        )
         Schedule.create!(
           person: people(:john),
           medication: oos_medication,

--- a/spec/system/medications/dose_options_spec.rb
+++ b/spec/system/medications/dose_options_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medication dose options editor' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages
+
+  before do
+    driven_by(:playwright)
+    login_as(users(:admin))
+  end
+
+  it 'applies frequency templates and supports remove/undo for persisted rows' do
+    visit edit_medication_path(medications(:calpol))
+
+    within first("[data-dosage-options-target='option']") do
+      expect(page).to have_field('medication_dosage_records_attributes_0_display_unit', with: 'ml', disabled: true)
+
+      click_button 'Every morning'
+
+      expect(page).to have_field('medication[dosage_records_attributes][0][frequency]', with: 'Every morning')
+      expect(page).to have_field('medication[dosage_records_attributes][0][default_max_daily_doses]', with: '1')
+      expect(
+        page
+      ).to have_field('medication[dosage_records_attributes][0][default_min_hours_between_doses]', with: '24')
+      expect(page).to have_select('medication[dosage_records_attributes][0][default_dose_cycle]', selected: 'Daily')
+
+      click_button 'Every 4-6 hours'
+
+      expect(page).to have_field('medication[dosage_records_attributes][0][frequency]', with: 'Every 4-6 hours')
+      expect(page).to have_field('medication[dosage_records_attributes][0][default_max_daily_doses]', with: '6')
+      expect(page).to have_field('medication[dosage_records_attributes][0][default_min_hours_between_doses]', with: '4')
+      expect(page).to have_select('medication[dosage_records_attributes][0][default_dose_cycle]', selected: 'Daily')
+
+      click_button 'Remove dose option'
+
+      expect(page).to have_content('Dose option removed')
+      expect(page).to have_button('Undo')
+
+      click_button 'Undo'
+
+      expect(page).to have_button('Remove dose option')
+      expect(page).to have_field('medication[dosage_records_attributes][0][frequency]', with: 'Every 4-6 hours')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- brighten the as-needed medication modal and improve contrast in the dose step
- make medication-owned dose options smarter with template-driven timing defaults and destructive remove/undo controls
- lock dose option units to the medication unit and fix the schedule edit regression so dose snapshots update correctly

## Verification
- task test TEST_FILE=spec/components/medications/form_view_spec.rb
- task test TEST_FILE=spec/components/person_medications/modal_spec.rb
- task test TEST_FILE=spec/models/medication_dosage_option_spec.rb
- task test TEST_FILE=spec/requests/dosages_frequency_suggestions_spec.rb
- task test TEST_FILE=spec/system/medications/dose_options_spec.rb
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
