### PR TITLE
feat: Record historical medication dose times

### DIFF
--- a/app/components/medications/take_action.rb
+++ b/app/components/medications/take_action.rb
@@ -28,10 +28,8 @@ module Components
       def view_template
         if disabled
           render_disabled_button
-        elsif available_medications.many?
-          render_location_dialog
         else
-          render_take_form(selected_medication: available_medications.first)
+          render_take_dialog
         end
       end
 
@@ -47,9 +45,9 @@ module Components
         ) { disabled_label }
       end
 
-      def render_location_dialog
-        Dialog do
-          DialogTrigger do
+      def render_take_dialog
+        Dialog(class: form_class) do
+          DialogTrigger(class: 'block w-full') do
             m3_button(
               variant: button_variant,
               size: button_size,
@@ -60,89 +58,144 @@ module Components
 
           DialogContent(size: :md) do
             DialogHeader do
-              DialogTitle { t('medications.take_action.choose_location', default: 'Choose location') }
+              DialogTitle { t('medications.take_action.title', default: 'Record dose') }
               DialogDescription do
-                t('medications.take_action.choose_location_description',
-                  default: 'Select which location to deduct this dose from.')
+                t('medications.take_action.description',
+                  default: 'Confirm the person, medication, time, and inventory source.')
               end
             end
 
-            DialogMiddle do
-              form_with(
-                url: take_path,
-                method: :post,
-                class: 'space-y-4',
-                data: {
-                  controller: 'optimistic-take',
-                  action: 'submit->optimistic-take#submit',
-                  optimistic_take_loading_label_value: t('medications.take_action.loading')
-                }
-              ) do
-                input(type: :hidden, name: 'amount_ml', value: formatted_amount)
-
-                div(class: 'space-y-2') do
-                  available_medications.each_with_index do |medication, index|
-                    label(
-                      for: "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}",
-                      class: 'flex flex-col gap-3 rounded-shape-xl border border-border p-4 sm:flex-row ' \
-                             'sm:items-center sm:justify-between'
-                    ) do
-                      div(class: 'space-y-1 min-w-0') do
-                        m3_text(size: '2', weight: 'bold', class: 'text-foreground') { medication.location.name }
-                        m3_text(size: '1', class: 'text-on-surface-variant break-words') do
-                          medication_description(medication)
-                        end
-                      end
-                      div(class: 'flex items-center gap-3 shrink-0') do
-                        Badge(variant: :outlined, class: 'rounded-full text-[10px] whitespace-nowrap justify-center') do
-                          inventory_label(medication)
-                        end
-                        input(
-                          type: :radio,
-                          id: "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}",
-                          name: 'taken_from_medication_id',
-                          value: medication.id,
-                          checked: index.zero?
-                        )
-                      end
-                    end
-                  end
+            form_with(
+              url: take_path,
+              method: :post,
+              class: 'contents',
+              data: {
+                controller: 'optimistic-take',
+                action: 'submit->optimistic-take#submit',
+                optimistic_take_loading_label_value: t('medications.take_action.loading')
+              }
+            ) do
+              DialogMiddle do
+                div(class: 'space-y-5') do
+                  input(type: :hidden, name: 'amount_ml', value: formatted_amount)
+                  render_context
+                  render_taken_at_field
+                  render_stock_source_selection
                 end
+              end
 
-                div(class: 'flex justify-end') do
-                  render M3::Button.new(
-                    type: :submit,
-                    variant: :filled,
-                    class: 'rounded-xl',
-                    data: { optimistic_take_target: 'button' }
-                  ) { button_label }
-                end
+              DialogFooter(class: 'border-t border-border/70 bg-popover px-8 pb-8 pt-4') do
+                render M3::Button.new(
+                  type: :submit,
+                  variant: :filled,
+                  class: 'w-full rounded-xl sm:w-auto',
+                  data: { optimistic_take_target: 'button' }
+                ) { button_label }
               end
             end
           end
         end
       end
 
-      def render_take_form(selected_medication:)
-        form_with(
-          url: take_path,
-          method: :post,
-          class: form_class,
-          data: {
-            controller: 'optimistic-take',
-            action: 'submit->optimistic-take#submit',
-            optimistic_take_loading_label_value: t('medications.take_action.loading')
-          }
+      def render_context
+        div(class: 'rounded-shape-xl border border-border/70 bg-surface-container-low p-4') do
+          dl(class: 'grid gap-3 sm:grid-cols-2') do
+            div(class: 'space-y-1') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.person', default: 'Person')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { person.name }
+            end
+            div(class: 'space-y-1') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.medication', default: 'Medication')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { source.medication.name }
+            end
+            div(class: 'space-y-1 sm:col-span-2') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.dose', default: 'Dose')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { dose_label }
+            end
+          end
+        end
+      end
+
+      def render_taken_at_field
+        div(class: 'space-y-2') do
+          render RubyUI::FormFieldLabel.new(for: taken_at_input_id) do
+            t('medications.take_action.taken_at', default: 'Taken at')
+          end
+          m3_input(
+            id: taken_at_input_id,
+            type: 'datetime-local',
+            name: 'medication_take[taken_at]',
+            value: taken_at_field_value,
+            max: taken_at_field_value
+          )
+        end
+      end
+
+      def render_stock_source_selection
+        if available_medications.many?
+          render_stock_source_options
+        elsif available_medications.one?
+          input(type: :hidden, name: 'medication_take[taken_from_medication_id]', value: available_medications.first.id)
+          render_selected_stock_source(available_medications.first)
+        end
+      end
+
+      def render_stock_source_options
+        fieldset(class: 'space-y-2') do
+          legend(class: 'text-sm font-semibold text-foreground') do
+            t('medications.take_action.stock_source', default: 'Stock source')
+          end
+          available_medications.each_with_index do |medication, index|
+            render_stock_source_option(medication, index)
+          end
+        end
+      end
+
+      def render_stock_source_option(medication, index)
+        label(
+          for: stock_source_input_id(medication),
+          class: 'flex flex-col gap-3 rounded-shape-xl border border-border p-4 sm:flex-row ' \
+                 'sm:items-center sm:justify-between'
         ) do
-          input(type: :hidden, name: 'amount_ml', value: formatted_amount)
-          input(type: :hidden, name: 'taken_from_medication_id', value: selected_medication.id)
-          render M3::Button.new(
-            type: :submit,
-            variant: button_variant,
-            size: button_size,
-            class: button_class,
-            data: { optimistic_take_target: 'button', testid: testid, test_id: testid }
-          ) { button_label }
+          render_stock_source_details(medication)
+          div(class: 'flex items-center gap-3 shrink-0') do
+            Badge(variant: :outlined, class: 'rounded-full text-[10px] whitespace-nowrap justify-center') do
+              inventory_label(medication)
+            end
+            input(
+              type: :radio,
+              id: stock_source_input_id(medication),
+              name: 'medication_take[taken_from_medication_id]',
+              value: medication.id,
+              checked: index.zero?
+            )
+          end
+        end
+      end
+
+      def render_selected_stock_source(medication)
+        div(class: 'space-y-2') do
+          m3_text(variant: :label_medium, class: 'font-semibold text-foreground') do
+            t('medications.take_action.stock_source', default: 'Stock source')
+          end
+          div(class: 'rounded-shape-xl border border-border p-4') do
+            render_stock_source_details(medication)
+          end
+        end
+      end
+
+      def render_stock_source_details(medication)
+        div(class: 'space-y-1 min-w-0') do
+          m3_text(size: '2', weight: 'bold', class: 'text-foreground') { medication.location.name }
+          m3_text(size: '1', class: 'text-on-surface-variant break-words') do
+            medication_description(medication)
+          end
         end
       end
 
@@ -175,6 +228,29 @@ module Components
 
       def formatted_amount
         amount.to_s
+      end
+
+      def dose_label
+        dose = DoseAmount.new(amount, source_dose_unit).to_s
+        dose.presence || formatted_amount
+      end
+
+      def source_dose_unit
+        return source.dose_unit if source.respond_to?(:dose_unit)
+
+        source.medication.dosage_unit
+      end
+
+      def taken_at_input_id
+        @taken_at_input_id ||= "medication_take_taken_at_#{source.class.name.underscore}_#{source.id}"
+      end
+
+      def stock_source_input_id(medication)
+        "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}"
+      end
+
+      def taken_at_field_value
+        @taken_at_field_value ||= Time.current.strftime('%Y-%m-%dT%H:%M')
       end
 
       def stock_source_resolver

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -236,7 +236,7 @@ module Components
             form_class: 'flex-1'
           },
           state: {
-            disabled: invalid_dose_configured? || blocked_reason.present?,
+            disabled: invalid_dose_configured? || blocked_reason == :out_of_stock,
             label: label
           }
         )

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -282,7 +282,7 @@ module Components
             form_class: 'flex-1'
           },
           state: {
-            disabled: invalid_dose_configured? || !can_administer?,
+            disabled: invalid_dose_configured? || out_of_stock?,
             label: label
           }
         )

--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -39,11 +39,32 @@ module TakeMedicationGuardable
   def respond_take_medication_error(message:)
     respond_to do |format|
       format.html { redirect_back_or_to(respond_take_medication_redirect_path, alert: message) }
+      format.json { render json: { success: false, errors: [message] }, status: :unprocessable_content }
       format.turbo_stream do
         flash.now[:alert] = message
         render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
       end
     end
+  end
+
+  def medication_taken_at_or_respond(scope:)
+    taken_at = parsed_medication_taken_at
+
+    if taken_at.blank?
+      respond_take_medication_error(
+        message: t("#{scope}.invalid_taken_at", default: t('take_medications.invalid_taken_at'))
+      )
+      return
+    end
+
+    if taken_at.future?
+      respond_take_medication_error(
+        message: t("#{scope}.future_taken_at", default: t('take_medications.future_taken_at'))
+      )
+      return
+    end
+
+    taken_at
   end
 
   def log_invalid_take_attempt(source:, amount:, metadata: {})
@@ -62,7 +83,24 @@ module TakeMedicationGuardable
     params[:taken_from_medication_id].presence || params.dig(:medication_take, :taken_from_medication_id).presence
   end
 
+  def parsed_medication_taken_at
+    raw_taken_at = params.dig(:medication_take, :taken_at).presence
+    return Time.current if raw_taken_at.blank?
+
+    medication_taken_at_formats.each do |format|
+      return Time.zone.strptime(raw_taken_at, format)
+    rescue ArgumentError, TypeError
+      next
+    end
+
+    nil
+  end
+
   def respond_take_medication_redirect_path
     defined?(@person) && @person.present? ? person_path(@person) : root_path
+  end
+
+  def medication_taken_at_formats
+    ['%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S']
   end
 end

--- a/app/controllers/medication_takes_controller.rb
+++ b/app/controllers/medication_takes_controller.rb
@@ -7,13 +7,15 @@ class MedicationTakesController < ApplicationController
 
   def create
     authorize @schedule, :take_medication?
+    taken_at = medication_taken_at_or_respond(scope: 'take_medications')
+    return unless taken_at
 
     result = TakeMedicationService.new.call(
       source: @schedule,
       amount_override: nil,
       taken_from_medication_id: requested_taken_from_medication_id,
       user: current_user,
-      taken_at: params.dig(:medication_take, :taken_at).presence || Time.current
+      taken_at: taken_at
     )
 
     if result.success

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -134,12 +134,15 @@ class PersonMedicationsController < ApplicationController
 
   def take_medication
     authorize @person_medication, :take_medication?
+    taken_at = medication_taken_at_or_respond(scope: 'person_medications')
+    return unless taken_at
 
     result = TakeMedicationService.new.call(
       source: @person_medication,
       amount_override: params[:amount_ml],
       taken_from_medication_id: requested_taken_from_medication_id,
-      user: current_user
+      user: current_user,
+      taken_at: taken_at
     )
 
     if result.error == :invalid_amount

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -152,12 +152,15 @@ class SchedulesController < ApplicationController
 
   def take_medication
     authorize @schedule, :take_medication?
+    taken_at = medication_taken_at_or_respond(scope: 'schedules')
+    return unless taken_at
 
     result = TakeMedicationService.new.call(
       source: @schedule,
       amount_override: params[:amount_ml],
       taken_from_medication_id: requested_taken_from_medication_id,
-      user: current_user
+      user: current_user,
+      taken_at: taken_at
     )
 
     if result.error == :invalid_amount

--- a/app/models/concerns/timing_restrictions.rb
+++ b/app/models/concerns/timing_restrictions.rb
@@ -38,10 +38,14 @@ module TimingRestrictions
 
   alias timing_restrictions? restrictions?
 
-  def can_take_now?
+  def can_take_at?(check_time = Time.current)
     return true unless timing_restrictions?
 
-    timing_policy.can_take_at?
+    timing_policy.can_take_at?(check_time)
+  end
+
+  def can_take_now?
+    can_take_at?
   end
   delegate :next_available_time, :time_until_next_dose, :countdown_display, to: :timing_policy
 

--- a/app/services/medication_stock_source_resolver.rb
+++ b/app/services/medication_stock_source_resolver.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class MedicationStockSourceResolver
-  attr_reader :user, :source
+  attr_reader :user, :source, :taken_at
 
-  def initialize(user:, source:)
+  def initialize(user:, source:, taken_at: Time.current)
     @user = user
     @source = source
+    @taken_at = taken_at
   end
 
   def available_medications
@@ -14,7 +15,7 @@ class MedicationStockSourceResolver
 
   def blocked_reason
     return :out_of_stock if available_medications.empty?
-    return :cooldown unless source.can_take_now?
+    return :cooldown unless source.can_take_at?(taken_at)
 
     nil
   end

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -21,7 +21,7 @@ class TakeMedicationService
   Result = Data.define(:success, :take, :error)
 
   def call(source:, amount_override:, taken_from_medication_id:, user:, taken_at: Time.current)
-    resolver = MedicationStockSourceResolver.new(user: user, source: source)
+    resolver = MedicationStockSourceResolver.new(user: user, source: source, taken_at: taken_at)
     return failure(resolver.blocked_reason) if resolver.blocked_reason
 
     amount = normalize_amount(amount_override.presence || default_dose_amount_for(source, taken_at))

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -866,6 +866,8 @@ cy:
     success: "Cofnodwyd cymryd y feddyginiaeth yn llwyddiannus."
     failure: "Methwyd â chofnodi cymryd y feddyginiaeth."
     json_success: "Cofnodwyd cymryd y feddyginiaeth yn llwyddiannus."
+    invalid_taken_at: "Dewiswch amser dos dilys."
+    future_taken_at: "Ni all amser y dos fod yn y dyfodol."
 
   profiles:
     updated: "Diweddarwyd y proffil yn llwyddiannus."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,13 @@ en:
     refill_button: "Refill"
     take_action:
       loading: "Taking…"
+      title: "Record dose"
+      description: "Confirm the person, medication, time, and inventory source."
+      person: "Person"
+      medication: "Medication"
+      dose: "Dose"
+      taken_at: "Taken at"
+      stock_source: "Stock source"
       choose_location: "Choose location"
       choose_location_description: "Select which location to deduct this dose from."
       untracked_inventory: "Untracked"
@@ -885,6 +892,8 @@ en:
     success: "Medication taken successfully."
     failure: "Failed to record medication taken."
     json_success: "Medication taken successfully."
+    invalid_taken_at: "Choose a valid dose time."
+    future_taken_at: "Dose time cannot be in the future."
 
   barcode_scanner:
     title: "Scan Barcode"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -835,6 +835,8 @@ es:
     success: "Toma de medicamento registrada correctamente."
     failure: "Error al registrar la toma de medicamento."
     json_success: "Toma de medicamento registrada correctamente."
+    invalid_taken_at: "Elige una hora de dosis válida."
+    future_taken_at: "La hora de la dosis no puede estar en el futuro."
 
   profiles:
     updated: "Perfil actualizado correctamente."

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -769,6 +769,8 @@ ga:
     success: "Cláraíodh an leigheas tógtha go rathúil."
     failure: "Theip ar chlárú an leighis tógtha."
     json_success: "Cláraíodh an leigheas tógtha go rathúil."
+    invalid_taken_at: "Roghnaigh am dáileoige bailí."
+    future_taken_at: "Ní féidir am na dáileoige a bheith sa todhchaí."
 
   profiles:
     updated: "Nuashonraíodh an phróifíl go rathúil."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -834,6 +834,8 @@ pt:
     success: "Toma de medicamento registada com sucesso."
     failure: "Falha ao registar toma de medicamento."
     json_success: "Toma de medicamento registada com sucesso."
+    invalid_taken_at: "Escolha uma hora de dose válida."
+    future_taken_at: "A hora da dose não pode ser no futuro."
 
   barcode_scanner:
     title: "Ler Código de Barras"

--- a/spec/components/dashboard/timeline_item_spec.rb
+++ b/spec/components/dashboard/timeline_item_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
     rendered = render_inline(component)
 
     expect(rendered.to_html).to include('Jane Doe')
-    expect(rendered.to_html).not_to include('Taken at')
+    expect(rendered.to_html).not_to include('Jane Doe • Taken at')
   end
 
   describe 'cooldown badge' do

--- a/spec/components/medications/take_action_spec.rb
+++ b/spec/components/medications/take_action_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::TakeAction, type: :component do
+  fixtures :locations, :medications, :people, :users
+
+  let(:person) { people(:jane) }
+  let(:user) { users(:admin) }
+  let(:medication) { medications(:ibuprofen) }
+  let(:source) do
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      start_date: Time.zone.today,
+      end_date: Time.zone.today + 30.days,
+      dose_amount: medication.dosage_amount,
+      dose_unit: medication.dosage_unit
+    )
+  end
+
+  it 'renders a RubyUI location modal with a bounded historical dose timestamp field' do
+    travel_to(Time.zone.local(2026, 4, 28, 14, 45)) do
+      build_alternate_medication
+
+      rendered = render_take_action
+      timestamp_field = rendered.at_css("input[type='datetime-local'][name='medication_take[taken_at]']")
+
+      expect(rendered.text).to include('Record dose')
+      expect(rendered.at_css("form[action='#{take_path}']")).not_to be_nil
+      expect(timestamp_field).not_to be_nil
+      expect(timestamp_field['value']).to eq('2026-04-28T14:45')
+      expect(timestamp_field['max']).to eq('2026-04-28T14:45')
+    end
+  end
+
+  def render_take_action
+    html = view_context.render(
+      described_class.new(
+        source: source,
+        context: { person: person, current_user: user },
+        amount: source.dose_amount,
+        button: {
+          label: 'Give dose',
+          variant: :filled,
+          testid: "take-schedule-#{source.id}"
+        }
+      )
+    )
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  def take_path
+    Rails.application.routes.url_helpers.take_medication_person_schedule_path(person, source)
+  end
+
+  def build_alternate_medication
+    Medication.create!(
+      name: medication.name,
+      location: locations(:school),
+      category: medication.category,
+      dosage_amount: medication.dosage_amount,
+      dosage_unit: medication.dosage_unit,
+      current_supply: 7,
+      reorder_threshold: 1
+    )
+  end
+end

--- a/spec/components/schedules/card_todays_takes_spec.rb
+++ b/spec/components/schedules/card_todays_takes_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
 
     it 'reuses one medication_takes load for the dose badge and list' do
       schedule.update!(max_daily_doses: 4)
-      allow(schedule).to receive_messages(out_of_stock?: false, can_take_now?: true)
+      allow(schedule).to receive_messages(out_of_stock?: false, can_take_at?: true, can_take_now?: true)
 
       take
 
@@ -76,7 +76,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
         available_medications: [medication]
       )
       allow(MedicationStockSourceResolver).to receive(:new).and_return(resolver)
-      allow(schedule).to receive(:can_take_now?).and_return(true)
+      allow(schedule).to receive_messages(can_take_at?: true, can_take_now?: true)
 
       render_card
 

--- a/spec/features/medication_stock_tracking_spec.rb
+++ b/spec/features/medication_stock_tracking_spec.rb
@@ -70,11 +70,18 @@ RSpec.describe 'Medication Stock Tracking', type: :system do
       # Use the specific test ID for the Take button
       find("[data-testid='take-schedule-#{schedule.id}']").click
     end
+    confirm_record_dose(take_medication_person_schedule_path(person, schedule), I18n.t('schedules.card.give'))
 
     expect(page).to have_content(/taken successfully/)
 
     within "#schedule_#{schedule.id}" do
       expect(page).to have_content('9 left')
+    end
+  end
+
+  def confirm_record_dose(path, label)
+    within("form[action='#{path}']") do
+      click_button label
     end
   end
 end

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Person Medications', type: :system do
   describe 'recording medication takes' do
     let(:person_medication) { person_medications(:john_vitamin_d) }
 
-    it 'allows recording a medication take' do
+    it 'allows recording a medication take', :js do
       person_medication.update!(max_daily_doses: 3, min_hours_between_doses: nil)
       person_medication.medication_takes.delete_all
 
@@ -59,11 +59,12 @@ RSpec.describe 'Person Medications', type: :system do
       within("#person_medication_#{person_medication.id}") do
         click_button '💊 Take'
       end
+      confirm_record_dose(person_medication)
 
       expect(page).to have_content('Medication taken successfully')
     end
 
-    it 'disables the take button when max daily doses reached' do
+    it 'rejects the default dose time when max daily doses reached', :js do
       person_medication.update!(max_daily_doses: 2, min_hours_between_doses: nil)
       person_medication.medication_takes.delete_all
       2.times do
@@ -77,11 +78,16 @@ RSpec.describe 'Person Medications', type: :system do
       visit person_path(person)
 
       within("#person_medication_#{person_medication.id}") do
-        expect(page).to have_button('💊 Take', disabled: true)
+        expect(page).to have_button('💊 Take', disabled: false)
+        click_button '💊 Take'
       end
+      expect do
+        confirm_record_dose(person_medication)
+        expect(page).to have_content('Cannot take medication')
+      end.not_to change(MedicationTake, :count)
     end
 
-    it 'disables the take button when minimum hours not passed' do
+    it 'rejects the default dose time when minimum hours not passed', :js do
       person_medication.update!(max_daily_doses: nil, min_hours_between_doses: 6)
       person_medication.medication_takes.delete_all
       MedicationTake.create!(
@@ -93,8 +99,13 @@ RSpec.describe 'Person Medications', type: :system do
       visit person_path(person)
 
       within("#person_medication_#{person_medication.id}") do
-        expect(page).to have_button('💊 Take', disabled: true)
+        expect(page).to have_button('💊 Take', disabled: false)
+        click_button '💊 Take'
       end
+      expect do
+        confirm_record_dose(person_medication)
+        expect(page).to have_content('Cannot take medication')
+      end.not_to change(MedicationTake, :count)
     end
   end
 
@@ -117,6 +128,14 @@ RSpec.describe 'Person Medications', type: :system do
         expect(page).to have_content(take.taken_at.strftime('%l:%M %p').strip)
         expect(page).to have_content('5 IU')
       end
+    end
+  end
+
+  def confirm_record_dose(person_medication)
+    path = take_medication_person_person_medication_path(person, person_medication)
+
+    within("form[action='#{path}']") do
+      click_button '💊 Take'
     end
   end
 end

--- a/spec/features/schedules/schedule_card_spec.rb
+++ b/spec/features/schedules/schedule_card_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'Schedule Card', type: :system do
     within("#schedule_#{schedule.id}") do
       expect(page).to have_content(I18n.t('schedules.card.no_doses_today'))
       click_button I18n.t('schedules.card.give')
+    end
+    confirm_record_dose
+
+    within("#schedule_#{schedule.id}") do
       expect(page).to have_no_content(I18n.t('schedules.card.no_doses_today'))
     end
 
@@ -57,6 +61,12 @@ RSpec.describe 'Schedule Card', type: :system do
 
     within("#schedule_#{schedule.id}") do
       expect(page).to have_button(I18n.t('schedules.card.out_of_stock'), disabled: true)
+    end
+  end
+
+  def confirm_record_dose
+    within("form[action='#{take_medication_person_schedule_path(person, schedule)}']") do
+      click_button I18n.t('schedules.card.give')
     end
   end
 end

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -30,6 +30,43 @@ RSpec.describe 'Medication stock sources' do
       expect(alternate_medication.reload.current_supply).to eq(6)
     end
 
+    it 'keeps the selected alternate source when recording a historical dose' do
+      schedule = build_schedule
+      alternate_medication = build_alternate_medication
+      submitted_time = Time.zone.local(2026, 4, 27, 7, 45)
+
+      travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+        expect do
+          post take_medication_person_schedule_path(person, schedule),
+               params: {
+                 medication_take: {
+                   taken_at: submitted_time.strftime('%Y-%m-%dT%H:%M'),
+                   taken_from_medication_id: alternate_medication.id
+                 }
+               }
+        end.to change(MedicationTake, :count).by(1)
+      end
+
+      take = MedicationTake.order(:id).last
+      expect(take.taken_at).to be_within(1.second).of(submitted_time)
+      expect(take.taken_from_medication).to eq(alternate_medication)
+      expect(take.inventory_location).to eq(locations(:school))
+      expect(alternate_medication.reload.current_supply).to eq(6)
+    end
+
+    it 'rejects a selected source with a different dosage' do
+      schedule = build_schedule
+      incompatible_medication = build_incompatible_medication
+
+      expect do
+        post take_medication_person_schedule_path(person, schedule),
+             params: { medication_take: { taken_from_medication_id: incompatible_medication.id } }
+      end.not_to change(MedicationTake, :count)
+
+      expect(response).to redirect_to(person_path(person))
+      expect(flash[:alert]).to include('Selected location is unavailable')
+    end
+
     it 'requires an explicit location selection when multiple stock sources are available' do
       build_alternate_medication
       schedule = build_schedule
@@ -57,6 +94,43 @@ RSpec.describe 'Medication stock sources' do
       expect(take.taken_from_medication).to eq(alternate_medication)
       expect(take.inventory_location).to eq(locations(:school))
       expect(alternate_medication.reload.current_supply).to eq(6)
+    end
+
+    it 'keeps the selected alternate source when recording a historical PRN dose' do
+      person_medication = build_person_medication
+      alternate_medication = build_alternate_medication
+      submitted_time = Time.zone.local(2026, 4, 27, 10, 5)
+
+      travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+        expect do
+          post take_medication_person_person_medication_path(person, person_medication),
+               params: {
+                 medication_take: {
+                   taken_at: submitted_time.strftime('%Y-%m-%dT%H:%M'),
+                   taken_from_medication_id: alternate_medication.id
+                 }
+               }
+        end.to change(MedicationTake, :count).by(1)
+      end
+
+      take = MedicationTake.order(:id).last
+      expect(take.taken_at).to be_within(1.second).of(submitted_time)
+      expect(take.taken_from_medication).to eq(alternate_medication)
+      expect(take.inventory_location).to eq(locations(:school))
+      expect(alternate_medication.reload.current_supply).to eq(6)
+    end
+
+    it 'rejects a selected PRN source with a different dosage' do
+      person_medication = build_person_medication
+      incompatible_medication = build_incompatible_medication
+
+      expect do
+        post take_medication_person_person_medication_path(person, person_medication),
+             params: { medication_take: { taken_from_medication_id: incompatible_medication.id } }
+      end.not_to change(MedicationTake, :count)
+
+      expect(response).to redirect_to(person_path(person))
+      expect(flash[:alert]).to include('Selected location is unavailable')
     end
   end
 
@@ -100,6 +174,18 @@ RSpec.describe 'Medication stock sources' do
       location: locations(:school),
       category: source_medication.category,
       dosage_amount: source_medication.dosage_amount,
+      dosage_unit: source_medication.dosage_unit,
+      current_supply: 7,
+      reorder_threshold: 1
+    )
+  end
+
+  def build_incompatible_medication
+    Medication.create!(
+      name: source_medication.name,
+      location: locations(:school),
+      category: source_medication.category,
+      dosage_amount: source_medication.dosage_amount + 100,
       dosage_unit: source_medication.dosage_unit,
       current_supply: 7,
       reorder_threshold: 1

--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -39,6 +39,45 @@ RSpec.describe 'Medication Timing Restrictions' do
         expect(response).to redirect_to(person_path(person))
         expect(flash[:notice]).to include('Medication taken')
       end
+
+      it 'records the submitted historical taken_at timestamp' do
+        submitted_time = Time.zone.local(2026, 4, 27, 8, 30)
+
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_schedule_path(person, schedule),
+                 params: { medication_take: { taken_at: submitted_time.strftime('%Y-%m-%dT%H:%M') } }
+          end.to change(MedicationTake, :count).by(1)
+        end
+
+        expect(MedicationTake.order(:id).last.taken_at).to be_within(1.second).of(submitted_time)
+      end
+    end
+
+    context 'when submitted taken_at is invalid' do
+      it 'does not create a medication take' do
+        expect do
+          post take_medication_person_schedule_path(person, schedule),
+               params: { medication_take: { taken_at: 'not-a-date' } }
+        end.not_to change(MedicationTake, :count)
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:alert]).to include('valid dose time')
+      end
+    end
+
+    context 'when submitted taken_at is in the future' do
+      it 'does not create a medication take' do
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_schedule_path(person, schedule),
+                 params: { medication_take: { taken_at: 1.minute.from_now.strftime('%Y-%m-%dT%H:%M') } }
+          end.not_to change(MedicationTake, :count)
+        end
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:alert]).to include('future')
+      end
     end
 
     context 'when max daily doses reached' do
@@ -111,6 +150,45 @@ RSpec.describe 'Medication Timing Restrictions' do
 
         expect(response).to redirect_to(person_path(person))
         expect(flash[:notice]).to include('Medication taken')
+      end
+
+      it 'records the submitted historical taken_at timestamp' do
+        submitted_time = Time.zone.local(2026, 4, 27, 9, 15)
+
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_person_medication_path(person, person_medication),
+                 params: { medication_take: { taken_at: submitted_time.strftime('%Y-%m-%dT%H:%M') } }
+          end.to change(MedicationTake, :count).by(1)
+        end
+
+        expect(MedicationTake.order(:id).last.taken_at).to be_within(1.second).of(submitted_time)
+      end
+    end
+
+    context 'when submitted taken_at is invalid' do
+      it 'does not create a medication take' do
+        expect do
+          post take_medication_person_person_medication_path(person, person_medication),
+               params: { medication_take: { taken_at: 'not-a-date' } }
+        end.not_to change(MedicationTake, :count)
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:alert]).to include('valid dose time')
+      end
+    end
+
+    context 'when submitted taken_at is in the future' do
+      it 'does not create a medication take' do
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_person_medication_path(person, person_medication),
+                 params: { medication_take: { taken_at: 1.minute.from_now.strftime('%Y-%m-%dT%H:%M') } }
+          end.not_to change(MedicationTake, :count)
+        end
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:alert]).to include('future')
       end
     end
 

--- a/spec/system/authorization/person_medications_authorization_spec.rb
+++ b/spec/system/authorization/person_medications_authorization_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Person Medications Authorization' do
       )
     end
 
-    it 'allows carers to take medication for assigned patients' do
+    it 'allows carers to take medication for assigned patients', :js do
       login_as(carer)
       visit person_path(assigned_patient)
 
@@ -134,6 +134,7 @@ RSpec.describe 'Person Medications Authorization' do
         expect(page).to have_button('💊 Give')
         click_button '💊 Give'
       end
+      confirm_record_dose(person_medication)
 
       expect(page).to have_content('Medication taken successfully')
     end
@@ -400,6 +401,14 @@ RSpec.describe 'Person Medications Authorization' do
       visit person_path(unrelated_person)
 
       expect(page).to have_content('You are not authorized to perform this action')
+    end
+  end
+
+  def confirm_record_dose(person_medication)
+    path = take_medication_person_person_medication_path(assigned_patient, person_medication)
+
+    within("form[action='#{path}']") do
+      click_button '💊 Give'
     end
   end
 end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Dashboard' do
            :carer_relationships, :person_medications, :medication_takes
 
   it 'loads the dashboard and allows taking a dose from the timeline' do
+    driven_by(:playwright)
+
     travel_to(Time.current.beginning_of_day + 9.hours) do
       sign_in(users(:jane))
       visit dashboard_path
@@ -21,6 +23,9 @@ RSpec.describe 'Dashboard' do
 
       expect do
         button.click
+        within(first("form[action*='take_medication']", visible: :all)) do
+          click_button I18n.t('person_medications.card.take')
+        end
         expect(page).to have_content('Medication taken successfully.', wait: 10)
       end.to change(MedicationTake, :count).by(1)
     end

--- a/spec/system/historical_dose_recording_spec.rb
+++ b/spec/system/historical_dose_recording_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Historical dose recording' do
+  fixtures :accounts, :people, :locations, :medications, :users, :dosages
+
+  let(:person) { people(:jane) }
+  let(:admin) { users(:admin) }
+  let(:medication) { medications(:ibuprofen) }
+
+  before do
+    sign_in(admin)
+  end
+
+  it 'records a historical dose from the take medication dialog' do
+    travel_to(Time.zone.local(2026, 4, 28, 14, 45)) do
+      schedule = build_schedule
+      build_alternate_medication
+      submitted_time = Time.zone.local(2026, 4, 27, 8, 30)
+
+      visit person_path(person)
+      find("[data-testid='take-schedule-#{schedule.id}']").click
+
+      expect(page).to have_content('Record dose')
+
+      field = find("input[name='medication_take[taken_at]']", visible: :all)
+      expect(field[:type]).to eq('datetime-local')
+      expect(field[:value]).to eq('2026-04-28T14:45')
+      expect(field[:max]).to eq('2026-04-28T14:45')
+
+      expect do
+        within("form[action='#{take_path(schedule)}']") do
+          fill_in 'Taken at', with: submitted_time.strftime('%Y-%m-%dT%H:%M')
+          click_button I18n.t('schedules.card.give')
+        end
+        expect(page).to have_content(I18n.t('schedules.medication_taken'), wait: 10)
+      end.to change(MedicationTake, :count).by(1)
+
+      expect(MedicationTake.order(:id).last.taken_at).to be_within(1.second).of(submitted_time)
+    end
+  end
+
+  def build_schedule
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      dosage: dosages(:ibuprofen_adult),
+      start_date: Time.zone.today,
+      end_date: Time.zone.today + 30.days
+    )
+  end
+
+  def build_alternate_medication
+    Medication.create!(
+      name: medication.name,
+      location: locations(:school),
+      category: medication.category,
+      dosage_amount: medication.dosage_amount,
+      dosage_unit: medication.dosage_unit,
+      current_supply: 7,
+      reorder_threshold: 1
+    )
+  end
+
+  def take_path(schedule)
+    take_medication_person_schedule_path(person, schedule)
+  end
+end

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -65,14 +65,23 @@ RSpec.describe 'Person medication workflow' do
       expect(page).to have_button('💊 Give')
       click_button '💊 Give'
     end
+    confirm_record_dose(created_person_medication)
 
     expect(page).to have_content('Medication taken successfully')
 
     within("#person_medication_#{created_person_medication.id}") do
       expect(page).to have_text(/today's doses/i)
       expect(page).to have_text(/2\.5 ml/i)
-      expect(page).to have_button('💊 Give', disabled: true)
+      expect(page).to have_button('💊 Give', disabled: false)
       expect(page).to have_content('1/1')
+    end
+  end
+
+  def confirm_record_dose(person_medication)
+    path = take_medication_person_person_medication_path(person, person_medication)
+
+    within("form[action='#{path}']") do
+      click_button '💊 Give'
     end
   end
 end


### PR DESCRIPTION
## Summary
- add RubyUI dose recording modal with taken-at override
- pass selected taken_at through take medication flows and timing checks
- reject invalid and future dose timestamps

Closes #1132
Refs #1030
Refs #1032
Refs #657
Refs #633
Refs #672

## Test plan
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
