### PR TITLE
feat: publish medication domain events

### DIFF
--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -299,7 +299,10 @@ module Components
             id: 'schedule_frequency',
             value: schedule.frequency,
             placeholder: t('schedules.form.frequency_placeholder'),
-            data: { action: 'input->schedule-form#validate', schedule_form_target: 'frequencyInput' }
+            data: {
+              action: 'input->schedule-form#validate change->schedule-form#validate',
+              schedule_form_target: 'frequencyInput'
+            }
           )
         end
       end
@@ -319,7 +322,7 @@ module Components
             placeholder: t('schedules.form.select_date'),
             data: {
               controller: 'ruby-ui--calendar-input',
-              action: 'input->schedule-form#validate'
+              action: 'input->schedule-form#validate change->schedule-form#validate'
             }
           )
           Calendar(

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -124,34 +124,18 @@ class MedicationTake < ApplicationRecord
   end
 
   def decrement_inventory_stock(inventory)
-    inventory.class.connection.exec_query(
-      stock_decrement_sql(inventory),
-      'Decrement Medication Stock',
-      stock_decrement_binds(inventory)
-    ).first
-  end
+    inventory.with_lock do
+      previous_current_supply = inventory.current_supply
+      current_supply = [previous_current_supply.to_i - 1, 0].max
 
-  def stock_decrement_sql(inventory)
-    <<~SQL.squish
-      WITH target AS (
-        SELECT id, current_supply AS previous_current_supply, reorder_threshold FROM #{inventory.class.table_name}
-        WHERE id = $1 FOR UPDATE
-      ),
-      updated AS (
-        UPDATE #{inventory.class.table_name} medications
-        SET current_supply = GREATEST(COALESCE(medications.current_supply, 0) - 1, 0)
-        FROM target
-        WHERE medications.id = target.id
-        RETURNING target.previous_current_supply, medications.current_supply, target.reorder_threshold
-      )
-      SELECT * FROM updated
-    SQL
-  end
+      inventory.update!(current_supply: current_supply)
 
-  def stock_decrement_binds(inventory)
-    [
-      ActiveRecord::Relation::QueryAttribute.new('id', inventory.id, ActiveRecord::Type::BigInteger.new)
-    ]
+      {
+        'previous_current_supply' => previous_current_supply,
+        'current_supply' => current_supply,
+        'reorder_threshold' => inventory.reorder_threshold
+      }
+    end
   end
 
   def remember_low_stock_threshold_crossing(inventory:, stock_row:)

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -25,6 +25,7 @@ class MedicationTake < ApplicationRecord
 
   before_validation :assign_taken_from_location
   after_create :decrement_medication_stock
+  after_commit :publish_low_stock_threshold_reached, on: :create
 
   # Delegate to get the source (schedule or person_medication)
   def source
@@ -54,13 +55,10 @@ class MedicationTake < ApplicationRecord
     return unless inventory
     return if inventory.current_supply.blank?
 
-    # rubocop:disable Rails/SkipsModelValidations -- Intentional: atomic SQL update prevents race conditions
-    # Using update_all with GREATEST ensures supply never goes negative even under concurrent requests
-    # We only decrement current_supply (the live dispensable-units counter)
-    # Each 'take' represents one dispensable unit (e.g. 1 tablet, 1 sachet, or 1 multi-ml dose)
-    inventory.class.where(id: inventory.id)
-             .update_all('current_supply = GREATEST(COALESCE(current_supply, 0) - 1, 0)')
-    # rubocop:enable Rails/SkipsModelValidations
+    stock_row = decrement_inventory_stock(inventory)
+    return unless stock_row
+
+    remember_low_stock_threshold_crossing(inventory:, stock_row:)
   end
 
   def exactly_one_source
@@ -123,5 +121,75 @@ class MedicationTake < ApplicationRecord
     attrs = { 'medication_take.taken_from_medication_id' => taken_from_medication_id.to_s }
     attrs['medication_take.taken_from_location_id'] = taken_from_location_id.to_s if taken_from_location_id
     attrs
+  end
+
+  def decrement_inventory_stock(inventory)
+    inventory.class.connection.exec_query(
+      stock_decrement_sql(inventory),
+      'Decrement Medication Stock',
+      stock_decrement_binds(inventory)
+    ).first
+  end
+
+  def stock_decrement_sql(inventory)
+    <<~SQL.squish
+      WITH target AS (
+        SELECT id, current_supply AS previous_current_supply, reorder_threshold FROM #{inventory.class.table_name}
+        WHERE id = $1 FOR UPDATE
+      ),
+      updated AS (
+        UPDATE #{inventory.class.table_name} medications
+        SET current_supply = GREATEST(COALESCE(medications.current_supply, 0) - 1, 0)
+        FROM target
+        WHERE medications.id = target.id
+        RETURNING target.previous_current_supply, medications.current_supply, target.reorder_threshold
+      )
+      SELECT * FROM updated
+    SQL
+  end
+
+  def stock_decrement_binds(inventory)
+    [
+      ActiveRecord::Relation::QueryAttribute.new('id', inventory.id, ActiveRecord::Type::BigInteger.new)
+    ]
+  end
+
+  def remember_low_stock_threshold_crossing(inventory:, stock_row:)
+    return unless low_stock_threshold_crossed?(inventory:, stock_row:)
+
+    @low_stock_threshold_payload = low_stock_threshold_payload(inventory:, stock_row:)
+  end
+
+  def publish_low_stock_threshold_reached
+    return unless @low_stock_threshold_payload
+
+    ActiveSupport::Notifications.instrument(
+      'low_stock_threshold_reached.med_tracker',
+      @low_stock_threshold_payload
+    )
+  ensure
+    @low_stock_threshold_payload = nil
+  end
+
+  def low_stock_threshold_crossed?(inventory:, stock_row:)
+    SupplyLevel.new(
+      current: stock_row['current_supply'],
+      reorder_threshold: stock_row['reorder_threshold'],
+      last_restock: inventory.supply_at_last_restock
+    ).crossed_low_stock_threshold_from?(previous_current: stock_row['previous_current_supply'])
+  end
+
+  def low_stock_threshold_payload(inventory:, stock_row:)
+    {
+      medication_id: inventory.id,
+      location_id: inventory.location_id,
+      take_id: id,
+      source_type: schedule_id.present? ? 'schedule' : 'person_medication',
+      source_id: schedule_id || person_medication_id,
+      previous_current_supply: stock_row['previous_current_supply'],
+      current_supply: stock_row['current_supply'],
+      reorder_threshold: stock_row['reorder_threshold'],
+      taken_at: taken_at
+    }
   end
 end

--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -30,6 +30,13 @@ class SupplyLevel
     current <= reorder_threshold
   end
 
+  def crossed_low_stock_threshold_from?(previous_current:)
+    return false unless tracked?
+    return false if previous_current.nil?
+
+    previous_current.to_i > reorder_threshold && current <= reorder_threshold
+  end
+
   def out_of_stock?
     return false unless tracked?
 

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -31,13 +31,20 @@ class TakeMedicationService
     return failure(error) if error
 
     take = record_take(source: source, amount: amount, medication: medication, taken_at: taken_at)
-    take.persisted? ? Result.new(success: true, take: take, error: nil) : failure(:create_failed)
+    return failure(:create_failed) unless take.persisted?
+
+    success(take)
   end
 
   private
 
   def failure(error)
     Result.new(success: false, take: nil, error: error)
+  end
+
+  def success(take)
+    publish_dose_taken(take)
+    Result.new(success: true, take: take, error: nil)
   end
 
   def resolve_stock_source(resolver, taken_from_medication_id)
@@ -68,5 +75,31 @@ class TakeMedicationService
 
   def invalid_amount?(amount)
     amount.nil? || amount <= 0
+  end
+
+  def publish_dose_taken(take)
+    ActiveSupport::Notifications.instrument('dose_taken.med_tracker', dose_taken_payload(take))
+  end
+
+  def dose_taken_payload(take)
+    {
+      take_id: take.id,
+      source_type: take_source_type(take),
+      source_id: take_source_id(take),
+      person_id: take.person&.id,
+      medication_id: take.medication&.id,
+      inventory_medication_id: take.inventory_medication&.id,
+      inventory_location_id: take.inventory_location&.id,
+      amount_ml: take.amount_ml&.to_f,
+      taken_at: take.taken_at
+    }
+  end
+
+  def take_source_type(take)
+    take.schedule_id.present? ? 'schedule' : 'person_medication'
+  end
+
+  def take_source_id(take)
+    take.schedule_id || take.person_medication_id
   end
 end

--- a/docs/adrs/0004-domain-events-with-active-support-notifications.md
+++ b/docs/adrs/0004-domain-events-with-active-support-notifications.md
@@ -1,0 +1,69 @@
+# ADR 0004: Domain Events with ActiveSupport::Notifications
+
+- Status: Accepted
+- Date: 2026-04-14
+
+## Context
+
+MedTracker records audit history with PaperTrail, but it does not currently publish domain events for important medication operations. That forces any secondary behaviour such as notifications or analytics to infer intent by polling database state instead of reacting to the operation that just happened.
+
+Issue `#1051` identifies four initial domain events:
+
+- `DoseTaken`
+- `MedicationRestocked`
+- `ScheduleCreated`
+- `LowStockThresholdReached`
+
+The minimum tranche needed now is to choose an event mechanism and implement `DoseTaken` plus `LowStockThresholdReached`.
+
+## Decision
+
+We will use `ActiveSupport::Notifications` as the in-process domain event mechanism.
+
+Event names for the initial tranche:
+
+- `dose_taken.med_tracker`
+- `low_stock_threshold_reached.med_tracker`
+
+Publishers will emit raw notification payloads directly at the domain/service boundary. We are not introducing a custom event bus, wrapper object, or subscriber framework in this tranche.
+
+## Rationale
+
+### Why `ActiveSupport::Notifications`
+
+1. It is already part of Rails and needs no new dependency.
+2. It is lightweight and sufficient for in-process publication.
+3. It keeps the first event tranche small and easy to review.
+4. It gives us a standard subscription API for later notification and analytics consumers.
+
+### Why not a custom event bus
+
+A custom bus would add structure before we have even proven the event set, naming, or subscriber needs. That would increase design surface area without solving a concrete problem in this tranche.
+
+### Why not `wisper` or another gem
+
+An additional gem would add dependency and pattern overhead for a problem Rails already solves adequately for best-effort in-process notifications.
+
+## Consequences
+
+### Positive
+
+- Domain intent is published at the point where it occurs.
+- Notifications and analytics can subscribe without coupling themselves to controllers or models.
+- The implementation stays small and aligned with current Rails conventions.
+
+### Negative
+
+- These are best-effort in-process events, not durable integration events.
+- Subscribers are not replayable if the process crashes after the database commit.
+- We still need follow-up work for additional publishers and subscribers.
+
+## Follow-up
+
+Deferred from this ADR tranche:
+
+- `MedicationRestocked`
+- `ScheduleCreated`
+- notification subscribers
+- analytics subscribers
+- any durable or cross-process event transport

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -194,6 +194,159 @@ RSpec.describe MedicationTake do
     end
   end
 
+  describe 'low_stock_threshold_reached.med_tracker' do
+    def captured_event_payloads(event_name, &)
+      payloads = []
+      subscriber = lambda do |*args|
+        payloads << ActiveSupport::Notifications::Event.new(*args).payload
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, event_name, &)
+
+      payloads
+    end
+
+    def capture_low_stock_payloads(&)
+      captured_event_payloads('low_stock_threshold_reached.med_tracker', &)
+    end
+
+    def expect_low_stock_payload(payloads, take:, expected:)
+      expect(payloads).to contain_exactly(
+        include(
+          take_id: take.id,
+          source_type: 'schedule',
+          source_id: schedule.id,
+          taken_at: take.taken_at,
+          **expected
+        )
+      )
+    end
+
+    def capture_threshold_crossing_for(schedule:, medication:, location:)
+      take = nil
+      payloads = capture_low_stock_payloads do
+        take = create_taken_from_schedule(
+          schedule: schedule,
+          taken_from_medication: medication,
+          taken_from_location: location
+        )
+      end
+
+      [payloads, take]
+    end
+
+    def expect_threshold_crossing_for(schedule:, medication:, location:, expected:)
+      payloads, take = capture_threshold_crossing_for(
+        schedule: schedule,
+        medication: medication,
+        location: location
+      )
+
+      expect_low_stock_payload(
+        payloads,
+        take: take,
+        expected: expected
+      )
+    end
+
+    def create_alternate_inventory_medication(current_supply: 3, reorder_threshold: 2)
+      location = Location.create!(name: 'Event Alt')
+      medication = create_matching_medication(
+        medication: self.medication,
+        location: location,
+        current_supply: current_supply,
+        reorder_threshold: reorder_threshold
+      )
+
+      [location, medication]
+    end
+
+    def expected_low_stock_event(medication:, location:, previous_current_supply:, current_supply:, reorder_threshold:)
+      {
+        medication_id: medication.id,
+        location_id: location.id,
+        previous_current_supply: previous_current_supply,
+        current_supply: current_supply,
+        reorder_threshold: reorder_threshold
+      }
+    end
+
+    it 'publishes when stock crosses the reorder threshold' do
+      medication.update!(current_supply: 11, reorder_threshold: 10)
+      expect_threshold_crossing_for(
+        schedule: schedule,
+        medication: medication,
+        location: medication.location,
+        expected: expected_low_stock_event(
+          medication: medication,
+          location: medication.location,
+          previous_current_supply: 11,
+          current_supply: 10,
+          reorder_threshold: 10
+        )
+      )
+    end
+
+    it 'does not publish when stock remains above the threshold' do
+      medication.update!(current_supply: 12, reorder_threshold: 10)
+
+      payloads = capture_low_stock_payloads do
+        described_class.create!(
+          schedule: schedule,
+          taken_at: Time.current,
+          amount_ml: 10.0
+        )
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'does not publish when stock was already low' do
+      medication.update!(current_supply: 10, reorder_threshold: 10)
+
+      payloads = capture_low_stock_payloads do
+        described_class.create!(
+          schedule: schedule,
+          taken_at: Time.current,
+          amount_ml: 10.0
+        )
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'does not publish when stock is untracked' do
+      medication.update!(current_supply: nil, reorder_threshold: 10)
+
+      payloads = capture_low_stock_payloads do
+        described_class.create!(
+          schedule: schedule,
+          taken_at: Time.current,
+          amount_ml: 10.0
+        )
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'publishes for an alternate inventory medication when that stock crosses the threshold' do
+      alternate_location, alternate_medication = create_alternate_inventory_medication
+
+      expect_threshold_crossing_for(
+        schedule: schedule,
+        medication: alternate_medication,
+        location: alternate_location,
+        expected: expected_low_stock_event(
+          medication: alternate_medication,
+          location: alternate_location,
+          previous_current_supply: 3,
+          current_supply: 2,
+          reorder_threshold: 2
+        )
+      )
+    end
+  end
+
   describe 'taken_from validation' do
     context 'when the selected medication uses a different identity' do
       it 'requires taken_from_medication to match the assigned medication identity' do

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -183,4 +183,144 @@ RSpec.describe TakeMedicationService do
       expect { result.success = false }.to raise_error(NoMethodError)
     end
   end
+
+  describe 'dose_taken.med_tracker' do
+    def captured_event_payloads(event_name, &)
+      payloads = []
+      subscriber = lambda do |*args|
+        payloads << ActiveSupport::Notifications::Event.new(*args).payload
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, event_name, &)
+
+      payloads
+    end
+
+    def expect_dose_taken_payload(payloads, result:, source:, amount_ml:, source_type:)
+      expect(payloads).to contain_exactly(
+        include(
+          take_id: result.take.id,
+          source_type: source_type,
+          source_id: source.id,
+          person_id: source.person_id,
+          medication_id: source.medication_id,
+          inventory_medication_id: source.medication_id,
+          inventory_location_id: source.medication.location_id,
+          amount_ml: amount_ml,
+          taken_at: result.take.taken_at
+        )
+      )
+    end
+
+    it 'publishes one event for a successful scheduled dose' do
+      schedule = schedules(:john_paracetamol)
+      result = nil
+
+      travel_to Time.current.end_of_day - 1.minute do
+        payloads = captured_event_payloads('dose_taken.med_tracker') do
+          result = call_service(source: schedule, amount_override: '750')
+        end
+
+        expect_dose_taken_payload(
+          payloads,
+          result: result,
+          source: schedule,
+          amount_ml: 750.0,
+          source_type: 'schedule'
+        )
+      end
+    end
+
+    it 'publishes one event for a successful as-needed dose' do
+      person_medication = person_medications(:jane_vitamin_d)
+      result = nil
+
+      payloads = captured_event_payloads('dose_taken.med_tracker') do
+        result = call_service(source: person_medication)
+      end
+
+      expect_dose_taken_payload(
+        payloads,
+        result: result,
+        source: person_medication,
+        amount_ml: 1000.0,
+        source_type: 'person_medication'
+      )
+    end
+
+    it 'does not publish when dose creation fails because stock is unavailable' do
+      schedule = schedules(:john_paracetamol)
+      schedule.medication.update!(current_supply: 0)
+
+      payloads = captured_event_payloads('dose_taken.med_tracker') do
+        call_service(source: schedule)
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'does not publish when timing restrictions block the dose' do
+      schedule = schedules(:john_paracetamol)
+
+      travel_to Time.current.end_of_day - 1.minute do
+        schedule.medication_takes.create!(
+          taken_at: 1.minute.ago,
+          amount_ml: schedule.default_dose_amount,
+          taken_from_medication: schedule.medication,
+          taken_from_location: schedule.medication.location
+        )
+
+        payloads = captured_event_payloads('dose_taken.med_tracker') do
+          call_service(source: schedule)
+        end
+
+        expect(payloads).to be_empty
+      end
+    end
+
+    it 'does not publish when the amount is invalid' do
+      schedule = schedules(:john_paracetamol)
+
+      payloads = captured_event_payloads('dose_taken.med_tracker') do
+        call_service(source: schedule, amount_override: '0')
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'does not publish when stock-source selection is required' do
+      schedule = schedules(:john_paracetamol)
+      create_matching_medication(
+        medication: schedule.medication,
+        location: Location.create!(name: 'Selection Required Home')
+      )
+
+      payloads = captured_event_payloads('dose_taken.med_tracker') do
+        call_service(source: schedule)
+      end
+
+      expect(payloads).to be_empty
+    end
+
+    it 'does not publish when the selected inventory source is invalid' do
+      schedule = schedules(:john_paracetamol)
+
+      payloads = captured_event_payloads('dose_taken.med_tracker') do
+        call_service(source: schedule, taken_from_medication_id: -1)
+      end
+
+      expect(payloads).to be_empty
+    end
+  end
+
+  def create_matching_medication(medication:, location:)
+    Medication.create!(
+      name: medication.name,
+      location: location,
+      dosage_amount: medication.dosage_amount,
+      dosage_unit: medication.dosage_unit,
+      current_supply: 12,
+      reorder_threshold: 2
+    )
+  end
 end

--- a/spec/system/schedules/add_schedule_modal_spec.rb
+++ b/spec/system/schedules/add_schedule_modal_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'Add schedule modal flow' do
     fill_in 'End date', with: 1.week.from_now.to_date.strftime('%Y-%m-%d')
     fill_in 'Notes', with: 'Turbo modal e2e schedule'
 
+    expect(page).to have_button('Add Plan', disabled: false)
     click_button 'Add Plan'
 
     expect(page).to have_content('Schedule was successfully created.')


### PR DESCRIPTION
## Summary
- adopt `ActiveSupport::Notifications` for in-process domain events in ADR 0004
- publish `dose_taken.med_tracker` after successful dose recording
- publish `low_stock_threshold_reached.med_tracker` when a tracked stock level crosses the reorder threshold during a take
- add focused specs covering payloads and non-publication failure paths

## Why
The app had audit logging via PaperTrail, but no domain events for downstream reactions such as notifications or analytics. That forced secondary behaviour to infer domain intent from persisted state instead of reacting to the operation itself.

This PR implements the minimum event set from `#1051` without introducing an event bus or subscriber framework.

## Impact
- domain intent is now published at the service/model boundary for dose recording and low-stock crossing
- no subscriber behaviour is added yet; this PR only defines and emits the events
- stock decrement remains race-safe and now captures previous/current supply for threshold-crossing detection

## Testing
- `task test TEST_FILE=spec/services/take_medication_service_spec.rb`
- `task test TEST_FILE=spec/models/medication_take_spec.rb`
- `task rubocop`
- `task test`

Closes #1051
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
