### PR TITLE
refactor: extract medication supply status presenter

### DIFF
--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -50,37 +50,26 @@ module Components
 
       private
 
-      def render_status_badge
-        supply_level = medication.supply_level
+      def presenter
+        @presenter ||= ::Medications::SupplyStatusPresenter.new(medication: medication)
+      end
 
-        if medication.reorder_ordered?
-          Badge(variant: :default) { t('medications.reorder_statuses.ordered') }
-        elsif medication.reorder_received?
-          Badge(variant: :success) { t('medications.reorder_statuses.received') }
-        elsif supply_level.out_of_stock?
-          Badge(variant: :destructive) { t('dashboard.statuses.out_of_stock') }
-        elsif supply_level.low_stock?
-          Badge(variant: :warning) { t('medications.show.low_stock_alert') }
-        else
-          Badge(variant: :success) { t('medications.index.in_stock', default: 'In Stock') }
-        end
+      def render_status_badge
+        Badge(variant: presenter.status_variant) { presenter.status_label }
       end
 
       def render_supply_bar
-        supply_level = medication.supply_level
-        bar_color = supply_level.low_stock? ? 'bg-destructive' : 'bg-primary'
-
         div(class: 'space-y-2') do
           div(
             class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
                    'tracking-widest text-muted-foreground'
           ) do
             span { t('medications.index.inventory_level') }
-            span { pluralize(supply_level.current, 'unit') }
+            span { presenter.inventory_units_label }
           end
           div(class: 'h-1.5 w-full bg-surface-container-low rounded-full overflow-hidden') do
-            div(class: "h-full #{bar_color} rounded-full transition-all duration-1000",
-                style: "width: #{supply_level.percentage}%")
+            div(class: "h-full #{presenter.list_supply_bar_class} rounded-full transition-all duration-1000",
+                style: "width: #{presenter.supply_level.percentage}%")
           end
         end
       end

--- a/app/components/medications/supply_status_card.rb
+++ b/app/components/medications/supply_status_card.rb
@@ -16,28 +16,20 @@ module Components
         Card(class: 'p-8 space-y-6 overflow-hidden relative') do
           Heading(level: 3, size: '4', class: 'font-bold') { t('medications.show.inventory_status') }
 
-          supply_level = medication.supply_level
-
           div(class: 'space-y-4') do
             div(class: 'flex items-baseline gap-2') do
-              stock_count_class = if supply_level.low_stock?
-                                    'text-5xl font-black text-on-error-container'
-                                  else
-                                    'text-5xl font-black text-primary'
-                                  end
-
-              span(class: stock_count_class) do
-                supply_level.current.to_s
+              span(class: presenter.stock_count_class) do
+                presenter.supply_level.current.to_s
               end
               Text(size: '2', weight: 'bold', class: 'text-muted-foreground') do
-                supply_level.current == 1 ? 'unit remaining' : 'units remaining'
+                presenter.remaining_units_label
               end
             end
 
             div(class: 'space-y-2') do
               div(class: 'h-2 w-full bg-surface-container-low rounded-full overflow-hidden') do
-                div(class: "h-full #{supply_level.low_stock? ? 'bg-error' : 'bg-primary'} rounded-full",
-                    style: "width: #{supply_level.percentage}%")
+                div(class: "h-full #{presenter.supply_bar_class} rounded-full",
+                    style: "width: #{presenter.supply_level.percentage}%")
               end
               div(
                 class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
@@ -48,13 +40,13 @@ module Components
               end
             end
 
-            if supply_level.low_stock?
+            if presenter.supply_level.low_stock?
               div(class: 'pt-2 space-y-2') do
                 Badge(variant: :destructive, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
                   t('medications.show.low_stock_alert')
                 end
 
-                render_reorder_status_badge if medication.reorder_status.present?
+                render_reorder_status_badge if presenter.reorder_status_badge?
               end
             end
 
@@ -65,15 +57,15 @@ module Components
 
       private
 
+      def presenter
+        @presenter ||= ::Medications::SupplyStatusPresenter.new(medication: medication)
+      end
+
       def render_forecast_section
-        if medication.forecast_available?
+        if presenter.forecast_items.any?
           div(class: 'pt-4 border-t border-surface-container-low space-y-2') do
-            if medication.days_until_low_stock&.positive?
-              forecast_item(t('medications.show.forecast.low_in_days', days: medication.days_until_low_stock), :warning)
-            end
-            if medication.days_until_out_of_stock&.positive?
-              forecast_item(t('medications.show.forecast.empty_in_days', days: medication.days_until_out_of_stock),
-                            :destructive)
+            presenter.forecast_items.each do |item|
+              forecast_item(item[:message], item[:variant])
             end
           end
         else
@@ -95,27 +87,18 @@ module Components
       end
 
       def render_reorder_status_badge
-        variant = case medication.reorder_status.to_sym
-                  when :ordered then :default
-                  when :received then :success
-                  else :outline
-                  end
-
         div(class: 'flex flex-col gap-1') do
-          Badge(variant: variant, class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide') do
-            t("medications.reorder_statuses.#{medication.reorder_status}")
+          Badge(
+            variant: presenter.reorder_status_variant,
+            class: 'w-full py-2 rounded-xl justify-center text-xs tracking-wide'
+          ) do
+            presenter.reorder_status_label
           end
 
-          timestamp = if medication.reorder_received?
-                        medication.reordered_at
-                      elsif medication.reorder_ordered?
-                        medication.ordered_at
-                      end
-
-          if timestamp
+          if presenter.reorder_status_timestamp
             Text(size: '1', class: 'text-center text-muted-foreground font-medium') do
-              status_text = t("medications.reorder_statuses.#{medication.reorder_status}")
-              time_ago = time_ago_in_words(timestamp)
+              status_text = presenter.reorder_status_label
+              time_ago = time_ago_in_words(presenter.reorder_status_timestamp)
               "#{status_text} #{time_ago} ago"
             end
           end

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Medications
+  class SupplyStatusPresenter
+    attr_reader :medication
+
+    delegate :supply_level, to: :medication
+
+    def initialize(medication:)
+      @medication = medication
+    end
+
+    def status_variant
+      return :default if medication.reorder_ordered?
+      return :success if medication.reorder_received?
+      return :destructive if supply_level.out_of_stock?
+      return :warning if supply_level.low_stock?
+
+      :success
+    end
+
+    def status_label
+      return I18n.t('medications.reorder_statuses.ordered') if medication.reorder_ordered?
+      return I18n.t('medications.reorder_statuses.received') if medication.reorder_received?
+      return I18n.t('dashboard.statuses.out_of_stock') if supply_level.out_of_stock?
+      return I18n.t('medications.show.low_stock_alert') if supply_level.low_stock?
+
+      I18n.t('medications.index.in_stock', default: 'In Stock')
+    end
+
+    def stock_count_class
+      if supply_level.low_stock?
+        'text-5xl font-black text-on-error-container'
+      else
+        'text-5xl font-black text-primary'
+      end
+    end
+
+    def supply_bar_class
+      supply_level.low_stock? ? 'bg-error' : 'bg-primary'
+    end
+
+    def list_supply_bar_class
+      supply_level.low_stock? ? 'bg-destructive' : 'bg-primary'
+    end
+
+    def remaining_units_label
+      supply_level.current == 1 ? 'unit remaining' : 'units remaining'
+    end
+
+    def inventory_units_label
+      ActionController::Base.helpers.pluralize(supply_level.current, 'unit')
+    end
+
+    def forecast_items
+      return [] unless medication.forecast_available?
+
+      [low_stock_forecast, out_of_stock_forecast].compact
+    end
+
+    def reorder_status_badge?
+      supply_level.low_stock? && medication.reorder_status.present?
+    end
+
+    def reorder_status_variant
+      case medication.reorder_status&.to_sym
+      when :ordered then :default
+      when :received then :success
+      else :outline
+      end
+    end
+
+    def reorder_status_label
+      I18n.t("medications.reorder_statuses.#{medication.reorder_status}")
+    end
+
+    def reorder_status_timestamp
+      return medication.reordered_at if medication.reorder_received?
+      return medication.ordered_at if medication.reorder_ordered?
+
+      nil
+    end
+
+    private
+
+    def low_stock_forecast
+      return unless medication.days_until_low_stock&.positive?
+
+      {
+        message: I18n.t('medications.show.forecast.low_in_days', days: medication.days_until_low_stock),
+        variant: :warning
+      }
+    end
+
+    def out_of_stock_forecast
+      return unless medication.days_until_out_of_stock&.positive?
+
+      {
+        message: I18n.t(
+          'medications.show.forecast.empty_in_days',
+          days: medication.days_until_out_of_stock
+        ),
+        variant: :destructive
+      }
+    end
+  end
+end

--- a/spec/presenters/medications/supply_status_presenter_spec.rb
+++ b/spec/presenters/medications/supply_status_presenter_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Medications::SupplyStatusPresenter do
+  describe '#status_variant' do
+    it 'prioritizes reorder ordered status over stock state' do
+      medication = create(:medication,
+                          current_supply: 5,
+                          reorder_threshold: 10,
+                          reorder_status: :ordered)
+
+      presenter = described_class.new(medication:)
+
+      expect(presenter.status_variant).to eq(:default)
+      expect(presenter.status_label).to eq('Ordered')
+    end
+
+    it 'returns warning for low stock medications' do
+      medication = create(:medication, current_supply: 5, reorder_threshold: 10)
+
+      presenter = described_class.new(medication:)
+
+      expect(presenter.status_variant).to eq(:warning)
+      expect(presenter.status_label).to eq('⚠️ Low Stock Alert')
+    end
+
+    it 'returns success for in stock medications' do
+      medication = create(:medication, current_supply: 50, reorder_threshold: 10)
+
+      presenter = described_class.new(medication:)
+
+      expect(presenter.status_variant).to eq(:success)
+      expect(presenter.status_label).to eq('In Stock')
+    end
+  end
+
+  describe '#forecast_items' do
+    it 'builds the low-stock and empty forecasts' do
+      medication = create(:medication, current_supply: 50, reorder_threshold: 10)
+      create(
+        :schedule,
+        medication: medication,
+        dose_amount: 500,
+        dose_unit: 'mg',
+        max_daily_doses: 10,
+        dose_cycle: :daily
+      )
+
+      presenter = described_class.new(medication:)
+
+      expected_items = [
+        { message: 'Supply will be low in 4 days', variant: :warning },
+        { message: 'Supply will be empty in 5 days', variant: :destructive }
+      ]
+
+      expect(presenter.forecast_items).to eq(expected_items)
+    end
+
+    it 'returns an empty list when no forecast is available' do
+      presenter = described_class.new(medication: create(:medication, current_supply: 50, reorder_threshold: 10))
+
+      expect(presenter.forecast_items).to eq([])
+    end
+  end
+
+  describe '#reorder_status_badge?' do
+    it 'only shows reorder status when the medication is low stock and reordered' do
+      low_stock = create(:medication, current_supply: 5, reorder_threshold: 10, reorder_status: :ordered)
+      in_stock = create(:medication, current_supply: 50, reorder_threshold: 10, reorder_status: :ordered)
+
+      expect(described_class.new(medication: low_stock).reorder_status_badge?).to be(true)
+      expect(described_class.new(medication: in_stock).reorder_status_badge?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract a medication supply status presenter for shared supply/status formatting
- remove duplicated stock badge, forecast, and reorder-status formatting from medication list/show components
- keep the medication views as composition roots while moving display logic into a presenter

## Testing
- `task test TEST_FILE=spec/presenters/medications/supply_status_presenter_spec.rb`
- `task test TEST_FILE=spec/components/medications/supply_status_card_spec.rb`
- `task test TEST_FILE=spec/components/medications/list_item_component_spec.rb`
- `task test TEST_FILE=spec/components/medications/show_view_spec.rb`
- `task rubocop`
- `task test`

Closes #1049
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
