### PR TITLE
refactor: Extract schedule form presenters

### DIFF
--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -7,12 +7,11 @@ module Components
       include Phlex::Rails::Helpers::ButtonTo
       include Pundit::Authorization
 
-      attr_reader :person, :schedules, :take_medication_url_generator, :current_user
+      attr_reader :person, :schedules, :current_user
 
-      def initialize(person:, schedules:, take_medication_url_generator: nil, current_user: nil)
+      def initialize(person:, schedules:, current_user: nil)
         @person = person
         @schedules = schedules
-        @take_medication_url_generator = take_medication_url_generator
         @current_user = current_user
         super()
       end

--- a/app/components/dashboard/schedule.rb
+++ b/app/components/dashboard/schedule.rb
@@ -51,13 +51,8 @@ module Components
         render Components::Dashboard::PersonSchedule.new(
           person: person,
           schedules: schedules,
-          take_medication_url_generator: take_medication_url_generator,
           current_user: current_user
         )
-      end
-
-      def take_medication_url_generator
-        ->(schedule) { schedule_medication_takes_path(schedule) }
       end
 
       def render_empty_state(message, help_text)

--- a/app/components/layouts/current_user_context.rb
+++ b/app/components/layouts/current_user_context.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Components
+  module Layouts
+    module CurrentUserContext
+      attr_reader :current_user
+
+      def initialize(current_user: nil)
+        @current_user = current_user
+        super()
+      end
+
+      private
+
+      def authenticated?
+        current_user.present?
+      end
+
+      def user_is_admin?
+        current_user&.administrator? || false
+      end
+
+      def current_user_name
+        current_user&.name
+      end
+
+      def current_user_initials
+        return 'U' if current_user_name.blank?
+
+        current_user_name.split.map(&:first).join.upcase
+      end
+    end
+  end
+end

--- a/app/components/layouts/mobile_menu.rb
+++ b/app/components/layouts/mobile_menu.rb
@@ -4,15 +4,9 @@ module Components
   module Layouts
     # Mobile hamburger menu using RubyUI::Sheet
     class MobileMenu < Components::Base
+      include Components::Layouts::CurrentUserContext
       include Phlex::Rails::Helpers::LinkTo
       include Phlex::Rails::Helpers::CurrentPage
-
-      attr_reader :current_user
-
-      def initialize(current_user: nil)
-        @current_user = current_user
-        super()
-      end
 
       def view_template
         div(class: 'md:hidden') do
@@ -113,10 +107,6 @@ module Components
             plain t('layouts.mobile_menu.logout')
           end
         end
-      end
-
-      def user_is_admin?
-        current_user&.administrator? || false
       end
     end
   end

--- a/app/components/layouts/navigation.rb
+++ b/app/components/layouts/navigation.rb
@@ -4,12 +4,8 @@ module Components
   module Layouts
     # Navigation component that renders differently based on authentication state
     class Navigation < Components::Base
+      include Components::Layouts::CurrentUserContext
       include Phlex::Rails::Helpers::LinkTo
-
-      def initialize(current_user: nil)
-        @current_user = current_user
-        super()
-      end
 
       def view_template
         header(
@@ -38,13 +34,9 @@ module Components
         ) { t('layouts.navigation.skip_to_content') }
       end
 
-      def authenticated?
-        @current_user.present?
-      end
-
       def render_left_section
         div(class: 'nav__left flex items-center gap-6') do
-          render Components::Layouts::MobileMenu.new(current_user: @current_user) if authenticated?
+          render Components::Layouts::MobileMenu.new(current_user: current_user) if authenticated?
           render_brand
         end
       end
@@ -64,7 +56,7 @@ module Components
       def render_auth_actions
         div(class: 'nav__user-menu hidden md:block') do
           if authenticated?
-            render Components::Layouts::ProfileMenu.new(current_user: @current_user)
+            render Components::Layouts::ProfileMenu.new(current_user: current_user)
           else
             link_to(t('layouts.navigation.login'), '/login', class: 'nav__link text-sm font-medium')
           end

--- a/app/components/layouts/profile_menu.rb
+++ b/app/components/layouts/profile_menu.rb
@@ -4,19 +4,13 @@ module Components
   module Layouts
     # Profile dropdown menu for authenticated users
     class ProfileMenu < Components::Base
+      include Components::Layouts::CurrentUserContext
       include Phlex::Rails::Helpers::LinkTo
-
-      attr_reader :current_user
-
-      def initialize(current_user: nil)
-        @current_user = current_user
-        super()
-      end
 
       def view_template
         render RubyUI::DropdownMenu.new do
           render RubyUI::DropdownMenuTrigger.new(class: 'w-full') do
-            m3_button(variant: :outlined) { current_user_name }
+            m3_button(variant: :outlined) { current_user_name || t('layouts.profile_menu.account') }
           end
           render RubyUI::DropdownMenuContent.new do
             render(RubyUI::DropdownMenuLabel.new { t('layouts.profile_menu.my_account') })
@@ -41,14 +35,6 @@ module Components
           href: '/logout',
           data: { turbo_method: :post }
         ) { t('layouts.profile_menu.logout') }
-      end
-
-      def current_user_name
-        current_user&.name || t('layouts.profile_menu.account')
-      end
-
-      def user_is_admin?
-        current_user&.administrator? || false
       end
     end
   end

--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -3,15 +3,9 @@
 module Components
   module Layouts
     class Sidebar < Components::Base
+      include Components::Layouts::CurrentUserContext
       include Phlex::Rails::Helpers::LinkTo
       include Phlex::Rails::Helpers::Routes
-
-      attr_reader :current_user
-
-      def initialize(current_user: nil)
-        @current_user = current_user
-        super()
-      end
 
       def view_template
         return unless authenticated?
@@ -29,10 +23,6 @@ module Components
       end
 
       private
-
-      def authenticated?
-        @current_user.present?
-      end
 
       def render_brand
         div(class: 'mb-12 px-4 w-full flex justify-center md:justify-start') do
@@ -62,7 +52,7 @@ module Components
           render_nav_link(medication_finder_path, Icons::Search, t('layouts.sidebar.finder'))
           render_nav_link(people_path, Icons::Users, t('layouts.sidebar.people'))
           render_nav_link(reports_path, Icons::AlertCircle, t('layouts.sidebar.reports'))
-          if current_user.administrator?
+          if user_is_admin?
             render_nav_link(admin_root_path, Icons::Settings,
                             t('layouts.sidebar.administration'))
           end
@@ -106,15 +96,11 @@ module Components
               class: 'w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary ' \
                      'font-bold text-xs overflow-hidden flex-shrink-0 z-10'
             ) do
-              if current_user.person&.name.present?
-                current_user.person.name.split.map(&:first).join.upcase
-              else
-                'U'
-              end
+              current_user_initials
             end
             div(class: 'hidden md:block overflow-hidden z-10') do
               p(class: 'text-xs font-bold truncate text-foreground') do
-                current_user.person&.name || t('layouts.sidebar.user_fallback')
+                current_user_name || t('layouts.sidebar.user_fallback')
               end
               p(class: 'text-[10px] font-medium text-on-surface-variant') do
                 t("activerecord.attributes.user.roles.#{current_user.role}", default: current_user.role.to_s.humanize)

--- a/app/components/medications/search_component.rb
+++ b/app/components/medications/search_component.rb
@@ -20,107 +20,117 @@ module Components
 
         div(class: 'mb-12 grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl') do
           form_with(url: medications_path, method: :get, class: 'contents', data: { controller: 'form-submit' }) do
-            render_location_filter if locations.any?
-            render_category_filter if categories.any?
+            render_filter(location_filter_config) if locations.any?
+            render_filter(category_filter_config) if categories.any?
           end
         end
       end
 
       private
 
-      def render_location_filter
+      def render_filter(config)
         div(class: 'space-y-2') do
-          render RubyUI::FormFieldLabel.new(
-            for: 'inventory_location_trigger',
-            class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1'
-          ) { t('medications.show.location') }
-          render RubyUI::Combobox.new(class: 'w-full') do
-            render RubyUI::ComboboxTrigger.new(
-              placeholder: current_location_name || t('medications.index.all_locations', default: 'All locations')
-            )
-
-            render RubyUI::ComboboxPopover.new do
-              render RubyUI::ComboboxSearchInput.new(
-                placeholder: t('medications.index.search_locations', default: 'Filter locations')
-              )
-
-              render RubyUI::ComboboxList.new do
-                render RubyUI::ComboboxEmptyState.new do
-                  t('medications.index.no_locations_found', default: 'No locations found')
-                end
-
-                render RubyUI::ComboboxItem.new do
-                  render RubyUI::ComboboxRadio.new(
-                    name: 'location_id',
-                    value: '',
-                    checked: current_location_id.blank?,
-                    data: { action: 'change->form-submit#submitForm' }
-                  )
-                  span { t('medications.index.all_locations', default: 'All locations') }
-                end
-
-                locations.each do |location|
-                  render RubyUI::ComboboxItem.new do
-                    render RubyUI::ComboboxRadio.new(
-                      name: 'location_id',
-                      value: location.id,
-                      checked: current_location_id == location.id,
-                      data: { action: 'change->form-submit#submitForm' }
-                    )
-                    span { location.name }
-                  end
-                end
-              end
-            end
-          end
+          render_filter_label(config)
+          render_filter_combobox(config)
         end
       end
 
-      def render_category_filter
-        div(class: 'space-y-2') do
-          render RubyUI::FormFieldLabel.new(
-            for: 'inventory_category_trigger',
-            class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1'
-          ) { 'Category' }
-          render RubyUI::Combobox.new(class: 'w-full') do
-            render RubyUI::ComboboxTrigger.new(
-              placeholder: current_category.presence || t('medications.index.all')
-            )
+      def render_filter_label(config)
+        render RubyUI::FormFieldLabel.new(
+          for: config.fetch(:label_for),
+          class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1'
+        ) { config.fetch(:label_text) }
+      end
 
-            render RubyUI::ComboboxPopover.new do
-              render RubyUI::ComboboxSearchInput.new(
-                placeholder: t('forms.medications.filter_categories')
-              )
+      def render_filter_combobox(config)
+        render RubyUI::Combobox.new(class: 'w-full') do
+          render RubyUI::ComboboxTrigger.new(placeholder: config.fetch(:trigger_placeholder))
+          render_filter_popover(config)
+        end
+      end
 
-              render RubyUI::ComboboxList.new do
-                render RubyUI::ComboboxEmptyState.new do
-                  t('forms.medications.no_categories_found')
-                end
+      def render_filter_popover(config)
+        render RubyUI::ComboboxPopover.new do
+          render RubyUI::ComboboxSearchInput.new(placeholder: config.fetch(:search_placeholder))
+          render_filter_list(config)
+        end
+      end
 
-                render RubyUI::ComboboxItem.new do
-                  render RubyUI::ComboboxRadio.new(
-                    name: 'category',
-                    value: '',
-                    checked: current_category.blank?,
-                    data: { action: 'change->form-submit#submitForm' }
-                  )
-                  span { t('medications.index.all') }
-                end
+      def render_filter_list(config)
+        render RubyUI::ComboboxList.new do
+          render(RubyUI::ComboboxEmptyState.new { config.fetch(:empty_text) })
+          render_filter_option(
+            name: config.fetch(:name),
+            value: '',
+            checked: config.fetch(:current_value).blank?,
+            label: config.fetch(:all_text)
+          )
+          render_filter_options(config)
+        end
+      end
 
-                categories.each do |category|
-                  render RubyUI::ComboboxItem.new do
-                    render RubyUI::ComboboxRadio.new(
-                      name: 'category',
-                      value: category,
-                      checked: current_category == category,
-                      data: { action: 'change->form-submit#submitForm' }
-                    )
-                    span { category }
-                  end
-                end
-              end
-            end
-          end
+      def render_filter_options(config)
+        config.fetch(:options).each do |option|
+          option_value = option_value_for(config, option)
+          render_filter_option(
+            name: config.fetch(:name),
+            value: option_value,
+            checked: config.fetch(:current_value) == option_value,
+            label: option_label_for(config, option)
+          )
+        end
+      end
+
+      def location_filter_config
+        {
+          label_for: 'inventory_location_trigger',
+          label_text: t('medications.show.location'),
+          trigger_placeholder: current_location_name ||
+            t('medications.index.all_locations', default: 'All locations'),
+          search_placeholder: t('medications.index.search_locations', default: 'Filter locations'),
+          empty_text: t('medications.index.no_locations_found', default: 'No locations found'),
+          name: 'location_id',
+          current_value: current_location_id,
+          all_text: t('medications.index.all_locations', default: 'All locations'),
+          options: locations,
+          value_key: :id,
+          label_key: :name
+        }
+      end
+
+      def category_filter_config
+        {
+          label_for: 'inventory_category_trigger',
+          label_text: 'Category',
+          trigger_placeholder: current_category.presence || t('medications.index.all'),
+          search_placeholder: t('forms.medications.filter_categories'),
+          empty_text: t('forms.medications.no_categories_found'),
+          name: 'category',
+          current_value: current_category,
+          all_text: t('medications.index.all'),
+          options: categories
+        }
+      end
+
+      def option_value_for(config, option)
+        value_key = config[:value_key]
+        value_key ? option.public_send(value_key) : option
+      end
+
+      def option_label_for(config, option)
+        label_key = config[:label_key]
+        label_key ? option.public_send(label_key) : option
+      end
+
+      def render_filter_option(name:, value:, checked:, label:)
+        render RubyUI::ComboboxItem.new do
+          render RubyUI::ComboboxRadio.new(
+            name: name,
+            value: value,
+            checked: checked,
+            data: { action: 'change->form-submit#submitForm' }
+          )
+          span { label }
         end
       end
 

--- a/app/components/person_medications/form_view.rb
+++ b/app/components/person_medications/form_view.rb
@@ -56,7 +56,9 @@ module Components
           data: {
             controller: 'person-medication-form',
             person_type: person.person_type,
-            person_medication_form_dose_options_value: medication_dose_options.to_json
+            person_medication_form_dose_options_value: ::Medications::DoseOptionsPayloadPresenter.new(
+              medications: medications
+            ).to_h.to_json
           }
         ) do |form|
           render_errors if person_medication.errors.any?
@@ -94,12 +96,6 @@ module Components
               t('person_medications.form.add_medication_button')
             end
           end
-        end
-      end
-
-      def medication_dose_options
-        medications.each_with_object({}) do |medication, dose_options|
-          dose_options[medication.id.to_s] = medication.dose_options_payload
         end
       end
     end

--- a/app/components/person_medications/modal.rb
+++ b/app/components/person_medications/modal.rb
@@ -59,7 +59,9 @@ module Components
           data: {
             controller: 'person-medication-form',
             person_type: person.person_type,
-            person_medication_form_dose_options_value: medication_dose_options.to_json,
+            person_medication_form_dose_options_value: ::Medications::DoseOptionsPayloadPresenter.new(
+              medications: medications
+            ).to_h.to_json,
             person_medication_form_current_step_value: workflow_initial_step,
             person_medication_form_translations_value: {
               chooseMedication: t('person_medications.form.workflow.choose_medication_title'),
@@ -168,12 +170,6 @@ module Components
 
       def dialog_size
         editing ? :xl : :md
-      end
-
-      def medication_dose_options
-        medications.each_with_object({}) do |medication, dose_options|
-          dose_options[medication.id.to_s] = medication.dose_options_payload
-        end
       end
     end
   end

--- a/app/components/ruby_ui/action_style_helpers.rb
+++ b/app/components/ruby_ui/action_style_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RubyUI
+  module ActionStyleHelpers
+    BASE_CLASSES = [
+      'whitespace-nowrap inline-flex items-center justify-center rounded-shape-xl font-medium transition-colors',
+      'disabled:pointer-events-none disabled:opacity-50',
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+      'aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed'
+    ].freeze
+
+    private
+
+    def base_classes
+      BASE_CLASSES
+    end
+
+    def size_classes
+      if @icon
+        case @size
+        when :sm then 'h-8 w-8 min-h-[32px] min-w-[32px]'
+        when :md then 'h-9 w-9 min-h-[36px] min-w-[36px]'
+        when :lg then 'h-10 w-10 min-h-[40px] min-w-[40px]'
+        when :xl then 'h-12 w-12 min-h-[48px] min-w-[48px]'
+        end
+      else
+        case @size
+        when :sm then 'px-3 py-1.5 h-8 min-h-[32px] text-xs'
+        when :md then 'px-4 py-2 h-9 min-h-[36px] text-sm'
+        when :lg then 'px-4 py-2 h-10 min-h-[40px] text-base'
+        when :xl then 'px-6 py-3 h-12 min-h-[48px] text-base'
+        end
+      end
+    end
+  end
+end

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_footer.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_footer.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class AlertDialogFooter < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2'
-      }
-    end
+  class AlertDialogFooter < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2'
   end
 end

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_header.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_header.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class AlertDialogHeader < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col gap-2 text-center sm:text-left rtl:sm:text-right'
-      }
-    end
+  class AlertDialogHeader < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col gap-2 text-center sm:text-left rtl:sm:text-right'
   end
 end

--- a/app/components/ruby_ui/button/button.rb
+++ b/app/components/ruby_ui/button/button.rb
@@ -2,12 +2,7 @@
 
 module RubyUI
   class Button < Base
-    BASE_CLASSES = [
-      'whitespace-nowrap inline-flex items-center justify-center rounded-shape-xl font-medium transition-colors',
-      'disabled:pointer-events-none disabled:opacity-50',
-      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-      'aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed'
-    ].freeze
+    include ActionStyleHelpers
 
     def initialize(type: :button, variant: :primary, size: :md, icon: false, **attrs)
       @type = type
@@ -23,27 +18,9 @@ module RubyUI
 
     private
 
-    def size_classes
-      if @icon
-        case @size
-        when :sm then 'h-8 w-8 min-h-[32px] min-w-[32px]'
-        when :md then 'h-9 w-9 min-h-[36px] min-w-[36px]'
-        when :lg then 'h-10 w-10 min-h-[40px] min-w-[40px]'
-        when :xl then 'h-12 w-12 min-h-[48px] min-w-[48px]'
-        end
-      else
-        case @size
-        when :sm then 'px-3 py-1.5 h-8 min-h-[32px] text-xs'
-        when :md then 'px-4 py-2 h-9 min-h-[36px] text-sm'
-        when :lg then 'px-4 py-2 h-10 min-h-[40px] text-base'
-        when :xl then 'px-6 py-3 h-12 min-h-[48px] text-base'
-        end
-      end
-    end
-
     def primary_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-primary text-primary-foreground',
         'hover:opacity-90 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -52,7 +29,7 @@ module RubyUI
 
     def link_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'text-primary underline-offset-4 font-bold',
         'hover:underline hover:opacity-80 transition-all'
@@ -61,7 +38,7 @@ module RubyUI
 
     def secondary_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-secondary-container text-on-secondary-container shadow-sm',
         'hover:opacity-80 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -70,7 +47,7 @@ module RubyUI
 
     def destructive_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-error text-on-error',
         'hover:opacity-90 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -79,7 +56,7 @@ module RubyUI
 
     def outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background',
         'hover:bg-tertiary-container hover:text-on-tertiary-container hover:scale-[1.02] transition-all'
@@ -88,7 +65,7 @@ module RubyUI
 
     def destructive_outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background',
         'text-error hover:bg-error-container hover:scale-[1.02] transition-all'
@@ -97,7 +74,7 @@ module RubyUI
 
     def success_outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background',
         'text-success hover:bg-success-container hover:scale-[1.02] transition-all'
@@ -106,7 +83,7 @@ module RubyUI
 
     def ghost_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'hover:bg-tertiary-container hover:text-on-tertiary-container'
       ]
@@ -114,7 +91,7 @@ module RubyUI
 
     def success_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-success text-success-foreground shadow-sm',
         'hover:opacity-90 hover:scale-[1.02] active:scale-[0.98] transition-all'

--- a/app/components/ruby_ui/card/card_content.rb
+++ b/app/components/ruby_ui/card/card_content.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class CardContent < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'p-6 pt-0'
-      }
-    end
+  class CardContent < DivWrapper
+    DEFAULT_CLASS = 'p-6 pt-0'
   end
 end

--- a/app/components/ruby_ui/card/card_footer.rb
+++ b/app/components/ruby_ui/card/card_footer.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class CardFooter < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'items-center p-6 pt-0'
-      }
-    end
+  class CardFooter < DivWrapper
+    DEFAULT_CLASS = 'items-center p-6 pt-0'
   end
 end

--- a/app/components/ruby_ui/card/card_header.rb
+++ b/app/components/ruby_ui/card/card_header.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class CardHeader < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col space-y-1.5 p-6'
-      }
-    end
+  class CardHeader < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col space-y-1.5 p-6'
   end
 end

--- a/app/components/ruby_ui/dialog/dialog_footer.rb
+++ b/app/components/ruby_ui/dialog/dialog_footer.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class DialogFooter < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-y-2 sm:gap-y-0 rtl:space-x-reverse'
-      }
-    end
+  class DialogFooter < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-y-2 sm:gap-y-0 rtl:space-x-reverse'
   end
 end

--- a/app/components/ruby_ui/dialog/dialog_header.rb
+++ b/app/components/ruby_ui/dialog/dialog_header.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class DialogHeader < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col gap-2 border-b border-border/60 bg-popover px-8 pb-4 pt-8 text-center sm:text-left rtl:sm:text-right'
-      }
-    end
+  class DialogHeader < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col gap-2 border-b border-border/60 bg-popover px-8 pb-4 pt-8 text-center sm:text-left rtl:sm:text-right'
   end
 end

--- a/app/components/ruby_ui/dialog/dialog_middle.rb
+++ b/app/components/ruby_ui/dialog/dialog_middle.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class DialogMiddle < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'bg-popover px-8 pb-8 pt-4'
-      }
-    end
+  class DialogMiddle < DivWrapper
+    DEFAULT_CLASS = 'bg-popover px-8 pb-8 pt-4'
   end
 end

--- a/app/components/ruby_ui/div_wrapper.rb
+++ b/app/components/ruby_ui/div_wrapper.rb
@@ -2,6 +2,8 @@
 
 module RubyUI
   class DivWrapper < Base
+    DEFAULT_CLASS = ''
+
     def view_template(&)
       div(**attrs, &)
     end

--- a/app/components/ruby_ui/div_wrapper.rb
+++ b/app/components/ruby_ui/div_wrapper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class DivWrapper < Base
+    def view_template(&)
+      div(**attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        class: self.class::DEFAULT_CLASS
+      }
+    end
+  end
+end

--- a/app/components/ruby_ui/link/link.rb
+++ b/app/components/ruby_ui/link/link.rb
@@ -2,12 +2,7 @@
 
 module RubyUI
   class Link < Base
-    BASE_CLASSES = [
-      'whitespace-nowrap inline-flex items-center justify-center rounded-shape-xl font-medium transition-colors',
-      'disabled:pointer-events-none disabled:opacity-50',
-      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-      'aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed'
-    ].freeze
+    include ActionStyleHelpers
 
     def initialize(href: '#', variant: :link, size: :md, icon: false, **attrs)
       @href = href
@@ -32,27 +27,9 @@ module RubyUI
       end
     end
 
-    def size_classes
-      if @icon
-        case @size
-        when :sm then 'h-8 w-8 min-h-[32px] min-w-[32px]'
-        when :md then 'h-9 w-9 min-h-[36px] min-w-[36px]'
-        when :lg then 'h-10 w-10 min-h-[40px] min-w-[40px]'
-        when :xl then 'h-12 w-12 min-h-[48px] min-w-[48px]'
-        end
-      else
-        case @size
-        when :sm then 'px-3 py-1.5 h-8 min-h-[32px] text-xs'
-        when :md then 'px-4 py-2 h-9 min-h-[36px] text-sm'
-        when :lg then 'px-4 py-2 h-10 min-h-[40px] text-base'
-        when :xl then 'px-6 py-3 h-12 min-h-[48px] text-base'
-        end
-      end
-    end
-
     def primary_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-primary text-primary-foreground no-underline',
         'hover:opacity-90 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -61,7 +38,7 @@ module RubyUI
 
     def link_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'text-primary underline-offset-4 font-bold',
         'hover:underline hover:opacity-80 transition-all'
@@ -70,7 +47,7 @@ module RubyUI
 
     def secondary_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-secondary text-secondary-foreground no-underline shadow-sm',
         'hover:opacity-80 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -79,7 +56,7 @@ module RubyUI
 
     def destructive_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'bg-error text-on-error no-underline',
         'hover:opacity-90 hover:scale-[1.02] active:scale-[0.98] transition-all'
@@ -88,7 +65,7 @@ module RubyUI
 
     def outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background no-underline',
         'hover:bg-tertiary-container hover:text-on-tertiary-container hover:scale-[1.02] transition-all'
@@ -97,7 +74,7 @@ module RubyUI
 
     def destructive_outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background no-underline',
         'text-error hover:bg-error-container hover:scale-[1.02] transition-all'
@@ -106,7 +83,7 @@ module RubyUI
 
     def success_outline_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'border border-outline bg-background no-underline',
         'text-success hover:bg-success-container hover:scale-[1.02] transition-all'
@@ -115,7 +92,7 @@ module RubyUI
 
     def ghost_classes
       [
-        BASE_CLASSES,
+        base_classes,
         size_classes,
         'no-underline hover:bg-tertiary-container hover:text-on-tertiary-container'
       ]

--- a/app/components/ruby_ui/sheet/sheet_footer.rb
+++ b/app/components/ruby_ui/sheet/sheet_footer.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class SheetFooter < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-y-2 sm:gap-y-0'
-      }
-    end
+  class SheetFooter < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-y-2 sm:gap-y-0'
   end
 end

--- a/app/components/ruby_ui/sheet/sheet_header.rb
+++ b/app/components/ruby_ui/sheet/sheet_header.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class SheetHeader < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'flex flex-col space-y-1.5 text-center sm:text-left'
-      }
-    end
+  class SheetHeader < DivWrapper
+    DEFAULT_CLASS = 'flex flex-col space-y-1.5 text-center sm:text-left'
   end
 end

--- a/app/components/ruby_ui/sheet/sheet_middle.rb
+++ b/app/components/ruby_ui/sheet/sheet_middle.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class SheetMiddle < Base
-    def view_template(&)
-      div(**attrs, &)
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: 'py-4'
-      }
-    end
+  class SheetMiddle < DivWrapper
+    DEFAULT_CLASS = 'py-4'
   end
 end

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -20,23 +20,7 @@ module Components
         form_with(
           model: [person, schedule],
           class: 'space-y-6',
-          data: {
-            controller: 'schedule-form',
-            turbo_stream: true,
-            person_type: person.person_type,
-            schedule_form_dose_options_value: medication_dose_options.to_json,
-            schedule_form_frame_id_value: frame_id,
-            schedule_form_next_url_value: new_person_schedule_path(person),
-            schedule_form_translations_value: {
-              selectDosage: t('schedules.form.select_dosage'),
-              selectMedicationFirst: t('schedules.form.select_medication_first'),
-              frequencyOncePerCycle: t('schedules.form.frequency_once_per_cycle'),
-              frequencyUpToPerCycle: t('schedules.form.frequency_up_to_per_cycle'),
-              frequencyOnce: t('schedules.form.frequency_once'),
-              frequencyUpTo: t('schedules.form.frequency_up_to'),
-              frequencyAtLeastHours: t('schedules.form.frequency_at_least_hours')
-            }.to_json
-          }
+          data: form_payload
         ) do |f|
           render_errors if schedule.errors.any?
           render_dose_snapshot_inputs
@@ -316,8 +300,8 @@ module Components
                 placeholder: t('schedules.form.select_medication_first'),
                 data: { schedule_form_target: 'dosageValue' }
               ) do
-                if selected_dosage_option
-                  format_dosage_option(selected_dosage_option)
+                if dosage_options.selected_dosage_option
+                  dosage_options.format_dosage_option(dosage_options.selected_dosage_option)
                 else
                   t('schedules.form.select_medication_first')
                 end
@@ -326,7 +310,7 @@ module Components
             SelectContent(data: { schedule_form_target: 'dosageContent' }) do
               (schedule.medication&.dosages || []).each do |dosage|
                 SelectItem(value: dosage.selection_key) do
-                  format_dosage_option(dosage)
+                  dosage_options.format_dosage_option(dosage)
                 end
               end
             end
@@ -530,7 +514,7 @@ module Components
       end
 
       def format_dosage_option(dosage)
-        "#{dosage.amount.to_f} #{dosage.unit} - #{dosage.description}"
+        dosage_options.format_dosage_option(dosage)
       end
 
       def dosage_card_classes(dosage)
@@ -544,40 +528,36 @@ module Components
       end
 
       def selected_dosage_option
-        return @selected_dosage_option if defined?(@selected_dosage_option)
-
-        @selected_dosage_option = (schedule.medication&.dosages || []).find do |dosage|
-          dosage.amount.to_s == schedule.dose_amount.to_s && dosage.unit == schedule.dose_unit
-        end
+        dosage_options.selected_dosage_option
       end
 
       def selected_dose_selection_key
-        selected_dosage_option&.selection_key
+        dosage_options.selected_dose_selection_key
       end
 
       def dosage_dom_id(dosage)
-        key = dosage.selection_key.parameterize(separator: '_')
-        return "schedule_dose_option_#{key}" unless duplicate_dose_selection_keys.include?(dosage.selection_key)
-
-        description = dosage.description.to_s.parameterize(separator: '_').presence || dosage.object_id
-        "schedule_dose_option_#{key}_#{description}"
+        dosage_options.dosage_dom_id(dosage)
       end
 
       def duplicate_dose_selection_keys
-        @duplicate_dose_selection_keys ||= begin
-          dosages = schedule.medication&.dosages || []
-          grouped_dosages = dosages.group_by(&:selection_key)
-
-          grouped_dosages.each_with_object([]) do |(selection_key, matching_dosages), selection_keys|
-            selection_keys << selection_key if matching_dosages.size > 1
-          end
-        end
+        dosage_options.duplicate_dose_selection_keys
       end
 
       def medication_dose_options
-        medications.each_with_object({}) do |medication, dose_options|
-          dose_options[medication.id.to_s] = medication.dose_options_payload
-        end
+        dosage_options.medication_dose_options
+      end
+
+      def dosage_options
+        @dosage_options ||= ::Schedules::DosageOptionsPresenter.new(schedule: schedule, medications: medications)
+      end
+
+      def form_payload
+        @form_payload ||= ::Schedules::FormPayloadPresenter.new(
+          person: person,
+          medications: medications,
+          frame_id: frame_id,
+          view_context: self
+        ).data
       end
     end
   end

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -230,9 +230,9 @@ module Components
                   input(
                     type: :radio,
                     name: 'schedule[dose_option_key]',
-                    id: dosage_dom_id(dosage),
+                    id: dosage_options.dosage_dom_id(dosage),
                     value: dosage.selection_key,
-                    checked: selected_dose_selection_key == dosage.selection_key,
+                    checked: dosage_options.selected_dose_selection_key == dosage.selection_key,
                     required: true,
                     class: 'sr-only',
                     data: {
@@ -286,7 +286,7 @@ module Components
             SelectInput(
               name: 'schedule[dose_option_key]',
               id: 'schedule_dose_option_key',
-              value: selected_dose_selection_key,
+              value: dosage_options.selected_dose_selection_key,
               required: true,
               data: { action: 'change->schedule-form#onDosageChange' }
             )
@@ -513,13 +513,9 @@ module Components
         end
       end
 
-      def format_dosage_option(dosage)
-        dosage_options.format_dosage_option(dosage)
-      end
-
       def dosage_card_classes(dosage)
         base = 'rounded-2xl border p-4 transition-colors cursor-pointer'
-        selected = if selected_dose_selection_key == dosage.selection_key
+        selected = if dosage_options.selected_dose_selection_key == dosage.selection_key
                      ' border-primary bg-primary/5 ring-2 ring-primary/20'
                    else
                      ' border-border bg-card'
@@ -527,28 +523,8 @@ module Components
         "#{base}#{selected}"
       end
 
-      def selected_dosage_option
-        dosage_options.selected_dosage_option
-      end
-
-      def selected_dose_selection_key
-        dosage_options.selected_dose_selection_key
-      end
-
-      def dosage_dom_id(dosage)
-        dosage_options.dosage_dom_id(dosage)
-      end
-
-      def duplicate_dose_selection_keys
-        dosage_options.duplicate_dose_selection_keys
-      end
-
-      def medication_dose_options
-        dosage_options.medication_dose_options
-      end
-
       def dosage_options
-        @dosage_options ||= ::Schedules::DosageOptionsPresenter.new(schedule: schedule, medications: medications)
+        @dosage_options ||= ::Schedules::DosageOptionsPresenter.new(schedule: schedule)
       end
 
       def form_payload

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -532,8 +532,21 @@ module Components
           person: person,
           medications: medications,
           frame_id: frame_id,
-          view_context: self
+          next_url: new_person_schedule_path(person),
+          translations: form_translations
         ).data
+      end
+
+      def form_translations
+        {
+          selectDosage: t('schedules.form.select_dosage'),
+          selectMedicationFirst: t('schedules.form.select_medication_first'),
+          frequencyOncePerCycle: t('schedules.form.frequency_once_per_cycle'),
+          frequencyUpToPerCycle: t('schedules.form.frequency_up_to_per_cycle'),
+          frequencyOnce: t('schedules.form.frequency_once'),
+          frequencyUpTo: t('schedules.form.frequency_up_to'),
+          frequencyAtLeastHours: t('schedules.form.frequency_at_least_hours')
+        }
       end
     end
   end

--- a/app/components/shared/metric_card.rb
+++ b/app/components/shared/metric_card.rb
@@ -137,11 +137,6 @@ module Components
         compact? ? 'text-2xl' : 'text-4xl'
       end
 
-      def background_class
-        # No longer used directly, but kept for logic if needed
-        variant == :warning ? 'bg-warning-container' : 'bg-surface-container-low'
-      end
-
       def border_class
         variant == :warning ? 'border border-warning/30' : 'border-none'
       end

--- a/app/components/shared/stock_badge.rb
+++ b/app/components/shared/stock_badge.rb
@@ -21,24 +21,25 @@ module Components
       private
 
       def badge_variant
-        if medication.out_of_stock?
-          :destructive
-        elsif medication.low_stock?
-          :warning
-        else
-          :outline
+        case stock_status
+        when :out_of_stock then :destructive
+        when :low_stock then :warning
+        else :outline
         end
       end
 
       def badge_text
         count = medication.current_supply.to_i
-        if medication.out_of_stock?
-          "Out of Stock (#{count})"
-        elsif medication.low_stock?
-          "Low Stock (#{count})"
-        else
-          "#{count} left"
+
+        case stock_status
+        when :out_of_stock then "Out of Stock (#{count})"
+        when :low_stock then "Low Stock (#{count})"
+        else "#{count} left"
         end
+      end
+
+      def stock_status
+        medication.supply_level.status
       end
     end
   end

--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -43,6 +43,13 @@ class SupplyLevel
     current <= 0
   end
 
+  def status
+    return :out_of_stock if out_of_stock?
+    return :low_stock if low_stock?
+
+    :in_stock
+  end
+
   def days_until_low_stock(daily_consumption:)
     return nil unless forecast_available?(daily_consumption:)
     return 0 if low_stock?

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -43,36 +43,35 @@ class DashboardPresenter
   def load_people
     return Person.none if current_user.nil?
 
-    return all_people if full_access?
-    return carer_patients if carer?
-    return parent_minor_patients if parent?
+    return people_scope(Person.all) if full_access?
 
-    own_person
+    current_person_scope
   end
 
-  def all_people
-    Person.includes(:user, schedules: [:medication], person_medications: :medication).all
+  def people_scope(scope_or_ids)
+    scope = if scope_or_ids.is_a?(ActiveRecord::Relation)
+              scope_or_ids
+            else
+              Person.where(id: Array(scope_or_ids).uniq)
+            end
+
+    scope.includes(:user, schedules: [:medication], person_medications: :medication)
   end
 
-  def carer_patients
-    return Person.none if current_user.person.nil?
-
-    current_user.person.patients.includes(:user, schedules: [:medication], person_medications: :medication)
+  def current_person
+    current_user.person
   end
 
-  def parent_minor_patients
-    return Person.none if current_user.person.nil?
+  def current_person_scope
+    return Person.none if current_person.nil?
+    return people_scope(current_person.patients) if carer?
+    return people_scope(parent_people_ids) if parent?
 
-    people_ids = [current_user.person.id] + current_user.person.patients.where(person_type: :minor).pluck(:id)
-    Person.where(id: people_ids.uniq)
-          .includes(:user, schedules: [:medication], person_medications: :medication)
+    people_scope(current_person.id)
   end
 
-  def own_person
-    return Person.none if current_user.person.nil?
-
-    Person.where(id: current_user.person.id)
-          .includes(:user, schedules: [:medication], person_medications: :medication)
+  def parent_people_ids
+    [current_person.id] + current_person.patients.where(person_type: :minor).pluck(:id)
   end
 
   def carer?

--- a/app/presenters/medications/dose_options_payload_presenter.rb
+++ b/app/presenters/medications/dose_options_payload_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Medications
+  class DoseOptionsPayloadPresenter
+    attr_reader :medications
+
+    def initialize(medications:)
+      @medications = medications
+    end
+
+    def to_h
+      medications.each_with_object({}) do |medication, dose_options|
+        dose_options[medication.id.to_s] = medication.dose_options_payload
+      end
+    end
+  end
+end

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -13,19 +13,23 @@ module Medications
     def status_variant
       return :default if medication.reorder_ordered?
       return :success if medication.reorder_received?
-      return :destructive if supply_level.out_of_stock?
-      return :warning if supply_level.low_stock?
 
-      :success
+      case supply_level.status
+      when :out_of_stock then :destructive
+      when :low_stock then :warning
+      else :success
+      end
     end
 
     def status_label
       return I18n.t('medications.reorder_statuses.ordered') if medication.reorder_ordered?
       return I18n.t('medications.reorder_statuses.received') if medication.reorder_received?
-      return I18n.t('dashboard.statuses.out_of_stock') if supply_level.out_of_stock?
-      return I18n.t('medications.show.low_stock_alert') if supply_level.low_stock?
 
-      I18n.t('medications.index.in_stock', default: 'In Stock')
+      case supply_level.status
+      when :out_of_stock then I18n.t('dashboard.statuses.out_of_stock')
+      when :low_stock then I18n.t('medications.show.low_stock_alert')
+      else I18n.t('medications.index.in_stock', default: 'In Stock')
+      end
     end
 
     def stock_count_class

--- a/app/presenters/schedules/dosage_options_presenter.rb
+++ b/app/presenters/schedules/dosage_options_presenter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Schedules
+  class DosageOptionsPresenter
+    attr_reader :schedule, :medications
+
+    def initialize(schedule:, medications:)
+      @schedule = schedule
+      @medications = medications
+    end
+
+    def format_dosage_option(dosage)
+      "#{dosage.amount.to_f} #{dosage.unit} - #{dosage.description}"
+    end
+
+    def selected_dosage_option
+      return @selected_dosage_option if defined?(@selected_dosage_option)
+
+      @selected_dosage_option = dosages.find do |dosage|
+        dosage.amount.to_s == schedule.dose_amount.to_s && dosage.unit == schedule.dose_unit
+      end
+    end
+
+    def selected_dose_selection_key
+      selected_dosage_option&.selection_key
+    end
+
+    def dosage_dom_id(dosage)
+      key = dosage.selection_key.parameterize(separator: '_')
+      return "schedule_dose_option_#{key}" unless duplicate_dose_selection_keys.include?(dosage.selection_key)
+
+      description = dosage.description.to_s.parameterize(separator: '_').presence || dosage.object_id
+      "schedule_dose_option_#{key}_#{description}"
+    end
+
+    def duplicate_dose_selection_keys
+      @duplicate_dose_selection_keys ||= dosages.group_by(&:selection_key).each_with_object([]) do |group,
+                                                                                                selection_keys|
+        selection_key, matching_dosages = group
+        selection_keys << selection_key if matching_dosages.size > 1
+      end
+    end
+
+    def medication_dose_options
+      medications.each_with_object({}) do |medication, dose_options|
+        dose_options[medication.id.to_s] = medication.dose_options_payload
+      end
+    end
+
+    private
+
+    def dosages
+      schedule.medication&.dosages || []
+    end
+  end
+end

--- a/app/presenters/schedules/dosage_options_presenter.rb
+++ b/app/presenters/schedules/dosage_options_presenter.rb
@@ -2,11 +2,10 @@
 
 module Schedules
   class DosageOptionsPresenter
-    attr_reader :schedule, :medications
+    attr_reader :schedule
 
-    def initialize(schedule:, medications:)
+    def initialize(schedule:)
       @schedule = schedule
-      @medications = medications
     end
 
     def format_dosage_option(dosage)
@@ -38,12 +37,6 @@ module Schedules
                                                                                                 selection_keys|
         selection_key, matching_dosages = group
         selection_keys << selection_key if matching_dosages.size > 1
-      end
-    end
-
-    def medication_dose_options
-      medications.each_with_object({}) do |medication, dose_options|
-        dose_options[medication.id.to_s] = medication.dose_options_payload
       end
     end
 

--- a/app/presenters/schedules/form_payload_presenter.rb
+++ b/app/presenters/schedules/form_payload_presenter.rb
@@ -2,13 +2,14 @@
 
 module Schedules
   class FormPayloadPresenter
-    attr_reader :person, :medications, :frame_id, :view_context
+    attr_reader :person, :medications, :frame_id, :next_url, :translations
 
-    def initialize(person:, medications:, frame_id:, view_context:)
+    def initialize(person:, medications:, frame_id:, next_url:, translations:)
       @person = person
       @medications = medications
       @frame_id = frame_id
-      @view_context = view_context
+      @next_url = next_url
+      @translations = translations
     end
 
     def data
@@ -20,22 +21,8 @@ module Schedules
           medications: medications
         ).to_h.to_json,
         schedule_form_frame_id_value: frame_id,
-        schedule_form_next_url_value: view_context.new_person_schedule_path(person),
+        schedule_form_next_url_value: next_url,
         schedule_form_translations_value: translations.to_json
-      }
-    end
-
-    private
-
-    def translations
-      {
-        selectDosage: view_context.t('schedules.form.select_dosage'),
-        selectMedicationFirst: view_context.t('schedules.form.select_medication_first'),
-        frequencyOncePerCycle: view_context.t('schedules.form.frequency_once_per_cycle'),
-        frequencyUpToPerCycle: view_context.t('schedules.form.frequency_up_to_per_cycle'),
-        frequencyOnce: view_context.t('schedules.form.frequency_once'),
-        frequencyUpTo: view_context.t('schedules.form.frequency_up_to'),
-        frequencyAtLeastHours: view_context.t('schedules.form.frequency_at_least_hours')
       }
     end
   end

--- a/app/presenters/schedules/form_payload_presenter.rb
+++ b/app/presenters/schedules/form_payload_presenter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Schedules
+  class FormPayloadPresenter
+    attr_reader :person, :medications, :frame_id, :view_context
+
+    def initialize(person:, medications:, frame_id:, view_context:)
+      @person = person
+      @medications = medications
+      @frame_id = frame_id
+      @view_context = view_context
+    end
+
+    def data
+      {
+        controller: 'schedule-form',
+        turbo_stream: true,
+        person_type: person.person_type,
+        schedule_form_dose_options_value: medication_dose_options.to_json,
+        schedule_form_frame_id_value: frame_id,
+        schedule_form_next_url_value: view_context.new_person_schedule_path(person),
+        schedule_form_translations_value: translations.to_json
+      }
+    end
+
+    private
+
+    def medication_dose_options
+      medications.each_with_object({}) do |medication, dose_options|
+        dose_options[medication.id.to_s] = medication.dose_options_payload
+      end
+    end
+
+    def translations
+      {
+        selectDosage: view_context.t('schedules.form.select_dosage'),
+        selectMedicationFirst: view_context.t('schedules.form.select_medication_first'),
+        frequencyOncePerCycle: view_context.t('schedules.form.frequency_once_per_cycle'),
+        frequencyUpToPerCycle: view_context.t('schedules.form.frequency_up_to_per_cycle'),
+        frequencyOnce: view_context.t('schedules.form.frequency_once'),
+        frequencyUpTo: view_context.t('schedules.form.frequency_up_to'),
+        frequencyAtLeastHours: view_context.t('schedules.form.frequency_at_least_hours')
+      }
+    end
+  end
+end

--- a/app/presenters/schedules/form_payload_presenter.rb
+++ b/app/presenters/schedules/form_payload_presenter.rb
@@ -16,7 +16,9 @@ module Schedules
         controller: 'schedule-form',
         turbo_stream: true,
         person_type: person.person_type,
-        schedule_form_dose_options_value: medication_dose_options.to_json,
+        schedule_form_dose_options_value: ::Medications::DoseOptionsPayloadPresenter.new(
+          medications: medications
+        ).to_h.to_json,
         schedule_form_frame_id_value: frame_id,
         schedule_form_next_url_value: view_context.new_person_schedule_path(person),
         schedule_form_translations_value: translations.to_json
@@ -24,12 +26,6 @@ module Schedules
     end
 
     private
-
-    def medication_dose_options
-      medications.each_with_object({}) do |medication, dose_options|
-        dose_options[medication.id.to_s] = medication.dose_options_payload
-      end
-    end
 
     def translations
       {

--- a/app/services/person_show_query.rb
+++ b/app/services/person_show_query.rb
@@ -12,34 +12,27 @@ class PersonShowQuery
   def call
     schedules = person.schedules.includes(:medication)
     person_medications = person.person_medications.includes(:medication).ordered
+    preloaded_takes = {
+      schedules: takes_by(schedules, :schedule_id),
+      person_medications: takes_by(person_medications, :person_medication_id)
+    }
 
     Result.new(
       person: person,
       schedules: schedules,
       person_medications: person_medications,
-      preloaded_takes: {
-        schedules: takes_by_schedule(schedules),
-        person_medications: takes_by_person_medication(person_medications)
-      }
+      preloaded_takes: preloaded_takes
     )
   end
 
   private
 
-  def takes_by_schedule(schedules)
+  def takes_by(records, foreign_key)
     MedicationTake
-      .where(schedule_id: schedules.map(&:id), taken_at: today_range)
+      .where(foreign_key => records.map(&:id), taken_at: today_range)
       .includes(:taken_from_location, :taken_from_medication)
       .order(taken_at: :desc)
-      .group_by(&:schedule_id)
-  end
-
-  def takes_by_person_medication(person_medications)
-    MedicationTake
-      .where(person_medication_id: person_medications.map(&:id), taken_at: today_range)
-      .includes(:taken_from_location, :taken_from_medication)
-      .order(taken_at: :desc)
-      .group_by(&:person_medication_id)
+      .group_by(&foreign_key)
   end
 
   def today_range

--- a/app/views/reports/index.rb
+++ b/app/views/reports/index.rb
@@ -84,9 +84,9 @@ module Views
 
       def summary_stat(label, value, subtext)
         div(class: 'space-y-1') do
-          m3_text(size: '1', class: 'font-bold uppercase tracking-widest text-primary-foreground/70') { label }
+          m3_text(size: '1', class: 'font-bold uppercase tracking-widest text-primary-foreground/85') { label }
           m3_heading(level: 2, size: '8', class: 'font-black') { value }
-          m3_text(size: '1', class: 'inline-block rounded-full bg-primary-foreground/12 px-2 py-0.5 font-bold text-primary-foreground') { subtext }
+          m3_text(size: '1', class: 'inline-block rounded-full bg-primary-foreground/20 px-2 py-0.5 font-bold text-primary-foreground') { subtext }
         end
       end
 

--- a/spec/components/dashboard/schedule_spec.rb
+++ b/spec/components/dashboard/schedule_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Dashboard::Schedule, type: :component do
+  fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules
+
+  let(:person) { people(:john) }
+  let(:schedules_for_person) { person.schedules.where(active: true) }
+  let(:upcoming_schedules) { { person => schedules_for_person } }
+
+  it 'renders person schedules without passing a take medication URL generator' do
+    allow(Components::Dashboard::PersonSchedule).to receive(:new).and_call_original
+
+    render_inline(described_class.new(people: [person], upcoming_schedules: upcoming_schedules))
+
+    expect(Components::Dashboard::PersonSchedule).to have_received(:new).with(
+      person: person,
+      schedules: schedules_for_person,
+      current_user: nil
+    )
+  end
+end

--- a/spec/components/layouts/current_user_context_spec.rb
+++ b/spec/components/layouts/current_user_context_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Layouts::CurrentUserContext do
+  subject(:component) { component_class.new(current_user: current_user) }
+
+  let(:current_user) { build_user(name: 'Admin Doe', administrator: true) }
+  let(:component_class) do
+    Class.new(Components::Base) do
+      include Components::Layouts::CurrentUserContext
+    end
+  end
+
+  describe '#authenticated?' do
+    it 'is true when current_user is present' do
+      expect(component.send(:authenticated?)).to be(true)
+    end
+
+    context 'when current_user is nil' do
+      let(:current_user) { nil }
+
+      it 'is false' do
+        expect(component.send(:authenticated?)).to be(false)
+      end
+    end
+  end
+
+  describe '#user_is_admin?' do
+    it 'is true for administrators' do
+      expect(component.send(:user_is_admin?)).to be(true)
+    end
+
+    context 'when current_user is not an administrator' do
+      let(:current_user) { build_user(name: 'Carer Person', administrator: false) }
+
+      it 'is false' do
+        expect(component.send(:user_is_admin?)).to be(false)
+      end
+    end
+  end
+
+  describe '#current_user_name' do
+    it 'returns the delegated user name' do
+      expect(component.send(:current_user_name)).to eq('Admin Doe')
+    end
+
+    context 'when current_user is nil' do
+      let(:current_user) { nil }
+
+      it 'returns nil' do
+        expect(component.send(:current_user_name)).to be_nil
+      end
+    end
+  end
+
+  describe '#current_user_initials' do
+    it 'returns initials from the user name' do
+      expect(component.send(:current_user_initials)).to eq('AD')
+    end
+
+    context 'when the user has no name' do
+      let(:current_user) { build_user(name: nil, administrator: false) }
+
+      it 'falls back to U' do
+        expect(component.send(:current_user_initials)).to eq('U')
+      end
+    end
+  end
+
+  def build_user(name:, administrator:)
+    Class.new do
+      attr_reader :name
+
+      def initialize(name:, administrator:)
+        @name = name
+        @administrator = administrator
+      end
+
+      def administrator?
+        @administrator
+      end
+    end.new(name: name, administrator: administrator)
+  end
+end

--- a/spec/components/person_medications/form_view_spec.rb
+++ b/spec/components/person_medications/form_view_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Components::PersonMedications::FormView, type: :component do
+  def rendered_dose_options(component)
+    rendered = render_inline(component)
+    form = rendered.at_css('form[data-controller="person-medication-form"]')
+
+    expect(form).to be_present
+    JSON.parse(form['data-person-medication-form-dose-options-value'])
+  end
+
   describe 'i18n translations' do
     it 'renders form with default locale translations' do
       person_medication = PersonMedication.new
@@ -21,5 +29,24 @@ RSpec.describe Components::PersonMedications::FormView, type: :component do
       expect(rendered.to_html).to include('Add Medication for John Doe')
       expect(rendered.to_html).to include('Cancel')
     end
+  end
+
+  it 'renders medication dose options for the Stimulus controller' do
+    person_medication = PersonMedication.new
+    person = instance_double(Person, name: 'John Doe', person_type: 'adult')
+    medication = create(:medication, name: 'Calpol')
+    allow(medication).to receive(:dose_options_payload).and_return([{ 'amount' => '1' }])
+
+    payload = rendered_dose_options(
+      described_class.new(
+        person_medication: person_medication,
+        person: person,
+        medications: [medication]
+      )
+    )
+
+    expect(payload).to eq(
+      medication.id.to_s => [{ 'amount' => '1' }]
+    )
   end
 end

--- a/spec/components/person_medications/modal_spec.rb
+++ b/spec/components/person_medications/modal_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Components::PersonMedications::Modal, type: :component do
+  def rendered_dose_options(component)
+    rendered = render_inline(component)
+    form = rendered.at_css('form[data-controller="person-medication-form"]')
+
+    expect(form).to be_present
+    JSON.parse(form['data-person-medication-form-dose-options-value'])
+  end
+
   it 'renders a token-driven modal shell for the medication workflow' do
     person = create(:person, name: 'Damacus User')
     medication = create(:medication, name: 'Calpol')
@@ -22,5 +30,24 @@ RSpec.describe Components::PersonMedications::Modal, type: :component do
     expect(html).to include('bg-foreground/10')
     expect(html).to include('shadow-elevation-5')
     expect(html).not_to include('bg-white')
+  end
+
+  it 'renders medication dose options for the Stimulus controller' do
+    person = create(:person, name: 'Damacus User')
+    medication = create(:medication, name: 'Calpol')
+    allow(medication).to receive(:dose_options_payload).and_return([{ 'amount' => '1' }])
+    person_medication = build(:person_medication, person: person)
+
+    payload = rendered_dose_options(
+      described_class.new(
+        person_medication: person_medication,
+        person: person,
+        medications: [medication]
+      )
+    )
+
+    expect(payload).to eq(
+      medication.id.to_s => [{ 'amount' => '1' }]
+    )
   end
 end

--- a/spec/components/ruby_ui/action_style_helpers_spec.rb
+++ b/spec/components/ruby_ui/action_style_helpers_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RubyUI::ActionStyleHelpers do
+  subject(:helper) { helper_class.new(size:, icon:) }
+
+  let(:helper_class) do
+    Class.new do
+      include RubyUI::ActionStyleHelpers
+
+      def initialize(size:, icon:)
+        @size = size
+        @icon = icon
+      end
+
+      public :base_classes, :size_classes
+    end
+  end
+
+  describe '#base_classes' do
+    let(:size) { :md }
+    let(:icon) { false }
+    let(:expected_classes) do
+      [
+        'whitespace-nowrap inline-flex items-center justify-center rounded-shape-xl font-medium transition-colors',
+        'disabled:pointer-events-none disabled:opacity-50',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed'
+      ]
+    end
+
+    it 'returns the shared interactive element classes' do
+      expect(helper.base_classes).to eq(expected_classes)
+    end
+  end
+
+  describe '#size_classes' do
+    context 'when icon is false and size is md' do
+      let(:icon) { false }
+      let(:size) { :md }
+
+      it 'returns the shared text button spacing' do
+        expect(helper.size_classes).to eq('px-4 py-2 h-9 min-h-[36px] text-sm')
+      end
+    end
+
+    context 'when icon is true and size is lg' do
+      let(:icon) { true }
+      let(:size) { :lg }
+
+      it 'returns the shared icon sizing' do
+        expect(helper.size_classes).to eq('h-10 w-10 min-h-[40px] min-w-[40px]')
+      end
+    end
+  end
+end

--- a/spec/components/ruby_ui/div_wrapper_spec.rb
+++ b/spec/components/ruby_ui/div_wrapper_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe RubyUI::DivWrapper, type: :component do
       expect(root['class'].split).to include(*default_classes.split)
     end
   end
+
+  it 'falls back to a blank class when a subclass does not set DEFAULT_CLASS' do
+    subclass = Class.new(described_class)
+
+    rendered = render_inline(subclass.new(class: 'only-custom') { 'Body' })
+    root = Nokogiri::HTML.fragment(rendered.to_html).element_children.first
+
+    expect(root.name).to eq('div')
+    expect(root.text).to include('Body')
+    expect(root['class'].to_s.split).to include('only-custom')
+  end
 end

--- a/spec/components/ruby_ui/div_wrapper_spec.rb
+++ b/spec/components/ruby_ui/div_wrapper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RubyUI::DivWrapper, type: :component do
+  wrappers = {
+    RubyUI::AlertDialogFooter => 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2',
+    RubyUI::AlertDialogHeader => 'flex flex-col gap-2 text-center sm:text-left rtl:sm:text-right',
+    RubyUI::CardContent => 'p-6 pt-0',
+    RubyUI::CardFooter => 'items-center p-6 pt-0',
+    RubyUI::CardHeader => 'flex flex-col space-y-1.5 p-6',
+    RubyUI::DialogFooter => 'flex flex-col-reverse sm:flex-row sm:justify-end ' \
+                            'sm:space-x-2 gap-y-2 sm:gap-y-0 rtl:space-x-reverse',
+    RubyUI::DialogHeader => 'flex flex-col gap-2 border-b border-border/60 bg-popover ' \
+                            'px-8 pb-4 pt-8 text-center sm:text-left rtl:sm:text-right',
+    RubyUI::DialogMiddle => 'bg-popover px-8 pb-8 pt-4',
+    RubyUI::SheetFooter => 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-y-2 sm:gap-y-0',
+    RubyUI::SheetHeader => 'flex flex-col space-y-1.5 text-center sm:text-left',
+    RubyUI::SheetMiddle => 'py-4'
+  }
+
+  wrappers.each do |wrapper, default_classes|
+    it "#{wrapper.name} renders a div with merged default and custom classes" do
+      rendered = render_inline(wrapper.new(class: 'custom-wrapper') { 'Wrapper body' })
+      root = Nokogiri::HTML.fragment(rendered.to_html).element_children.first
+
+      expect(root.name).to eq('div')
+      expect(root.text).to include('Wrapper body')
+      expect(root['class'].split).to include('custom-wrapper')
+      expect(root['class'].split).to include(*default_classes.split)
+    end
+  end
+end

--- a/spec/components/schedules/form_translations_spec.rb
+++ b/spec/components/schedules/form_translations_spec.rb
@@ -26,16 +26,4 @@ RSpec.describe Components::Schedules::Form, type: :component do
       'frequencyOncePerCycle' => I18n.t('schedules.form.frequency_once_per_cycle')
     )
   end
-
-  it 'memoizes duplicate dose selection key computation' do
-    duplicate_a = double(selection_key: '200|mg')
-    duplicate_b = double(selection_key: '200|mg')
-    component = described_class.new(schedule:, person:, medications: [medication])
-
-    allow(medication).to receive(:dosages).and_return([duplicate_a, duplicate_b])
-
-    2.times { component.send(:duplicate_dose_selection_keys) }
-
-    expect(medication).to have_received(:dosages).once
-  end
 end

--- a/spec/components/shared/stock_badge_spec.rb
+++ b/spec/components/shared/stock_badge_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe Components::Shared::StockBadge, type: :component do
   subject(:component) { described_class.new(medication: medication) }
 
+  let(:supply_level) { instance_double(SupplyLevel, status: status) }
   let(:medication) do
-    instance_double(Medication, current_supply: current_supply, low_stock?: low_stock, out_of_stock?: out_of_stock)
+    instance_double(Medication, current_supply: current_supply, supply_level: supply_level)
   end
   let(:current_supply) { 100 }
-  let(:low_stock) { false }
-  let(:out_of_stock) { false }
+  let(:status) { :in_stock }
 
   describe '#view_template' do
     context 'when medication has no current_supply value' do
@@ -33,7 +33,7 @@ RSpec.describe Components::Shared::StockBadge, type: :component do
 
     context 'when medication is low stock' do
       let(:current_supply) { 5 }
-      let(:low_stock) { true }
+      let(:status) { :low_stock }
 
       it 'renders Low Stock badge with count' do
         result = render_inline(component)
@@ -43,7 +43,7 @@ RSpec.describe Components::Shared::StockBadge, type: :component do
 
     context 'when medication is out of stock' do
       let(:current_supply) { 0 }
-      let(:out_of_stock) { true }
+      let(:status) { :out_of_stock }
 
       it 'renders Out of Stock badge with count' do
         result = render_inline(component)

--- a/spec/models/supply_level_spec.rb
+++ b/spec/models/supply_level_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe SupplyLevel do
     end
   end
 
+  describe '#status' do
+    it 'returns out_of_stock before low_stock' do
+      supply_level = described_class.new(current: 0, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.status).to eq(:out_of_stock)
+    end
+
+    it 'returns low_stock at the reorder threshold' do
+      supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.status).to eq(:low_stock)
+    end
+
+    it 'returns in_stock above the reorder threshold' do
+      supply_level = described_class.new(current: 11, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.status).to eq(:in_stock)
+    end
+  end
+
   describe '#days_until_low_stock' do
     it 'returns nil when daily consumption is not positive' do
       supply_level = described_class.new(current: 50, reorder_threshold: 10, last_restock: 80)

--- a/spec/presenters/dashboard_presenter_spec.rb
+++ b/spec/presenters/dashboard_presenter_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe DashboardPresenter do
     end
   end
 
+  describe 'private people scope assembly' do
+    it 'builds an eager-loaded scope for explicit person ids' do
+      presenter = described_class.new(current_user: parent_user)
+
+      scoped_people = presenter.send(:people_scope, [parent_user.person.id, parent_user.person.id]).to_a
+
+      expect(scoped_people.map(&:id)).to eq([parent_user.person.id])
+      expect(scoped_people.first.association(:user)).to be_loaded
+      expect(scoped_people.first.association(:schedules)).to be_loaded
+      expect(scoped_people.first.association(:person_medications)).to be_loaded
+    end
+  end
+
   describe '#active_schedules' do
     it 'returns date-active schedules for scoped people' do
       presenter = described_class.new(current_user: admin_user)

--- a/spec/presenters/medications/dose_options_payload_presenter_spec.rb
+++ b/spec/presenters/medications/dose_options_payload_presenter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Medications::DoseOptionsPayloadPresenter do
+  describe '#to_h' do
+    let(:medication) do
+      instance_double(Medication, id: 123, dose_options_payload: [{ 'amount' => '1' }])
+    end
+
+    it 'maps medications to their dose option payloads' do
+      payload = described_class.new(medications: [medication]).to_h
+
+      expect(payload).to eq('123' => [{ 'amount' => '1' }])
+    end
+  end
+end

--- a/spec/presenters/schedules/dosage_options_presenter_spec.rb
+++ b/spec/presenters/schedules/dosage_options_presenter_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schedules::DosageOptionsPresenter do
+  let(:schedule) { Schedule.new(dose_amount: 200, dose_unit: 'mg') }
+  let(:matching_dosage) do
+    double(
+      amount: schedule.dose_amount,
+      unit: 'mg',
+      description: 'tablet',
+      selection_key: '200|mg'
+    )
+  end
+  let(:duplicate_dosage) do
+    double(
+      amount: schedule.dose_amount,
+      unit: 'mg',
+      description: 'capsule',
+      selection_key: '200|mg'
+    )
+  end
+  let(:medication) do
+    instance_double(
+      Medication,
+      id: 123,
+      dosages: [matching_dosage, duplicate_dosage],
+      dose_options_payload: [{ 'amount' => '1' }]
+    )
+  end
+
+  before do
+    allow(schedule).to receive(:medication).and_return(medication)
+  end
+
+  describe '#selected_dosage_option' do
+    it 'returns the dosage matching the schedule selection' do
+      presenter = described_class.new(schedule: schedule, medications: [medication])
+
+      expect(presenter.selected_dosage_option).to eq(matching_dosage)
+    end
+  end
+
+  describe '#duplicate_dose_selection_keys' do
+    it 'memoizes duplicate selection key calculation' do
+      presenter = described_class.new(schedule: schedule, medications: [medication])
+
+      2.times { presenter.duplicate_dose_selection_keys }
+
+      expect(medication).to have_received(:dosages).once
+      expect(presenter.duplicate_dose_selection_keys).to eq(['200|mg'])
+    end
+  end
+
+  describe '#dosage_dom_id' do
+    it 'adds a description suffix when selection keys are duplicated' do
+      presenter = described_class.new(schedule: schedule, medications: [medication])
+
+      expect(presenter.dosage_dom_id(duplicate_dosage)).to eq('schedule_dose_option_200_mg_capsule')
+    end
+  end
+
+  describe '#medication_dose_options' do
+    it 'maps medications to their dose option payloads' do
+      presenter = described_class.new(schedule: schedule, medications: [medication])
+
+      expect(presenter.medication_dose_options).to eq('123' => [{ 'amount' => '1' }])
+    end
+  end
+end

--- a/spec/presenters/schedules/dosage_options_presenter_spec.rb
+++ b/spec/presenters/schedules/dosage_options_presenter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Schedules::DosageOptionsPresenter do
 
   describe '#selected_dosage_option' do
     it 'returns the dosage matching the schedule selection' do
-      presenter = described_class.new(schedule: schedule, medications: [medication])
+      presenter = described_class.new(schedule: schedule)
 
       expect(presenter.selected_dosage_option).to eq(matching_dosage)
     end
@@ -43,7 +43,7 @@ RSpec.describe Schedules::DosageOptionsPresenter do
 
   describe '#duplicate_dose_selection_keys' do
     it 'memoizes duplicate selection key calculation' do
-      presenter = described_class.new(schedule: schedule, medications: [medication])
+      presenter = described_class.new(schedule: schedule)
 
       2.times { presenter.duplicate_dose_selection_keys }
 
@@ -54,17 +54,9 @@ RSpec.describe Schedules::DosageOptionsPresenter do
 
   describe '#dosage_dom_id' do
     it 'adds a description suffix when selection keys are duplicated' do
-      presenter = described_class.new(schedule: schedule, medications: [medication])
+      presenter = described_class.new(schedule: schedule)
 
       expect(presenter.dosage_dom_id(duplicate_dosage)).to eq('schedule_dose_option_200_mg_capsule')
-    end
-  end
-
-  describe '#medication_dose_options' do
-    it 'maps medications to their dose option payloads' do
-      presenter = described_class.new(schedule: schedule, medications: [medication])
-
-      expect(presenter.medication_dose_options).to eq('123' => [{ 'amount' => '1' }])
     end
   end
 end

--- a/spec/presenters/schedules/form_payload_presenter_spec.rb
+++ b/spec/presenters/schedules/form_payload_presenter_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schedules::FormPayloadPresenter do
+  describe '#data' do
+    let(:person) { instance_double(Person, person_type: 'adult') }
+    let(:medication) do
+      instance_double(Medication, id: 123, dose_options_payload: [{ 'amount' => '1' }])
+    end
+    let(:view_context) do
+      instance_double(
+        Components::Schedules::Form,
+        new_person_schedule_path: '/people/1/schedules/new'
+      )
+    end
+
+    before do
+      allow(view_context).to receive(:t) { |key| I18n.t(key) }
+    end
+
+    it 'includes the core stimulus metadata' do
+      data = described_class.new(
+        person: person,
+        medications: [medication],
+        frame_id: 'schedule_frame',
+        view_context: view_context
+      ).data
+
+      expect(data).to include(
+        controller: 'schedule-form',
+        turbo_stream: true,
+        person_type: 'adult',
+        schedule_form_frame_id_value: 'schedule_frame',
+        schedule_form_next_url_value: '/people/1/schedules/new'
+      )
+    end
+
+    it 'builds the schedule form stimulus payload' do
+      data = described_class.new(
+        person: person,
+        medications: [medication],
+        frame_id: 'schedule_frame',
+        view_context: view_context
+      ).data
+
+      expect(data[:schedule_form_dose_options_value]).to eq({ '123' => [{ 'amount' => '1' }] }.to_json)
+      expect(JSON.parse(data[:schedule_form_translations_value])).to include(
+        'selectDosage' => I18n.t('schedules.form.select_dosage'),
+        'selectMedicationFirst' => I18n.t('schedules.form.select_medication_first'),
+        'frequencyAtLeastHours' => I18n.t('schedules.form.frequency_at_least_hours')
+      )
+    end
+  end
+end

--- a/spec/presenters/schedules/form_payload_presenter_spec.rb
+++ b/spec/presenters/schedules/form_payload_presenter_spec.rb
@@ -8,26 +8,26 @@ RSpec.describe Schedules::FormPayloadPresenter do
     let(:medication) do
       instance_double(Medication, id: 123, dose_options_payload: [{ 'amount' => '1' }])
     end
-    let(:view_context) do
-      instance_double(
-        Components::Schedules::Form,
-        new_person_schedule_path: '/people/1/schedules/new'
-      )
+    let(:translations) do
+      {
+        selectDosage: 'Select dosage',
+        selectMedicationFirst: 'Select medication first',
+        frequencyAtLeastHours: 'At least %<hours>s hours apart'
+      }
     end
 
-    before do
-      allow(view_context).to receive(:t) { |key| I18n.t(key) }
-    end
-
-    it 'includes the core stimulus metadata' do
-      data = described_class.new(
+    def build_presenter
+      described_class.new(
         person: person,
         medications: [medication],
         frame_id: 'schedule_frame',
-        view_context: view_context
-      ).data
+        next_url: '/people/1/schedules/new',
+        translations: translations
+      )
+    end
 
-      expect(data).to include(
+    it 'includes the core stimulus metadata' do
+      expect(build_presenter.data).to include(
         controller: 'schedule-form',
         turbo_stream: true,
         person_type: 'adult',
@@ -37,18 +37,13 @@ RSpec.describe Schedules::FormPayloadPresenter do
     end
 
     it 'builds the schedule form stimulus payload' do
-      data = described_class.new(
-        person: person,
-        medications: [medication],
-        frame_id: 'schedule_frame',
-        view_context: view_context
-      ).data
+      data = build_presenter.data
 
       expect(data[:schedule_form_dose_options_value]).to eq({ '123' => [{ 'amount' => '1' }] }.to_json)
       expect(JSON.parse(data[:schedule_form_translations_value])).to include(
-        'selectDosage' => I18n.t('schedules.form.select_dosage'),
-        'selectMedicationFirst' => I18n.t('schedules.form.select_medication_first'),
-        'frequencyAtLeastHours' => I18n.t('schedules.form.frequency_at_least_hours')
+        'selectDosage' => 'Select dosage',
+        'selectMedicationFirst' => 'Select medication first',
+        'frequencyAtLeastHours' => 'At least %<hours>s hours apart'
       )
     end
   end

--- a/spec/services/nhs_dmd/barcode_lookup_spec.rb
+++ b/spec/services/nhs_dmd/barcode_lookup_spec.rb
@@ -25,5 +25,24 @@ RSpec.describe NhsDmd::BarcodeLookup do
         concept_class: 'AMPP'
       )
     end
+
+    it 'finds the configured mapping for a zero-prefixed barcode' do
+      result = described_class.new.lookup('05016298210989')
+
+      expect(result).to include(
+        code: '13629411000001105',
+        display: 'Laxido Orange oral powder sachets (Galen Ltd)',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+    end
+
+    it 'returns nil for a blank barcode' do
+      expect(described_class.new.lookup('')).to be_nil
+    end
+
+    it 'returns nil when the barcode is not mapped' do
+      expect(described_class.new.lookup('0000')).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## What changed
- extracted schedule-form Stimulus payload building into `Schedules::FormPayloadPresenter`
- extracted dosage formatting and selection logic into `Schedules::DosageOptionsPresenter`
- rewired `Components::Schedules::Form` to delegate those responsibilities instead of shaping that data inline
- expanded barcode lookup coverage for zero-prefixed, blank, and missing barcode inputs

## Why
The schedule form component had accumulated both rendering responsibilities and state-shaping/query behavior. This separates those concerns so the form remains focused on rendering and workflow orchestration.

## Impact
- no intended UI or workflow changes for schedule creation/editing
- schedule-form payload generation and dosage option behavior are now covered by focused presenter specs
- barcode lookup behavior has broader edge-case coverage

## Validation
- `task rubocop`
- `task test`
- targeted presenter and component specs during refactor