### PR TITLE
refactor: remove dead code flagged by Jules

### DIFF
--- a/app/components/admin/carer_relationships/index_view.rb
+++ b/app/components/admin/carer_relationships/index_view.rb
@@ -4,9 +4,6 @@ module Components
   module Admin
     module CarerRelationships
       class IndexView < Components::Base
-        include Phlex::Rails::Helpers::ButtonTo
-        include Phlex::Rails::Helpers::FormWith
-
         attr_reader :relationships, :current_user, :pagy_obj
 
         def initialize(relationships:, current_user: nil, pagy: nil)
@@ -87,60 +84,6 @@ module Components
 
         def render_relationship_row(relationship)
           render Row.new(relationship: relationship)
-        end
-
-        def render_status_badge(relationship)
-          if relationship.active?
-            render RubyUI::Badge.new(variant: :success) { t('admin.carer_relationships.index.active') }
-          else
-            render RubyUI::Badge.new(variant: :destructive) { t('admin.carer_relationships.index.inactive') }
-          end
-        end
-
-        def render_activation_button(relationship)
-          if relationship.active?
-            render_deactivate_dialog(relationship)
-          else
-            form_with(
-              url: "/admin/carer_relationships/#{relationship.id}/activate",
-              method: :post,
-              class: 'inline-block'
-            ) do
-              m3_button(
-                type: :submit,
-                variant: :success_outline,
-                size: :sm
-              ) { t('admin.carer_relationships.index.activate') }
-            end
-          end
-        end
-
-        def render_deactivate_dialog(relationship)
-          render RubyUI::AlertDialog.new do
-            render RubyUI::AlertDialogTrigger.new do
-              m3_button(variant: :destructive_outline, size: :sm) do
-                t('admin.carer_relationships.index.deactivate')
-              end
-            end
-            render RubyUI::AlertDialogContent.new do
-              render RubyUI::AlertDialogHeader.new do
-                render(RubyUI::AlertDialogTitle.new { t('admin.carer_relationships.index.deactivate_dialog.title') })
-                render RubyUI::AlertDialogDescription.new do
-                  t('admin.carer_relationships.index.deactivate_dialog.confirm',
-                    carer: relationship.carer.name,
-                    patient: relationship.patient.name)
-                end
-              end
-              render RubyUI::AlertDialogFooter.new do
-                render(RubyUI::AlertDialogCancel.new { t('admin.carer_relationships.index.deactivate_dialog.cancel') })
-                form_with(url: "/admin/carer_relationships/#{relationship.id}", method: :delete, class: 'inline') do
-                  m3_button(variant: :destructive, type: :submit) do
-                    t('admin.carer_relationships.index.deactivate_dialog.submit')
-                  end
-                end
-              end
-            end
-          end
         end
 
         def render_pagination

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -155,15 +155,6 @@ module Components
         end
       end
 
-      # Form fields renderers remain mostly the same logic, but we can enhance the
-      # input styles if needed via global classes.
-      # For now, relying on the central input styling updates we made earlier.
-
-      def render_form_fields(form)
-        # This method is now redundant as logic is moved to render_form,
-        # but keeping helper methods below for field rendering
-      end
-
       def render_location_field(_form)
         div(class: 'space-y-2') do
           render RubyUI::FormFieldLabel.new(

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -68,10 +68,6 @@ module Components
         end
       end
 
-      def render_header
-        # Header is rendered by Modal component
-      end
-
       def render_form
         form_with(model: person, id: 'person_form', class: 'space-y-6') do |f|
           render_errors if person.errors.any?

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -7,14 +7,13 @@ module Components
       include Phlex::Rails::Helpers::TurboFrameTag
       include Phlex::Rails::Helpers::FormWith
 
-      attr_reader :person, :schedules, :person_medications, :editing,
+      attr_reader :person, :schedules, :person_medications,
                   :takes_by_schedule, :takes_by_person_medication, :current_user
 
-      def initialize(person:, schedules:, person_medications: nil, editing: false, **opts)
+      def initialize(person:, schedules:, person_medications: nil, **opts)
         @person = person
         @schedules = schedules
         @person_medications = person_medications || person.person_medications
-        @editing = editing
         preloaded_takes = opts.fetch(:preloaded_takes, {})
         @takes_by_schedule = preloaded_takes.fetch(:schedules, {})
         @takes_by_person_medication = preloaded_takes.fetch(:person_medications, {})
@@ -209,61 +208,6 @@ module Components
 
       def can_add_medication?
         can_create_schedule? || view_context.policy(PersonMedication.new(person: person)).create?
-      end
-
-      def render_edit_form
-        # Keep current logic for editing, just wrapping in new aesthetic container
-        div(class: 'container mx-auto px-4 py-12 max-w-2xl') do
-          m3_card(variant: :elevated, class: 'overflow-hidden border-none shadow-elevation-3 rounded-[2.5rem]') do
-            form_with(model: person, class: 'space-y-8 p-10', data: { controller: 'auto-submit' }) do |f|
-              div do
-                m3_heading(variant: :headline_small, level: 2, class: 'font-bold mb-1') do
-                  t('people.form.edit_heading')
-                end
-                m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') do
-                  t('people.form.edit_subheading', name: person.name)
-                end
-              end
-
-              div(class: 'space-y-6') do
-                div(class: 'space-y-2') do
-                  render RubyUI::FormFieldLabel.new(
-                    for: 'person_name',
-                    class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1'
-                  ) { t('people.form.name') }
-                  render f.text_field(
-                    :name,
-                    class: 'rounded-2xl border-outline-variant bg-surface-container-lowest py-6 px-5 ' \
-                           'focus:ring-2 focus:ring-primary/10 focus:border-primary transition-all'
-                  )
-                end
-
-                div(class: 'space-y-2') do
-                  render RubyUI::FormFieldLabel.new(
-                    for: 'person_date_of_birth',
-                    class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1'
-                  ) { t('people.form.date_of_birth') }
-                  render f.date_field(
-                    :date_of_birth,
-                    class: 'rounded-2xl border-outline-variant bg-surface-container-lowest py-6 px-5 ' \
-                           'focus:ring-2 focus:ring-primary/10 focus:border-primary transition-all'
-                  )
-                end
-              end
-
-              div(class: 'flex gap-3 pt-4') do
-                m3_button(type: :submit, variant: :filled, size: :lg,
-                          class: 'flex-1 py-7 font-bold shadow-lg shadow-primary/20') do
-                  t('people.form.save')
-                end
-                m3_link(href: person_path(person), variant: :text, size: :lg,
-                        class: 'py-7 px-8 font-bold text-on-surface-variant hover:text-foreground') do
-                  t('people.form.cancel')
-                end
-              end
-            end
-          end
-        end
       end
     end
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -14,13 +14,11 @@ class PeopleController < ApplicationController
   def show
     authorize @person
     show_data = PersonShowQuery.new(person: @person).call
-    editing = params[:editing] == 'true'
 
     render Components::People::ShowView.new(
       person: @person,
       schedules: show_data.schedules,
       person_medications: show_data.person_medications,
-      editing: editing,
       preloaded_takes: show_data.preloaded_takes,
       current_user: current_user
     )

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,10 +2,6 @@
 import { Turbo } from "@hotwired/turbo-rails"
 import "session_expiry"
 
-// Enable debug mode
-// Turbo.config.drive.progressBarDelay = 0
-// Turbo.config.drive.enabled = true
-
 // Import all controllers
 import "controllers"
 

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -1,37 +1,20 @@
 # frozen_string_literal: true
 
 class RodauthApp < Rodauth::Rails::App
-  # primary configuration
   configure RodauthMain
-
-  # secondary configuration
-  # configure RodauthAdmin, :admin
 
   route do |r|
     rodauth.load_memory # autologin remembered users
 
-    # Handle GET request for passkey removal confirmation
     r.get 'webauthn-remove' do
       rodauth.require_two_factor_authenticated
       rodauth.view 'webauthn-remove', 'Remove Passkey'
     end
 
-    r.rodauth # route rodauth requests
+    r.rodauth
   rescue ActionController::InvalidAuthenticityToken
     r.session.clear
     flash[:alert] = I18n.t('authentication.session_expired', default: 'Your session expired. Please sign in again.')
     r.redirect rodauth.login_path
-
-    # ==> Authenticating requests
-    # Call `rodauth.require_account` for requests that you want to
-    # require authentication for. For example:
-    #
-    # # authenticate /dashboard/* and /account/* requests
-    # if r.path.start_with?("/dashboard") || r.path.start_with?("/account")
-    #   rodauth.require_account
-    # end
-
-    # ==> Secondary configurations
-    # r.rodauth(:admin) # route admin rodauth requests
   end
 end


### PR DESCRIPTION
## Summary

Bundled cleanup of dead code and commented-out blocks flagged by Jules. All changes are removals — no behavior change.

## Changes

- **`people/show_view`**: drop `render_edit_form` + unused `editing` param (never invoked; edit flow uses `FormView`/`Modal` instead). Controller stops forwarding `params[:editing]`.
- **`medications/form_view`**: drop empty `render_form_fields` stub (method body was a comment).
- **`admin/carer_relationships/index_view`**: drop unused `render_status_badge`, `render_activation_button`, and `render_deactivate_dialog` — the `Row` component owns these. Also drop the now-unused `ButtonTo` / `FormWith` includes.
- **`people/form_view`**: drop empty `render_header` placeholder method.
- **`rodauth_app`**: drop commented admin secondary-config lines.
- **`application.js`**: drop commented Turbo Drive debug config.

Skipped from Jules's list for this PR:
- "Redundant map iteration" — couldn't identify the specific location from the label alone.
- Other bundles (console.log cleanup, missing tests, insecure cookie) to follow as separate PRs.

## Test plan

- [x] `task rubocop` — clean
- [x] Full RSpec suite — 1792 examples, 0 failures
- [ ] Manual smoke of `/people/:id` show and admin carer relationships index
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
