### PR TITLE
fix: update metric icons

### DIFF
--- a/app/components/admin/dashboard/index_view.rb
+++ b/app/components/admin/dashboard/index_view.rb
@@ -65,7 +65,7 @@ module Components
               title: t('admin.dashboard.metrics.active_schedules'),
               value: metrics[:active_schedules] || 0,
               testid: 'metric-active-schedules',
-              icon_type: 'pill'
+              icon_type: 'active_schedules'
             )
             render_metric_card(
               title: t('admin.dashboard.metrics.no_carers'),

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -91,13 +91,13 @@ module Components
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.active_schedules'),
             value: active_schedules.size,
-            icon_type: 'pill',
+            icon_type: 'active_schedules',
             href: schedules_path
           )
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.compliance'),
             value: "#{compliance_percentage}%",
-            icon_type: 'check',
+            icon_type: 'compliance',
             href: reports_path
           )
           render Components::Shared::MetricCard.new(

--- a/app/components/icons/active_schedules.rb
+++ b/app/components/icons/active_schedules.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class ActiveSchedules < Base
+      def view_template
+        svg(**attrs) do |s|
+          s.path(d: 'M200-640h560v-80H200v80Zm0 0v-80 80Zm0 560q-33 0-56.5-23.5T120-160v-560q0-33 23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v227q-19-9-39-15t-41-9v-43H200v400h252q7 22 16.5 42T491-80H200Zm378.5-18.5Q520-157 520-240t58.5-141.5Q637-440 720-440t141.5 58.5Q920-323 920-240T861.5-98.5Q803-40 720-40T578.5-98.5ZM787-145l28-28-75-75v-112h-40v128l87 87Z')
+        end
+      end
+
+      private
+
+      def default_attrs
+        {
+          xmlns: 'http://www.w3.org/2000/svg',
+          width: size.to_s,
+          height: size.to_s,
+          viewBox: '0 -960 960 960',
+          fill: 'currentColor',
+          stroke: 'none'
+        }
+      end
+    end
+  end
+end

--- a/app/components/icons/compliance.rb
+++ b/app/components/icons/compliance.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class Compliance < Base
+      def view_template
+        svg(**attrs) do |s|
+          s.path(d: 'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 118-57 57-120-119q-18 11-38.5 16.5T480-320Z')
+        end
+      end
+
+      private
+
+      def default_attrs
+        {
+          xmlns: 'http://www.w3.org/2000/svg',
+          width: size.to_s,
+          height: size.to_s,
+          viewBox: '0 -960 960 960',
+          fill: 'currentColor',
+          stroke: 'none'
+        }
+      end
+    end
+  end
+end

--- a/app/components/shared/metric_card.rb
+++ b/app/components/shared/metric_card.rb
@@ -145,7 +145,9 @@ module Components
         case icon_type
         when 'users' then render Icons::Users.new(size: size)
         when 'pill' then render Icons::Pill.new(size: size)
+        when 'active_schedules' then render Icons::ActiveSchedules.new(size: size)
         when 'check' then render Icons::CheckCircle.new(size: size)
+        when 'compliance' then render Icons::Compliance.new(size: size)
         when 'clock' then render Icons::Clock.new(size: size)
         else render Icons::Activity.new(size: size)
         end
@@ -156,7 +158,7 @@ module Components
 
         case icon_type
         when 'users' then 'bg-primary/10'
-        when 'pill' then 'bg-success-container/50'
+        when 'pill', 'active_schedules' then 'bg-success-container/50'
         else 'bg-secondary-container'
         end
       end
@@ -166,8 +168,8 @@ module Components
 
         case icon_type
         when 'users' then 'text-primary'
-        when 'pill' then 'text-on-success-container'
-        when 'check' then 'text-on-secondary-container'
+        when 'pill', 'active_schedules' then 'text-on-success-container'
+        when 'check', 'compliance' then 'text-on-secondary-container'
         when 'clock' then 'text-on-warning-container'
         else 'text-foreground'
         end

--- a/spec/components/admin/dashboard/index_view_spec.rb
+++ b/spec/components/admin/dashboard/index_view_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Admin::Dashboard::IndexView, type: :component do
+  let(:active_schedules_icon_path) do
+    [
+      'M200-640h560v-80H200v80Zm0 0v-80 80Zm0 560q-33 0-56.5-23.5T120-160v-560q0-33 ',
+      '23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v227q-19-9-39-15t-41-9v-43H200v400h252q7 ',
+      '22 16.5 42T491-80H200Zm378.5-18.5Q520-157 520-240t58.5-141.5Q637-440 ',
+      '720-440t141.5 58.5Q920-323 920-240T861.5-98.5Q803-40 ',
+      '720-40T578.5-98.5ZM787-145l28-28-75-75v-112h-40v128l87 87Z'
+    ].join
+  end
+
+  it 'renders the active schedules metric with the active schedules icon' do
+    rendered = render_inline(
+      described_class.new(metrics: { active_schedules: 7 })
+    )
+    metric = rendered.at_css('[data-testid="metric-active-schedules"]')
+
+    expect(metric.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
+  end
+end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     described_class.new(presenter: presenter)
   end
 
+  let(:active_schedules_icon_path) do
+    [
+      'M200-640h560v-80H200v80Zm0 0v-80 80Zm0 560q-33 0-56.5-23.5T120-160v-560q0-33 ',
+      '23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v227q-19-9-39-15t-41-9v-43H200v400h252q7 ',
+      '22 16.5 42T491-80H200Zm378.5-18.5Q520-157 520-240t58.5-141.5Q637-440 ',
+      '720-440t141.5 58.5Q920-323 920-240T861.5-98.5Q803-40 ',
+      '720-40T578.5-98.5ZM787-145l28-28-75-75v-112h-40v128l87 87Z'
+    ].join
+  end
+
+  let(:compliance_icon_path) do
+    [
+      'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 ',
+      '90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 ',
+      '800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 ',
+      '840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 ',
+      '56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 ',
+      '56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 ',
+      '0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 ',
+      '118-57 57-120-119q-18 11-38.5 16.5T480-320Z'
+    ].join
+  end
+
   let(:admin_user) { users(:admin) }
   let(:presenter) { DashboardPresenter.new(current_user: admin_user) }
 
@@ -78,6 +101,20 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(dashboard_view)
 
       expect(rendered.css("a[href='/reports']")).to be_present
+    end
+
+    it 'renders the active schedules icon on the active schedules stat card' do
+      rendered = render_inline(dashboard_view)
+      card = rendered.at_css("a[href='/schedules']")
+
+      expect(card.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
+    end
+
+    it 'renders the compliance icon on the compliance stat card' do
+      rendered = render_inline(dashboard_view)
+      card = rendered.at_css("a[href='/reports']")
+
+      expect(card.at_css("path[d='#{compliance_icon_path}']")).to be_present
     end
   end
 

--- a/spec/components/shared/metric_card_spec.rb
+++ b/spec/components/shared/metric_card_spec.rb
@@ -3,6 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Components::Shared::MetricCard, type: :component do
+  let(:active_schedules_icon_path) do
+    [
+      'M200-640h560v-80H200v80Zm0 0v-80 80Zm0 560q-33 0-56.5-23.5T120-160v-560q0-33 ',
+      '23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v227q-19-9-39-15t-41-9v-43H200v400h252q7 ',
+      '22 16.5 42T491-80H200Zm378.5-18.5Q520-157 520-240t58.5-141.5Q637-440 ',
+      '720-440t141.5 58.5Q920-323 920-240T861.5-98.5Q803-40 ',
+      '720-40T578.5-98.5ZM787-145l28-28-75-75v-112h-40v128l87 87Z'
+    ].join
+  end
+
+  let(:compliance_icon_path) do
+    [
+      'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 ',
+      '90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 ',
+      '800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 ',
+      '840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 ',
+      '56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 ',
+      '56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 ',
+      '0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 ',
+      '118-57 57-120-119q-18 11-38.5 16.5T480-320Z'
+    ].join
+  end
+
   it 'renders a block link wrapper when href is provided' do
     rendered = render_inline(
       described_class.new(title: 'People', value: 5, icon_type: 'users', href: '/people')
@@ -70,5 +93,23 @@ RSpec.describe Components::Shared::MetricCard, type: :component do
     expect(html).to include('text-2xl')
     expect(html).not_to include('md:hover:scale-[1.02]')
     expect(card[:class]).not_to include('h-full')
+  end
+
+  it 'renders the active schedules icon path' do
+    rendered = render_inline(
+      described_class.new(title: 'Active Schedules', value: 10, icon_type: 'active_schedules')
+    )
+
+    expect(rendered.at_css('svg')['viewbox']).to eq('0 -960 960 960')
+    expect(rendered.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
+  end
+
+  it 'renders the compliance icon path' do
+    rendered = render_inline(
+      described_class.new(title: 'Compliance', value: '85%', icon_type: 'compliance')
+    )
+
+    expect(rendered.at_css('svg')['viewbox']).to eq('0 -960 960 960')
+    expect(rendered.at_css("path[d='#{compliance_icon_path}']")).to be_present
   end
 end


### PR DESCRIPTION
## Summary
- add dedicated Active Schedules and Compliance metric icons from the provided SVG paths
- apply them only to named dashboard/admin metric cards
- add component coverage for the new icon paths

## Verification
- task rubocop
- task test

Screenshot captured at tmp/screenshots/dashboard-metric-icons.png and will be attached in a PR comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
