### PR TITLE
fix: make dev rebuild work with postgres 18

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_MULTIPLE_DATABASES: medtracker_queue
     volumes:
-      - medtracker_dev_postgres:/var/lib/postgresql/data
+      - medtracker_dev_postgres:/var/lib/postgresql
       - ./compose/init-multiple-dbs.sh:/docker-entrypoint-initdb.d/init-multiple-dbs.sh:ro
 
   mail-dev:
@@ -28,8 +28,13 @@ services:
     extends:
       file: compose/base.yml
       service: rails
+    image: med-tracker-web-dev
     profiles: [dev]
     networks: [dev]
+    build:
+      target: assets
+      args:
+        RAILS_ENV: development
     command: bin/rails db:prepare
     depends_on:
       db-dev:
@@ -105,8 +110,11 @@ services:
     extends:
       file: compose/base.yml
       service: rails
+    image: med-tracker-web-test
     profiles: [test]
     networks: [test]
+    build:
+      target: test
     command: bin/rails db:prepare
     depends_on:
       db-test:
@@ -160,7 +168,7 @@ services:
     environment:
       POSTGRES_MULTIPLE_DATABASES: medtracker_production_queue,medtracker_production_cache,medtracker_production_cable
     volumes:
-      - medtracker_prod_postgres:/var/lib/postgresql/data
+      - medtracker_prod_postgres:/var/lib/postgresql
       - ./compose/init-multiple-dbs.sh:/docker-entrypoint-initdb.d/init-multiple-dbs.sh:ro
 
   migrate-prod:

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -14,4 +14,27 @@ RSpec.describe YAML do
   it 'isolates public assets in test web container' do
     expect(compose_config.dig('services', 'web-test', 'tmpfs')).to include('/app/public/assets:uid=1000,gid=1000')
   end
+
+  it 'mounts development PostgreSQL data at the PostgreSQL 18 data root' do
+    expect(compose_config.dig('services', 'db-dev', 'volumes')).to include(
+      'medtracker_dev_postgres:/var/lib/postgresql'
+    )
+  end
+
+  it 'mounts production PostgreSQL data at the PostgreSQL 18 data root' do
+    expect(compose_config.dig('services', 'db-prod', 'volumes')).to include(
+      'medtracker_prod_postgres:/var/lib/postgresql'
+    )
+  end
+
+  it 'builds the development migrate container from the development image target' do
+    expect(compose_config.dig('services', 'migrate-dev', 'image')).to eq('med-tracker-web-dev')
+    expect(compose_config.dig('services', 'migrate-dev', 'build', 'target')).to eq('assets')
+    expect(compose_config.dig('services', 'migrate-dev', 'build', 'args', 'RAILS_ENV')).to eq('development')
+  end
+
+  it 'builds the test migrate container from the test image target' do
+    expect(compose_config.dig('services', 'migrate-test', 'image')).to eq('med-tracker-web-test')
+    expect(compose_config.dig('services', 'migrate-test', 'build', 'target')).to eq('test')
+  end
 end


### PR DESCRIPTION
## Summary
- mount Postgres 18 dev/prod volumes at /var/lib/postgresql
- make dev/test migrate services share the web images and correct build targets
- add compose config regression specs for the rebuild assumptions

## Verification
- task dev:rebuild
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
