### PR TITLE
refactor: remove duplicated medication and layout assertions

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -144,13 +144,7 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   def default_dosage_for_person_type(person_type)
-    child_types = %w[minor dependent_adult]
-    loaded = dosages.to_a
-    if child_types.include?(person_type.to_s)
-      loaded.find(&:default_for_children) || loaded.first
-    else
-      loaded.find(&:default_for_adults) || loaded.first
-    end
+    child_person_type?(person_type) ? child_default_dosage : adult_default_dosage
   end
 
   def out_of_stock_date
@@ -180,19 +174,25 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   def adult_default_dosage
-    dosages.find(&:default_for_adults?) || dosages.first
+    default_dosage(:default_for_adults?)
   end
 
   def child_default_dosage
-    dosages.find(&:default_for_children?) || dosages.first
+    default_dosage(:default_for_children?)
   end
 
-  def dosage_for_person_type(person_type)
-    child_types = %w[minor dependent_adult]
-    child_types.include?(person_type.to_s) ? child_default_dosage : adult_default_dosage
-  end
+  alias dosage_for_person_type default_dosage_for_person_type
 
   private
+
+  def default_dosage(predicate)
+    loaded = dosages.to_a
+    loaded.find(&predicate) || loaded.first
+  end
+
+  def child_person_type?(person_type)
+    %w[minor dependent_adult].include?(person_type.to_s)
+  end
 
   def blank_dosage_record_attributes?(attributes)
     ignored_keys = %w[id _destroy unit default_dose_cycle]

--- a/spec/components/layouts/mobile_menu_spec.rb
+++ b/spec/components/layouts/mobile_menu_spec.rb
@@ -9,51 +9,27 @@ RSpec.describe Components::Layouts::MobileMenu, type: :component do
   let(:carer_user) { users(:carer) }
 
   describe 'rendering' do
-    it 'renders within a mobile-only container' do
+    it 'renders the mobile wrapper and trigger' do
       rendered = render_inline(described_class.new)
 
       expect(rendered.css('div.md\\:hidden')).to be_present
-    end
-
-    it 'renders a hamburger menu trigger' do
-      rendered = render_inline(described_class.new)
-
-      trigger = rendered.css('button[aria-label="Open menu"]')
-      expect(trigger).to be_present
+      expect(rendered.css('button[aria-label="Open menu"]')).to be_present
     end
   end
 
   describe 'navigation links' do
-    it 'renders Inventory link' do
+    it 'renders the primary navigation links' do
       rendered = render_inline(described_class.new)
 
-      expect(rendered.text).to include('Inventory')
-    end
-
-    it 'renders People link' do
-      rendered = render_inline(described_class.new)
-
-      expect(rendered.text).to include('People')
-    end
-
-    it 'renders Medication Finder link' do
-      rendered = render_inline(described_class.new)
-
-      expect(rendered.text).to include('Medication Finder')
+      expect(rendered.text).to include('Inventory', 'People', 'Medication Finder')
     end
   end
 
   describe 'auth actions' do
-    it 'renders Profile link' do
+    it 'renders the account actions' do
       rendered = render_inline(described_class.new)
 
-      expect(rendered.text).to include('Profile')
-    end
-
-    it 'renders Logout button' do
-      rendered = render_inline(described_class.new)
-
-      expect(rendered.text).to include('Logout')
+      expect(rendered.text).to include('Profile', 'Logout')
     end
 
     it 'renders Administration link for admin users' do

--- a/spec/components/layouts/profile_menu_spec.rb
+++ b/spec/components/layouts/profile_menu_spec.rb
@@ -9,36 +9,19 @@ RSpec.describe Components::Layouts::ProfileMenu, type: :component do
   let(:carer_user) { users(:carer) }
 
   describe 'rendering' do
-    it 'renders a dropdown menu' do
+    it 'renders the dropdown shell and account label' do
       rendered = render_inline(described_class.new(current_user: admin_user))
 
       expect(rendered.text).to include(admin_user.name)
-    end
-
-    it 'renders My Account label' do
-      rendered = render_inline(described_class.new(current_user: admin_user))
-
       expect(rendered.text).to include('My Account')
     end
   end
 
   describe 'menu items' do
-    it 'renders Dashboard link' do
+    it 'renders the account menu links' do
       rendered = render_inline(described_class.new(current_user: admin_user))
 
-      expect(rendered.text).to include('Dashboard')
-    end
-
-    it 'renders Profile link' do
-      rendered = render_inline(described_class.new(current_user: admin_user))
-
-      expect(rendered.text).to include('Profile')
-    end
-
-    it 'renders Logout link' do
-      rendered = render_inline(described_class.new(current_user: admin_user))
-
-      expect(rendered.text).to include('Logout')
+      expect(rendered.text).to include('Dashboard', 'Profile', 'Logout')
     end
   end
 

--- a/spec/components/layouts/sidebar_spec.rb
+++ b/spec/components/layouts/sidebar_spec.rb
@@ -18,33 +18,19 @@ RSpec.describe Components::Layouts::Sidebar, type: :component do
   end
 
   context 'when user is authenticated' do
-    it 'renders the brand name' do
-      rendered = render_sidebar(user: admin_user)
-      expect(rendered.text).to include('MedTracker')
-    end
-
-    it 'renders navigation links' do
-      rendered = render_sidebar(user: admin_user)
-      expect(rendered.text).to include('Dashboard')
-      expect(rendered.text).to include('Inventory')
-      expect(rendered.text).to include('Reports')
-    end
-
-    it 'renders Administration link for admin users' do
+    it 'renders the main sidebar content' do
       rendered = render_sidebar(user: admin_user)
 
-      expect(rendered.text).to include('Administration')
-    end
-
-    it 'renders the user profile section' do
-      rendered = render_sidebar(user: admin_user)
-      expect(rendered.text).to include(admin_user.person.name)
-      expect(rendered.text).to include('Administrator')
-    end
-
-    it 'renders the sign out button' do
-      rendered = render_sidebar(user: admin_user)
-      expect(rendered.text).to include('Sign Out')
+      expect(rendered.text).to include(
+        'MedTracker',
+        'Dashboard',
+        'Inventory',
+        'Reports',
+        'Administration',
+        admin_user.person.name,
+        'Administrator',
+        'Sign Out'
+      )
     end
 
     it 'uses a readable active state for the highlighted link' do

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Profiles' do
   end
 
   describe 'GET /profile' do
-    it 'renders the profile structure and account security content' do
+    it 'renders the profile page shell and key sections' do
       get profile_path
 
       expect(response).to have_http_status(:ok)
@@ -21,14 +21,7 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include(user.name)
       expect(response.body).to include(account.email)
       expect(response.body).to include('Account Security')
-      expect(response.body).to include('Change Email Address')
-      expect(response.body).to include('Change Password')
-      expect(response.body).to include('Danger Zone')
-      expect(response.body).to include('Close Account')
       expect(response.body).to include('System Information')
-      expect(response.body).to include('App Version')
-      expect(response.body).to include('Docs')
-      expect(response.body).to include('Release Notes')
       expect(response.body.scan('data-turbo-frame="modal"').size).to be >= 2
     end
 
@@ -78,7 +71,6 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include('Regenerate')
       expect(response.body).to include('Test Passkey')
       expect(response.body).to include('Remove')
-      expect(response.body).to include('Add a passkey')
     end
   end
 end


### PR DESCRIPTION
## Summary
- remove duplicated dosage-selection logic in `Medication` without adding a new abstraction layer
- collapse repeated layout component assertions into broader smoke examples
- trim redundant profile request assertions that were duplicating lower-level coverage

## Testing
- task test TEST_FILE=spec/models/medication_spec.rb
- task test TEST_FILE=spec/components/layouts/mobile_menu_spec.rb
- task test TEST_FILE=spec/components/layouts/profile_menu_spec.rb
- task test TEST_FILE=spec/components/layouts/sidebar_spec.rb
- task test TEST_FILE=spec/requests/profiles_show_spec.rb
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
