### PR TITLE
test: cover dose cycle boundaries

### DIFF
--- a/spec/domain/dose_cycle_spec.rb
+++ b/spec/domain/dose_cycle_spec.rb
@@ -21,6 +21,52 @@ RSpec.describe DoseCycle do
     it 'defaults to all_day for unknown value' do
       expect(described_class.new('bogus').range_for(now)).to eq(now.all_day)
     end
+
+    it 'starts a new daily range exactly at midnight' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 4, 26, 0, 0, 0)
+
+        expect(described_class.new('daily').range_for(time).begin).to eq(time)
+      end
+    end
+
+    it 'keeps the last second before midnight in the current daily range' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 4, 25, 23, 59, 59)
+
+        expect(described_class.new('daily').range_for(time)).to cover(time)
+      end
+    end
+
+    it 'covers the final day of shorter months for monthly cycles' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 4, 30, 12, 0, 0)
+        range = described_class.new('monthly').range_for(time)
+
+        expect(range.begin).to eq(Time.zone.local(2026, 4, 1, 0, 0, 0))
+        expect(range.end).to eq(Time.zone.local(2026, 4, 30, 12, 0, 0).end_of_day)
+      end
+    end
+
+    it 'uses local day boundaries when clocks go forward' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 3, 29, 12, 0, 0)
+        range = described_class.new('daily').range_for(time)
+
+        expect(range.begin).to eq(Time.zone.local(2026, 3, 29, 0, 0, 0))
+        expect(range.end).to eq(Time.zone.local(2026, 3, 29, 12, 0, 0).end_of_day)
+      end
+    end
+
+    it 'uses local day boundaries when clocks go back' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 10, 25, 12, 0, 0)
+        range = described_class.new('daily').range_for(time)
+
+        expect(range.begin).to eq(Time.zone.local(2026, 10, 25, 0, 0, 0))
+        expect(range.end).to eq(Time.zone.local(2026, 10, 25, 12, 0, 0).end_of_day)
+      end
+    end
   end
 
   describe '#next_reset_time' do
@@ -34,6 +80,24 @@ RSpec.describe DoseCycle do
 
     it 'returns end_of_month + 1s for monthly' do
       expect(described_class.new('monthly').next_reset_time(now)).to be_within(1.second).of(now.end_of_month + 1.second)
+    end
+
+    it 'returns midnight for the next day at the end of a daily cycle' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 4, 25, 23, 59, 59)
+
+        expect(described_class.new('daily').next_reset_time(time))
+          .to eq(Time.zone.local(2026, 4, 26, 0, 0, 0))
+      end
+    end
+
+    it 'returns the first day of the next month after a shorter month' do
+      Time.use_zone('Europe/London') do
+        time = Time.zone.local(2026, 4, 30, 12, 0, 0)
+
+        expect(described_class.new('monthly').next_reset_time(time))
+          .to eq(Time.zone.local(2026, 5, 1, 0, 0, 0))
+      end
     end
   end
 

--- a/spec/domain/dose_cycle_spec.rb
+++ b/spec/domain/dose_cycle_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe DoseCycle do
         time = Time.zone.local(2026, 4, 25, 23, 59, 59)
 
         expect(described_class.new('daily').next_reset_time(time))
-          .to eq(Time.zone.local(2026, 4, 26, 0, 0, 0))
+          .to be_within(1.second).of(Time.zone.local(2026, 4, 26, 0, 0, 0))
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe DoseCycle do
         time = Time.zone.local(2026, 4, 30, 12, 0, 0)
 
         expect(described_class.new('monthly').next_reset_time(time))
-          .to eq(Time.zone.local(2026, 5, 1, 0, 0, 0))
+          .to be_within(1.second).of(Time.zone.local(2026, 5, 1, 0, 0, 0))
       end
     end
   end


### PR DESCRIPTION
## Summary
- add DoseCycle specs for exact daily rollover boundaries
- cover monthly cycles in shorter months
- cover local day boundaries across UK daylight-saving transitions

Closes #1043

## Verification
- task test TEST_FILE=spec/domain/dose_cycle_spec.rb (blocked: Docker socket unavailable)
- task rubocop (blocked: Docker socket unavailable)
- git diff --check
- security review: focused scan/manual review passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
