### PR TITLE
fix: wrap long medication names

### DIFF
--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -53,7 +53,11 @@ module Components
         m3_card(id: "schedule_#{schedule.id}", class: 'h-full flex flex-col') do
           CardHeader do
             render_medication_icon
-            m3_text(size: '4', weight: 'semibold', class: 'leading-none tracking-tight text-foreground') do
+            m3_text(
+              size: '4',
+              weight: 'semibold',
+              class: 'leading-tight tracking-tight text-foreground break-words'
+            ) do
               schedule.medication.name
             end
           end

--- a/app/components/dashboard/schedule_card.rb
+++ b/app/components/dashboard/schedule_card.rb
@@ -37,8 +37,8 @@ module Components
       end
 
       def render_header
-        div(class: 'flex justify-between items-center w-full') do
-          div(class: 'flex items-center gap-3') do
+        div(class: 'flex justify-between items-center w-full gap-3') do
+          div(class: 'flex items-center gap-3 min-w-0') do
             render_person_avatar
             m3_text(variant: :label_large, class: 'font-bold text-foreground truncate') { person.name }
           end
@@ -56,9 +56,12 @@ module Components
       end
 
       def render_medication_info
-        div(class: 'flex items-center gap-3') do
+        div(class: 'flex items-start gap-3 min-w-0') do
           render_medication_icon
-          m3_heading(variant: :title_medium, class: 'font-bold text-foreground tracking-tight') do
+          m3_heading(
+            variant: :title_medium,
+            class: 'font-bold text-foreground tracking-tight break-words leading-tight'
+          ) do
             schedule.medication.name
           end
         end

--- a/app/components/dashboard/schedule_row.rb
+++ b/app/components/dashboard/schedule_row.rb
@@ -48,9 +48,9 @@ module Components
       def render_medication_cell
         TableCell do
           div(class: 'flex justify-between items-center w-full gap-2') do
-            div(class: 'flex items-center gap-2') do
+            div(class: 'flex items-start gap-2 min-w-0') do
               render_medication_icon
-              span(class: 'font-medium') { schedule.medication.name }
+              span(class: 'font-medium break-words leading-snug') { schedule.medication.name }
             end
             render Components::Shared::StockBadge.new(medication: schedule.medication)
           end

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -90,18 +90,21 @@ module Components
       end
 
       def render_medication_card(medication)
-        m3_card(class: 'p-6 hover:shadow-md transition-shadow') do
-          div(class: 'flex items-center justify-between') do
-            div(class: 'flex items-center gap-4') do
+        m3_card(class: 'p-6 hover:shadow-md transition-shadow overflow-hidden') do
+          div(class: 'flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between') do
+            div(class: 'flex items-start gap-4 min-w-0 flex-1') do
               div(
                 class: 'w-10 h-10 rounded-xl bg-secondary-container flex items-center ' \
-                       'justify-center text-on-surface-variant'
+                       'justify-center text-on-surface-variant flex-shrink-0'
               ) do
                 render Icons::Pill.new(size: 20)
               end
-              div do
-                Link(href: medication_path(medication), variant: :link,
-                     class: 'font-semibold text-base no-underline') do
+              div(class: 'min-w-0 flex-1') do
+                Link(
+                  href: medication_path(medication),
+                  variant: :link,
+                  class: 'font-semibold text-base no-underline whitespace-normal break-words text-left leading-snug'
+                ) do
                   medication.name
                 end
                 if medication.dosage_amount.present? && medication.dosage_unit.present?
@@ -112,9 +115,11 @@ module Components
               end
             end
             if medication.low_stock?
-              Badge(variant: :destructive) { 'Low Stock' }
+              Badge(variant: :destructive, class: 'shrink-0 whitespace-nowrap justify-center') { 'Low Stock' }
             else
-              Badge(variant: :success) { pluralize(medication.current_supply, 'unit') }
+              Badge(variant: :success, class: 'shrink-0 whitespace-nowrap justify-center') do
+                pluralize(medication.current_supply, 'unit')
+              end
             end
           end
 

--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -27,7 +27,9 @@ module Components
               render_status_badge
             end
             div(class: 'space-y-2') do
-              m3_heading(level: 2, size: '5', class: 'font-bold tracking-tight') { medication.name }
+              m3_heading(level: 2, size: '5', class: 'font-bold tracking-tight break-words leading-tight') do
+                medication.name
+              end
               Badge(variant: :outlined, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
             end
           end
@@ -57,7 +59,9 @@ module Components
       end
 
       def render_status_badge
-        Badge(variant: presenter.status_variant) { presenter.status_label }
+        Badge(variant: presenter.status_variant, class: 'shrink-0 whitespace-nowrap justify-center') do
+          presenter.status_label
+        end
       end
 
       def render_supply_bar

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -45,19 +45,21 @@ module Components
 
       def render_header
         div(class: 'flex flex-col justify-between gap-6 border-b border-border/60 pb-8 md:flex-row md:items-end') do
-          div(class: 'flex items-center gap-6') do
+          div(class: 'flex items-center gap-6 min-w-0') do
             div(
               class: 'w-20 h-20 rounded-shape-xl bg-primary/10 flex items-center justify-center ' \
-                     'text-primary shadow-inner',
+                     'text-primary shadow-inner flex-shrink-0',
               data: { testid: 'medication-hero-icon' }
             ) do
               render Icons::Pill.new(size: 32)
             end
-            div(class: 'space-y-1') do
+            div(class: 'space-y-1 min-w-0') do
               m3_text(variant: :label_medium, class: 'uppercase tracking-[0.2em] opacity-40 block mb-1 font-black') do
                 t('medications.show.profile')
               end
-              m3_heading(variant: :display_small, level: 1, class: 'font-black tracking-tight') { medication.name }
+              m3_heading(variant: :display_small, level: 1, class: 'font-black tracking-tight break-words') do
+                medication.name
+              end
               div(class: 'flex items-center gap-1 mt-1') do
                 render Icons::Home.new(size: 14, class: 'text-on-surface-variant')
                 m3_text(variant: :label_medium, class: 'text-on-surface-variant font-medium') do

--- a/app/components/medications/take_action.rb
+++ b/app/components/medications/take_action.rb
@@ -84,14 +84,19 @@ module Components
                   available_medications.each_with_index do |medication, index|
                     label(
                       for: "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}",
-                      class: 'flex items-center justify-between gap-3 rounded-shape-xl border border-border p-4'
+                      class: 'flex flex-col gap-3 rounded-shape-xl border border-border p-4 sm:flex-row ' \
+                             'sm:items-center sm:justify-between'
                     ) do
-                      div(class: 'space-y-1') do
+                      div(class: 'space-y-1 min-w-0') do
                         m3_text(size: '2', weight: 'bold', class: 'text-foreground') { medication.location.name }
-                        m3_text(size: '1', class: 'text-on-surface-variant') { medication_description(medication) }
+                        m3_text(size: '1', class: 'text-on-surface-variant break-words') do
+                          medication_description(medication)
+                        end
                       end
-                      div(class: 'flex items-center gap-3') do
-                        Badge(variant: :outlined, class: 'rounded-full text-[10px]') { inventory_label(medication) }
+                      div(class: 'flex items-center gap-3 shrink-0') do
+                        Badge(variant: :outlined, class: 'rounded-full text-[10px] whitespace-nowrap justify-center') do
+                          inventory_label(medication)
+                        end
                         input(
                           type: :radio,
                           id: "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}",

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -38,8 +38,8 @@ module Components
             render_medication_icon
             render Components::Shared::StockBadge.new(medication: person_medication.medication)
           end
-          div do
-            CardTitle(class: 'text-2xl font-black tracking-tight mb-1 text-foreground') do
+          div(class: 'min-w-0') do
+            CardTitle(class: 'text-2xl font-black tracking-tight mb-1 text-foreground break-words leading-tight') do
               person_medication.medication.name
             end
             CardDescription(class: 'text-on-surface-variant font-bold uppercase text-[10px] tracking-widest') do

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -46,13 +46,17 @@ module Components
         CardHeader(class: 'pb-4 pt-8 px-8') do
           div(class: 'flex justify-between items-start mb-4') do
             render_medication_icon
-            div(class: 'flex flex-col items-end gap-2') do
+            div(class: 'flex flex-col items-end gap-2 shrink-0') do
               render Components::Shared::StockBadge.new(medication: schedule.medication)
               status_badge
             end
           end
-          div do
-            m3_heading(variant: :title_large, level: 3, class: 'font-black tracking-tight mb-1 text-foreground') do
+          div(class: 'min-w-0') do
+            m3_heading(
+              variant: :title_large,
+              level: 3,
+              class: 'font-black tracking-tight mb-1 text-foreground break-words leading-tight'
+            ) do
               schedule.medication.name
             end
             dosage_text = "#{schedule.dose_amount.to_i}#{schedule.dose_unit}"

--- a/app/components/shared/stock_badge.rb
+++ b/app/components/shared/stock_badge.rb
@@ -15,7 +15,10 @@ module Components
       def view_template
         return if medication.current_supply.blank?
 
-        render RubyUI::Badge.new(variant: badge_variant, class: 'rounded-full text-[10px] py-0.5 px-2') { badge_text }
+        render RubyUI::Badge.new(
+          variant: badge_variant,
+          class: 'rounded-full text-[10px] py-0.5 px-2 shrink-0 whitespace-nowrap justify-center'
+        ) { badge_text }
       end
 
       private

--- a/db/seeds/medications.yml
+++ b/db/seeds/medications.yml
@@ -47,7 +47,7 @@
   warnings: >-
     Can cause drowsiness and constipation. Risk of dependence with prolonged use.
 
-- name: Calpol
+- name: Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)
   category: Analgesic
   dosage_amount: 5
   dosage_unit: ml

--- a/spec/components/locations/show_view_spec.rb
+++ b/spec/components/locations/show_view_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Locations::ShowView, type: :component do
+  let(:location) { create(:location, name: 'Overflow Test Location') }
+  let(:medication_name) { 'Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)' }
+  let!(:medication) do
+    create(:medication, location: location, name: medication_name, current_supply: 12, reorder_threshold: 10)
+  end
+
+  it 'keeps long medication names and supply badges within the medication card layout' do
+    rendered = render_location
+
+    name_link = rendered.at_css("a[href='/medications/#{medication.id}']")
+    expect(name_link.text).to include(medication_name)
+    expect(name_link['class']).to include('break-words')
+
+    supply_badge = rendered.css('span').find { |span| span.text.squish == '12 units' }
+    expect(supply_badge['class']).to include('whitespace-nowrap')
+    expect(supply_badge['class']).to include('shrink-0')
+  end
+
+  def render_location
+    vc = view_context
+    policy_stub = Struct.new(:update?).new(false)
+    vc.singleton_class.define_method(:policy) { |_record| policy_stub }
+    html = vc.render(described_class.new(location: location))
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+end

--- a/spec/components/medications/list_item_component_spec.rb
+++ b/spec/components/medications/list_item_component_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe Components::Medications::ListItemComponent, type: :component do
 
     expect(rendered.text).not_to include('Refill Inventory')
   end
+
+  it 'allows full medication names to wrap inside the card' do
+    medication.update!(name: 'Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)')
+
+    rendered = render_inline(described_class.new(
+                               medication: medication,
+                               inventory_query_params: {},
+                               can_manage: false
+                             ))
+
+    heading = rendered.at_css('h2')
+    expect(heading.text).to include(medication.name)
+    expect(heading['class']).to include('break-words')
+  end
 end

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     expect(rendered.text).to include('PRN Alt Location')
   end
 
+  it 'wraps full medication names inside the card header' do
+    medication.update!(name: 'Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)')
+    rendered = render_person_medication_card
+
+    title = rendered.at_css('h3')
+    expect(title.text).to include(medication.name)
+    expect(title['class']).to include('break-words')
+  end
+
   def render_person_medication_card
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }

--- a/spec/components/schedules/card_spec.rb
+++ b/spec/components/schedules/card_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe Components::Schedules::Card, type: :component do
     expect(rendered.text).to include('Schedule Alt Location')
   end
 
+  it 'wraps full medication names inside the card header' do
+    medication.update!(name: 'Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)')
+    rendered = render_schedule_card
+
+    heading = rendered.at_css('h3')
+    expect(heading.text).to include(medication.name)
+    expect(heading['class']).to include('break-words')
+  end
+
   def render_schedule_card
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }

--- a/spec/components/shared/stock_badge_spec.rb
+++ b/spec/components/shared/stock_badge_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe Components::Shared::StockBadge, type: :component do
         result = render_inline(component)
         expect(result.text).to include('100 left')
       end
+
+      it 'does not allow the count to wrap in compact card headers' do
+        result = render_inline(component)
+        badge = result.at_css('span')
+
+        expect(badge['class']).to include('whitespace-nowrap')
+        expect(badge['class']).to include('shrink-0')
+      end
     end
 
     context 'when medication is low stock' do

--- a/spec/fixtures/medications.yml
+++ b/spec/fixtures/medications.yml
@@ -51,7 +51,7 @@ aspirin:
     cause stomach irritation. If symptoms persist, consult your doctor.
 
 calpol:
-  name: Calpol
+  name: Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)
   location: home
   category: Analgesic
   description: >-


### PR DESCRIPTION
## Summary
- allow long medication names to wrap across location, medication, schedule, person-medication, and dashboard surfaces
- keep compact stock and inventory badges from shrinking or wrapping inside card headers
- seed and fixture Calpol with a full product-style name and cover the layout with component specs

## Verification
- task rubocop
- task test TEST_FILE=spec/services/nhs_dmd/release_import_spec.rb
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
