### PR TITLE
fix: stabilize OIDC local setup

### DIFF
--- a/Taskfiles/dev.yml
+++ b/Taskfiles/dev.yml
@@ -33,6 +33,18 @@ tasks:
       - task: :internal:up
         vars: { ENVIRONMENT: dev }
 
+  portless:
+    desc: Start development server and register a Portless OIDC URL
+    summary: |
+      Start the development server, register its Docker-assigned host port with
+      Portless, and print the stable local OIDC URL.
+      Requires a globally installed Portless CLI:
+        npm install -g portless
+        portless trust
+      Usage: task dev:portless
+    cmds:
+      - ./scripts/portless_oidc.fish dev med-tracker
+
   seed:
     desc: Seed development database with fixtures
     summary: |

--- a/Taskfiles/dev.yml
+++ b/Taskfiles/dev.yml
@@ -43,6 +43,8 @@ tasks:
         portless trust
       Usage: task dev:portless
     cmds:
+      - task: :internal:up
+        vars: { ENVIRONMENT: dev }
       - ./scripts/portless_oidc.fish dev med-tracker
 
   seed:

--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -162,15 +162,10 @@ tasks:
     internal: false
     requires:
       vars: [ENVIRONMENT]
+    vars:
+      WEB_SERVICE: "web-{{ .ENVIRONMENT }}"
     cmds:
-      - |
-        PORT=$(docker ps --format {{`"{{.Ports}}"`}} -f name={{ .COMPOSE_PROJECT }}-web-{{ .ENVIRONMENT }} | grep -oE '0\.0\.0\.0:[0-9]+' | cut -d':' -f2)
-        if [ -z "$PORT" ]; then
-          echo "Error: Could not find running container {{ .COMPOSE_PROJECT }}-web-{{ .ENVIRONMENT }}"
-          echo "Run 'task {{.ENVIRONMENT}}:up' first to start the {{.ENVIRONMENT}} server"
-          exit 1
-        fi
-        echo $PORT
+      - "{{ .COMPOSE_CMD }} --profile {{ .ENVIRONMENT }} port {{ .WEB_SERVICE }} 3000 | sed -E 's/.*:([0-9]+)$/\\1/'"
 
   open-ui:
     desc: Open WebUI

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -25,6 +25,18 @@ tasks:
       - task: :internal:up-db
         vars: { ENVIRONMENT: test }
 
+  portless:
+    desc: Start test server and register a Portless OIDC URL
+    summary: |
+      Start the test web server, register its Docker-assigned host port with
+      Portless, and print the stable local OIDC URL.
+      Requires a globally installed Portless CLI:
+        npm install -g portless
+        portless trust
+      Usage: task test:portless
+    cmds:
+      - ./scripts/portless_oidc.fish test med-tracker-test
+
   seed:
     desc: Seed test database with fixtures
     summary: |

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -35,6 +35,8 @@ tasks:
         portless trust
       Usage: task test:portless
     cmds:
+      - task: :internal:up
+        vars: { ENVIRONMENT: test }
       - ./scripts/portless_oidc.fish test med-tracker-test
 
   seed:

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -240,8 +240,8 @@ class RodauthMain < Rodauth::Rails::Auth
                         client_options: {
                           identifier: oidc_client_id,
                           secret: oidc_client_secret,
-                          redirect_uri: ENV.fetch('OIDC_REDIRECT_URI',
-                                                  "#{ENV.fetch('APP_URL', 'http://localhost:3000')}/auth/oidc/callback")
+                          redirect_uri: ENV.fetch('OIDC_REDIRECT_URI', nil).presence ||
+                                        "#{ENV.fetch('APP_URL', 'http://localhost:3000')}/auth/oidc/callback"
                         }
     end
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,6 +46,12 @@ services:
       SOLID_QUEUE_DATABASE_URL: postgresql://medtracker:medtracker_password@db-dev:5432/medtracker_queue
       NHS_DMD_CLIENT_ID: ${NHS_DMD_CLIENT_ID:-}
       NHS_DMD_CLIENT_SECRET: ${NHS_DMD_CLIENT_SECRET:-}
+      APP_URL: ${APP_URL:-http://localhost:3000}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
+      OIDC_PROVIDER_NAME: ${OIDC_PROVIDER_NAME:-OIDC}
+      OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:-}
     volumes:
       - .:/app
       - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
@@ -123,6 +129,12 @@ services:
       RAILS_ENV: test
       DATABASE_URL: postgresql://medtracker:medtracker_password@db-test:5432/medtracker
       SMTP_ADDRESS: mail-test
+      APP_URL: ${TEST_APP_URL:-http://localhost:3000}
+      OIDC_CLIENT_ID: ${TEST_OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${TEST_OIDC_CLIENT_SECRET:-}
+      OIDC_ISSUER_URL: ${TEST_OIDC_ISSUER_URL:-}
+      OIDC_PROVIDER_NAME: ${TEST_OIDC_PROVIDER_NAME:-OIDC}
+      OIDC_REDIRECT_URI: ${TEST_OIDC_REDIRECT_URI:-}
     volumes:
       - .:/app
       - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro

--- a/db/migrate/20260428100000_add_defaults_to_account_identities_timestamps.rb
+++ b/db/migrate/20260428100000_add_defaults_to_account_identities_timestamps.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddDefaultsToAccountIdentitiesTimestamps < ActiveRecord::Migration[8.1]
+  def up
+    change_column_default :account_identities, :created_at, -> { 'CURRENT_TIMESTAMP' }
+    change_column_default :account_identities, :updated_at, -> { 'CURRENT_TIMESTAMP' }
+
+    execute <<~SQL.squish
+      UPDATE account_identities
+      SET created_at = CURRENT_TIMESTAMP
+      WHERE created_at IS NULL
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE account_identities
+      SET updated_at = CURRENT_TIMESTAMP
+      WHERE updated_at IS NULL
+    SQL
+  end
+
+  def down
+    change_column_default :account_identities, :created_at, nil
+    change_column_default :account_identities, :updated_at, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -26,10 +26,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_120000) do
 
   create_table "account_identities", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "provider", null: false
     t.string "uid", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["account_id"], name: "index_account_identities_on_account_id"
     t.index ["provider", "uid"], name: "index_account_identities_on_provider_and_uid", unique: true
   end

--- a/scripts/portless_oidc.fish
+++ b/scripts/portless_oidc.fish
@@ -30,15 +30,23 @@ else
     set -lx OIDC_REDIRECT_URI $callback_url
 end
 
-task internal:up ENVIRONMENT=$environment
-
 set port (task "$environment:port")
 if test -z "$port"
     echo "Could not determine the Docker-assigned $environment web port." >&2
     exit 1
 end
 
+portless proxy start
 portless alias $route_name $port --force
+
+set route_line (portless list | string match -r "https://$route_name\\.localhost[^ ]*")
+if not string match -qr "https://$route_name\\.localhost\\s" $route_line
+    echo "Portless registered $route_line, not $base_url." >&2
+    echo "For Zitadel's clean redirect URI, restart Portless on port 443 from an interactive terminal:" >&2
+    echo "  portless proxy stop -p 1355" >&2
+    echo "  portless proxy start" >&2
+    exit 1
+end
 
 echo "Portless URL: $base_url"
 echo "OIDC callback: $callback_url"

--- a/scripts/portless_oidc.fish
+++ b/scripts/portless_oidc.fish
@@ -36,15 +36,13 @@ if test -z "$port"
     exit 1
 end
 
-portless proxy start
+portless proxy start --port 443 --https --force
 portless alias $route_name $port --force
 
-set route_line (portless list | string match -r "https://$route_name\\.localhost[^ ]*")
-if not string match -qr "https://$route_name\\.localhost\\s" $route_line
-    echo "Portless registered $route_line, not $base_url." >&2
-    echo "For Zitadel's clean redirect URI, restart Portless on port 443 from an interactive terminal:" >&2
-    echo "  portless proxy stop -p 1355" >&2
-    echo "  portless proxy start" >&2
+if not curl --silent --show-error --head --fail --max-time 5 $base_url >/dev/null
+    echo "Portless did not respond at $base_url." >&2
+    echo "For Zitadel's clean redirect URI, restart Portless on port 443:" >&2
+    echo "  portless proxy start --port 443 --https --force" >&2
     exit 1
 end
 

--- a/scripts/portless_oidc.fish
+++ b/scripts/portless_oidc.fish
@@ -1,0 +1,44 @@
+#!/usr/bin/env fish
+
+set environment $argv[1]
+set route_name $argv[2]
+
+if test -z "$environment"; or test -z "$route_name"
+    echo "Usage: scripts/portless_oidc.fish <dev|test> <route-name>" >&2
+    exit 64
+end
+
+if not type -q portless
+    echo "Portless is required for this task." >&2
+    echo "Install it globally with: npm install -g portless" >&2
+    echo "Then trust its local CA once with: portless trust" >&2
+    exit 127
+end
+
+set base_url "https://$route_name.localhost"
+set callback_url "$base_url/auth/oidc/callback"
+
+if test "$environment" = test
+    set -lx TEST_APP_URL $base_url
+    set -lx TEST_OIDC_CLIENT_ID $OIDC_CLIENT_ID
+    set -lx TEST_OIDC_CLIENT_SECRET $OIDC_CLIENT_SECRET
+    set -lx TEST_OIDC_ISSUER_URL $OIDC_ISSUER_URL
+    set -lx TEST_OIDC_PROVIDER_NAME $OIDC_PROVIDER_NAME
+    set -lx TEST_OIDC_REDIRECT_URI $callback_url
+else
+    set -lx APP_URL $base_url
+    set -lx OIDC_REDIRECT_URI $callback_url
+end
+
+task internal:up ENVIRONMENT=$environment
+
+set port (task "$environment:port")
+if test -z "$port"
+    echo "Could not determine the Docker-assigned $environment web port." >&2
+    exit 1
+end
+
+portless alias $route_name $port --force
+
+echo "Portless URL: $base_url"
+echo "OIDC callback: $callback_url"

--- a/scripts/portless_oidc.fish
+++ b/scripts/portless_oidc.fish
@@ -39,7 +39,16 @@ end
 portless proxy start --port 443 --https --force
 portless alias $route_name $port --force
 
-if not curl --silent --show-error --head --fail --max-time 5 $base_url >/dev/null
+set portless_ready false
+for attempt in (seq 1 10)
+    if curl --silent --show-error --head --fail --max-time 5 $base_url >/dev/null
+        set portless_ready true
+        break
+    end
+    sleep 1
+end
+
+if test "$portless_ready" != true
     echo "Portless did not respond at $base_url." >&2
     echo "For Zitadel's clean redirect URI, restart Portless on port 443:" >&2
     echo "  portless proxy start --port 443 --https --force" >&2

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -25,9 +25,14 @@ RSpec.describe 'Taskfiles' do
   end
 
   it 'probes the clean HTTPS URL after registering the alias' do
-    expect(portless_script).to include('curl --silent --show-error --head --fail --max-time 5 $base_url')
-    expect(portless_script).to include('Portless did not respond at $base_url.')
-    expect(portless_script).to include('portless proxy start --port 443 --https --force')
+    expect(portless_script).to include(
+      'set portless_ready false',
+      'for attempt in (seq 1 10)',
+      'curl --silent --show-error --head --fail --max-time 5 $base_url',
+      'sleep 1',
+      'Portless did not respond at $base_url.',
+      'portless proxy start --port 443 --https --force'
+    )
   end
 
   it 'uses test-scoped OIDC variables for the Portless test task' do

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe 'Taskfiles' do
     expect(portless_script).not_to include('npx portless')
   end
 
-  it 'fails clearly when Portless is not serving the clean HTTPS URL' do
-    expect(portless_script).to include('Portless registered $route_line, not $base_url.')
-    expect(portless_script).to include('portless proxy start')
+  it 'probes the clean HTTPS URL after registering the alias' do
+    expect(portless_script).to include('curl --silent --show-error --head --fail --max-time 5 $base_url')
+    expect(portless_script).to include('Portless did not respond at $base_url.')
+    expect(portless_script).to include('portless proxy start --port 443 --https --force')
   end
 
   it 'uses test-scoped OIDC variables for the Portless test task' do

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Taskfiles' do
+  let(:dev_taskfile) do
+    YAML.safe_load(Rails.root.join('Taskfiles/dev.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+  let(:test_taskfile) do
+    YAML.safe_load(Rails.root.join('Taskfiles/test.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+  let(:portless_script) { Rails.root.join('scripts/portless_oidc.fish').read }
+
+  it 'defines opt-in Portless tasks for dev and test' do
+    expect(dev_taskfile.dig('tasks', 'portless', 'cmds')).to include('./scripts/portless_oidc.fish dev med-tracker')
+    expect(test_taskfile.dig('tasks', 'portless', 'cmds')).to include(
+      './scripts/portless_oidc.fish test med-tracker-test'
+    )
+  end
+
+  it 'requires a globally installed Portless CLI' do
+    expect(portless_script).to include('type -q portless')
+    expect(portless_script).to include('npm install -g portless')
+    expect(portless_script).not_to include('npx portless')
+  end
+
+  it 'uses test-scoped OIDC variables for the Portless test task' do
+    expect(portless_script).to include('set -lx TEST_APP_URL $base_url')
+    expect(portless_script).to include('set -lx TEST_OIDC_CLIENT_ID $OIDC_CLIENT_ID')
+    expect(portless_script).to include('set -lx TEST_OIDC_REDIRECT_URI $callback_url')
+  end
+end

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe 'Taskfiles' do
     expect(portless_script).not_to include('npx portless')
   end
 
+  it 'fails clearly when Portless is not serving the clean HTTPS URL' do
+    expect(portless_script).to include('Portless registered $route_line, not $base_url.')
+    expect(portless_script).to include('portless proxy start')
+  end
+
   it 'uses test-scoped OIDC variables for the Portless test task' do
     expect(portless_script).to include('set -lx TEST_APP_URL $base_url')
     expect(portless_script).to include('set -lx TEST_OIDC_CLIENT_ID $OIDC_CLIENT_ID')

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -37,4 +37,41 @@ RSpec.describe YAML do
     expect(compose_config.dig('services', 'migrate-test', 'image')).to eq('med-tracker-web-test')
     expect(compose_config.dig('services', 'migrate-test', 'build', 'target')).to eq('test')
   end
+
+  it 'passes OIDC environment through to Rails containers used for local OIDC flows' do
+    expected_keys = %w[
+      APP_URL
+      OIDC_CLIENT_ID
+      OIDC_CLIENT_SECRET
+      OIDC_ISSUER_URL
+      OIDC_PROVIDER_NAME
+      OIDC_REDIRECT_URI
+    ]
+
+    expected_keys.each do |key|
+      expect(compose_config.dig('services', 'migrate-dev', 'environment')).to include(key)
+      expect(compose_config.dig('services', 'web-dev', 'environment')).to include(key)
+      expect(compose_config.dig('services', 'migrate-test', 'environment')).to include(key)
+      expect(compose_config.dig('services', 'web-test', 'environment')).to include(key)
+    end
+  end
+
+  it 'keeps normal test runs isolated from local development OIDC credentials' do
+    test_environment = compose_config.dig('services', 'migrate-test', 'environment')
+
+    expect(test_environment.slice('APP_URL', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_ISSUER_URL',
+                                  'OIDC_PROVIDER_NAME', 'OIDC_REDIRECT_URI')).to eq(
+                                    'APP_URL' => '${TEST_APP_URL:-http://localhost:3000}',
+                                    'OIDC_CLIENT_ID' => '${TEST_OIDC_CLIENT_ID:-}',
+                                    'OIDC_CLIENT_SECRET' => '${TEST_OIDC_CLIENT_SECRET:-}',
+                                    'OIDC_ISSUER_URL' => '${TEST_OIDC_ISSUER_URL:-}',
+                                    'OIDC_PROVIDER_NAME' => '${TEST_OIDC_PROVIDER_NAME:-OIDC}',
+                                    'OIDC_REDIRECT_URI' => '${TEST_OIDC_REDIRECT_URI:-}'
+                                  )
+  end
+
+  it 'keeps development and test web host ports Docker-assigned for parallel worktrees' do
+    expect(compose_config.dig('services', 'web-dev', 'ports')).to be_nil
+    expect(compose_config.dig('services', 'web-test', 'ports')).to be_nil
+  end
 end

--- a/spec/features/authentication/omniauth_auto_link_spec.rb
+++ b/spec/features/authentication/omniauth_auto_link_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'AUTH: OmniAuth Auto Linking', type: :system do
   fixtures :accounts, :people, :users
 
   before do
-    skip 'OIDC not configured' unless ENV.key?('OIDC_CLIENT_ID') && ENV.key?('OIDC_ISSUER_URL')
+    skip 'OIDC not configured' unless ENV.fetch('OIDC_CLIENT_ID', nil).present? &&
+                                      ENV.fetch('OIDC_ISSUER_URL', nil).present?
 
     OmniAuth.config.test_mode = true
   end

--- a/spec/security/oidc_security_spec.rb
+++ b/spec/security/oidc_security_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe 'OIDC Security' do # rubocop:disable RSpec/DescribeClass
       rodauth_file = Rails.root.join('app/misc/rodauth_main.rb').read
       expect(rodauth_file).to include('/auth/oidc/callback')
     end
+
+    it 'treats a blank redirect URI environment variable as unset' do
+      rodauth_file = Rails.root.join('app/misc/rodauth_main.rb').read
+      expect(rodauth_file).to include("ENV.fetch('OIDC_REDIRECT_URI', nil).presence ||")
+    end
   end
 
   describe 'OIDC-SEC-007: Access token not stored long-term' do

--- a/spec/security/oidc_security_spec.rb
+++ b/spec/security/oidc_security_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe 'OIDC Security' do # rubocop:disable RSpec/DescribeClass
       expect(columns).not_to include('access_token')
       expect(columns).not_to include('refresh_token')
     end
+
+    it 'uses database timestamp defaults for Rodauth-managed identities' do
+      columns = ActiveRecord::Base.connection.columns(:account_identities)
+      defaults = columns.index_by(&:name).transform_values(&:default_function)
+
+      expect(defaults['created_at']).to eq('CURRENT_TIMESTAMP')
+      expect(defaults['updated_at']).to eq('CURRENT_TIMESTAMP')
+    end
   end
 
   describe 'OIDC-SEC-011: Account hijacking prevention via email verification' do

--- a/spec/services/nhs_dmd/release_import_spec.rb
+++ b/spec/services/nhs_dmd/release_import_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 require 'fileutils'
+require 'tmpdir'
 
 RSpec.describe NhsDmd::ReleaseImport do
   let(:importer) { described_class.new }
-  let(:release_dir) { Rails.root.join('tmp/dmd-release-spec') }
+  let(:release_dir) { Pathname.new(Dir.mktmpdir('dmd-release-spec', Rails.root.join('tmp'))) }
 
-  before { FileUtils.mkdir_p(release_dir) }
   after { FileUtils.rm_rf(release_dir) }
 
   def write_ampp_xml(entries)


### PR DESCRIPTION
## Summary
- add opt-in Portless tasks for clean local HTTPS OIDC callback URLs
- pass OIDC environment through dev/test Rails containers while keeping normal test runs isolated
- add database timestamp defaults for Rodauth-managed account identities to prevent OIDC sign-in failures

## Security review
- reviewed branch diff against origin/main for auth, redirect URI, local proxy, compose environment, and migration changes
- targeted secrets scan of changed files found no new literal OIDC secrets, private keys, or bearer tokens
- no new security findings identified in the PR changes

## Verification
- task dev:portless
- task dev:db-migrate
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
