### PR TITLE
refactor: move medication take source api

### DIFF
--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -32,6 +32,14 @@ class MedicationTake < ApplicationRecord
     schedule || person_medication
   end
 
+  def source_type
+    schedule_id.present? ? 'schedule' : 'person_medication'
+  end
+
+  def source_record_id
+    schedule_id || person_medication_id
+  end
+
   def person
     schedule&.person || person_medication&.person
   end
@@ -168,8 +176,8 @@ class MedicationTake < ApplicationRecord
       medication_id: inventory.id,
       location_id: inventory.location_id,
       take_id: id,
-      source_type: schedule_id.present? ? 'schedule' : 'person_medication',
-      source_id: schedule_id || person_medication_id,
+      source_type: source_type,
+      source_id: source_record_id,
       previous_current_supply: stock_row['previous_current_supply'],
       current_supply: stock_row['current_supply'],
       reorder_threshold: stock_row['reorder_threshold'],

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -84,8 +84,8 @@ class TakeMedicationService
   def dose_taken_payload(take)
     {
       take_id: take.id,
-      source_type: take_source_type(take),
-      source_id: take_source_id(take),
+      source_type: take.source_type,
+      source_id: take.source_record_id,
       person_id: take.person&.id,
       medication_id: take.medication&.id,
       inventory_medication_id: take.inventory_medication&.id,
@@ -93,13 +93,5 @@ class TakeMedicationService
       amount_ml: take.amount_ml&.to_f,
       taken_at: take.taken_at
     }
-  end
-
-  def take_source_type(take)
-    take.schedule_id.present? ? 'schedule' : 'person_medication'
-  end
-
-  def take_source_id(take)
-    take.schedule_id || take.person_medication_id
   end
 end

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe MedicationTake do
     it { is_expected.to belong_to(:taken_from_location).class_name('Location').optional }
   end
 
+  describe '#source_type' do
+    it 'returns schedule for scheduled doses' do
+      expect(described_class.new(schedule: schedule).source_type).to eq('schedule')
+    end
+
+    it 'returns person_medication for as-needed doses' do
+      expect(described_class.new(person_medication: person_medication).source_type).to eq('person_medication')
+    end
+  end
+
+  describe '#source_record_id' do
+    it 'returns the schedule id for scheduled doses' do
+      expect(described_class.new(schedule: schedule).source_record_id).to eq(schedule.id)
+    end
+
+    it 'returns the person_medication id for as-needed doses' do
+      expect(described_class.new(person_medication: person_medication).source_record_id).to eq(person_medication.id)
+    end
+  end
+
   describe 'source validation' do
     context 'when neither schedule nor person_medication is set' do
       subject(:medication_take) { described_class.new(taken_at: Time.current, amount_ml: 10.0) }


### PR DESCRIPTION
## Summary
- move medication take source identity behind MedicationTake#source_type and #source_record_id
- update dose-taken and low-stock event payloads to use the model API instead of duplicating source conditionals
- add model specs covering both source helper methods

## Testing
- task rubocop
- task test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
