### PR TITLE
refactor: extract remaining controller queries

### DIFF
--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -12,20 +12,22 @@ module Admin
     # GET /admin/audit_logs
     # Lists all audit log entries with optional filtering
     def index
-      base_query = PaperTrail::Version.order(created_at: :desc)
-      base_query = apply_filters_to_query(base_query)
+      result = Admin::AuditLogsQuery.new(
+        scope: PaperTrail::Version.all,
+        filters: params.permit(:item_type, :event, :whodunnit).to_h.symbolize_keys,
+        page: params[:page],
+        per_page: AUDIT_LOGS_PER_PAGE
+      ).call
 
-      @total_count = base_query.count
-      @versions = base_query
-                  .limit(AUDIT_LOGS_PER_PAGE)
-                  .offset((page_number - 1) * AUDIT_LOGS_PER_PAGE)
+      @total_count = result.total_count
+      @versions = result.versions
 
       render Components::Admin::AuditLogs::IndexView.new(
         versions: @versions,
         filter_params: params.permit(:item_type, :event, :whodunnit),
-        current_page: page_number,
+        current_page: result.page,
         total_count: @total_count,
-        per_page: AUDIT_LOGS_PER_PAGE
+        per_page: result.per_page
       )
     end
 
@@ -42,21 +44,6 @@ module Admin
 
     def authorize_audit_access
       authorize :audit_log, :index?, policy_class: AuditLogPolicy
-    end
-
-    # Ensures page number is at least 1
-    def page_number
-      [params[:page].to_i, 1].max
-    end
-
-    # Applies filter parameters to the versions query
-    # @param query [ActiveRecord::Relation] Base query to filter
-    # @return [ActiveRecord::Relation] Filtered query
-    def apply_filters_to_query(query)
-      query = query.where(item_type: params[:item_type]) if params[:item_type].present?
-      query = query.where(event: params[:event]) if params[:event].present?
-      query = query.where(whodunnit: params[:whodunnit]) if params[:whodunnit].present?
-      query
     end
   end
 end

--- a/app/controllers/admin/carer_relationships_controller.rb
+++ b/app/controllers/admin/carer_relationships_controller.rb
@@ -5,8 +5,7 @@ module Admin
   class CarerRelationshipsController < ApplicationController
     def index
       authorize CarerRelationship
-      relationships = policy_scope(CarerRelationship).includes(:carer, :patient)
-      relationships = relationships.order(created_at: :desc)
+      relationships = Admin::CarerRelationshipsIndexQuery.new(scope: policy_scope(CarerRelationship)).call
       @pagy, relationships = pagy(:offset, relationships)
       render Components::Admin::CarerRelationships::IndexView.new(
         relationships: relationships,
@@ -19,13 +18,14 @@ module Admin
       @relationship = CarerRelationship.new(patient_id: params[:patient_id])
       authorize @relationship
       is_modal = request.headers['Turbo-Frame'] == 'modal'
+      options = carer_relationship_options
 
       respond_to do |format|
         format.html do
           render Components::Admin::CarerRelationships::FormView.new(
             relationship: @relationship,
-            carers: available_carers,
-            patients: available_patients,
+            carers: options.carers,
+            patients: options.patients,
             modal: is_modal
           ), layout: false
         end
@@ -34,8 +34,8 @@ module Admin
             'modal',
             Components::Admin::CarerRelationships::FormView.new(
               relationship: @relationship,
-              carers: available_carers,
-              patients: available_patients,
+              carers: options.carers,
+              patients: options.patients,
               modal: true
             )
           )
@@ -46,6 +46,7 @@ module Admin
     def create
       @relationship = CarerRelationship.new(relationship_params)
       authorize @relationship
+      options = carer_relationship_options
 
       respond_to do |format|
         if @relationship.save
@@ -66,8 +67,8 @@ module Admin
           format.html do
             render Components::Admin::CarerRelationships::FormView.new(
               relationship: @relationship,
-              carers: available_carers,
-              patients: available_patients
+              carers: options.carers,
+              patients: options.patients
             ), status: :unprocessable_content
           end
           format.turbo_stream do
@@ -75,8 +76,8 @@ module Admin
               'modal',
               Components::Admin::CarerRelationships::FormView.new(
                 relationship: @relationship,
-                carers: available_carers,
-                patients: available_patients,
+                carers: options.carers,
+                patients: options.patients,
                 modal: true
               )
             ), status: :unprocessable_content
@@ -119,12 +120,8 @@ module Admin
       params.expect(carer_relationship: %i[carer_id patient_id relationship_type])
     end
 
-    def available_carers
-      Person.joins(:user).where.not(users: { role: :minor }).order(:name)
-    end
-
-    def available_patients
-      Person.order(:name)
+    def carer_relationship_options
+      @carer_relationship_options ||= Admin::CarerRelationshipOptionsQuery.new(scope: policy_scope(Person)).call
     end
 
     def relationship_row_streams(relationship)

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -6,33 +6,9 @@ module Admin
     def index
       authorize :admin_dashboard, :index?
 
-      metrics = {
-        total_users: User.count,
-        active_users: User.active.count,
-        recent_signups: User.where(created_at: 7.days.ago..).count,
-        users_by_role: User.group(:role).count,
-        total_people: Person.count,
-        people_by_type: Person.group(:person_type).count,
-        active_schedules: Schedule.where(active: true).count,
-        patients_without_carers: patients_without_carers_count
-      }
+      metrics = Admin::DashboardMetricsQuery.new.call
 
       render Components::Admin::Dashboard::IndexView.new(metrics: metrics)
-    end
-
-    private
-
-    def patients_without_carers_count
-      # Find people without capacity who don't have active carer relationships
-      Person.where(has_capacity: false)
-            .where.missing(:carer_relationships)
-            .or(
-              Person.where(has_capacity: false)
-                    .left_joins(:carer_relationships)
-                    .where(carer_relationships: { active: false })
-            )
-            .distinct
-            .count
     end
   end
 end

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -56,10 +56,6 @@ module Admin
       params.expect(invitation: %i[email role])
     end
 
-    def invitations
-      Invitation.order(created_at: :desc)
-    end
-
     def render_index_turbo
       render turbo_stream: [
         turbo_stream.replace('admin_invitations', invitation_index_view),
@@ -68,24 +64,12 @@ module Admin
     end
 
     def invitation_index_view(invitation: Invitation.new)
-      current_invitations = invitations
+      result = Admin::InvitationsIndexQuery.new(scope: Invitation.all).call
       Components::Admin::Invitations::IndexView.new(
         invitation: invitation,
-        invitations: current_invitations,
-        resendable_invitation_ids: resendable_invitation_ids(current_invitations)
+        invitations: result.invitations,
+        resendable_invitation_ids: result.resendable_invitation_ids
       )
-    end
-
-    def resendable_invitation_ids(current_invitations)
-      pending_counts_by_email = Invitation.pending.group(:email).count
-
-      current_invitations.filter_map do |invitation|
-        next if invitation.accepted?
-
-        pending_count = pending_counts_by_email[invitation.email].to_i
-        next invitation.id if invitation.pending? && pending_count == 1
-        next invitation.id if invitation.expired? && pending_count.zero?
-      end
     end
 
     def redirect_with_invitation_notice(message)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,11 +5,10 @@ module Admin
   class UsersController < ApplicationController
     def index
       authorize User
-      users = policy_scope(User).includes(:person)
-      users = apply_search(users) if params[:search].present?
-      users = apply_role_filter(users) if params[:role].present?
-      users = apply_status_filter(users) if params[:status].present?
-      users = apply_sorting(users)
+      users = Admin::UsersIndexQuery.new(
+        scope: policy_scope(User),
+        filters: search_params.to_h.symbolize_keys
+      ).call
       @pagy, users = pagy(:offset, users)
       render Components::Admin::Users::IndexView.new(users: users, search_params: search_params, current_user: current_user, pagy: @pagy)
     end
@@ -171,48 +170,6 @@ module Admin
 
     def render_user_form_with_errors
       render Components::Admin::Users::FormView.new(user: @user), status: :unprocessable_content
-    end
-
-    def apply_search(scope)
-      search_term = "%#{ActiveRecord::Base.sanitize_sql_like(params[:search])}%"
-      scope.joins(:person)
-           .where('people.name ILIKE ? OR users.email_address ILIKE ?', search_term, search_term)
-    end
-
-    def apply_role_filter(scope)
-      scope.where(role: params[:role])
-    end
-
-    def apply_status_filter(scope)
-      case params[:status]
-      when 'active' then scope.active
-      when 'inactive' then scope.inactive
-      when 'soft_deleted' then scope.left_joins(person: :account).where(accounts: { id: nil }).or(scope.left_joins(person: :account).where(accounts: { status: Account.statuses[:closed] }))
-      else scope
-      end
-    end
-
-    def apply_sorting(scope)
-      sort_column = params[:sort].presence_in(allowed_sort_columns) || 'created_at'
-      sort_direction = params[:direction].presence_in(%w[asc desc]) || 'asc'
-      direction_sym = { 'asc' => :asc, 'desc' => :desc }[sort_direction]
-
-      case sort_column
-      when 'name'
-        # Security: sort_direction is already validated against %w[asc desc] above
-
-        scope.left_joins(:person).merge(Person.order(name: direction_sym))
-      when 'email'
-        scope.order(email_address: direction_sym)
-      when 'role'
-        scope.order(role: direction_sym)
-      else
-        scope.order(created_at: direction_sym)
-      end
-    end
-
-    def allowed_sort_columns
-      %w[name email created_at role]
     end
 
     def search_params

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -8,7 +8,7 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def index
     @current_category = params[:category]
-    base_scope = policy_scope(Medication).includes(:location)
+    base_scope = policy_scope(Medication)
     locations = accessible_inventory_locations(base_scope)
     @current_location_id = resolved_inventory_location_id(locations)
 
@@ -180,7 +180,7 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
   end
 
   def available_locations
-    policy_scope(Location).order(:name)
+    LocationsQuery.new(scope: policy_scope(Location)).options
   end
 
   def primary_location

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,7 +7,7 @@ class PeopleController < ApplicationController
 
   def index
     authorize Person
-    people = policy_scope(Person).includes(:user, :schedules, :person_medications)
+    people = PeopleIndexQuery.new(scope: policy_scope(Person)).call
     render Components::People::IndexView.new(people: people)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,11 +11,9 @@ class ReportsController < ApplicationController
     # Aggregating data for the current user and their patients
     # We use PersonPolicy::Scope to fetch people the user is authorized to see
     @people = policy_scope(Person)
-
-    # Calculate real compliance for the date range
-    @daily_data = calculate_daily_compliance(@people, @start_date, @end_date)
-
-    @inventory_alerts = calculate_inventory_alerts(@people)
+    report_data = Reports::IndexQuery.new(people: @people, start_date: @start_date, end_date: @end_date).call
+    @daily_data = report_data.daily_data
+    @inventory_alerts = report_data.inventory_alerts
 
     render Views::Reports::Index.new(
       daily_data: @daily_data,
@@ -27,63 +25,5 @@ class ReportsController < ApplicationController
     # rubocop:disable Rails/I18nLocaleTexts
     redirect_to reports_path, alert: 'Invalid date format provided.'
     # rubocop:enable Rails/I18nLocaleTexts
-  end
-
-  private
-
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  def calculate_daily_compliance(people, start_date, end_date)
-    person_ids = people.pluck(:id)
-
-    # Pre-fetch takes and schedules to avoid N+1
-    schedules = Schedule.where(person_id: person_ids)
-                        .where('start_date <= ? AND (end_date IS NULL OR end_date >= ?)', end_date, start_date)
-                        .to_a
-
-    takes = MedicationTake.where(schedule_id: schedules.map(&:id))
-                          .where(taken_at: start_date.beginning_of_day..end_date.end_of_day)
-                          .group_by { |t| t.taken_at.to_date }
-
-    (start_date..end_date).map do |date|
-      active_schedules = schedules.select do |p|
-        p.start_date <= date && (p.end_date.nil? || p.end_date >= date)
-      end
-
-      expected_doses = active_schedules.sum { |p| p.max_daily_doses || 1 }
-      actual_doses = takes[date]&.size || 0
-
-      percentage = if expected_doses.zero?
-                     100 # No meds expected = 100% compliance
-                   else
-                     [(actual_doses.to_f / expected_doses * 100).round, 100].min
-                   end
-
-      {
-        date: date,
-        day_name: date.strftime('%a'),
-        percentage: percentage,
-        expected: expected_doses,
-        actual: actual_doses
-      }
-    end
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
-  def calculate_inventory_alerts(people)
-    alerts = Schedule.active.where(person_id: people.pluck(:id))
-                     .includes(:medication)
-                     .map do |p|
-                       burn_rate = p.max_daily_doses || 1
-                       current = p.medication.current_supply || 0
-                       days_left = (current.to_f / burn_rate).floor
-
-                       {
-                         medication_name: p.medication.name,
-                         days_left: days_left,
-                         doses_left: current,
-                         low_stock: days_left <= 3
-                       }
-    end
-    alerts.select { |alert| alert[:days_left] < 14 }.sort_by { |a| a[:days_left] }.take(2)
   end
 end

--- a/app/services/admin/audit_logs_query.rb
+++ b/app/services/admin/audit_logs_query.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Admin
+  class AuditLogsQuery
+    Result = Data.define(:versions, :total_count, :page, :per_page)
+
+    attr_reader :scope, :filters, :page, :per_page
+
+    def initialize(scope:, filters:, page:, per_page:)
+      @scope = scope
+      @filters = filters
+      @page = [page.to_i, 1].max
+      @per_page = per_page
+    end
+
+    def call
+      Result.new(
+        versions: filtered_scope.limit(per_page).offset((page - 1) * per_page),
+        total_count: filtered_scope.count,
+        page: page,
+        per_page: per_page
+      )
+    end
+
+    private
+
+    def filtered_scope
+      relation = scope.order(created_at: :desc)
+      relation = relation.where(item_type: item_type) if item_type.present?
+      relation = relation.where(event: event) if event.present?
+      relation = relation.where(whodunnit: whodunnit) if whodunnit.present?
+      relation
+    end
+
+    def item_type
+      filters[:item_type].to_s.presence
+    end
+
+    def event
+      filters[:event].to_s.presence
+    end
+
+    def whodunnit
+      filters[:whodunnit].to_s.presence
+    end
+  end
+end

--- a/app/services/admin/carer_relationship_options_query.rb
+++ b/app/services/admin/carer_relationship_options_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  class CarerRelationshipOptionsQuery
+    Result = Data.define(:carers, :patients)
+
+    attr_reader :scope
+
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def call
+      Result.new(
+        carers: scope.joins(:user).where.not(users: { role: :minor }).order(:name),
+        patients: scope.order(:name)
+      )
+    end
+  end
+end

--- a/app/services/admin/carer_relationships_index_query.rb
+++ b/app/services/admin/carer_relationships_index_query.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Admin
+  class CarerRelationshipsIndexQuery
+    attr_reader :scope
+
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def call
+      scope.includes(:carer, :patient).order(created_at: :desc)
+    end
+  end
+end

--- a/app/services/admin/dashboard_metrics_query.rb
+++ b/app/services/admin/dashboard_metrics_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin
+  class DashboardMetricsQuery
+    def call
+      {
+        total_users: User.count,
+        active_users: User.active.count,
+        recent_signups: User.where(created_at: 7.days.ago..).count,
+        users_by_role: User.group(:role).count,
+        total_people: Person.count,
+        people_by_type: Person.group(:person_type).count,
+        active_schedules: Schedule.where(active: true).count,
+        patients_without_carers: patients_without_carers_count
+      }
+    end
+
+    private
+
+    def patients_without_carers_count
+      without_capacity = Person.where(has_capacity: false)
+
+      without_capacity.where.missing(:carer_relationships)
+                      .or(
+                        without_capacity.left_joins(:carer_relationships)
+                                        .where(carer_relationships: { active: false })
+                      )
+                      .distinct
+                      .count
+    end
+  end
+end

--- a/app/services/admin/invitations_index_query.rb
+++ b/app/services/admin/invitations_index_query.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Admin
+  class InvitationsIndexQuery
+    Result = Data.define(:invitations, :resendable_invitation_ids)
+
+    attr_reader :scope
+
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def call
+      current_invitations = scope.order(created_at: :desc)
+
+      Result.new(
+        invitations: current_invitations,
+        resendable_invitation_ids: resendable_invitation_ids(current_invitations)
+      )
+    end
+
+    private
+
+    def resendable_invitation_ids(current_invitations)
+      pending_counts_by_email = scope.pending.group(:email).count
+
+      current_invitations.filter_map do |invitation|
+        next if invitation.accepted?
+
+        pending_count = pending_counts_by_email[invitation.email].to_i
+        next invitation.id if invitation.pending? && pending_count == 1
+        next invitation.id if invitation.expired? && pending_count.zero?
+      end
+    end
+  end
+end

--- a/app/services/admin/users_index_query.rb
+++ b/app/services/admin/users_index_query.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Admin
+  class UsersIndexQuery
+    attr_reader :scope, :filters
+
+    def initialize(scope:, filters:)
+      @scope = scope
+      @filters = filters
+    end
+
+    def call
+      apply_sorting(filtered_scope)
+    end
+
+    private
+
+    def apply_sorting(relation)
+      case sort_column
+      when 'name'
+        relation.left_joins(:person).order(Person.arel_table[:name].public_send(direction_symbol))
+      when 'email'
+        relation.order(email_address: direction_symbol)
+      when 'role'
+        relation.order(role: direction_symbol)
+      else
+        relation.order(created_at: direction_symbol)
+      end
+    end
+
+    def filtered_scope
+      relation = scope.includes(:person)
+      relation = apply_search(relation) if search.present?
+      relation = relation.where(role: role) if role.present?
+      relation = apply_status_filter(relation) if status.present?
+      relation
+    end
+
+    def search
+      filters[:search].to_s.presence
+    end
+
+    def role
+      filters[:role].to_s.presence
+    end
+
+    def status
+      filters[:status].to_s.presence
+    end
+
+    def sort
+      filters[:sort].to_s.presence
+    end
+
+    def direction
+      filters[:direction].to_s.presence
+    end
+
+    def apply_search(relation)
+      search_term = "%#{ActiveRecord::Base.sanitize_sql_like(search)}%"
+      relation.joins(:person).where('people.name ILIKE ? OR users.email_address ILIKE ?', search_term, search_term)
+    end
+
+    def apply_status_filter(relation)
+      case status
+      when 'active'
+        relation.active
+      when 'inactive'
+        relation.inactive
+      when 'soft_deleted'
+        soft_deleted_scope(relation)
+      else
+        relation
+      end
+    end
+
+    def soft_deleted_scope(relation)
+      account_join = relation.left_joins(person: :account)
+      account_join.where(accounts: { id: nil }).or(account_join.where(accounts: { status: Account.statuses[:closed] }))
+    end
+
+    def sort_column
+      sort.presence_in(%w[name email created_at role]) || 'created_at'
+    end
+
+    def direction_symbol
+      { 'desc' => :desc }.fetch(direction, :asc)
+    end
+  end
+end

--- a/app/services/locations_query.rb
+++ b/app/services/locations_query.rb
@@ -15,6 +15,10 @@ class LocationsQuery
     scoped_locations.find(id)
   end
 
+  def options
+    scope.order(:name)
+  end
+
   private
 
   def scoped_locations

--- a/app/services/medication_query.rb
+++ b/app/services/medication_query.rb
@@ -10,7 +10,7 @@ class MedicationQuery
   end
 
   def call
-    filtered_scope.order(:name)
+    filtered_scope.includes(:location).order(:name)
   end
 
   def categories

--- a/app/services/people_index_query.rb
+++ b/app/services/people_index_query.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PeopleIndexQuery
+  attr_reader :scope
+
+  def initialize(scope:)
+    @scope = scope
+  end
+
+  def call
+    scope.includes(:user, :schedules, :person_medications)
+  end
+end

--- a/app/services/reports/index_query.rb
+++ b/app/services/reports/index_query.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Reports
+  class IndexQuery
+    Result = Data.define(:daily_data, :inventory_alerts)
+
+    attr_reader :people, :start_date, :end_date
+
+    def initialize(people:, start_date:, end_date:)
+      @people = people
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def call
+      Result.new(
+        daily_data: daily_data,
+        inventory_alerts: inventory_alerts
+      )
+    end
+
+    private
+
+    def daily_data
+      (start_date..end_date).map { |date| daily_row_for(date) }
+    end
+
+    def inventory_alerts
+      alerts = Schedule.active.where(person_id: person_ids)
+                       .includes(:medication)
+                       .map { |schedule| inventory_alert_for(schedule) }
+
+      alerts.select { |alert| alert[:days_left] < 14 }
+            .sort_by { |alert| alert[:days_left] }
+            .take(2)
+    end
+
+    def schedules
+      @schedules ||= Schedule.where(person_id: person_ids)
+                             .where('start_date <= ? AND (end_date IS NULL OR end_date >= ?)', end_date, start_date)
+                             .to_a
+    end
+
+    def takes_by_date
+      @takes_by_date ||= MedicationTake.where(schedule_id: schedules.map(&:id))
+                                       .where(taken_at: start_date.beginning_of_day..end_date.end_of_day)
+                                       .group_by { |take| take.taken_at.to_date }
+    end
+
+    def person_ids
+      @person_ids ||= if people.respond_to?(:pluck)
+                        people.pluck(:id)
+                      else
+                        Array(people).map(&:id)
+                      end
+    end
+
+    def daily_row_for(date)
+      expected_doses = expected_doses_for(date)
+      actual_doses = takes_by_date[date]&.size || 0
+
+      {
+        date: date,
+        day_name: date.strftime('%a'),
+        percentage: compliance_percentage(expected_doses:, actual_doses:),
+        expected: expected_doses,
+        actual: actual_doses
+      }
+    end
+
+    def expected_doses_for(date)
+      schedules_for(date).sum { |schedule| schedule.max_daily_doses || 1 }
+    end
+
+    def schedules_for(date)
+      schedules.select do |schedule|
+        schedule.start_date <= date && (schedule.end_date.nil? || schedule.end_date >= date)
+      end
+    end
+
+    def inventory_alert_for(schedule)
+      burn_rate = schedule.max_daily_doses || 1
+      current = schedule.medication.current_supply || 0
+      days_left = (current.to_f / burn_rate).floor
+
+      {
+        medication_name: schedule.medication.name,
+        days_left: days_left,
+        doses_left: current,
+        low_stock: days_left <= 3
+      }
+    end
+
+    def compliance_percentage(expected_doses:, actual_doses:)
+      return 100 if expected_doses.zero?
+
+      [(actual_doses.to_f / expected_doses * 100).round, 100].min
+    end
+  end
+end

--- a/spec/factories/carer_relationships.rb
+++ b/spec/factories/carer_relationships.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :carer_relationship do
+    carer { association :person }
+    patient { association :person }
+    relationship_type { 'family_member' }
+    active { true }
+  end
+end

--- a/spec/services/admin/audit_logs_query_spec.rb
+++ b/spec/services/admin/audit_logs_query_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AuditLogsQuery do
+  fixtures :accounts, :people, :users
+
+  let(:scope) { PaperTrail::Version.all }
+  let(:admin) { users(:admin) }
+
+  before do
+    PaperTrail.request.whodunnit = admin.id
+    PaperTrail.request(enabled: true) do
+      users(:jane).update!(role: :nurse)
+      people(:john).update!(name: 'John Updated')
+    end
+  end
+
+  describe '#call' do
+    it 'filters by item_type, event, and whodunnit in descending order' do
+      result = described_class.new(
+        scope: scope,
+        filters: { item_type: 'User', event: 'update', whodunnit: admin.id.to_s },
+        page: 1,
+        per_page: 10
+      ).call
+
+      expect(result.total_count).to eq(1)
+      expect(result.versions.map(&:item_type)).to eq(['User'])
+      expect(result.versions.map(&:event)).to eq(['update'])
+      expect(result.versions.map(&:whodunnit)).to eq([admin.id.to_s])
+    end
+
+    it 'applies page and per-page limits' do
+      result = described_class.new(scope: scope, filters: {}, page: 2, per_page: 1).call
+
+      expect(result.total_count).to be >= 2
+      expect(result.versions.size).to eq(1)
+    end
+  end
+end

--- a/spec/services/admin/carer_relationship_options_query_spec.rb
+++ b/spec/services/admin/carer_relationship_options_query_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::CarerRelationshipOptionsQuery do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  describe '#call' do
+    it 'returns carers excluding minors and patients ordered by name' do
+      result = described_class.new(scope: Person.all).call
+
+      expect(result.carers).to include(people(:jane), people(:bob))
+      expect(result.carers).not_to include(people(:child_patient))
+      expect(result.carers).to include(people(:child_user_person))
+      expect(result.patients.map(&:name)).to eq(result.patients.map(&:name).sort)
+    end
+  end
+end

--- a/spec/services/admin/carer_relationships_index_query_spec.rb
+++ b/spec/services/admin/carer_relationships_index_query_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::CarerRelationshipsIndexQuery do
+  fixtures :accounts, :people, :users, :carer_relationships
+
+  describe '#call' do
+    it 'returns only relationships from the passed scope with expected preloads in newest-first order' do
+      older = carer_relationships(:jane_cares_for_child)
+      newer = create(:carer_relationship, carer: people(:bob), patient: create(:person), created_at: 1.minute.from_now)
+
+      result = described_class.new(scope: CarerRelationship.where(id: [older.id, newer.id])).call
+
+      expect(result.map(&:id)).to eq([newer.id, older.id])
+      expect(result.first.association(:carer)).to be_loaded
+      expect(result.first.association(:patient)).to be_loaded
+    end
+  end
+end

--- a/spec/services/admin/dashboard_metrics_query_spec.rb
+++ b/spec/services/admin/dashboard_metrics_query_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::DashboardMetricsQuery do
+  fixtures :accounts, :people, :users, :schedules, :medications, :locations, :location_memberships, :carer_relationships
+
+  describe '#call' do
+    it 'returns the current count metrics' do
+      result = described_class.new.call
+
+      expect(result[:total_users]).to eq(User.count)
+      expect(result[:active_users]).to eq(User.active.count)
+      expect(result[:recent_signups]).to eq(User.where(created_at: 7.days.ago..).count)
+      expect(result[:total_people]).to eq(Person.count)
+      expect(result[:active_schedules]).to eq(Schedule.where(active: true).count)
+    end
+
+    it 'returns the current grouped metrics' do
+      result = described_class.new.call
+
+      expect(result[:users_by_role]).to eq(User.group(:role).count)
+      expect(result[:people_by_type]).to eq(Person.group(:person_type).count)
+    end
+
+    it 'counts people without capacity who have no active carers' do
+      no_carer = create(:person)
+      no_carer.has_capacity = false
+      no_carer.save!(validate: false)
+
+      inactive_only = create(:person)
+      inactive_only.has_capacity = false
+      inactive_only.save!(validate: false)
+      create(:carer_relationship, patient: inactive_only, carer: people(:jane), active: false)
+
+      active_carer = create(:person)
+      active_carer.has_capacity = false
+      active_carer.save!(validate: false)
+      create(:carer_relationship, patient: active_carer, carer: people(:jane), active: true)
+
+      result = described_class.new.call
+
+      expect(result[:patients_without_carers]).to be >= 2
+    end
+  end
+end

--- a/spec/services/admin/invitations_index_query_spec.rb
+++ b/spec/services/admin/invitations_index_query_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::InvitationsIndexQuery do
+  describe '#call' do
+    it 'returns invitations newest first with the resendable ids' do
+      newest_pending = create(:invitation, email: 'solo.pending@example.com', created_at: 1.hour.from_now)
+      expired_duplicate = create(:invitation, :expired, email: 'duplicate@example.com')
+      pending_duplicate = create(:invitation, email: 'duplicate@example.com')
+      expired_singleton = create(:invitation, :expired, email: 'solo.expired@example.com')
+      accepted = create(:invitation, :accepted, email: 'accepted@example.com')
+
+      result = described_class.new(scope: Invitation.all).call
+
+      expect(result.invitations.first).to eq(newest_pending)
+      expect(result.resendable_invitation_ids).to include(newest_pending.id, pending_duplicate.id, expired_singleton.id)
+      expect(result.resendable_invitation_ids).not_to include(expired_duplicate.id, accepted.id)
+    end
+  end
+end

--- a/spec/services/admin/users_index_query_spec.rb
+++ b/spec/services/admin/users_index_query_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UsersIndexQuery do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  let(:scope) { User.all }
+  let!(:soft_deleted_user) do
+    account = Account.create!(
+      email: 'soft.deleted@example.com',
+      password_hash: RodauthApp.rodauth.allocate.password_hash('password'),
+      status: :closed
+    )
+    person = Person.create!(
+      name: 'Soft Deleted User',
+      date_of_birth: '1990-01-01',
+      account: account
+    )
+    person.update!(account: nil)
+    User.create!(
+      person: person,
+      email_address: 'soft.deleted@example.com',
+      role: :parent,
+      active: true
+    )
+  end
+
+  describe '#call' do
+    it 'searches by person name or email' do
+      result = described_class.new(scope: scope, filters: { search: 'Jane' }).call
+
+      expect(result).to include(users(:jane))
+      expect(result).not_to include(users(:bob))
+    end
+
+    it 'filters by role' do
+      result = described_class.new(scope: scope, filters: { role: 'doctor' }).call
+
+      expect(result).to contain_exactly(users(:doctor))
+    end
+
+    it 'filters soft deleted users' do
+      result = described_class.new(scope: scope, filters: { status: 'soft_deleted' }).call
+
+      expect(result).to contain_exactly(soft_deleted_user)
+    end
+
+    it 'sorts by associated person name' do
+      result = described_class.new(
+        scope: scope.where(id: [users(:jane).id, users(:bob).id]),
+        filters: { sort: 'name', direction: 'asc' }
+      ).call
+
+      expect(result.map(&:name)).to eq(['Bob Smith', 'Jane Doe'])
+    end
+
+    it 'sorts by email when requested' do
+      result = described_class.new(
+        scope: scope.where(id: [users(:jane).id, users(:bob).id]),
+        filters: { sort: 'email', direction: 'desc' }
+      ).call
+
+      expect(result.map(&:email_address)).to eq(['jane.doe@example.com', 'bob.smith@example.com'])
+    end
+  end
+end

--- a/spec/services/locations_query_spec.rb
+++ b/spec/services/locations_query_spec.rb
@@ -34,4 +34,13 @@ RSpec.describe LocationsQuery do
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '#options' do
+    it 'returns the passed scope in name order without index preloads' do
+      result = described_class.new(scope: Location.where(id: [locations(:school).id, locations(:home).id])).options
+
+      expect(result.map(&:name)).to eq(%w[Home School])
+      expect(result.first.association(:medications)).not_to be_loaded
+    end
+  end
 end

--- a/spec/services/medication_query_spec.rb
+++ b/spec/services/medication_query_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe MedicationQuery do
   fixtures :locations, :medications
 
-  let(:scope) { Medication.includes(:location) }
+  let(:scope) { Medication.all }
 
   before do
     Medication.create!(
@@ -23,6 +23,7 @@ RSpec.describe MedicationQuery do
     results = described_class.new(scope: scope).call
 
     expect(results.map(&:name)).to include('Paracetamol', 'Vitamin D', 'School Only Medicine')
+    expect(results.first.association(:location)).to be_loaded
   end
 
   it 'filters by category' do

--- a/spec/services/people_index_query_spec.rb
+++ b/spec/services/people_index_query_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PeopleIndexQuery do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :schedules, :person_medications
+
+  describe '#call' do
+    it 'returns only people from the passed scope with the expected preloads' do
+      result = described_class.new(scope: Person.where(id: [people(:john).id])).call
+
+      expect(result).to contain_exactly(people(:john))
+      expect(result.first.association(:user)).to be_loaded
+      expect(result.first.association(:schedules)).to be_loaded
+      expect(result.first.association(:person_medications)).to be_loaded
+    end
+  end
+end

--- a/spec/services/reports/index_query_spec.rb
+++ b/spec/services/reports/index_query_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reports::IndexQuery do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :schedules, :medication_takes
+
+  let(:people_scope) { Person.where(id: [people(:john).id, people(:jane).id]) }
+  let(:start_date) { Time.zone.today - 1.day }
+  let(:end_date) { Time.zone.today }
+
+  describe '#call' do
+    it 'returns daily compliance data and inventory alerts for the passed people and date range' do
+      result = described_class.new(people: people_scope, start_date: start_date, end_date: end_date).call
+
+      expect(result.daily_data.pluck(:date)).to eq([start_date, end_date])
+      expect(result.daily_data.last[:expected]).to be >= 1
+      expect(result.daily_data.last[:actual]).to be >= 0
+      expect(result.inventory_alerts).to all(include(:medication_name, :days_left, :doses_left, :low_stock))
+    end
+
+    it 'treats days with no expected doses as 100 percent compliance' do
+      result = described_class.new(people: Person.none, start_date: start_date, end_date: end_date).call
+
+      expect(result.daily_data).to all(include(percentage: 100, expected: 0, actual: 0))
+    end
+
+    it 'limits inventory alerts to the soonest two items under 14 days left' do
+      medication_one = create(:medication, current_supply: 3, supply_at_last_restock: 3)
+      medication_two = create(:medication, current_supply: 5, supply_at_last_restock: 5)
+      medication_three = create(:medication, current_supply: 10, supply_at_last_restock: 10)
+
+      create(:schedule, person: people(:john), medication: medication_one, max_daily_doses: 1)
+      create(:schedule, person: people(:john), medication: medication_two, max_daily_doses: 1)
+      create(:schedule, person: people(:john), medication: medication_three, max_daily_doses: 1)
+
+      result = described_class.new(
+        people: Person.where(id: people(:john).id),
+        start_date: start_date,
+        end_date: end_date
+      ).call
+
+      expect(result.inventory_alerts.size).to be <= 2
+      expect(result.inventory_alerts.pluck(:days_left)).to eq(result.inventory_alerts.pluck(:days_left).sort)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract the remaining controller-side list, filter, and report queries into focused query objects
- rewire the affected controllers so they orchestrate authorized scopes and render results without owning relation composition
- add focused service specs for the new query objects and extend the medication/location query coverage

## Testing
- task rubocop
- task test

Closes #1045
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
