### PR TITLE
refactor: remove requested reorder state

### DIFF
--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -58,7 +58,7 @@ class Medication < ApplicationRecord # :nodoc:
   validate :nested_dosage_records_are_valid
   after_commit :sync_dosages, on: :update
 
-  enum :reorder_status, { requested: 0, ordered: 1, received: 2 }, prefix: :reorder
+  enum :reorder_status, { ordered: 1, received: 2 }, prefix: :reorder
 
   validates :barcode, format: { with: /\A\d{13,14}\z/ }, allow_blank: true
   validates :barcode, uniqueness: true, allow_blank: true

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -478,7 +478,6 @@ cy:
       choose_location_description: "Dewiswch pa leoliad i ddidynnu'r dos hwn ohono."
       untracked_inventory: "Heb ei olrhain"
     reorder_statuses:
-      requested: "Wedi gofyn"
       ordered: "Wedi archebu"
       received: "Wedi derbyn"
     administration:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,7 +469,6 @@ en:
       choose_location_description: "Select which location to deduct this dose from."
       untracked_inventory: "Untracked"
     reorder_statuses:
-      requested: "Requested"
       ordered: "Ordered"
       received: "Received"
     refill_modal:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -478,7 +478,6 @@ es:
       choose_location_description: "Selecciona de qué ubicación deducir esta dosis."
       untracked_inventory: "Sin seguimiento"
     reorder_statuses:
-      requested: "Solicitado"
       ordered: "Pedido"
       received: "Recibido"
     administration:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -478,7 +478,6 @@ ga:
       choose_location_description: "Roghnaigh cén suíomh as a dtabharfar an dáileog seo."
       untracked_inventory: "Neamhrianaithe"
     reorder_statuses:
-      requested: "Iarrtha"
       ordered: "Ordaithe"
       received: "Faighte"
     refill_modal:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -478,7 +478,6 @@ pt:
       choose_location_description: "Selecione de que localização quer deduzir esta dose."
       untracked_inventory: "Não rastreado"
     reorder_statuses:
-      requested: "Pedido"
       ordered: "Encomendado"
       received: "Recebido"
     administration:

--- a/db/migrate/20260426000100_clear_requested_reorder_status.rb
+++ b/db/migrate/20260426000100_clear_requested_reorder_status.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ClearRequestedReorderStatus < ActiveRecord::Migration[8.1]
+  def up
+    execute 'UPDATE medicines SET reorder_status = NULL WHERE reorder_status = 0'
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260426000100_clear_requested_reorder_status.rb
+++ b/db/migrate/20260426000100_clear_requested_reorder_status.rb
@@ -2,7 +2,7 @@
 
 class ClearRequestedReorderStatus < ActiveRecord::Migration[8.1]
   def up
-    execute 'UPDATE medicines SET reorder_status = NULL WHERE reorder_status = 0'
+    execute 'UPDATE medications SET reorder_status = NULL WHERE reorder_status = 0'
   end
 
   def down

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe Medication do
     it { is_expected.to have_many(:schedules).dependent(:destroy) }
   end
 
+  describe 'reorder_status' do
+    it 'only exposes reachable reorder workflow states' do
+      expect(described_class.reorder_statuses).to eq('ordered' => 1, 'received' => 2)
+    end
+  end
+
   describe 'nested dosage records' do
     it 'ignores untouched auto-appended dose option rows on update' do
       medication = create(:medication, dosage_unit: 'ml')


### PR DESCRIPTION
## Summary
- remove the unreachable requested reorder_status enum value
- preserve existing ordered/received integer values
- clear legacy requested rows to nil via migration
- remove dead reorder status locale labels

Closes #1028

## Verification
- task test TEST_FILE=spec/models/medication_spec.rb (blocked: Docker socket unavailable)
- task rubocop (blocked: Docker socket unavailable)
- git diff --check
- security review: focused grep/manual review passed; locale password-label matches were false positives
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
