### PR TITLE
feat: import release GTIN data and persist dm+d identity

### DIFF
--- a/Taskfiles/dev.yml
+++ b/Taskfiles/dev.yml
@@ -156,6 +156,28 @@ tasks:
           ENVIRONMENT: dev
           COMMAND: 'rails runner db/seeds/import_nhs_dmd_barcodes.rb "{{ .FILE }}"'
 
+  import-dmd-release:
+    desc: Import NHS dm+d release XML (AMPP names + GTIN barcodes)
+    summary: |
+      Parse the dm+d release XML files and import AMPP product names
+      with their GTIN barcodes into the development database.
+      Automatically extracts the GTIN zip if only the zip is present.
+      RELEASE_DIR is a host path; it is bind-mounted into the container.
+      Usage: task dev:import-dmd-release RELEASE_DIR=storage/nhs_dmd/releases/current
+    requires:
+      vars: [RELEASE_DIR]
+    vars:
+      COMPOSE_PROJECT:
+        sh: basename $PWD
+      ABS_RELEASE_DIR:
+        sh: 'cd "{{ .RELEASE_DIR }}" && pwd'
+      CONTAINER_MOUNT: /tmp/dmd-release
+    cmds:
+      - >-
+        docker compose -p {{ .COMPOSE_PROJECT }} --profile dev run --rm
+        -v "{{ .ABS_RELEASE_DIR }}:{{ .CONTAINER_MOUNT }}:ro"
+        web-dev rails runner db/seeds/import_nhs_dmd_release.rb "{{ .CONTAINER_MOUNT }}"
+
   port:
     desc: Print the host port of the running development server
     summary: |

--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -10,7 +10,9 @@ version: "3"
 vars:
   COMPOSE_PROJECT:
     sh: basename $PWD
-  COMPOSE_CMD: docker compose -p {{ .COMPOSE_PROJECT }}
+  GIT_COMMON_DIR:
+    sh: git rev-parse --path-format=absolute --git-common-dir
+  COMPOSE_CMD: MEDTRACKER_GIT_COMMON_DIR={{ .GIT_COMMON_DIR }} docker compose -p {{ .COMPOSE_PROJECT }}
 
 tasks:
   # Execute arbitrary commands in Docker containers

--- a/Taskfiles/prod.yml
+++ b/Taskfiles/prod.yml
@@ -102,6 +102,31 @@ tasks:
           ENVIRONMENT: prod
           COMMAND: 'rails runner db/seeds/import_nhs_dmd_barcodes.rb "{{ .FILE }}"'
 
+  import-dmd-release:
+    desc: Import NHS dm+d release XML (AMPP names + GTIN barcodes)
+    summary: |
+      Parse the dm+d release XML files and import AMPP product names
+      with their GTIN barcodes into the production database.
+      Automatically extracts the GTIN zip if only the zip is present.
+      This task is for local Docker Compose prod validation only.
+      For Kubernetes production, use the one-off Job flow in
+      docs/kubernetes-nhs-dmd-import.md.
+      RELEASE_DIR is a host path; it is bind-mounted into the container.
+      Usage: task prod:import-dmd-release RELEASE_DIR=storage/nhs_dmd/releases/current
+    requires:
+      vars: [RELEASE_DIR]
+    vars:
+      COMPOSE_PROJECT:
+        sh: basename $PWD
+      ABS_RELEASE_DIR:
+        sh: 'cd "{{ .RELEASE_DIR }}" && pwd'
+      CONTAINER_MOUNT: /tmp/dmd-release
+    cmds:
+      - >-
+        docker compose -p {{ .COMPOSE_PROJECT }} --profile prod run --rm
+        -v "{{ .ABS_RELEASE_DIR }}:{{ .CONTAINER_MOUNT }}:ro"
+        web-prod rails runner db/seeds/import_nhs_dmd_release.rb "{{ .CONTAINER_MOUNT }}"
+
   logs:
     desc: View production server logs
     summary: |

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -21,8 +21,6 @@ module Components
               render_timeline_section
             end
             div(class: 'space-y-8') do
-              render_right_rail_next_dose
-              render_schedules_section
               render_supply_levels
             end
             div(class: 'lg:col-span-2') do
@@ -170,64 +168,6 @@ module Components
               end
             end
           end
-        end
-      end
-
-      def render_schedules_section
-        upcoming_doses = doses.reject { |d| d[:status] == :taken }.first(5)
-        return if upcoming_doses.empty?
-
-        div(class: 'space-y-6') do
-          m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
-            t('dashboard.medication_schedule')
-          end
-          div(class: 'space-y-4') do
-            upcoming_doses.each { |dose| upcoming_dose_item(dose) }
-          end
-        end
-      end
-
-      def render_right_rail_next_dose
-        render Components::Shared::MetricCard.new(
-          title: t('dashboard.stats.next_dose'),
-          value: next_dose_value,
-          icon_type: 'clock',
-          layout: :compact,
-          testid: 'dashboard-right-rail-next-dose'
-        )
-      end
-
-      def upcoming_dose_item(dose)
-        source = dose[:source]
-        medication = source.medication
-        time_str = dose[:scheduled_at]&.strftime('%H:%M') || '--:--'
-        status = dose[:status]
-
-        div(class: 'flex items-start gap-3 p-1') do
-          div(class: "w-2 h-2 rounded-full mt-2 flex-shrink-0 #{status_dot_color(status)}")
-          div do
-            m3_text(weight: 'bold', size: '3') { "#{time_str} — #{medication.name}" }
-            m3_text(size: '2', weight: 'muted') do
-              "#{dose[:person].name} · #{dosage_label(source)}"
-            end
-          end
-        end
-      end
-
-      def status_dot_color(status)
-        case status
-        when :upcoming then 'bg-primary'
-        when :cooldown then 'bg-warning'
-        when :out_of_stock then 'bg-destructive'
-        else 'bg-primary/15'
-        end
-      end
-
-      def dosage_label(source)
-        if source.is_a?(::Schedule)
-          "#{source.dose_amount} #{source.dose_unit}"
-        else
-          source.dose_display
         end
       end
 

--- a/app/components/medications/finder_view.rb
+++ b/app/components/medications/finder_view.rb
@@ -20,6 +20,7 @@ module Components
               resultsTitle: t('medications.finder.results_title'),
               source: t('medications.finder.source'),
               dmdCode: t('medications.finder.dmd_code'),
+              addMedication: t('medications.index.add_medication'),
               resultCount: {
                 one: t('medications.finder.result_count.one'),
                 other: t('medications.finder.result_count.other')

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -66,50 +66,71 @@ module Components
           data: { testid: 'medication-form' }
         ) do |form|
           render_errors(form) if medication.errors.any?
-          input(type: 'hidden', name: 'return_to', value: return_to) if return_to.present?
+          render_hidden_form_state
+          render_form_card(form)
+        end
+      end
 
-          m3_card(variant: :elevated, class: 'overflow-visible border-none shadow-elevation-3 rounded-[2.5rem]') do
-            div(class: 'p-10 space-y-8') do
-              div(class: 'space-y-6') do
-                render_location_field(form)
-                render_name_field(form)
-                render_category_field(form)
-                render_description_field(form)
-              end
+      def render_hidden_form_state
+        render_hidden_input('return_to', return_to) if return_to.present?
+        render_hidden_input('medication[barcode]', medication.barcode) if medication.barcode.present?
+        render_hidden_dmd_state
+      end
 
-              div(class: 'h-px bg-outline-variant w-full opacity-50')
+      def render_hidden_dmd_state
+        return if medication.dmd_code.blank?
 
-              div(class: 'space-y-6') do
-                m3_heading(variant: :title_large, level: 3, class: 'font-bold text-foreground') do
-                  t('forms.medications.dosage_and_supply')
-                end
-                div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-6') do
-                  render_dosage_fields(form)
-                  render_supply_fields(form)
-                end
-              end
+        render_hidden_input('medication[dmd_code]', medication.dmd_code)
+        render_hidden_input('medication[dmd_system]', medication.dmd_system)
+        render_hidden_input('medication[dmd_concept_class]', medication.dmd_concept_class)
+      end
 
-              div(class: 'h-px bg-outline-variant w-full opacity-50')
+      def render_hidden_input(name, value)
+        input(type: 'hidden', name: name, value: value)
+      end
 
-              render_dosage_options_section
-
-              div(class: 'h-px bg-outline-variant w-full opacity-50')
-
-              render_warnings_field(form)
+      def render_form_card(form)
+        m3_card(variant: :elevated, class: 'overflow-visible border-none shadow-elevation-3 rounded-[2.5rem]') do
+          div(class: 'p-10 space-y-8') do
+            div(class: 'space-y-6') do
+              render_location_field(form)
+              render_name_field(form)
+              render_category_field(form)
+              render_description_field(form)
             end
 
-            div(
-              class: 'px-10 py-6 bg-surface-container-low border-t border-outline-variant/30 ' \
-                     'flex items-center justify-between gap-4 rounded-b-[2.5rem]'
-            ) do
-              m3_link(href: return_to.presence || medications_path, variant: :text, size: :lg,
-                      class: 'font-bold text-on-surface-variant hover:text-foreground') do
-                t('forms.medications.back')
+            div(class: 'h-px bg-outline-variant w-full opacity-50')
+
+            div(class: 'space-y-6') do
+              m3_heading(variant: :title_large, level: 3, class: 'font-bold text-foreground') do
+                t('forms.medications.dosage_and_supply')
               end
-              m3_button(type: :submit, variant: :filled, size: :lg,
-                        class: 'px-8 rounded-shape-xl shadow-lg shadow-primary/20') do
-                t('forms.medications.save_medication')
+              div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-6') do
+                render_dosage_fields(form)
+                render_supply_fields(form)
               end
+            end
+
+            div(class: 'h-px bg-outline-variant w-full opacity-50')
+
+            render_dosage_options_section
+
+            div(class: 'h-px bg-outline-variant w-full opacity-50')
+
+            render_warnings_field(form)
+          end
+
+          div(
+            class: 'px-10 py-6 bg-surface-container-low border-t border-outline-variant/30 ' \
+                   'flex items-center justify-between gap-4 rounded-b-[2.5rem]'
+          ) do
+            m3_link(href: return_to.presence || medications_path, variant: :text, size: :lg,
+                    class: 'font-bold text-on-surface-variant hover:text-foreground') do
+              t('forms.medications.back')
+            end
+            m3_button(type: :submit, variant: :filled, size: :lg,
+                      class: 'px-8 rounded-shape-xl shadow-lg shadow-primary/20') do
+              t('forms.medications.save_medication')
             end
           end
         end

--- a/app/components/medications/wizard/step_content.rb
+++ b/app/components/medications/wizard/step_content.rb
@@ -33,6 +33,14 @@ module Components
             ) do |_form|
               render_errors if medication.errors.any?
               input(type: 'hidden', name: 'wizard', value: 'true')
+              if medication.barcode.present?
+                input(type: 'hidden', name: 'medication[barcode]', value: medication.barcode)
+              end
+              if medication.dmd_code.present?
+                input(type: 'hidden', name: 'medication[dmd_code]', value: medication.dmd_code)
+                input(type: 'hidden', name: 'medication[dmd_system]', value: medication.dmd_system)
+                input(type: 'hidden', name: 'medication[dmd_concept_class]', value: medication.dmd_concept_class)
+              end
 
               render_step_panels
               render_navigation

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -48,6 +48,7 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
     @medication = Medication.new
     @medication.location_id ||= primary_location&.id
     authorize @medication
+    @medication.assign_attributes(finder_prefill_attributes)
 
     render wizard_wrapper_class.new(
       medication: @medication,
@@ -178,7 +179,11 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
     return render_medication_search_unavailable unless result
 
     if result.success?
-      render json: { results: result.results.map(&:to_h) }
+      render json: {
+        results: result.results.map(&:to_h),
+        query: result.resolved_query.presence || query,
+        barcode: result.barcode
+      }
     else
       render_medication_search_unavailable
     end
@@ -202,6 +207,10 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
     params.expect(
       medication: [
         :name,
+        :barcode,
+        :dmd_code,
+        :dmd_system,
+        :dmd_concept_class,
         :category,
         :description,
         :dosage_amount,
@@ -277,6 +286,18 @@ class MedicationsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def render_medication_search_unavailable
     render json: { results: [], error: 'Medication search is temporarily unavailable.' }, status: :service_unavailable
+  end
+
+  def finder_prefill_attributes
+    attrs = {}
+    attrs[:name] = params[:name].presence if params[:name].present?
+
+    barcode = params[:barcode].presence
+    attrs[:barcode] = barcode if NhsDmd::BarcodeLookup.barcode_query?(barcode)
+    attrs[:dmd_code] = params[:dmd_code].presence if params[:dmd_code].present?
+    attrs[:dmd_system] = params[:dmd_system].presence if params[:dmd_code].present?
+    attrs[:dmd_concept_class] = params[:dmd_concept_class].presence if params[:dmd_code].present?
+    attrs
   end
 
   def administration_schedules

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -37,7 +37,14 @@ export default class extends Controller {
       if (data.error) {
         this.showError(data.error)
       } else {
-        this.showResults(query, data.results)
+        const resolvedQuery = data.query || query
+        const barcode = data.barcode || this.barcodeQuery(query)
+
+        if (data.query && data.query !== query) {
+          this.inputTarget.value = data.query
+        }
+
+        this.showResults(resolvedQuery, data.results, barcode)
       }
     } catch (error) {
       this.showError(this.t("unavailableMessage"))
@@ -79,7 +86,7 @@ export default class extends Controller {
     `
   }
 
-  showResults(query, results) {
+  showResults(query, results, barcode) {
     if (results.length === 0) {
       this.resultsTarget.innerHTML = `
         <div class="text-center py-12 text-on-surface-variant" data-testid="no-results">
@@ -100,18 +107,30 @@ export default class extends Controller {
       </div>
     `
 
-    const items = results.map(result => this.renderResultCard(result)).join('')
+    const items = results.map(result => this.renderResultCard(result, barcode)).join('')
 
     this.resultsTarget.innerHTML = header + `<div class="space-y-2" data-testid="results-list">${items}</div>`
   }
 
-  renderResultCard(result) {
+  renderResultCard(result, barcode) {
     const badge = result.concept_class
       ? `<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-primary-container text-on-primary-container">${this.escapeHtml(result.concept_class)}</span>`
       : ''
 
     const label = result.concept_class_label && result.concept_class_label !== result.concept_class
       ? `<span class="text-xs text-on-surface-variant">${this.escapeHtml(result.concept_class_label)}</span>`
+      : ''
+
+    const addAction = result.display
+      ? `
+        <div class="mt-4 flex justify-end">
+          <a
+            href="${this.hrefAttribute(this.addMedicationUrl(result, barcode))}"
+            class="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-on-primary shadow-sm transition-all hover:shadow-md"
+            data-testid="add-medication-link"
+          >${this.escapeHtml(this.t("addMedication"))}</a>
+        </div>
+      `
       : ''
 
     return `
@@ -126,14 +145,43 @@ export default class extends Controller {
             ${label}
           </div>
         </div>
+        ${addAction}
       </div>
     `
+  }
+
+  addMedicationUrl(result, barcode) {
+    const url = new URL("/medications/new", window.location.origin)
+    url.searchParams.set("name", result.display || "")
+
+    if (barcode) {
+      url.searchParams.set("barcode", barcode)
+    }
+
+    if (result.code) {
+      url.searchParams.set("dmd_code", result.code)
+      url.searchParams.set("dmd_system", result.system || "")
+      url.searchParams.set("dmd_concept_class", result.concept_class || "")
+    }
+
+    return url.toString()
+  }
+
+  barcodeQuery(query) {
+    const normalized = String(query || "").trim().replace(/\D/g, "")
+    return /^\d{13,14}$/.test(normalized) ? normalized : null
   }
 
   escapeHtml(str) {
     const div = document.createElement('div')
     div.appendChild(document.createTextNode(String(str || '')))
     return div.innerHTML
+  }
+
+  hrefAttribute(url) {
+    const link = document.createElement('a')
+    link.setAttribute('href', String(url || ''))
+    return link.getAttribute('href') || ''
   }
 
   t(key) {

--- a/app/models/barcode_catalog_entry.rb
+++ b/app/models/barcode_catalog_entry.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BarcodeCatalogEntry < ApplicationRecord
+  validates :gtin, presence: true
+  validates :display, presence: true
+  validates :source, presence: true
+  validates :gtin, uniqueness: { scope: :source }
+
+  def self.normalize_gtin(value)
+    value.to_s.gsub(/\D/, '')
+  end
+end

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -60,7 +60,9 @@ class Medication < ApplicationRecord # :nodoc:
 
   enum :reorder_status, { requested: 0, ordered: 1, received: 2 }, prefix: :reorder
 
+  validates :barcode, format: { with: /\A\d{13,14}\z/ }, allow_blank: true
   validates :barcode, uniqueness: true, allow_blank: true
+  validates :dmd_system, presence: true, if: -> { dmd_code.present? }
   validates :name, presence: true
   validates :category, inclusion: { in: CATEGORIES }, allow_blank: true
   validates :dosage_amount, numericality: { greater_than: 0 }, allow_nil: true

--- a/app/services/barcode_catalog/import_csv.rb
+++ b/app/services/barcode_catalog/import_csv.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module BarcodeCatalog
+  class ImportCsv
+    Result = Struct.new(:imported_count, :invalid_rows, keyword_init: true)
+
+    REQUIRED_HEADERS = %w[gtin display source].freeze
+
+    def call(path)
+      invalid_rows = []
+      imported_count = 0
+
+      csv_rows(path).each_with_index do |row, index|
+        attrs = build_attrs(row)
+        if attrs
+          persist(attrs)
+          imported_count += 1
+        else
+          invalid_rows << (index + 2)
+        end
+      end
+
+      Result.new(imported_count: imported_count, invalid_rows: invalid_rows)
+    end
+
+    private
+
+    def csv_rows(path)
+      rows = CSV.read(path, headers: true)
+      validate_headers!(rows.headers)
+      rows
+    end
+
+    def validate_headers!(headers)
+      normalized_headers = headers.compact.map(&:strip)
+      missing_headers = REQUIRED_HEADERS - normalized_headers
+      raise ArgumentError, "Missing required headers: #{missing_headers.join(', ')}" if missing_headers.any?
+    end
+
+    def persist(attrs)
+      record = BarcodeCatalogEntry.find_or_initialize_by(gtin: attrs[:gtin], source: attrs[:source])
+      record.assign_attributes(attrs)
+      record.save!
+    end
+
+    def build_attrs(row)
+      gtin = normalized(row, 'gtin', digits_only: true)
+      display = normalized(row, 'display')
+      source = normalized(row, 'source')
+      return nil if gtin.blank? || display.blank? || source.blank?
+
+      {
+        gtin: gtin,
+        display: display,
+        source: source,
+        code: normalized(row, 'code').presence,
+        system: normalized(row, 'system').presence,
+        concept_class: normalized(row, 'concept_class').presence
+      }
+    end
+
+    def normalized(row, key, digits_only: false)
+      value = row[key]
+      return BarcodeCatalogEntry.normalize_gtin(value) if digits_only
+
+      value&.strip
+    end
+  end
+end

--- a/app/services/barcode_catalog/lookup.rb
+++ b/app/services/barcode_catalog/lookup.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module BarcodeCatalog
+  class Lookup
+    def lookup(barcode)
+      barcode_candidates(barcode).each do |candidate|
+        external = lookup_external(candidate)
+        return external if external
+
+        local = lookup_local(candidate)
+        return local if local
+      end
+
+      nil
+    end
+
+    private
+
+    def barcode_candidates(barcode)
+      NhsDmd::BarcodeLookup.candidates_for(barcode)
+    end
+
+    def lookup_external(candidate)
+      record = BarcodeCatalogEntry.find_by(gtin: candidate)
+      return nil unless record
+
+      {
+        code: record.code,
+        display: record.display,
+        system: record.system,
+        concept_class: record.concept_class,
+        source: record.source
+      }
+    end
+
+    def lookup_local(candidate)
+      record = NhsDmdBarcode.find_by(gtin: candidate)
+      return nil unless record
+
+      {
+        code: record.code,
+        display: record.display,
+        system: record.system,
+        concept_class: record.concept_class,
+        source: 'nhs_dmd'
+      }
+    end
+  end
+end

--- a/app/services/nhs_dmd/barcode_lookup.rb
+++ b/app/services/nhs_dmd/barcode_lookup.rb
@@ -4,6 +4,11 @@ module NhsDmd
   class BarcodeLookup
     CACHE_PREFIX = 'nhs_dmd/barcode'
 
+    def self.barcode_query?(barcode)
+      normalized = NhsDmdBarcode.normalize_gtin(barcode)
+      normalized.match?(/\A\d{13,14}\z/)
+    end
+
     def lookup(barcode)
       barcode_candidates(barcode).filter_map { |candidate| fetch(candidate) }.first
     end
@@ -20,8 +25,9 @@ module NhsDmd
     end
 
     def self.candidates_for(barcode)
+      return [] unless barcode_query?(barcode)
+
       normalized = NhsDmdBarcode.normalize_gtin(barcode)
-      return [] if normalized.blank?
 
       candidates = [normalized]
       candidates << normalized.rjust(14, '0') if normalized.length == 13

--- a/app/services/nhs_dmd/release_import.rb
+++ b/app/services/nhs_dmd/release_import.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+module NhsDmd
+  class ReleaseImport
+    Result = Struct.new(:imported_count, :skipped_count, keyword_init: true)
+
+    def import(release_dir)
+      dir = Pathname.new(release_dir)
+      ampp_file = glob_one(dir, 'f_ampp2_3*.xml')
+      gtin_file = find_gtin_file(dir)
+
+      names = parse_ampp_names(ampp_file)
+      import_gtins(gtin_file, names)
+    end
+
+    private
+
+    def glob_one(dir, pattern)
+      matches = Dir.glob(dir.join(pattern))
+      raise ArgumentError, "No file matching #{pattern} in #{dir}" if matches.empty?
+
+      matches.first
+    end
+
+    def find_gtin_file(dir)
+      existing = Dir.glob(dir.join('f_gtin2_0*.xml'))
+      return existing.first if existing.any?
+
+      zip = Dir.glob(dir.join('*GTIN.zip')).first
+      raise ArgumentError, "No GTIN XML or ZIP found in #{dir}" unless zip
+
+      extract_dir = Dir.mktmpdir('dmd-gtin')
+      extract_gtin_xml(zip, extract_dir)
+      Dir.glob(File.join(extract_dir, 'f_gtin2_0*.xml')).first
+    end
+
+    def extract_gtin_xml(zip_path, dest)
+      system('unzip', '-o', zip_path.to_s, 'f_gtin2_0*.xml', '-d', dest.to_s,
+             exception: true)
+    end
+
+    def parse_ampp_names(path)
+      each_ampp_doc(path).with_object({}) do |doc, names|
+        appid = node_text(doc, 'APPID')
+        name = node_text(doc, 'NM')
+        next if appid.blank? || name.blank?
+
+        names[appid] = name
+      end
+    end
+
+    def import_gtins(path, names)
+      counts = { imported: 0, skipped: 0 }
+      today = Time.zone.today
+
+      each_ampp_doc(path) do |doc|
+        import_ampp_gtins(doc, names:, today:, counts:)
+      end
+
+      Result.new(imported_count: counts[:imported], skipped_count: counts[:skipped])
+    end
+
+    def each_ampp_doc(path)
+      return enum_for(__method__, path) unless block_given?
+
+      Nokogiri::XML::Reader(File.open(path)).each do |node|
+        next unless ampp_element?(node)
+
+        yield Nokogiri::XML(node.outer_xml)
+      end
+    end
+
+    def ampp_element?(node)
+      node.name == 'AMPP' && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+    end
+
+    def import_ampp_gtins(doc, names:, today:, counts:)
+      amppid = node_text(doc, 'AMPPID')
+      return if amppid.blank?
+
+      display = names[amppid]
+      doc.css('GTINDATA').each do |gtin_data|
+        import_gtin_data(gtin_data, amppid:, display:, today:, counts:)
+      end
+    end
+
+    def import_gtin_data(gtin_data, amppid:, display:, today:, counts:)
+      gtin = node_text(gtin_data, 'GTIN')
+      return if gtin.blank? || expired?(gtin_data, today)
+
+      if display.blank?
+        counts[:skipped] += 1
+        return
+      end
+
+      persist(
+        gtin: NhsDmdBarcode.normalize_gtin(gtin),
+        code: amppid,
+        display: display,
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+      counts[:imported] += 1
+    end
+
+    def expired?(gtin_data, today)
+      end_date = node_text(gtin_data, 'ENDDT')
+      end_date.present? && Date.parse(end_date) <= today
+    end
+
+    def node_text(doc, selector)
+      doc.at(selector)&.text
+    end
+
+    def persist(attrs)
+      record = NhsDmdBarcode.find_or_initialize_by(gtin: attrs[:gtin])
+      record.assign_attributes(attrs)
+      record.save!
+    end
+  end
+end

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -2,13 +2,13 @@
 
 module NhsDmd
   class Search
-    Result = Struct.new(:results, :error, keyword_init: true) do
+    Result = Struct.new(:results, :error, :resolved_query, :barcode, keyword_init: true) do
       def success?
         error.nil?
       end
     end
 
-    def initialize(client: Client.new, barcode_lookup: BarcodeLookup.new)
+    def initialize(client: Client.new, barcode_lookup: BarcodeCatalog::Lookup.new)
       @client = client
       @barcode_lookup = barcode_lookup
     end
@@ -17,7 +17,7 @@ module NhsDmd
       return Result.new(results: [], error: nil) if query.blank?
 
       barcode_match = @barcode_lookup.lookup(query)
-      return Result.new(results: [build_result(barcode_match)], error: nil) if barcode_match
+      return barcode_result(query, barcode_match) if barcode_match
 
       return not_configured_result unless @client.configured?
 
@@ -35,7 +35,7 @@ module NhsDmd
     end
 
     def search_results(query)
-      @client.search(query).map { |item| build_result(item) }
+      build_results(@client.search(query))
     end
 
     def failed_result(message, exception = nil)
@@ -58,6 +58,34 @@ module NhsDmd
         system: item[:system],
         concept_class: item[:concept_class]
       )
+    end
+
+    def barcode_result(query, barcode_match)
+      translated_query = barcode_match[:display]
+
+      Result.new(
+        results: build_results(barcode_items(translated_query, barcode_match)),
+        error: nil,
+        resolved_query: translated_query,
+        barcode: NhsDmdBarcode.normalize_gtin(query)
+      )
+    end
+
+    def build_results(items)
+      items.uniq { |item| item[:code] }.map { |item| build_result(item) }
+    end
+
+    def barcode_items(translated_query, barcode_match)
+      items = []
+      items << barcode_match if barcode_match[:code].present?
+      items.concat(@client.search(translated_query)) if @client.configured?
+      items
+    rescue Client::ApiError => e
+      log_failure(e.message)
+      [barcode_match]
+    rescue StandardError => e
+      log_failure('unexpected_error', e)
+      [barcode_match]
     end
   end
 end

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,6 +39,7 @@ services:
       NHS_DMD_CLIENT_SECRET: ${NHS_DMD_CLIENT_SECRET:-}
     volumes:
       - .:/app
+      - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
       - medtracker_dev_bundle:/usr/local/bundle
       - medtracker_dev_node_modules:/app/node_modules
       - medtracker_dev_storage:/app/storage
@@ -63,6 +64,7 @@ services:
     environment: *rails_env_dev
     volumes:
       - .:/app
+      - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
       - medtracker_dev_bundle:/usr/local/bundle
       - medtracker_dev_node_modules:/app/node_modules
       - medtracker_dev_storage:/app/storage
@@ -109,6 +111,7 @@ services:
       SMTP_ADDRESS: mail-test
     volumes:
       - .:/app
+      - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
       - medtracker_test_bundle:/usr/local/bundle
       - medtracker_test_node_modules:/app/node_modules
 
@@ -130,6 +133,7 @@ services:
     environment: *rails_env_test
     volumes:
       - .:/app
+      - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
       - medtracker_test_bundle:/usr/local/bundle
       - medtracker_test_node_modules:/app/node_modules
       - ./tmp/capybara:/app/tmp/capybara

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -25,6 +25,13 @@ cy:
           carer: "Gofalwr"
           parent: "Rhiant"
           self: "Hunan"
+    errors:
+      models:
+        medication:
+          attributes:
+            barcode:
+              invalid: "rhaid iddo fod yn GTIN 13 neu 14 digid"
+              taken: "eisoes wedi'i gysylltu â meddyginiaeth arall yn y rhestr"
 
   app:
     name: "MedTracker"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,13 @@ en:
           carer: "Carer"
           parent: "Parent"
           self: "Self"
+    errors:
+      models:
+        medication:
+          attributes:
+            barcode:
+              invalid: "must be a 13 or 14 digit GTIN"
+              taken: "is already linked to another medication in inventory"
 
   admin:
     invitations:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -25,6 +25,13 @@ es:
           carer: "Cuidador"
           parent: "Padre/Madre"
           self: "Mismo"
+    errors:
+      models:
+        medication:
+          attributes:
+            barcode:
+              invalid: "debe ser un GTIN de 13 o 14 dígitos"
+              taken: "ya está vinculado a otro medicamento en el inventario"
 
   app:
     name: "MedTracker"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -25,6 +25,13 @@ ga:
           carer: "Cúramóir"
           parent: "Tuismitheoir"
           self: "Féin"
+    errors:
+      models:
+        medication:
+          attributes:
+            barcode:
+              invalid: "caithfidh sé a bheith ina GTIN 13 nó 14 digit"
+              taken: "ceangailte cheana le cógas eile sa stórliosta"
   app:
     name: "MedTracker"
 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -25,6 +25,13 @@ pt:
           carer: "Cuidador"
           parent: "Pai/Mãe"
           self: "Próprio"
+    errors:
+      models:
+        medication:
+          attributes:
+            barcode:
+              invalid: "deve ser um GTIN de 13 ou 14 dígitos"
+              taken: "já está vinculado a outro medicamento no inventário"
 
   app:
     name: "MedTracker"

--- a/db/migrate/20260418083500_create_barcode_catalog_entries.rb
+++ b/db/migrate/20260418083500_create_barcode_catalog_entries.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateBarcodeCatalogEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :barcode_catalog_entries do |t|
+      t.string :gtin, null: false
+      t.string :display, null: false
+      t.string :source, null: false
+      t.string :code
+      t.string :system
+      t.string :concept_class
+      t.timestamps
+    end
+
+    add_index :barcode_catalog_entries, %i[source gtin], unique: true
+    add_index :barcode_catalog_entries, :gtin
+  end
+end

--- a/db/migrate/20260418083600_add_dmd_fields_to_medications.rb
+++ b/db/migrate/20260418083600_add_dmd_fields_to_medications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDmdFieldsToMedications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :medications, :dmd_code, :string
+    add_column :medications, :dmd_system, :string
+    add_column :medications, :dmd_concept_class, :string
+
+    add_index :medications, :dmd_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_161000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_083600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -149,6 +149,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_161000) do
     t.index ["revoked_at"], name: "index_api_sessions_on_revoked_at"
   end
 
+  create_table "barcode_catalog_entries", force: :cascade do |t|
+    t.string "code"
+    t.string "concept_class"
+    t.datetime "created_at", null: false
+    t.string "display", null: false
+    t.string "gtin", null: false
+    t.string "source", null: false
+    t.string "system"
+    t.datetime "updated_at", null: false
+    t.index ["gtin"], name: "index_barcode_catalog_entries_on_gtin"
+    t.index ["source", "gtin"], name: "index_barcode_catalog_entries_on_source_and_gtin", unique: true
+  end
+
   create_table "carer_relationships", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.bigint "carer_id", null: false
@@ -231,6 +244,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_161000) do
     t.datetime "created_at", null: false
     t.integer "current_supply"
     t.text "description"
+    t.string "dmd_code"
+    t.string "dmd_concept_class"
+    t.string "dmd_system"
     t.float "dosage_amount"
     t.string "dosage_unit"
     t.date "expiry_date"
@@ -244,6 +260,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_161000) do
     t.datetime "updated_at", null: false
     t.text "warnings"
     t.index ["barcode"], name: "index_medications_on_barcode", unique: true, where: "((barcode IS NOT NULL) AND ((barcode)::text <> ''::text))"
+    t.index ["dmd_code"], name: "index_medications_on_dmd_code"
     t.index ["location_id"], name: "index_medications_on_location_id"
   end
 

--- a/db/seeds/import_barcode_catalog.rb
+++ b/db/seeds/import_barcode_catalog.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+path = ARGV.first.to_s
+
+raise ArgumentError, 'Usage: rails runner db/seeds/import_barcode_catalog.rb path/to/file.csv' if path.blank?
+
+result = BarcodeCatalog::ImportCsv.new.call(path)
+puts({ imported_count: result.imported_count, invalid_rows: result.invalid_rows }.inspect)

--- a/db/seeds/import_nhs_dmd_release.rb
+++ b/db/seeds/import_nhs_dmd_release.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+dir = ARGV.first.to_s
+
+raise ArgumentError, 'Usage: rails runner db/seeds/import_nhs_dmd_release.rb /path/to/release/dir' if dir.blank?
+
+result = NhsDmd::ReleaseImport.new.import(dir)
+puts "Imported: #{result.imported_count}, Skipped: #{result.skipped_count}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,7 @@ Kubernetes operators should use the dedicated runbook for complete seeding
 procedures:
 
 - [Kubernetes User Seeding Runbook](kubernetes-user-seeding.md)
+- [Kubernetes NHS dm+d Release Import Runbook](kubernetes-nhs-dmd-import.md)
 
 Quick flow selection:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ ensuring medications are given on time and safely.
 *These guides focus on clinical accuracy and deep integrations.*
 
 - [NHS dm+d Integration](nhs-dmd-integration.md): use the UK's medicine dictionary to find accurate names.
+- [Kubernetes NHS dm+d Release Import](kubernetes-nhs-dmd-import.md): import dm+d AMPP and GTIN release files in production.
 - [UK Regulatory Compliance Plan](uk-regulatory-compliance-plan.md): how MedTracker aligns with health data standards.
 - [Audit Trail](audit-trail.md): how we ensure clinical records are safe and traceable.
 

--- a/docs/kubernetes-nhs-dmd-import.md
+++ b/docs/kubernetes-nhs-dmd-import.md
@@ -1,0 +1,210 @@
+# Kubernetes NHS dm+d Release Import Runbook
+
+Use this guide to import NHS dm+d release XML files into a Kubernetes-hosted
+MedTracker production environment.
+
+## TL;DR
+
+1. Upload one dm+d release directory to object storage under a versioned path.
+2. Create or update a Secret / ExternalSecret with normal Rails production env
+   plus object-storage access credentials.
+3. Apply a one-off Kubernetes Job that:
+   - downloads the release into an `emptyDir` from an init container
+   - expands the GTIN ZIP in that init container if the release is stored as a ZIP
+   - runs `bundle exec rails runner db/seeds/import_nhs_dmd_release.rb /work/nhs-dmd/current`
+4. Check the Job logs for `Imported:` / `Skipped:` counts.
+5. Spot-check a known GTIN in the live app.
+6. Remove the one-off Job manifest from GitOps after success.
+
+## What the importer needs
+
+The release importer expects a directory containing:
+
+- `f_ampp2_3*.xml`
+- either `f_gtin2_0*.xml` or the GTIN zip file
+
+The Rails entrypoint is:
+
+```bash
+bundle exec rails runner db/seeds/import_nhs_dmd_release.rb /work/nhs-dmd/current
+```
+
+The importer resolves AMPP product names from the AMPP XML and GTIN mappings
+from the GTIN XML. It can also extract the GTIN ZIP, but only when the runtime
+environment provides `unzip`.
+
+## Recommended production pattern
+
+Use a **one-off Kubernetes Job per release**.
+
+Do not run the import:
+
+- from the web Deployment startup path
+- from an init container on every app pod
+- from a CronJob
+
+Why:
+
+- imports are operational and can take time
+- pod restarts must not re-trigger imports
+- the importer does not currently record a release version marker, so a CronJob
+  would just reprocess the same release repeatedly
+
+## Pattern A: object storage + init container + emptyDir
+
+Store each release under a versioned object-storage path, for example:
+
+```text
+s3://med-tracker-nhs-dmd/releases/2026-04/current/
+```
+
+Prefer storing the release as extracted XML files in object storage.
+
+If you only store the GTIN ZIP, make ZIP extraction part of the init-container
+step. The normal app image does not install `unzip`, so do not rely on the
+Rails container to unpack production release artifacts.
+
+### Runtime Secret
+
+Use your normal application Secret if it already contains the required Rails env
+values. Add object-storage credentials if needed.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: med-tracker-dmd-import-env
+  namespace: <namespace>
+type: Opaque
+stringData:
+  RAILS_ENV: production
+  DATABASE_URL: postgresql://...
+  SECRET_KEY_BASE: <secret-key-base>
+  SOLID_QUEUE_DATABASE_URL: postgresql://...
+  SOLID_CACHE_DATABASE_URL: postgresql://...
+  SOLID_CABLE_DATABASE_URL: postgresql://...
+  AWS_ACCESS_KEY_ID: <access-key>
+  AWS_SECRET_ACCESS_KEY: <secret-key>
+  AWS_DEFAULT_REGION: eu-west-2
+  DMD_RELEASE_URI: s3://med-tracker-nhs-dmd/releases/2026-04/current/
+```
+
+### One-off import Job
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: med-tracker-import-dmd-release-2026-04
+  namespace: <namespace>
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: fetch-dmd-release
+          image: amazon/aws-cli:2.22.35
+          command:
+            - sh
+            - -lc
+            - |
+              mkdir -p /work/nhs-dmd/current
+              aws s3 sync "${DMD_RELEASE_URI}" /work/nhs-dmd/current --no-progress
+          envFrom:
+            - secretRef:
+                name: med-tracker-dmd-import-env
+          volumeMounts:
+            - name: dmd-release
+              mountPath: /work/nhs-dmd
+      containers:
+        - name: import-dmd-release
+          image: ghcr.io/damacus/med-tracker:<image-tag>
+          command:
+            - bundle
+            - exec
+            - rails
+            - runner
+            - db/seeds/import_nhs_dmd_release.rb
+            - /work/nhs-dmd/current
+          envFrom:
+            - secretRef:
+                name: med-tracker-dmd-import-env
+          volumeMounts:
+            - name: dmd-release
+              mountPath: /work/nhs-dmd
+      volumes:
+        - name: dmd-release
+          emptyDir: {}
+```
+
+Notes:
+
+- use the same app image tag as the production release
+- if the release path contains a GTIN ZIP instead of extracted XML, use an init
+  container image that includes `unzip` and expand it into `/work/nhs-dmd/current`
+- if your object store is S3-compatible, add the appropriate endpoint/env flags
+  to the init container
+- keep the Job manifest in GitOps only until the import succeeds
+
+## Pattern B: read-only PVC mount
+
+If the cluster already exposes release artifacts through a PersistentVolumeClaim,
+reuse the same Rails command and skip the download init container.
+
+Requirements:
+
+- mount the PVC read-only into the Job
+- expose the release directory at `/work/nhs-dmd/current`
+
+Example container command stays the same:
+
+```yaml
+command:
+  - bundle
+  - exec
+  - rails
+  - runner
+  - db/seeds/import_nhs_dmd_release.rb
+  - /work/nhs-dmd/current
+```
+
+## Verification
+
+Check Job status:
+
+```bash
+kubectl get jobs -n <namespace>
+kubectl logs job/med-tracker-import-dmd-release-2026-04 -n <namespace>
+```
+
+Expected log output includes:
+
+```text
+Imported: <count>, Skipped: <count>
+```
+
+Then verify application behavior:
+
+1. Confirm `nhs_dmd_barcodes` row count increased as expected.
+2. Search the live finder with a known GTIN from the imported release.
+3. Confirm the finder resolves the barcode to a dm+d term and result set.
+
+## Operational workflow per release
+
+1. Upload the new release to object storage or stage it on the PVC.
+2. Create or update the import Job manifest with the new release path and a
+   unique Job name.
+3. Reconcile GitOps or apply the Job directly.
+4. Wait for success and inspect logs.
+5. Perform the spot checks above.
+6. Remove the one-off Job from Git after success.
+
+## Future improvement
+
+If imports need to become scheduled, first add release-version tracking so the
+app can detect whether a release has already been imported. Until then, keep
+imports as explicit one-off Jobs.

--- a/docs/nhs-dmd-integration.md
+++ b/docs/nhs-dmd-integration.md
@@ -182,6 +182,27 @@ To test the live API locally:
 4. Visit `/medication-finder` and search for a medication name,
    for example `Aspirin`.
 
+## Importing dm+d release GTIN data
+
+Barcode lookup uses imported NHS release files in addition to live
+Terminology Server search.
+
+Local development:
+
+```fish
+task dev:import-dmd-release RELEASE_DIR=storage/nhs_dmd/releases/current
+```
+
+Production Kubernetes:
+
+- use a one-off Job per release
+- stage extracted XML files or expand the GTIN ZIP in the Job init container
+- mount the release into the Job at a stable path
+- run `bundle exec rails runner db/seeds/import_nhs_dmd_release.rb /work/nhs-dmd/current`
+
+See the full operational runbook:
+[Kubernetes NHS dm+d Release Import Runbook](kubernetes-nhs-dmd-import.md)
+
 ## Drug interactions
 
 The dm+d API provides **no interaction data** — it is a

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -104,24 +104,22 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(rendered.text).to include('Stock Inventory')
     end
 
-    it 'renders a compact Next Dose card in the right rail' do
+    it 'does not render a duplicate Next Dose card in the right rail' do
       rendered = render_inline(dashboard_view)
-      expected_value = presenter.next_dose_time&.strftime('%H:%M') || I18n.t('dashboard.stats.no_upcoming_doses')
 
-      compact_card = rendered.at_css('[data-testid="dashboard-right-rail-next-dose"]')
-
-      expect(compact_card).to be_present
-      expect(compact_card.text).to include('Next Dose')
-      expect(compact_card.text).to include(expected_value)
-      expect(compact_card.to_html).to include('min-h-[7rem]')
-      expect(compact_card[:class]).not_to include('h-full')
+      expect(rendered.at_css('[data-testid="dashboard-right-rail-next-dose"]')).not_to be_present
     end
 
-    it 'renders the mobile content flow with schedule and inventory before insights' do
+    it 'does not render a duplicate Medication Schedule section in the right rail' do
+      rendered = render_inline(dashboard_view)
+
+      expect(rendered.css('h2').map(&:text)).not_to include('Medication Schedule')
+    end
+
+    it 'renders the mobile content flow with inventory before insights' do
       rendered = render_inline(dashboard_view)
       html = rendered.to_html
 
-      expect(html.index('Medication Schedule')).to be < html.index('Smart Insights')
       expect(html.index('Stock Inventory')).to be < html.index('Smart Insights')
     end
   end

--- a/spec/features/medication_lookup_spec.rb
+++ b/spec/features/medication_lookup_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe 'Medication Lookup', type: :system do
     ]
   end
 
+  let(:barcode_results) do
+    [
+      {
+        code: '13629411000001105',
+        display: 'Laxido Orange oral powder sachets (Galen Ltd)',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      }
+    ]
+  end
+
   before do
     # Set credentials for NhsDmd::Client
     allow(ENV).to receive(:fetch).and_call_original
@@ -77,6 +88,72 @@ RSpec.describe 'Medication Lookup', type: :system do
     click_button 'Search'
 
     expect(page).to have_content('Search unavailable')
+  end
+
+  it 'allows selecting a search result and prefill a new inventory item' do
+    stub_nhs_dmd_search(query: '5016298210989', results: barcode_results)
+
+    sign_in(doctor)
+    visit medication_finder_path
+
+    fill_in 'medication-search-input', with: '5016298210989'
+    click_button 'Search'
+    within('[data-testid="result-card"]', match: :first) do
+      click_link 'Add Medication'
+    end
+
+    expect(page).to have_current_path(%r{/medications/new})
+    expect(page).to have_field('medication_name', with: 'Laxido Orange oral powder sachets (Galen Ltd)')
+    expect(page).to have_field('medication[barcode]', with: '5016298210989', type: :hidden)
+  end
+
+  it 'translates an imported barcode into a searchable dm+d term in the finder UI' do
+    NhsDmdBarcode.create!(
+      gtin: '05016298210989',
+      code: '13629411000001105',
+      display: 'Laxido Orange oral powder sachets (Galen Ltd)',
+      system: 'https://dmd.nhs.uk',
+      concept_class: 'AMPP'
+    )
+    stub_nhs_dmd_search(query: 'Laxido Orange oral powder sachets (Galen Ltd)', results: barcode_results)
+
+    sign_in(doctor)
+    visit medication_finder_path
+
+    fill_in 'medication-search-input', with: '5016298210989'
+    click_button 'Search'
+
+    expect(page).to have_field('medication-search-input', with: 'Laxido Orange oral powder sachets (Galen Ltd)')
+    expect(page).to have_css(
+      '[data-testid="search-results-header"]',
+      text: 'Laxido Orange oral powder sachets (Galen Ltd)'
+    )
+    expect(page).to have_no_css('[data-testid="search-results-header"]', text: '5016298210989')
+
+    within('[data-testid="result-card"]', match: :first) do
+      click_link 'Add Medication'
+    end
+
+    expect(page).to have_current_path(%r{/medications/new})
+    expect(page).to have_field('medication_name', with: 'Laxido Orange oral powder sachets (Galen Ltd)')
+    expect(page).to have_field('medication[barcode]', with: '5016298210989', type: :hidden)
+  end
+
+  it 'does not persist a non-GTIN numeric query as a barcode' do
+    stub_nhs_dmd_search(query: '1234567890', results: aspirin_results)
+
+    sign_in(doctor)
+    visit medication_finder_path
+
+    fill_in 'medication-search-input', with: '1234567890'
+    click_button 'Search'
+    within('[data-testid="result-card"]', match: :first) do
+      click_link 'Add Medication'
+    end
+
+    expect(page).to have_current_path(%r{/medications/new})
+    expect(page).to have_field('medication_name', with: 'Aspirin 300mg tablets')
+    expect(page).to have_no_field('medication[barcode]', type: :hidden)
   end
 
   it 'User views drug interactions (not yet implemented)' do

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -63,18 +63,43 @@ RSpec.describe Medication do
     it { is_expected.to allow_value(nil).for(:barcode) }
     it { is_expected.to allow_value('').for(:barcode) }
     it { is_expected.to allow_value('5000158100138').for(:barcode) }
+    it { is_expected.to allow_value('05000158100138').for(:barcode) }
+    it { is_expected.to allow_value(nil).for(:dmd_code) }
+    it { is_expected.to allow_value('').for(:dmd_code) }
+
+    it 'rejects non-GTIN barcodes' do
+      medication.barcode = '1234567890'
+      medication.valid?
+
+      expect(medication.errors[:barcode]).to include('must be a 13 or 14 digit GTIN')
+    end
+
+    it 'rejects non-numeric barcodes' do
+      medication.barcode = 'abc123'
+      medication.valid?
+
+      expect(medication.errors[:barcode]).to include('must be a 13 or 14 digit GTIN')
+    end
 
     it 'rejects duplicate barcodes' do
       create(:medication, barcode: '5000158100138')
       medication.barcode = '5000158100138'
       medication.valid?
-      expect(medication.errors[:barcode]).to include('has already been taken')
+      expect(medication.errors[:barcode]).to include('is already linked to another medication in inventory')
     end
 
     it 'allows multiple nil barcodes' do
       create(:medication, barcode: nil)
       other = build(:medication, barcode: nil)
       expect(other).to be_valid
+    end
+
+    it 'requires a dm+d system when a dm+d code is present' do
+      medication.dmd_code = '4585411000001109'
+      medication.dmd_system = ''
+      medication.valid?
+
+      expect(medication.errors[:dmd_system]).to include("can't be blank")
     end
   end
 

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe 'Medication creation scope' do
       expect(response.body).to include(locations(:school).name)
       expect(response.body).not_to include(foreign_location.name)
     end
+
+    it 'prefills the medication name and barcode from the finder selection' do
+      get new_medication_path, params: {
+        name: 'Laxido Orange oral powder sachets (Galen Ltd)',
+        barcode: '5016298210989',
+        dmd_code: '13629411000001105',
+        dmd_system: 'https://dmd.nhs.uk',
+        dmd_concept_class: 'AMPP'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-testid="medication-wizard-form"')
+      expect(response.body).to include('value="Laxido Orange oral powder sachets (Galen Ltd)"')
+      expect(response.body).to include('name="medication[barcode]"')
+      expect(response.body).to include('value="5016298210989"')
+      expect(response.body).to include('name="medication[dmd_code]"')
+      expect(response.body).to include('value="13629411000001105"')
+      expect(response.body).to include('name="medication[dmd_system]"')
+      expect(response.body).to include('name="medication[dmd_concept_class]"')
+    end
+
+    it 'ignores an invalid non-GTIN barcode from the finder selection' do
+      get new_medication_path, params: {
+        name: 'Aspirin 300mg tablets',
+        barcode: '1234567890'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-testid="medication-wizard-form"')
+      expect(response.body).to include('value="Aspirin 300mg tablets"')
+      expect(response.body).not_to include('name="medication[barcode]"')
+      expect(response.body).not_to include('value="1234567890"')
+    end
   end
 
   describe 'POST /medications' do
@@ -39,6 +72,54 @@ RSpec.describe 'Medication creation scope' do
 
       expect(response).to redirect_to(medication_path(Medication.last))
       expect(Medication.last.location).to eq(locations(:home))
+    end
+
+    it 'persists a barcode selected from the finder flow' do
+      expect do
+        post medications_path, params: {
+          medication: {
+            name: 'Laxido Orange oral powder sachets (Galen Ltd)',
+            barcode: '5016298210989',
+            dmd_code: '13629411000001105',
+            dmd_system: 'https://dmd.nhs.uk',
+            dmd_concept_class: 'AMPP',
+            category: 'Osmotic Laxative',
+            dosage_amount: 1,
+            dosage_unit: 'sachet',
+            current_supply: 30,
+            reorder_threshold: 5,
+            location_id: locations(:home).id
+          }
+        }
+      end.to change(Medication, :count).by(1)
+
+      expect(Medication.last.barcode).to eq('5016298210989')
+      expect(Medication.last.dmd_code).to eq('13629411000001105')
+      expect(Medication.last.dmd_system).to eq('https://dmd.nhs.uk')
+      expect(Medication.last.dmd_concept_class).to eq('AMPP')
+    end
+
+    it 'shows a friendly error when the barcode is already used in another inaccessible inventory item' do
+      create(:medication, barcode: '5016298210989', location: foreign_location)
+
+      expect do
+        post medications_path, params: {
+          medication: {
+            name: 'Laxido Orange oral powder sachets (Galen Ltd)',
+            barcode: '5016298210989',
+            category: 'Osmotic Laxative',
+            dosage_amount: 1,
+            dosage_unit: 'sachet',
+            current_supply: 30,
+            reorder_threshold: 5,
+            location_id: locations(:home).id
+          }
+        }
+      end.not_to change(Medication, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Barcode is already linked to another medication in inventory')
+      expect(response.body).not_to include('has already been taken')
     end
 
     it 'rejects a forged foreign location_id' do

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -145,6 +145,8 @@ RSpec.describe 'GET /medication-finder/search' do
             'concept_class' => 'AMPP'
           )
         )
+        expect(response.parsed_body['query']).to eq('Laxido Orange oral powder sachets (Galen Ltd)')
+        expect(response.parsed_body['barcode']).to eq('5016298210989')
       end
     end
 

--- a/spec/services/barcode_catalog/import_csv_spec.rb
+++ b/spec/services/barcode_catalog/import_csv_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.describe BarcodeCatalog::ImportCsv do
+  describe '#call' do
+    let(:importer) { described_class.new }
+    let(:path) { Rails.root.join('tmp/barcode-catalog-import-spec.csv') }
+
+    after do
+      FileUtils.rm_f(path)
+    end
+
+    it 'imports external barcode catalogue mappings' do
+      File.write(path, <<~CSV)
+        gtin,display,source,code,system,concept_class
+        3574661385488,Calprofen 100mg/5ml oral suspension,cd_data,4585411000001109,https://dmd.nhs.uk,AMPP
+      CSV
+
+      result = importer.call(path)
+
+      expect(result.imported_count).to eq(1)
+      expect(result.invalid_rows).to eq([])
+      expect(BarcodeCatalogEntry.find_by!(gtin: '3574661385488')).to have_attributes(
+        display: 'Calprofen 100mg/5ml oral suspension',
+        source: 'cd_data',
+        code: '4585411000001109',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+    end
+
+    it 'rejects files without the required headers' do
+      File.write(path, <<~CSV)
+        barcode,name
+        3574661385488,Calprofen 100mg/5ml oral suspension
+      CSV
+
+      expect { importer.call(path) }
+        .to raise_error(ArgumentError, 'Missing required headers: gtin, display, source')
+    end
+  end
+end

--- a/spec/services/barcode_catalog/lookup_spec.rb
+++ b/spec/services/barcode_catalog/lookup_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BarcodeCatalog::Lookup do
+  describe '#lookup' do
+    let(:lookup) { described_class.new }
+    let(:gtin) { '3574661385488' }
+
+    def create_external_entry
+      BarcodeCatalogEntry.create!(
+        gtin: gtin,
+        display: 'Calprofen 100mg/5ml oral suspension',
+        source: 'cd_data',
+        code: '4585411000001109',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+    end
+
+    def create_local_entry(code:, display:)
+      NhsDmdBarcode.create!(
+        gtin: gtin,
+        code: code,
+        display: display,
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+    end
+
+    it 'prefers an external catalogue entry over the local dm+d barcode table' do
+      create_external_entry
+      create_local_entry(code: 'old-code', display: 'Old dm+d mapping')
+
+      expect(lookup.lookup(gtin)).to include(
+        display: 'Calprofen 100mg/5ml oral suspension',
+        code: '4585411000001109',
+        source: 'cd_data'
+      )
+    end
+
+    it 'falls back to the local dm+d barcode table when no external catalogue entry exists' do
+      create_local_entry(
+        code: '4585411000001109',
+        display: 'Calprofen 100mg/5ml oral suspension (McNeil Products Ltd) 100 ml'
+      )
+
+      expect(lookup.lookup(gtin)).to include(
+        display: 'Calprofen 100mg/5ml oral suspension (McNeil Products Ltd) 100 ml',
+        code: '4585411000001109',
+        source: 'nhs_dmd'
+      )
+    end
+  end
+end

--- a/spec/services/nhs_dmd/release_import_spec.rb
+++ b/spec/services/nhs_dmd/release_import_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.describe NhsDmd::ReleaseImport do
+  let(:importer) { described_class.new }
+  let(:release_dir) { Rails.root.join('tmp/dmd-release-spec') }
+
+  before { FileUtils.mkdir_p(release_dir) }
+  after { FileUtils.rm_rf(release_dir) }
+
+  def write_ampp_xml(entries)
+    xml = +'<?xml version="1.0" encoding="utf-8" ?>'
+    xml << '<ACTUAL_MEDICINAL_PROD_PACKS><AMPPS>'
+    entries.each do |e|
+      xml << "<AMPP><APPID>#{e[:appid]}</APPID><NM>#{e[:nm]}</NM></AMPP>"
+    end
+    xml << '</AMPPS></ACTUAL_MEDICINAL_PROD_PACKS>'
+    File.write(release_dir.join('f_ampp2_3000000.xml'), xml)
+  end
+
+  def write_gtin_xml(entries)
+    xml = +'<?xml version="1.0" encoding="utf-8" ?>'
+    xml << '<GTIN_DETAILS><AMPPS>'
+    xml << entries.map { |entry| gtin_ampp_xml(entry) }.join
+    xml << '</AMPPS></GTIN_DETAILS>'
+    File.write(release_dir.join('f_gtin2_0000000.xml'), xml)
+  end
+
+  def gtin_ampp_xml(entry)
+    gtins = Array(entry[:gtins]).map { |gtin| gtin_data_xml(gtin) }.join
+    "<AMPP><AMPPID>#{entry[:amppid]}</AMPPID>#{gtins}</AMPP>"
+  end
+
+  def gtin_data_xml(gtin)
+    xml = "<GTINDATA><GTIN>#{gtin[:gtin]}</GTIN><STARTDT>#{gtin[:startdt]}</STARTDT>"
+    xml << "<ENDDT>#{gtin[:enddt]}</ENDDT>" if gtin[:enddt]
+    xml << '</GTINDATA>'
+  end
+
+  def write_single_gtin_xml(amppid:, gtin:, startdt:, enddt: nil)
+    write_gtin_xml([{ amppid: amppid, gtins: [{ gtin: gtin, startdt: startdt, enddt: enddt }.compact] }])
+  end
+
+  def gtin_entry(amppid:, gtins:)
+    { amppid: amppid, gtins: gtins }
+  end
+
+  def barcode_record(gtin)
+    NhsDmdBarcode.find_by!(gtin: gtin)
+  end
+
+  it 'imports active GTINs matched to AMPP names' do
+    write_ampp_xml([{ appid: '111', nm: 'Paracetamol 500mg tablets (Acme Ltd) 16 tablet' }])
+    write_single_gtin_xml(amppid: '111', gtin: '5016298210989', startdt: '2020-01-01')
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(1)
+    expect(result.skipped_count).to eq(0)
+    expect(barcode_record('5016298210989')).to have_attributes(
+      code: '111',
+      display: 'Paracetamol 500mg tablets (Acme Ltd) 16 tablet',
+      system: 'https://dmd.nhs.uk',
+      concept_class: 'AMPP'
+    )
+  end
+
+  it 'skips GTINs with a past end date' do
+    write_ampp_xml([{ appid: '222', nm: 'Expired Product 10mg tablets' }])
+    write_single_gtin_xml(
+      amppid: '222',
+      gtin: '1234567890123',
+      startdt: '2019-01-01',
+      enddt: '2020-01-01'
+    )
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(0)
+    expect(NhsDmdBarcode.find_by(gtin: '1234567890123')).to be_nil
+  end
+
+  it 'keeps GTINs with a future end date' do
+    write_ampp_xml([{ appid: '333', nm: 'Future Discontinue 25mg capsules' }])
+    write_single_gtin_xml(
+      amppid: '333',
+      gtin: '9876543210987',
+      startdt: '2020-01-01',
+      enddt: '2099-12-31'
+    )
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(1)
+    expect(barcode_record('9876543210987')).to have_attributes(code: '333')
+  end
+
+  it 'skips GTINs with no matching AMPP name' do
+    write_ampp_xml([]) # no AMPPs
+    write_single_gtin_xml(amppid: '444', gtin: '1111111111111', startdt: '2020-01-01')
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(0)
+    expect(result.skipped_count).to eq(1)
+  end
+
+  it 'imports multiple GTINs for the same AMPP' do
+    write_ampp_xml([{ appid: '555', nm: 'Multi-barcode Product' }])
+    gtins = [
+      { gtin: '2222222222222', startdt: '2020-01-01' },
+      { gtin: '3333333333333', startdt: '2021-01-01' }
+    ]
+    write_gtin_xml([gtin_entry(amppid: '555', gtins: gtins)])
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(2)
+    expect(NhsDmdBarcode.where(code: '555').count).to eq(2)
+  end
+
+  it 'normalizes GTIN values (strips non-digits)' do
+    write_ampp_xml([{ appid: '666', nm: 'Padded GTIN Product' }])
+    write_single_gtin_xml(amppid: '666', gtin: '05016298210989', startdt: '2020-01-01')
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(1)
+    expect(barcode_record('05016298210989')).to be_present
+  end
+
+  it 'updates existing records on re-import' do
+    NhsDmdBarcode.create!(
+      gtin: '5016298210989', code: 'old', display: 'Old Name',
+      system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
+    )
+
+    write_ampp_xml([{ appid: '777', nm: 'Updated Name' }])
+    write_single_gtin_xml(amppid: '777', gtin: '5016298210989', startdt: '2020-01-01')
+
+    result = importer.import(release_dir)
+
+    expect(result.imported_count).to eq(1)
+    expect(barcode_record('5016298210989')).to have_attributes(
+      code: '777',
+      display: 'Updated Name'
+    )
+  end
+
+  it 'raises when AMPP XML is missing' do
+    write_gtin_xml([{ amppid: '111', gtins: [] }])
+
+    expect { importer.import(release_dir) }
+      .to raise_error(ArgumentError, /No file matching f_ampp2_3/)
+  end
+
+  it 'raises when GTIN XML and ZIP are both missing' do
+    write_ampp_xml([{ appid: '111', nm: 'Test' }])
+
+    expect { importer.import(release_dir) }
+      .to raise_error(ArgumentError, /No GTIN XML or ZIP found/)
+  end
+end

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -84,17 +84,31 @@ RSpec.describe NhsDmd::Search do
           concept_class: 'AMPP'
         }
       end
+      let(:translated_results) do
+        [
+          {
+            code: '13629411000001105',
+            display: 'Laxido Orange oral powder sachets (Galen Ltd)',
+            system: 'https://dmd.nhs.uk',
+            concept_class: 'AMPP'
+          }
+        ]
+      end
 
       before do
         allow(client).to receive(:configured?).and_return(true)
         allow(barcode_lookup).to receive(:lookup).with('5016298210989').and_return(barcode_result)
         allow(client).to receive(:search)
+          .with('Laxido Orange oral powder sachets (Galen Ltd)')
+          .and_return(translated_results)
       end
 
-      it 'returns the mapped dm+d result without calling the remote search' do
+      it 'translates the barcode into a searchable dm+d query while preserving the scanned barcode' do
         result = search.call('5016298210989')
 
         expect(result).to be_success
+        expect(result.resolved_query).to eq('Laxido Orange oral powder sachets (Galen Ltd)')
+        expect(result.barcode).to eq('5016298210989')
         expect(result.results.map(&:to_h)).to contain_exactly(
           a_hash_including(
             code: '13629411000001105',
@@ -102,7 +116,47 @@ RSpec.describe NhsDmd::Search do
             concept_class: 'AMPP'
           )
         )
-        expect(client).not_to have_received(:search)
+        expect(client).to have_received(:search).with('Laxido Orange oral powder sachets (Galen Ltd)')
+      end
+    end
+
+    context 'when the barcode catalogue match needs dm+d enrichment by display name' do
+      let(:barcode_result) do
+        {
+          display: 'Calprofen 100mg/5ml oral suspension',
+          source: 'cd_data'
+        }
+      end
+      let(:translated_results) do
+        [
+          {
+            code: '4585411000001109',
+            display: 'Calprofen 100mg/5ml oral suspension (McNeil Products Ltd) 100 ml',
+            system: 'https://dmd.nhs.uk',
+            concept_class: 'AMPP'
+          }
+        ]
+      end
+
+      before do
+        allow(client).to receive(:configured?).and_return(true)
+        allow(barcode_lookup).to receive(:lookup).with('3574661385488').and_return(barcode_result)
+        allow(client).to receive(:search).with('Calprofen 100mg/5ml oral suspension').and_return(translated_results)
+      end
+
+      it 'returns enriched dm+d results keyed from the external barcode match' do
+        result = search.call('3574661385488')
+
+        expect(result).to be_success
+        expect(result.resolved_query).to eq('Calprofen 100mg/5ml oral suspension')
+        expect(result.barcode).to eq('3574661385488')
+        expect(result.results.map(&:to_h)).to contain_exactly(
+          a_hash_including(
+            code: '4585411000001109',
+            display: 'Calprofen 100mg/5ml oral suspension (McNeil Products Ltd) 100 ml',
+            concept_class: 'AMPP'
+          )
+        )
       end
     end
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -25,6 +25,7 @@ nav = [
   ] },
   { "🩺 For Clinicians" = [
     { "NHS dm+d Integration" = "nhs-dmd-integration.md" },
+    { "Kubernetes dm+d Import" = "kubernetes-nhs-dmd-import.md" },
     { "UK Regulatory Compliance" = "uk-regulatory-compliance-plan.md" }
   ] },
   { "Advanced Setup" = [


### PR DESCRIPTION
## Summary
- import NHS dm+d release GTIN data and persist dm+d identity through the medication finder flow
- translate scanned barcodes into searchable dm+d terms and carry barcode + dm+d metadata into medication creation
- remove duplicate dashboard right-rail sections and document the production one-off Kubernetes Job import flow

## Verification
- task rubocop
- task test

## Notes
- full test suite passed with 0 failures and 2 existing pending specs (OIDC not configured, MLKP-015 interactions placeholder)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
