### PR TITLE
fix: tighten carer policy access

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -41,7 +41,7 @@ class ApplicationPolicy
   end
 
   def carer_with_patient?
-    return false unless carer_or_parent? && user&.person
+    return false unless user&.carer? && user.person
 
     user.person.patients.exists?(person_id_for_authorization)
   end
@@ -49,7 +49,9 @@ class ApplicationPolicy
   def parent_with_minor?
     return false unless user&.parent? && user.person
 
-    user.person.patients.where(person_type: :minor).exists?(person_id_for_authorization)
+    user.person.patients
+        .where(person_type: %i[minor dependent_adult], has_capacity: false)
+        .exists?(person_id_for_authorization)
   end
 
   class Scope
@@ -80,7 +82,13 @@ class ApplicationPolicy
     end
 
     def parent_minor_patient_ids
-      Array(Person.where(id: user.person&.patient_ids, person_type: :minor).pluck(:id))
+      Array(
+        Person.where(
+          id: user.person&.patient_ids,
+          person_type: %i[minor dependent_adult],
+          has_capacity: false
+        ).pluck(:id)
+      )
     end
 
     def accessible_person_ids

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -46,12 +46,13 @@ class ApplicationPolicy
     CarerRelationship.active.exists?(carer_id: user.person_id, patient_id: person_id_for_authorization)
   end
 
-  def parent_with_minor?
+  def parent_with_dependent_patient?
     return false unless user&.parent? && user.person
 
-    user.person.patients
-        .where(person_type: %i[minor dependent_adult], has_capacity: false)
-        .exists?(person_id_for_authorization)
+    active_patient_relationships
+      .joins(:patient)
+      .where(patient_id: person_id_for_authorization)
+      .exists?(people: { person_type: %i[minor dependent_adult], has_capacity: false })
   end
 
   class Scope
@@ -73,22 +74,20 @@ class ApplicationPolicy
     def accessible_patient_ids
       [].tap do |ids|
         ids.concat(carer_patient_ids) if user.carer?
-        ids.concat(parent_minor_patient_ids) if user.parent?
+        ids.concat(parent_dependent_patient_ids) if user.parent?
       end
     end
 
     def carer_patient_ids
-      Array(user.person&.patient_ids)
+      active_patient_relationships.pluck(:patient_id)
     end
 
-    def parent_minor_patient_ids
-      Array(
-        Person.where(
-          id: user.person&.patient_ids,
-          person_type: %i[minor dependent_adult],
-          has_capacity: false
-        ).pluck(:id)
-      )
+    def parent_dependent_patient_ids
+      Person.where(
+        id: active_patient_relationships.select(:patient_id),
+        person_type: %i[minor dependent_adult],
+        has_capacity: false
+      ).pluck(:id)
     end
 
     def accessible_person_ids
@@ -96,5 +95,17 @@ class ApplicationPolicy
       ids.merge(accessible_patient_ids)
       ids.to_a
     end
+
+    def active_patient_relationships
+      return CarerRelationship.none unless user&.person_id
+
+      CarerRelationship.active.where(carer_id: user.person_id)
+    end
+  end
+
+  def active_patient_relationships
+    return CarerRelationship.none unless user&.person_id
+
+    CarerRelationship.active.where(carer_id: user.person_id)
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -43,7 +43,7 @@ class ApplicationPolicy
   def carer_with_patient?
     return false unless user&.carer? && user.person
 
-    user.person.patients.exists?(person_id_for_authorization)
+    CarerRelationship.active.exists?(carer_id: user.person_id, patient_id: person_id_for_authorization)
   end
 
   def parent_with_minor?

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -60,7 +60,7 @@ class LocationPolicy < ApplicationPolicy
     def parent_minor_patient_ids
       return [] unless user.parent?
 
-      user.person.patients.where(person_type: :minor).pluck(:id)
+      user.person.patients.where(person_type: %i[minor dependent_adult], has_capacity: false).pluck(:id)
     end
   end
 
@@ -90,6 +90,6 @@ class LocationPolicy < ApplicationPolicy
   def parent_minor_patient_ids_for_policy
     return [] unless user.parent?
 
-    user.person.patients.where(person_type: :minor).pluck(:id)
+    user.person.patients.where(person_type: %i[minor dependent_adult], has_capacity: false).pluck(:id)
   end
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -50,17 +50,21 @@ class LocationPolicy < ApplicationPolicy
     def accessible_person_ids
       return [] unless user&.person
 
-      [user.person_id, *carer_patient_ids, *parent_minor_patient_ids].compact.uniq
+      [user.person_id, *carer_patient_ids, *parent_dependent_patient_ids].compact.uniq
     end
 
     def carer_patient_ids
-      user.carer? ? user.person.patient_ids : []
+      user.carer? ? active_patient_relationships.pluck(:patient_id) : []
     end
 
-    def parent_minor_patient_ids
+    def parent_dependent_patient_ids
       return [] unless user.parent?
 
-      user.person.patients.where(person_type: %i[minor dependent_adult], has_capacity: false).pluck(:id)
+      Person.where(
+        id: active_patient_relationships.select(:patient_id),
+        person_type: %i[minor dependent_adult],
+        has_capacity: false
+      ).pluck(:id)
     end
   end
 
@@ -80,16 +84,20 @@ class LocationPolicy < ApplicationPolicy
   def accessible_person_ids_for_policy
     return [] unless user&.person
 
-    [user.person_id, *carer_patient_ids_for_policy, *parent_minor_patient_ids_for_policy].compact.uniq
+    [user.person_id, *carer_patient_ids_for_policy, *parent_dependent_patient_ids_for_policy].compact.uniq
   end
 
   def carer_patient_ids_for_policy
-    user.carer? ? user.person.patient_ids : []
+    user.carer? ? active_patient_relationships.pluck(:patient_id) : []
   end
 
-  def parent_minor_patient_ids_for_policy
+  def parent_dependent_patient_ids_for_policy
     return [] unless user.parent?
 
-    user.person.patients.where(person_type: %i[minor dependent_adult], has_capacity: false).pluck(:id)
+    Person.where(
+      id: active_patient_relationships.select(:patient_id),
+      person_type: %i[minor dependent_adult],
+      has_capacity: false
+    ).pluck(:id)
   end
 end

--- a/app/policies/medication_take_policy.rb
+++ b/app/policies/medication_take_policy.rb
@@ -2,7 +2,7 @@
 
 class MedicationTakePolicy < ApplicationPolicy
   def create?
-    admin? || medical_staff? || carer_with_patient? || parent_with_minor? || adult_with_own_medication?
+    admin? || medical_staff? || carer_with_patient? || parent_with_dependent_patient? || adult_with_own_medication?
   end
 
   def new?

--- a/app/policies/person_medication_policy.rb
+++ b/app/policies/person_medication_policy.rb
@@ -6,7 +6,7 @@ class PersonMedicationPolicy < ApplicationPolicy
   end
 
   def show?
-    admin_or_clinician? || self_or_dependent? || carer_with_patient? || parent_with_minor?
+    admin_or_clinician? || self_or_dependent? || carer_with_patient? || parent_with_dependent_patient?
   end
 
   def create?
@@ -19,23 +19,23 @@ class PersonMedicationPolicy < ApplicationPolicy
   alias new? create?
 
   def update?
-    admin? || self_or_dependent? || parent_with_minor?
+    admin? || self_or_dependent? || parent_with_dependent_patient?
   end
 
   alias edit? update?
 
   def destroy?
-    admin? || self_or_dependent? || parent_with_minor?
+    admin? || self_or_dependent? || parent_with_dependent_patient?
   end
 
   def take_medication?
-    admin? || self_or_dependent? || carer_with_patient? || parent_with_minor?
+    admin? || self_or_dependent? || carer_with_patient? || parent_with_dependent_patient?
   end
 
   private
 
   def create_person_permitted?
-    admin? || self_or_dependent? || parent_with_minor?
+    admin? || self_or_dependent? || parent_with_dependent_patient?
   end
 
   def permitted_medications

--- a/app/policies/person_medication_policy.rb
+++ b/app/policies/person_medication_policy.rb
@@ -6,7 +6,7 @@ class PersonMedicationPolicy < ApplicationPolicy
   end
 
   def show?
-    admin_or_clinician? || self_or_dependent? || carer_with_patient?
+    admin_or_clinician? || self_or_dependent? || carer_with_patient? || parent_with_minor?
   end
 
   def create?
@@ -29,7 +29,7 @@ class PersonMedicationPolicy < ApplicationPolicy
   end
 
   def take_medication?
-    admin? || self_or_dependent? || carer_with_patient?
+    admin? || self_or_dependent? || carer_with_patient? || parent_with_minor?
   end
 
   private

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -6,7 +6,7 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def show?
-    admin? || medical_staff? || owns_record? || carer_with_patient? || parent_with_minor?
+    admin? || medical_staff? || owns_record? || carer_with_patient? || parent_with_dependent_patient?
   end
 
   def new?

--- a/app/policies/schedule_policy.rb
+++ b/app/policies/schedule_policy.rb
@@ -2,7 +2,7 @@
 
 class SchedulePolicy < ApplicationPolicy
   def index?
-    admin? || doctor? || nurse? || carer_with_patient? || parent_with_minor?
+    admin? || doctor? || nurse? || carer_with_patient? || parent_with_dependent_patient?
   end
 
   def show?
@@ -32,7 +32,7 @@ class SchedulePolicy < ApplicationPolicy
   private
 
   def schedule_access?
-    admin? || doctor? || nurse? || carer_with_patient? || parent_with_minor?
+    admin? || doctor? || nurse? || carer_with_patient? || parent_with_dependent_patient?
   end
 
   def minor_with_supervision?
@@ -40,7 +40,7 @@ class SchedulePolicy < ApplicationPolicy
   end
 
   def supervisor?
-    parent_with_minor? || carer_with_patient?
+    parent_with_dependent_patient? || carer_with_patient?
   end
 
   def medical_staff_or_carer?

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe LocationPolicy, type: :policy do
 
   let(:location) { locations(:home) }
 
+  def patient_at_school_for(carer, name:)
+    patient = Person.new(
+      name: name,
+      date_of_birth: 6.years.ago.to_date,
+      person_type: :minor,
+      has_capacity: false,
+      primary_location: locations(:school)
+    )
+    patient.carer_relationships.build(
+      carer: carer,
+      relationship_type: :professional_carer,
+      active: true
+    )
+    patient.save!
+    patient
+  end
+
   describe 'for administrator' do
     let(:current_user) { users(:admin) }
 
@@ -75,6 +92,16 @@ RSpec.describe LocationPolicy, type: :policy do
       scoped_policy = described_class.new(current_user, foreign_location)
       expect(scoped_policy.show?).to be false
     end
+
+    it 'denies viewing a removed patient location after patients were loaded' do
+      former_patient = patient_at_school_for(current_user.person, name: 'Former Location Patient')
+      current_user.person.patients.load
+
+      CarerRelationship.where(carer: current_user.person, patient: former_patient).destroy_all
+
+      scoped_policy = described_class.new(current_user, locations(:school))
+      expect(scoped_policy.show?).to be false
+    end
   end
 
   describe 'for parent' do
@@ -122,6 +149,18 @@ RSpec.describe LocationPolicy, type: :policy do
 
       it 'returns only their household locations' do
         expect(scope).to contain_exactly(locations(:home))
+      end
+
+      context 'when a carer relationship is removed after patients were loaded' do
+        before do
+          former_patient = patient_at_school_for(current_user.person, name: 'Former Scoped Location Patient')
+          current_user.person.patients.load
+          CarerRelationship.where(carer: current_user.person, patient: former_patient).destroy_all
+        end
+
+        it 'excludes the removed patient locations' do
+          expect(scope).to contain_exactly(locations(:home))
+        end
       end
     end
 

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe LocationPolicy, type: :policy do
         expect(policy.destroy?).to be false
       end
     end
+
+    it 'permits viewing a dependent adult patient location' do
+      dependent_adult = Person.new(
+        name: 'Dependent Adult',
+        date_of_birth: 70.years.ago.to_date,
+        person_type: :dependent_adult,
+        has_capacity: false,
+        primary_location: locations(:school)
+      )
+      dependent_adult.carer_relationships.build(carer: current_user.person, relationship_type: :parent, active: true)
+      dependent_adult.save!
+
+      expect(described_class.new(current_user, locations(:school)).show?).to be true
+    end
   end
 
   describe 'for nil user' do
@@ -115,6 +129,26 @@ RSpec.describe LocationPolicy, type: :policy do
       let(:current_user) { users(:jane) }
 
       it 'returns the locations tied to their household' do
+        expect(scope).to contain_exactly(locations(:home), locations(:school))
+      end
+    end
+
+    context 'when user is a parent with a dependent adult patient' do
+      let(:current_user) { users(:parent) }
+
+      before do
+        dependent_adult = Person.new(
+          name: 'Dependent Adult',
+          date_of_birth: 70.years.ago.to_date,
+          person_type: :dependent_adult,
+          has_capacity: false,
+          primary_location: locations(:school)
+        )
+        dependent_adult.carer_relationships.build(carer: current_user.person, relationship_type: :parent, active: true)
+        dependent_adult.save!
+      end
+
+      it 'returns the dependent adult patient locations' do
         expect(scope).to contain_exactly(locations(:home), locations(:school))
       end
     end

--- a/spec/policies/person_medication_policy_spec.rb
+++ b/spec/policies/person_medication_policy_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe PersonMedicationPolicy do
       it { is_expected.to permit_action(:show) }
     end
 
+    context 'when user is a parent with their child' do
+      let(:user) { parent_user }
+      let(:person_medication) { PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d)) }
+
+      it { is_expected.to permit_action(:show) }
+    end
+
     context 'when user is a carer without assigned patient' do
       let(:user) { carer_user }
       let(:person_medication) { PersonMedication.create!(person: adult_patient, medication: medications(:vitamin_d)) }
@@ -228,7 +235,7 @@ RSpec.describe PersonMedicationPolicy do
 
       before do
         user.person.patients.load
-        carer_relationships(:carer_cares_for_patient).destroy!
+        CarerRelationship.where(carer: user.person, patient: child_patient).destroy_all
       end
 
       it { is_expected.not_to permit_action(:take_medication) }

--- a/spec/policies/person_medication_policy_spec.rb
+++ b/spec/policies/person_medication_policy_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe PersonMedicationPolicy do
       let(:user) { parent_user }
       let(:person_medication) { PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d)) }
 
-      # Parents can take medication for their children via parent_with_minor?
+      # Parents can take medication for their children via parent_with_dependent_patient?
       it { is_expected.to permit_action(:take_medication) }
     end
 
@@ -313,6 +313,36 @@ RSpec.describe PersonMedicationPolicy do
         it 'returns their own and linked child person medications only' do
           scope = described_class::Scope.new(user, PersonMedication.all).resolve
           expect(scope.pluck(:person_id).uniq).to contain_exactly(user.person_id, child_patient.id)
+        end
+      end
+
+      context 'when a parent relationship is removed after patients were loaded' do
+        let(:user) { parent_user }
+
+        before do
+          user.person.patients.load
+          PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d))
+          CarerRelationship.where(carer: user.person, patient: child_patient).destroy_all
+        end
+
+        it 'excludes the removed patient person medications' do
+          scope = described_class::Scope.new(user, PersonMedication.all).resolve
+          expect(scope.pluck(:person_id)).not_to include(child_patient.id)
+        end
+      end
+
+      context 'when a carer relationship is removed after patients were loaded' do
+        let(:user) { carer_user }
+
+        before do
+          user.person.patients.load
+          PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d))
+          CarerRelationship.where(carer: user.person, patient: child_patient).destroy_all
+        end
+
+        it 'excludes the removed patient person medications' do
+          scope = described_class::Scope.new(user, PersonMedication.all).resolve
+          expect(scope.pluck(:person_id)).not_to include(child_patient.id)
         end
       end
 

--- a/spec/policies/person_medication_policy_spec.rb
+++ b/spec/policies/person_medication_policy_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe PersonMedicationPolicy do
       let(:user) { parent_user }
       let(:person_medication) { PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d)) }
 
-      # Parents can take medication for their children via carer_with_patient?
+      # Parents can take medication for their children via parent_with_minor?
       it { is_expected.to permit_action(:take_medication) }
     end
 
@@ -220,6 +220,36 @@ RSpec.describe PersonMedicationPolicy do
 
       # Carers can take medication for their patients via carer_with_patient?
       it { is_expected.to permit_action(:take_medication) }
+    end
+
+    context 'when carer relationship has been removed' do
+      let(:user) { carer_user }
+      let(:person_medication) { PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d)) }
+
+      before do
+        user.person.patients.load
+        carer_relationships(:carer_cares_for_patient).destroy!
+      end
+
+      it { is_expected.not_to permit_action(:take_medication) }
+    end
+
+    context 'when carer is also a patient' do
+      let(:user) { carer_user }
+      let(:person_medication) { PersonMedication.create!(person: adult_patient, medication: medications(:vitamin_d)) }
+
+      it { is_expected.not_to permit_action(:take_medication) }
+    end
+
+    context 'when parent relationship patient becomes a self-managing adult' do
+      let(:user) { parent_user }
+      let(:person_medication) { PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d)) }
+
+      before do
+        child_patient.update!(person_type: :adult, has_capacity: true)
+      end
+
+      it { is_expected.not_to permit_action(:take_medication) }
     end
 
     context 'when user takes medication for unrelated person' do
@@ -276,6 +306,20 @@ RSpec.describe PersonMedicationPolicy do
         it 'returns their own and linked child person medications only' do
           scope = described_class::Scope.new(user, PersonMedication.all).resolve
           expect(scope.pluck(:person_id).uniq).to contain_exactly(user.person_id, child_patient.id)
+        end
+      end
+
+      context 'when parent relationship patient becomes a self-managing adult' do
+        let(:user) { parent_user }
+
+        before do
+          PersonMedication.create!(person: child_patient, medication: medications(:vitamin_d))
+          child_patient.update!(person_type: :adult, has_capacity: true)
+        end
+
+        it 'excludes the former child patient person medications' do
+          scope = described_class::Scope.new(user, PersonMedication.all).resolve
+          expect(scope.pluck(:person_id)).not_to include(child_patient.id)
         end
       end
 

--- a/spec/policies/schedule_policy_spec.rb
+++ b/spec/policies/schedule_policy_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe SchedulePolicy, type: :policy do
         dose_unit: 'IU',
         frequency: 'Daily',
         start_date: Date.current,
+        end_date: 1.year.from_now.to_date,
         max_daily_doses: 1,
         dose_cycle: :daily
       )

--- a/spec/policies/schedule_policy_spec.rb
+++ b/spec/policies/schedule_policy_spec.rb
@@ -90,6 +90,44 @@ RSpec.describe SchedulePolicy, type: :policy do
     end
   end
 
+  describe 'for carer after relationship removal' do
+    let(:current_user) { users(:carer) }
+    let(:schedule) { schedules(:patient_schedule) }
+
+    before do
+      current_user.person.patients.load
+      carer_relationships(:carer_cares_for_patient).destroy!
+    end
+
+    it 'forbids viewing and administering' do
+      expect(policy.show?).to be false
+      expect(policy.take_medication?).to be false
+    end
+  end
+
+  describe 'for carer who is also a patient' do
+    let(:current_user) { users(:carer) }
+    let(:schedule) do
+      Schedule.create!(
+        person: current_user.person,
+        medication: medications(:vitamin_d),
+        dose_amount: 1000,
+        dose_unit: 'IU',
+        frequency: 'Daily',
+        start_date: Date.current,
+        max_daily_doses: 1,
+        dose_cycle: :daily
+      )
+    end
+
+    it 'does not grant access to unrelated patient schedules' do
+      other_schedule = schedules(:adult_patient_schedule)
+
+      expect(described_class.new(current_user, schedule).show?).to be true
+      expect(described_class.new(current_user, other_schedule).show?).to be false
+    end
+  end
+
   describe 'for parent with child' do
     let(:current_user) { users(:parent) }
     let(:schedule) { schedules(:child_schedule) }
@@ -113,6 +151,20 @@ RSpec.describe SchedulePolicy, type: :policy do
     let(:schedule) { schedules(:adult_patient_schedule) }
 
     it 'forbids access' do
+      expect(policy.show?).to be false
+      expect(policy.take_medication?).to be false
+    end
+  end
+
+  describe 'for parent after child becomes a self-managing adult' do
+    let(:current_user) { users(:parent) }
+    let(:schedule) { schedules(:child_schedule) }
+
+    before do
+      schedule.person.update!(person_type: :adult, has_capacity: true)
+    end
+
+    it 'forbids viewing and administering' do
       expect(policy.show?).to be false
       expect(policy.take_medication?).to be false
     end
@@ -202,6 +254,12 @@ RSpec.describe SchedulePolicy, type: :policy do
       it 'returns schedules for their children only' do
         expect(scope).to include(schedules(:child_schedule))
         expect(scope).not_to include(schedules(:adult_patient_schedule))
+      end
+
+      it 'excludes former child patients after they become self-managing adults' do
+        schedules(:child_schedule).person.update!(person_type: :adult, has_capacity: true)
+
+        expect(scope).not_to include(schedules(:child_schedule))
       end
     end
 


### PR DESCRIPTION
## Summary
- restrict parent relationship access to dependent patients only
- keep carer relationship authorization limited to carer-role users
- add policy coverage for removed carer relationships, cross-person isolation, and self-managing adult transitions

Closes #1048

## Verification
- task test TEST_FILE=spec/policies/person_medication_policy_spec.rb (blocked: Docker socket unavailable)
- task test TEST_FILE=spec/policies/schedule_policy_spec.rb (blocked: Docker socket unavailable)
- task rubocop (blocked: Docker socket unavailable)
- security review: focused secret/policy grep and manual auth review passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
