### PR TITLE
refactor: split schedule card

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -50,7 +50,7 @@ Added focused component specs:
 - [Dose status component spec](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/spec/components/schedules/card/dose_status_component_spec.rb#L24)
 - [Actions component spec](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/spec/components/schedules/card/actions_component_spec.rb#L21)
 
-Existing `Components::Schedules::Card` specs still cover integration behavior, invalid dose disabling, i18n, memoization, and preloaded take histories.
+Existing `Components::Schedules::Card` specs still cover integration behavior, invalid dose disabling, cooldown disabling, i18n, memoization, and preloaded take histories.
 
 ## Tool Reports
 
@@ -65,8 +65,8 @@ SimpleCov is not configured in this repo (`rg 'SimpleCov|COVERAGE|simplecov'` fo
 ### Verification
 
 - `task rubocop`: passed with no offenses.
-- `task test TEST_FILE=spec/components/schedules`: passed, 17 examples.
-- `task test`: passed, 1997 examples, 0 failures, 2 expected pending.
+- `task test TEST_FILE=spec/components/schedules`: passed, 18 examples.
+- `task test`: passed, 1998 examples, 0 failures, 2 expected pending.
 
 ## Recommendations
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,365 +1,77 @@
-# Code Review - feature/passkey-webauthn-support
+# Code Review - codex/refactor-schedules-card-1038
 
 **Base Branch**: main
-**Changed Files**: 50 Ruby files
-**Review Date**: 2026-02-01
+**Changed Files**: 8 files
+**Review Date**: 2026-04-28
 
 ---
 
 ## Summary
 
-This branch implements WebAuthn/Passkey support for MedTracker, adding passwordless authentication as a second-factor option alongside TOTP. The implementation integrates with Rodauth's built-in WebAuthn features and includes comprehensive UI components using Phlex.
+Issue #1038 is implemented by turning the oversized schedule card into a thin container and three focused nested components:
 
-**Key Changes:**
-
-- New models: `AccountWebauthnKey`, `AccountWebauthnUserId`, `AccountOtpKey`, `AccountRecoveryCode`
-- New Phlex views for 2FA setup/auth flows
-- Profile page 2FA management card
-- Soft enforcement of 2FA for privileged roles (admin, doctor, nurse)
-- Database migrations for WebAuthn tables
-
----
+- [Card container](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card.rb#L17) now delegates rendering to `HeaderComponent`, `DoseStatusComponent`, and `ActionsComponent`.
+- [CardPresenter](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/presenters/schedules/card_presenter.rb#L14) owns schedule status, stock blocking, dose-count, and action-label decisions.
+- [ActionsComponent](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card/actions_component.rb#L17) isolates take/edit/delete actions.
+- [DoseStatusComponent](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card/dose_status_component.rb#L15) isolates date, notes, countdown, and take-history rendering.
+- [HeaderComponent](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card/header_component.rb#L14) isolates medication metadata and stock/status badges.
 
 ## Critical Issues
 
-### 1. Missing Foreign Key Constraint
-
-[WebAuthn migration lacks foreign key constraint](file:///Users/damacus/repos/damacus/med-tracker/db/migrate/20260126161624_create_rodauth_web_authn_tables.rb#L6)
-
-The `account_webauthn_keys` and `account_webauthn_user_ids` tables reference `account_id` but lack foreign key constraints:
-
-```ruby
-t.bigint :account_id, null: false  # No foreign key to accounts table
-```
-
-**Recommendation:** Add `add_foreign_key :account_webauthn_keys, :accounts` for referential integrity.
-
-### 2. Potential N+1 Query in Recovery Codes Check
-
-[Recovery codes count called multiple times](file:///Users/damacus/repos/damacus/med-tracker/app/views/profiles/two_factor_card.rb#L220)
-
-```ruby
-def recovery_codes_exist?
-  recovery_codes_count.positive?  # Calls count query
-end
-
-def recovery_codes_count
-  AccountRecoveryCode.where(id: account.id).count  # Another query
-end
-```
-
-`recovery_codes_count` is called from both `recovery_codes_exist?` and `render_recovery_codes_actions`. Consider memoization.
-
----
+No critical issues found.
 
 ## Design & Architecture
 
 ### OOP Violations
 
-#### Sandi Metz Rule #1: Classes > 100 lines
+No blocking SOLID violations found in the changed behavior. The main card dropped from 343 lines to [47 lines](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card.rb#L1), and the extracted components each have a single rendering responsibility.
 
-| File                                                                                                              | Lines | Rating |
-|-------------------------------------------------------------------------------------------------------------------|-------|--------|
-| [two_factor_card.rb](file:///Users/damacus/repos/damacus/med-tracker/app/views/profiles/two_factor_card.rb#L1)    | 238   | ⚠️     |
-| [otp_setup.rb](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/otp_setup.rb#L1)                 | 215   | ⚠️     |
-| [two_factor_manage.rb](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/two_factor_manage.rb#L1) | 199   | ⚠️     |
-
-**Note:** Phlex view components tend to be longer due to markup. Consider extracting reusable sub-components.
-
-#### Method Complexity (TooManyStatements)
-
-- [render_auth_method_card has 14 statements](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/two_factor_manage.rb#L116)
-- [render_setup_form has 9 statements](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/webauthn_setup.rb#L92)
-- [form_section has 8 statements](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/webauthn_auth.rb#L36)
-
-#### Uncommunicative Variable Names
-
-[Variable 's' used in SVG blocks](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/two_factor_manage.rb#L155)
-
-```ruby
-svg(...) do |s|
-  s.path(...)
-end
-```
-
-This is a common Phlex pattern for SVG builders, but consider renaming to `svg_builder` for clarity.
-
-### Code Duplication (DRY Violations)
-
-RubyCritic detected **significant duplication** across Rodauth views:
-
-#### Pattern 1: Header Section (7 files)
-
-Found in: `otp_auth.rb`, `otp_disable.rb`, `otp_setup.rb`, `two_factor_auth.rb`, `webauthn_auth.rb`, `webauthn_setup.rb`, `profiles/show.rb`
-
-```ruby
-def header_section
-  div(class: 'mx-auto max-w-xl text-center space-y-3') do
-    h1(class: 'text-3xl font-bold tracking-tight text-slate-800 sm:text-4xl') { ... }
-    p(class: 'text-lg text-slate-600') { ... }
-  end
-end
-```
-
-**Recommendation:** Extract to shared `Views::Rodauth::HeaderSection` component.
-
-#### Pattern 2: Decorative Glow (7 files)
-
-[Identical decorative_glow method](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/otp_auth.rb#L30)
-
-```ruby
-def decorative_glow
-  div(class: 'pointer-events-none absolute inset-x-0 top-24 flex justify-center opacity-60') do
-    div(class: 'h-64 w-64 rounded-full bg-sky-200 blur-3xl sm:h-80 sm:w-80')
-  end
-end
-```
-
-**Recommendation:** Extract to `Views::Shared::DecorativeGlow` or a concern.
-
-#### Pattern 3: Card Classes (7 files)
-
-```ruby
-def card_classes
-  'w-full backdrop-blur bg-white/90 shadow-2xl border border-white/70 ring-1 ring-black/5 rounded-2xl'
-end
-```
-
-**Recommendation:** Define as constant in `Views::Base` or extract to Tailwind component class.
-
-#### Pattern 4: Form Section Structure (4 files)
-
-[Duplicate form wrapper pattern](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/otp_auth.rb#L36)
-
-The card + header + content structure is repeated identically.
+The [presenter](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/presenters/schedules/card_presenter.rb#L51) deliberately centralizes memoized take-history and availability queries so the components do not duplicate conditional decisions.
 
 ### Rails Patterns
 
-#### ✅ Good: Model Validations
+The refactor follows existing repo patterns:
 
-[AccountWebauthnKey validations are comprehensive](file:///Users/damacus/repos/damacus/med-tracker/app/models/account_webauthn_key.rb#L6)
+- Reuses `app/presenters/schedules` beside existing schedule form presenters.
+- Keeps route and form rendering inside Phlex components.
+- Preserves preloaded `todays_takes` behavior via [resolved_todays_takes](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/presenters/schedules/card_presenter.rb#L51).
 
-```ruby
-validates :webauthn_id, presence: true, uniqueness: { scope: :account_id }
-validates :public_key, presence: true
-validates :sign_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
-validates :nickname, presence: true
-```
-
-#### ✅ Good: Proper Association Setup
-
-[Account associations properly configured](file:///Users/damacus/repos/damacus/med-tracker/app/models/account.rb#L8)
-
-```ruby
-has_many :account_webauthn_keys, dependent: :destroy
-has_many :account_webauthn_user_ids, dependent: :destroy
-```
-
-#### ⚠️ Consider: Table Existence Checks
-
-[Repeated table_exists? checks](file:///Users/damacus/repos/damacus/med-tracker/app/views/profiles/two_factor_card.rb#L213)
-
-```ruby
-def totp_enabled?
-  return false unless ActiveRecord::Base.connection.table_exists?('account_otp_keys')
-  AccountOtpKey.exists?(id: account.id)
-rescue StandardError
-  false
-end
-```
-
-These checks suggest the schema might not always be in a consistent state. Consider:
-1. Running migrations before deployment
-2. Using a feature flag instead of table existence checks
-
----
+No N+1 regression found; existing query-count spec still passes.
 
 ## Security Concerns
 
-### ✅ Positive Security Patterns
-
-1. **Password required for 2FA modifications**
-   [two_factor_modifications_require_password? true](file:///Users/damacus/repos/damacus/med-tracker/app/misc/rodauth_main.rb#L127)
-
-2. **Proper WebAuthn RP ID configuration**
-   [Dynamic RP ID based on environment](file:///Users/damacus/repos/damacus/med-tracker/app/misc/rodauth_main.rb#L112)
-
-3. **Session management configured**
-   [30-minute inactivity, 24-hour absolute timeout](file:///Users/damacus/repos/damacus/med-tracker/app/misc/rodauth_main.rb#L102)
-
-4. **Account lockout after failed attempts**
-   [5 failed logins, 30-minute lockout](file:///Users/damacus/repos/damacus/med-tracker/app/misc/rodauth_main.rb#L95)
-
-### ⚠️ Security Considerations
-
-#### 1. WebAuthn Origin Configuration
-
-[Origin uses ENV fallback to request.base_url](file:///Users/damacus/repos/damacus/med-tracker/app/misc/rodauth_main.rb#L120)
-
-```ruby
-webauthn_origin { ENV.fetch('APP_URL', request.base_url) }
-```
-
-Ensure `APP_URL` is always set in production to prevent origin mismatch attacks.
-
-#### 2. Passkey Removal Without Confirmation
-
-[Remove button triggers POST without re-authentication](file:///Users/damacus/repos/damacus/med-tracker/app/views/profiles/two_factor_card.rb#L157)
-
-```ruby
-button_to(
-  'Remove',
-  "/webauthn-remove?id=#{passkey.id}",
-  method: :post,
-  data: { turbo_confirm: 'Are you sure...' }
-)
-```
-
-Consider requiring password re-entry for passkey removal (critical security action).
-
-#### 3. CSRF Token Handling
-
-[All forms properly include authenticity tokens](file:///Users/damacus/repos/damacus/med-tracker/app/views/rodauth/webauthn_setup.rb#L112) ✅
-
----
+No new security concerns found. The delete form path remains scoped by person and schedule at [actions_component.rb#L90](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card/actions_component.rb#L90), and admin-only edit/delete rendering remains guarded at [actions_component.rb#L64](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/app/components/schedules/card/actions_component.rb#L64).
 
 ## Test Coverage
 
-### ✅ Good Test Coverage
+Added focused component specs:
 
-- [Passkey configuration tests](file:///Users/damacus/repos/damacus/med-tracker/spec/features/authentication/passkey_spec.rb#L1) - Database schema verification
-- [Passkey registration tests](file:///Users/damacus/repos/damacus/med-tracker/spec/features/authentication/passkey_registration_spec.rb#L1) - UI flow testing
-- [Two-factor management tests](file:///Users/damacus/repos/damacus/med-tracker/spec/features/profiles/two_factor_management_spec.rb#L1) - Comprehensive 266-line spec
-- [Soft enforcement tests](file:///Users/damacus/repos/damacus/med-tracker/spec/system/two_factor_soft_enforcement_spec.rb#L1) - Role-based 2FA prompting
+- [Header component spec](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/spec/components/schedules/card/header_component_spec.rb#L21)
+- [Dose status component spec](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/spec/components/schedules/card/dose_status_component_spec.rb#L24)
+- [Actions component spec](file:///Users/damacus/.codex/worktrees/3d0a/med-tracker/spec/components/schedules/card/actions_component_spec.rb#L21)
 
-### ⚠️ Missing Test Scenarios
-
-1. **WebAuthn authentication flow** - No end-to-end test for authenticating with a passkey (complex due to WebAuthn API mocking)
-1. **Edge case: Multiple passkeys** - Tests only cover 0-1 passkeys
-1. **Error handling** - Missing tests for WebAuthn failure scenarios
-1. **Recovery code regeneration** - No test for the regenerate button functionality
-
----
+Existing `Components::Schedules::Card` specs still cover integration behavior, invalid dose disabling, i18n, memoization, and preloaded take histories.
 
 ## Tool Reports
 
 ### RubyCritic Summary
 
-- **Overall Score**: 43.17 (out of 100)
-- **Files with F Rating**: 8 files
-- **Primary Issues**: Code duplication, method complexity
-- **Code Smells**: 50+ detected
-
-### Files Requiring Attention
-
-| File                   | Rating | Main Issues                      |
-|------------------------|--------|----------------------------------|
-| `two_factor_manage.rb` | F      | Duplication, TooManyStatements   |
-| `webauthn_auth.rb`     | F      | Duplication, IrresponsibleModule |
-| `webauthn_setup.rb`    | F      | Duplication, TooManyStatements   |
-| `otp_setup.rb`         | F      | Duplication, complexity          |
-| `otp_auth.rb`          | F      | Duplication                      |
-| `two_factor_card.rb`   | D      | ClassLength, complexity          |
+RubyCritic is not installed or configured in this repo environment (`which rubycritic` returned no executable), so no RubyCritic metrics were available.
 
 ### SimpleCov Summary
 
-*Unable to run - Docker not available. Run `task test` to generate coverage report.*
+SimpleCov is not configured in this repo (`rg 'SimpleCov|COVERAGE|simplecov'` found no matches), and the full suite did not create a `coverage/` directory. No coverage percentage is available.
 
----
+### Verification
+
+- `task rubocop`: passed with no offenses.
+- `task test TEST_FILE=spec/components/schedules`: passed, 17 examples.
+- `task test`: passed, 1997 examples, 0 failures, 2 expected pending.
 
 ## Recommendations
 
-### High Priority
-
-1. **Extract shared Rodauth view components**
-   - Create `Views::Rodauth::Base` with common methods
-   - Extract `HeaderSection`, `DecorativeGlow`, `CardWrapper` components
-   - Define shared CSS class constants
-
-2. **Add foreign key constraints** to WebAuthn tables in a follow-up migration
-
-3. **Memoize database queries** in `TwoFactorCard`:
-
-   ```ruby
-   def recovery_codes_count
-     @recovery_codes_count ||= AccountRecoveryCode.where(id: account.id).count
-   end
-   ```
-
-### Medium Priority
-
-1. **Improve variable naming** - Use `svg_builder` instead of `s` in SVG blocks
-
-2. **Add WebAuthn error handling tests** once a WebAuthn mocking strategy is established
-
-3. **Consider re-authentication for passkey removal** as an additional security measure
-
-### Low Priority
-
-1. **Remove table existence checks** if schema is guaranteed stable
-
-2. **Add module documentation** to satisfy IrresponsibleModule warnings
-
----
+No required follow-up for issue #1038. A later cleanup could introduce a shared take-history renderer for schedule and person-medication cards, but that is outside this issue and the current code follows the established component style.
 
 ## Positive Observations
 
-1. **Clean Rodauth integration** - Uses Rodauth's built-in WebAuthn support rather than custom implementation
-2. **Consistent UI patterns** - All 2FA views follow the same visual structure
-3. **Good separation of concerns** - Models are thin, views handle presentation
-4. **Comprehensive Phlex components** - RubyUI integration is well done
-5. **Thoughtful security defaults** - Password required for 2FA changes, proper session timeouts
-6. **Soft enforcement approach** - 2FA encouraged but not blocking for privileged users
-7. **Good test coverage** - 266-line spec for 2FA management with multiple scenarios
-8. **Proper migration structure** - Incremental migrations with proper defaults
-
----
-
-## Files Changed
-
-### Models (5)
-
-- `app/models/account.rb`
-- `app/models/account_otp_key.rb`
-- `app/models/account_recovery_code.rb`
-- `app/models/account_webauthn_key.rb`
-- `app/models/account_webauthn_user_id.rb`
-
-### Views (10)
-
-- `app/views/profiles/show.rb`
-- `app/views/profiles/two_factor_card.rb`
-- `app/views/rodauth/otp_auth.rb`
-- `app/views/rodauth/otp_disable.rb`
-- `app/views/rodauth/otp_setup.rb`
-- `app/views/rodauth/two_factor_auth.rb`
-- `app/views/rodauth/two_factor_manage.rb`
-- `app/views/rodauth/webauthn_auth.rb`
-- `app/views/rodauth/webauthn_setup.rb`
-
-### Components (4)
-
-- `app/components/icons/key.rb`
-- `app/components/icons/x_circle.rb`
-- `app/components/layouts/flash.rb`
-- `app/components/ruby_ui/alert/alert.rb`
-
-### Controllers/Concerns (1)
-
-- `app/controllers/concerns/authentication.rb`
-
-### Configuration (2)
-
-- `app/misc/rodauth_main.rb`
-- `config/routes.rb`
-
-### Migrations (4)
-
-- `db/migrate/20251103230827_simplify_person_types.rb`
-- `db/migrate/20260126161624_create_rodauth_web_authn_tables.rb`
-- `db/migrate/20260126162420_add_unique_index_to_account_webauthn_keys.rb`
-- `db/migrate/20260127134200_add_defaults_to_account_webauthn_keys_timestamps.rb`
-
-### Specs (16)
-
-- Various feature, system, and component specs
+The refactor keeps the external `Components::Schedules::Card` interface stable while making each subcomponent directly testable. The presenter preserves existing memoization for stock and timing checks, which keeps the previous query-count behavior intact.

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -4,9 +4,6 @@ module Components
   module Schedules
     # Renders a schedule card with medication details and take medication form
     class Card < Components::Base
-      include Phlex::Rails::Helpers::FormWith
-      include Phlex::Rails::Helpers::ButtonTo
-
       attr_reader :schedule, :person, :todays_takes, :current_user
 
       def initialize(schedule:, person:, todays_takes: nil, current_user: nil)
@@ -20,345 +17,30 @@ module Components
       def view_template
         render M3::Card.new(
           id: "schedule_#{schedule.id}",
-          class: "h-full flex flex-col border-none border-t-4 #{status_top_border_class} " \
+          class: "h-full flex flex-col border-none border-t-4 #{presenter.status_top_border_class} " \
                  'shadow-[0_15px_40px_rgba(0,0,0,0.08)] bg-card rounded-[2rem] transition-all ' \
                  'duration-300 hover:scale-[1.02] hover:shadow-2xl group overflow-hidden'
         ) do
-          render_card_header
-          render_card_content
-          render_card_footer
+          render HeaderComponent.new(schedule: schedule, presenter: presenter)
+          render DoseStatusComponent.new(schedule: schedule, presenter: presenter)
+          render ActionsComponent.new(
+            schedule: schedule,
+            person: person,
+            presenter: presenter,
+            current_user: current_user
+          )
         end
       end
 
       private
 
-      def status_top_border_class
-        if out_of_stock?
-          'border-t-rose-500'
-        elsif !can_take_now?
-          'border-t-amber-500'
-        else
-          'border-t-primary'
-        end
-      end
-
-      def render_card_header
-        CardHeader(class: 'pb-4 pt-8 px-8') do
-          div(class: 'flex justify-between items-start mb-4') do
-            render_medication_icon
-            div(class: 'flex flex-col items-end gap-2 shrink-0') do
-              render Components::Shared::StockBadge.new(medication: schedule.medication)
-              status_badge
-            end
-          end
-          div(class: 'min-w-0') do
-            m3_heading(
-              variant: :title_large,
-              level: 3,
-              class: 'font-black tracking-tight mb-1 text-foreground break-words leading-tight'
-            ) do
-              schedule.medication.name
-            end
-            dosage_text = "#{schedule.dose_amount.to_i}#{schedule.dose_unit}"
-            m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
-              "#{dosage_text} • #{schedule.frequency}"
-            end
-          end
-        end
-      end
-
-      def status_badge
-        return if out_of_stock?
-
-        if can_take_now?
-          m3_badge(variant: :tonal, class: 'px-3 py-1 text-[10px] font-black uppercase tracking-wider') do
-            t('schedules.card.ready_now')
-          end
-        else
-          m3_badge(variant: :outlined, class: 'px-3 py-1 text-[10px] font-black uppercase tracking-wider') do
-            t('schedules.card.waiting')
-          end
-        end
-      end
-
-      def render_card_content
-        CardContent(class: 'flex-grow space-y-6 px-8') do
-          div(class: 'pt-4 border-t border-border space-y-4') do
-            render_date_details
-            render_notes if schedule.notes.present?
-            render_countdown_notice if !can_take_now? && schedule.countdown_display
-            render_takes_section
-          end
-        end
-      end
-
-      def render_card_footer
-        CardFooter(class: 'px-8 pb-8 pt-2') do
-          render_schedule_actions
-        end
-      end
-
-      def render_medication_icon
-        div(
-          class: 'w-12 h-12 rounded-2xl bg-secondary-container flex items-center ' \
-                 'justify-center text-on-surface-variant ' \
-                 'group-hover:text-primary group-hover:bg-primary/5 transition-all'
-        ) do
-          render Icons::Pill.new(size: 24)
-        end
-      end
-
-      def render_date_details
-        div(class: 'flex items-center gap-6') do
-          div do
-            m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
-              t('schedules.card.started')
-            end
-            m3_text(variant: :body_medium, class: 'text-on-surface-variant font-bold') do
-              schedule.start_date.strftime('%b %d, %Y')
-            end
-          end
-
-          if schedule.end_date
-            div do
-              m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
-                t('schedules.card.ends')
-              end
-              m3_text(variant: :body_medium, class: 'text-on-surface-variant font-bold') do
-                schedule.end_date.strftime('%b %d, %Y')
-              end
-            end
-          end
-        end
-      end
-
-      def render_notes
-        div(class: 'p-4 bg-primary-container/40 border border-primary/20 rounded-2xl') do
-          div(class: 'flex items-center gap-2 mb-1') do
-            render Icons::AlertCircle.new(size: 14, class: 'text-on-primary-container')
-            m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-primary-container font-black') do
-              t('schedules.card.notes')
-            end
-          end
-          m3_text(variant: :body_medium, class: 'text-on-primary-container leading-relaxed font-medium') do
-            schedule.notes
-          end
-        end
-      end
-
-      def render_countdown_notice
-        div(class: 'p-4 bg-error-container/20 border border-error/20 rounded-2xl') do
-          div(class: 'flex items-center gap-2 mb-1') do
-            render Icons::AlertCircle.new(size: 14, class: 'text-on-error-container')
-            m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-error-container font-black') do
-              t('schedules.card.next_dose_available')
-            end
-          end
-          m3_text(variant: :body_medium, class: 'text-on-error-container font-bold') do
-            schedule.countdown_display
-          end
-        end
-      end
-
-      def render_takes_section
-        div(class: 'space-y-4 pt-2') do
-          div(class: 'flex items-center justify-between') do
-            m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
-              t('schedules.card.todays_doses')
-            end
-            if schedule.max_daily_doses.present?
-              m3_badge(variant: :outlined, class: 'px-2 py-0.5 text-[10px] font-black') do
-                "#{todays_takes_count}/#{schedule.max_daily_doses}"
-              end
-            end
-          end
-          render_todays_takes
-        end
-      end
-
-      def render_todays_takes
-        takes = resolved_todays_takes
-
-        if takes.any?
-          div(class: 'grid grid-cols-1 gap-2') do
-            takes.each do |take|
-              render_take_item(take)
-            end
-          end
-        else
-          m3_text(variant: :body_medium, class: 'italic text-on-surface-variant px-1 font-medium') do
-            t('schedules.card.no_doses_today')
-          end
-        end
-      end
-
-      def fetch_todays_takes
-        if schedule.medication_takes.loaded?
-          schedule.medication_takes
-                  .select { |t| t.taken_at >= Time.current.beginning_of_day }
-                  .sort_by(&:taken_at)
-                  .reverse
-        else
-          schedule.medication_takes
-                  .where(taken_at: Time.current.beginning_of_day..)
-                  .order(taken_at: :desc)
-        end
-      end
-
-      # Cache these per-render so the card doesn't rescan or requery the same data
-      # for the status badge, disabled button, dose count badge, and take history.
-      def out_of_stock?
-        blocked_reason == :out_of_stock
-      end
-
-      def can_take_now?
-        return @can_take_now if instance_variable_defined?(:@can_take_now)
-
-        @can_take_now = schedule.can_take_now?
-      end
-
-      def can_administer?
-        blocked_reason.nil?
-      end
-
-      def blocked_reason
-        return @blocked_reason if instance_variable_defined?(:@blocked_reason)
-
-        @blocked_reason = stock_source_resolver.blocked_reason
-      end
-
-      def resolved_todays_takes
-        return @resolved_todays_takes if instance_variable_defined?(:@resolved_todays_takes)
-
-        @resolved_todays_takes = (todays_takes || fetch_todays_takes).to_a
-      end
-
-      def todays_takes_count
-        @todays_takes_count ||= resolved_todays_takes.size
-      end
-
-      def render_take_item(take)
-        div(
-          class: 'flex items-center justify-between p-3 rounded-xl ' \
-                 'bg-surface-container-low group/item transition-colors ' \
-                 'hover:bg-surface-container-high'
-        ) do
-          div(class: 'flex items-center gap-3') do
-            render Icons::CheckCircle.new(size: 16, class: 'text-primary')
-            div(class: 'space-y-1') do
-              m3_text(variant: :body_medium, class: 'text-foreground font-bold') do
-                take.taken_at.strftime('%l:%M %p').strip
-              end
-              if take.inventory_location.present?
-                m3_text(variant: :label_small, class: 'text-on-surface-variant font-medium') do
-                  take.inventory_location.name
-                end
-              end
-            end
-          end
-          m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
-            "#{take.amount_ml.to_i}#{schedule.dose_unit}"
-          end
-        end
-      end
-
-      def render_take_medication_button
-        label = if invalid_dose_configured?
-                  t('schedules.card.invalid_dose')
-                else
-                  blocked_reason == :out_of_stock ? t('schedules.card.out_of_stock') : take_label('schedules')
-                end
-        render Components::Medications::TakeAction.new(
-          source: schedule,
-          context: { person: person, current_user: current_user },
-          amount: schedule.dose_amount,
-          button: {
-            label: take_label('schedules'),
-            variant: :filled,
-            size: :lg,
-            class: 'w-full rounded-xl py-6 font-bold shadow-lg shadow-primary/20 hover:shadow-xl ' \
-                   'hover:shadow-primary/30 transition-all',
-            testid: "take-schedule-#{schedule.id}",
-            form_class: 'flex-1'
-          },
-          state: {
-            disabled: invalid_dose_configured? || out_of_stock?,
-            label: label
-          }
+      def presenter
+        @presenter ||= ::Schedules::CardPresenter.new(
+          schedule: schedule,
+          todays_takes: todays_takes,
+          current_user: current_user,
+          person: person
         )
-      end
-
-      def own_dose?
-        return true if current_user.nil?
-
-        current_user.person == person
-      end
-
-      def take_label(scope)
-        own_dose? ? t("#{scope}.card.take") : t("#{scope}.card.give")
-      end
-
-      def invalid_dose_configured?
-        schedule.dose_amount.to_f <= 0
-      end
-
-      def stock_source_resolver
-        @stock_source_resolver ||= MedicationStockSourceResolver.new(user: current_user, source: schedule)
-      end
-
-      def render_schedule_actions
-        div(class: 'flex items-center gap-2 w-full') do
-          render_take_medication_button
-
-          if view_context.current_user&.administrator?
-            m3_link(
-              href: edit_person_schedule_path(person, schedule),
-              variant: :outlined,
-              size: :lg,
-              class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
-                     'hover:text-primary hover:border-primary/50 transition-all',
-              data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" }
-            ) do
-              span(class: 'sr-only') { t('schedules.card.edit', default: 'Edit schedule') }
-              render Icons::Pencil.new(size: 20)
-            end
-            render_delete_dialog
-          end
-        end
-      end
-
-      def render_delete_dialog
-        AlertDialog do
-          AlertDialogTrigger do
-            m3_button(variant: :text,
-                      class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
-                             'hover:text-error hover:bg-error/5 transition-all',
-                      data: { testid: "delete-schedule-#{schedule.id}" }) do
-              span(class: 'sr-only') { t('schedules.card.delete', default: 'Delete schedule') }
-              render Icons::Trash.new(size: 20)
-            end
-          end
-          AlertDialogContent(class: 'rounded-[2rem] border-none shadow-elevation-5 bg-surface-container-high') do
-            AlertDialogHeader do
-              AlertDialogTitle { t('schedules.card.delete_dialog.title') }
-              AlertDialogDescription do
-                plain t('schedules.card.delete_dialog.confirm', medication: schedule.medication.name)
-              end
-            end
-            AlertDialogFooter do
-              AlertDialogCancel(class: 'rounded-xl') { t('schedules.card.delete_dialog.cancel') }
-              form_with(
-                url: person_schedule_path(person, schedule),
-                method: :delete,
-                class: 'inline'
-              ) do
-                m3_button(variant: :destructive, type: :submit, class: 'rounded-xl shadow-lg shadow-error/20') do
-                  t('schedules.card.delete_dialog.submit')
-                end
-              end
-            end
-          end
-        end
       end
     end
   end

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Components
+  module Schedules
+    class Card
+      class ActionsComponent < Components::Base
+        attr_reader :schedule, :person, :presenter, :current_user
+
+        def initialize(schedule:, person:, presenter:, current_user:)
+          @schedule = schedule
+          @person = person
+          @presenter = presenter
+          @current_user = current_user
+          super()
+        end
+
+        def view_template
+          CardFooter(class: 'px-8 pb-8 pt-2') do
+            div(class: 'flex items-center gap-2 w-full') do
+              render_take_medication_button
+              render_admin_actions if administrator?
+            end
+          end
+        end
+
+        private
+
+        def render_take_medication_button
+          render Components::Medications::TakeAction.new(
+            source: schedule,
+            context: { person: person, current_user: current_user },
+            amount: schedule.dose_amount,
+            button: {
+              label: presenter.take_label,
+              variant: :filled,
+              size: :lg,
+              class: 'w-full rounded-xl py-6 font-bold shadow-lg shadow-primary/20 hover:shadow-xl ' \
+                     'hover:shadow-primary/30 transition-all',
+              testid: "take-schedule-#{schedule.id}",
+              form_class: 'flex-1'
+            },
+            state: {
+              disabled: presenter.take_disabled?,
+              label: presenter.take_state_label
+            }
+          )
+        end
+
+        def render_admin_actions
+          m3_link(
+            href: edit_person_schedule_path(person, schedule),
+            variant: :outlined,
+            size: :lg,
+            class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
+                   'hover:text-primary hover:border-primary/50 transition-all',
+            data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" }
+          ) do
+            span(class: 'sr-only') { t('schedules.card.edit', default: 'Edit schedule') }
+            render Icons::Pencil.new(size: 20)
+          end
+          render_delete_dialog
+        end
+
+        def administrator?
+          admin_candidate = current_user
+          admin_candidate ||= view_context.current_user if view_context.respond_to?(:current_user)
+          admin_candidate&.administrator?
+        end
+
+        def render_delete_dialog
+          AlertDialog do
+            AlertDialogTrigger do
+              m3_button(variant: :text,
+                        class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
+                               'hover:text-error hover:bg-error/5 transition-all',
+                        data: { testid: "delete-schedule-#{schedule.id}" }) do
+                span(class: 'sr-only') { t('schedules.card.delete', default: 'Delete schedule') }
+                render Icons::Trash.new(size: 20)
+              end
+            end
+            AlertDialogContent(class: 'rounded-[2rem] border-none shadow-elevation-5 bg-surface-container-high') do
+              AlertDialogHeader do
+                AlertDialogTitle { t('schedules.card.delete_dialog.title') }
+                AlertDialogDescription do
+                  plain t('schedules.card.delete_dialog.confirm', medication: schedule.medication.name)
+                end
+              end
+              AlertDialogFooter do
+                AlertDialogCancel(class: 'rounded-xl') { t('schedules.card.delete_dialog.cancel') }
+                form_with(
+                  url: person_schedule_path(person, schedule),
+                  method: :delete,
+                  class: 'inline'
+                ) do
+                  m3_button(variant: :destructive, type: :submit, class: 'rounded-xl shadow-lg shadow-error/20') do
+                    t('schedules.card.delete_dialog.submit')
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/schedules/card/dose_status_component.rb
+++ b/app/components/schedules/card/dose_status_component.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Components
+  module Schedules
+    class Card
+      class DoseStatusComponent < Components::Base
+        attr_reader :schedule, :presenter
+
+        def initialize(schedule:, presenter:)
+          @schedule = schedule
+          @presenter = presenter
+          super()
+        end
+
+        def view_template
+          CardContent(class: 'flex-grow space-y-6 px-8') do
+            div(class: 'pt-4 border-t border-border space-y-4') do
+              render_date_details
+              render_notes if schedule.notes.present?
+              render_countdown_notice if presenter.countdown_notice?
+              render_takes_section
+            end
+          end
+        end
+
+        private
+
+        def render_date_details
+          div(class: 'flex items-center gap-6') do
+            div do
+              m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
+                t('schedules.card.started')
+              end
+              m3_text(variant: :body_medium, class: 'text-on-surface-variant font-bold') do
+                schedule.start_date.strftime('%b %d, %Y')
+              end
+            end
+
+            if schedule.end_date
+              div do
+                m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
+                  t('schedules.card.ends')
+                end
+                m3_text(variant: :body_medium, class: 'text-on-surface-variant font-bold') do
+                  schedule.end_date.strftime('%b %d, %Y')
+                end
+              end
+            end
+          end
+        end
+
+        def render_notes
+          div(class: 'p-4 bg-primary-container/40 border border-primary/20 rounded-2xl') do
+            div(class: 'flex items-center gap-2 mb-1') do
+              render Icons::AlertCircle.new(size: 14, class: 'text-on-primary-container')
+              m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-primary-container font-black') do
+                t('schedules.card.notes')
+              end
+            end
+            m3_text(variant: :body_medium, class: 'text-on-primary-container leading-relaxed font-medium') do
+              schedule.notes
+            end
+          end
+        end
+
+        def render_countdown_notice
+          div(class: 'p-4 bg-error-container/20 border border-error/20 rounded-2xl') do
+            div(class: 'flex items-center gap-2 mb-1') do
+              render Icons::AlertCircle.new(size: 14, class: 'text-on-error-container')
+              m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-error-container font-black') do
+                t('schedules.card.next_dose_available')
+              end
+            end
+            m3_text(variant: :body_medium, class: 'text-on-error-container font-bold') do
+              schedule.countdown_display
+            end
+          end
+        end
+
+        def render_takes_section
+          div(class: 'space-y-4 pt-2') do
+            div(class: 'flex items-center justify-between') do
+              m3_text(variant: :label_small, class: 'uppercase tracking-widest text-on-surface-variant font-black') do
+                t('schedules.card.todays_doses')
+              end
+              if presenter.dose_count_badge?
+                m3_badge(variant: :outlined, class: 'px-2 py-0.5 text-[10px] font-black') do
+                  plain presenter.dose_count_label
+                end
+              end
+            end
+            render_todays_takes
+          end
+        end
+
+        def render_todays_takes
+          takes = presenter.resolved_todays_takes
+
+          if takes.any?
+            div(class: 'grid grid-cols-1 gap-2') do
+              takes.each do |take|
+                render_take_item(take)
+              end
+            end
+          else
+            m3_text(variant: :body_medium, class: 'italic text-on-surface-variant px-1 font-medium') do
+              t('schedules.card.no_doses_today')
+            end
+          end
+        end
+
+        def render_take_item(take)
+          div(
+            class: 'flex items-center justify-between p-3 rounded-xl ' \
+                   'bg-surface-container-low group/item transition-colors ' \
+                   'hover:bg-surface-container-high'
+          ) do
+            div(class: 'flex items-center gap-3') do
+              render Icons::CheckCircle.new(size: 16, class: 'text-primary')
+              div(class: 'space-y-1') do
+                m3_text(variant: :body_medium, class: 'text-foreground font-bold') do
+                  take.taken_at.strftime('%l:%M %p').strip
+                end
+                if take.inventory_location.present?
+                  m3_text(variant: :label_small, class: 'text-on-surface-variant font-medium') do
+                    take.inventory_location.name
+                  end
+                end
+              end
+            end
+            m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
+              "#{take.amount_ml.to_i}#{schedule.dose_unit}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/schedules/card/header_component.rb
+++ b/app/components/schedules/card/header_component.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Components
+  module Schedules
+    class Card
+      class HeaderComponent < Components::Base
+        attr_reader :schedule, :presenter
+
+        def initialize(schedule:, presenter:)
+          @schedule = schedule
+          @presenter = presenter
+          super()
+        end
+
+        def view_template
+          CardHeader(class: 'pb-4 pt-8 px-8') do
+            div(class: 'flex justify-between items-start mb-4') do
+              render_medication_icon
+              div(class: 'flex flex-col items-end gap-2 shrink-0') do
+                render Components::Shared::StockBadge.new(medication: schedule.medication)
+                status_badge
+              end
+            end
+            div(class: 'min-w-0') do
+              m3_heading(
+                variant: :title_large,
+                level: 3,
+                class: 'font-black tracking-tight mb-1 text-foreground break-words leading-tight'
+              ) do
+                schedule.medication.name
+              end
+              m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
+                presenter.dose_description
+              end
+            end
+          end
+        end
+
+        private
+
+        def render_medication_icon
+          div(
+            class: 'w-12 h-12 rounded-2xl bg-secondary-container flex items-center ' \
+                   'justify-center text-on-surface-variant ' \
+                   'group-hover:text-primary group-hover:bg-primary/5 transition-all'
+          ) do
+            render Icons::Pill.new(size: 24)
+          end
+        end
+
+        def status_badge
+          return unless presenter.status_badge?
+
+          m3_badge(
+            variant: presenter.status_badge_variant,
+            class: 'px-3 py-1 text-[10px] font-black uppercase tracking-wider'
+          ) do
+            plain presenter.status_badge_label
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/schedules/card_presenter.rb
+++ b/app/presenters/schedules/card_presenter.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Schedules
+  class CardPresenter
+    attr_reader :schedule, :todays_takes, :current_user, :person
+
+    def initialize(schedule:, todays_takes:, current_user:, person:)
+      @schedule = schedule
+      @todays_takes = todays_takes
+      @current_user = current_user
+      @person = person
+    end
+
+    def status_top_border_class
+      return 'border-t-rose-500' if out_of_stock?
+      return 'border-t-amber-500' unless can_take_now?
+
+      'border-t-primary'
+    end
+
+    def status_badge?
+      !out_of_stock?
+    end
+
+    def status_badge_variant
+      can_take_now? ? :tonal : :outlined
+    end
+
+    def status_badge_label
+      return I18n.t('schedules.card.ready_now') if can_take_now?
+
+      I18n.t('schedules.card.waiting')
+    end
+
+    def dose_description
+      "#{dose_text} • #{schedule.frequency}"
+    end
+
+    def countdown_notice?
+      !can_take_now? && schedule.countdown_display
+    end
+
+    def dose_count_badge?
+      schedule.max_daily_doses.present?
+    end
+
+    def dose_count_label
+      "#{todays_takes_count}/#{schedule.max_daily_doses}"
+    end
+
+    def resolved_todays_takes
+      return @resolved_todays_takes if instance_variable_defined?(:@resolved_todays_takes)
+
+      @resolved_todays_takes = (todays_takes || fetch_todays_takes).to_a
+    end
+
+    def todays_takes_count
+      @todays_takes_count ||= resolved_todays_takes.size
+    end
+
+    def out_of_stock?
+      blocked_reason == :out_of_stock
+    end
+
+    def can_take_now?
+      return @can_take_now if instance_variable_defined?(:@can_take_now)
+
+      @can_take_now = schedule.can_take_now?
+    end
+
+    def take_disabled?
+      invalid_dose_configured? || out_of_stock?
+    end
+
+    def take_label
+      own_dose? ? I18n.t('schedules.card.take') : I18n.t('schedules.card.give')
+    end
+
+    def take_state_label
+      return I18n.t('schedules.card.invalid_dose') if invalid_dose_configured?
+      return I18n.t('schedules.card.out_of_stock') if out_of_stock?
+
+      take_label
+    end
+
+    private
+
+    def dose_text
+      "#{schedule.dose_amount.to_i}#{schedule.dose_unit}"
+    end
+
+    def fetch_todays_takes
+      return loaded_todays_takes if schedule.medication_takes.loaded?
+
+      queried_todays_takes
+    end
+
+    def loaded_todays_takes
+      schedule.medication_takes
+              .select { |take| take.taken_at >= Time.current.beginning_of_day }
+              .sort_by(&:taken_at)
+              .reverse
+    end
+
+    def queried_todays_takes
+      schedule.medication_takes
+              .where(taken_at: Time.current.beginning_of_day..)
+              .order(taken_at: :desc)
+    end
+
+    def blocked_reason
+      return @blocked_reason if instance_variable_defined?(:@blocked_reason)
+
+      @blocked_reason = stock_source_resolver.blocked_reason
+    end
+
+    def invalid_dose_configured?
+      schedule.dose_amount.to_f <= 0
+    end
+
+    def own_dose?
+      return true if current_user.nil?
+
+      current_user.person == person
+    end
+
+    def stock_source_resolver
+      @stock_source_resolver ||= MedicationStockSourceResolver.new(user: current_user, source: schedule)
+    end
+  end
+end

--- a/app/presenters/schedules/card_presenter.rb
+++ b/app/presenters/schedules/card_presenter.rb
@@ -69,7 +69,11 @@ module Schedules
     end
 
     def take_disabled?
-      invalid_dose_configured? || out_of_stock?
+      invalid_dose_configured? || !can_administer?
+    end
+
+    def can_administer?
+      blocked_reason.nil?
     end
 
     def take_label
@@ -79,6 +83,7 @@ module Schedules
     def take_state_label
       return I18n.t('schedules.card.invalid_dose') if invalid_dose_configured?
       return I18n.t('schedules.card.out_of_stock') if out_of_stock?
+      return I18n.t('schedules.card.waiting') unless can_administer?
 
       take_label
     end

--- a/spec/components/schedules/card/actions_component_spec.rb
+++ b/spec/components/schedules/card/actions_component_spec.rb
@@ -38,4 +38,20 @@ RSpec.describe Components::Schedules::Card::ActionsComponent, type: :component d
       expect(button.text).to include('Invalid Dose Configured')
     end
   end
+
+  context 'when the schedule is on cooldown' do
+    it 'renders a disabled waiting action' do
+      allow(MedicationStockSourceResolver).to receive(:new).and_return(
+        instance_double(MedicationStockSourceResolver, blocked_reason: :cooldown)
+      )
+
+      rendered = render_inline(
+        described_class.new(schedule: schedule, person: person, presenter: presenter, current_user: nil)
+      )
+
+      button = rendered.at_css("button[data-testid='take-schedule-#{schedule.id}-disabled'][disabled]")
+      expect(button).to be_present
+      expect(button.text).to include('Waiting')
+    end
+  end
 end

--- a/spec/components/schedules/card/actions_component_spec.rb
+++ b/spec/components/schedules/card/actions_component_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Schedules::Card::ActionsComponent, type: :component do
+  let(:person) { create(:person) }
+  let(:medication) { create(:medication, name: 'Ibuprofen', current_supply: 1000, supply_at_last_restock: 1000) }
+  let(:schedule) do
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      dose_amount: 400.0,
+      dose_unit: 'mg',
+      frequency: 'Twice daily',
+      start_date: 1.month.ago,
+      end_date: 1.month.from_now
+    )
+  end
+  let(:presenter) { Schedules::CardPresenter.new(schedule: schedule, todays_takes: [], current_user: nil, person: person) }
+
+  it 'renders the take action with schedule context' do
+    rendered = render_inline(
+      described_class.new(schedule: schedule, person: person, presenter: presenter, current_user: nil)
+    )
+
+    expect(rendered.css("[data-testid='take-schedule-#{schedule.id}']")).to be_present
+  end
+
+  context 'when the dose is invalid' do
+    it 'renders a disabled take action' do
+      schedule.dose_amount = 0
+      rendered = render_inline(
+        described_class.new(schedule: schedule, person: person, presenter: presenter, current_user: nil)
+      )
+
+      button = rendered.at_css("button[data-testid='take-schedule-#{schedule.id}-disabled'][disabled]")
+      expect(button).to be_present
+      expect(button.text).to include('Invalid Dose Configured')
+    end
+  end
+end

--- a/spec/components/schedules/card/dose_status_component_spec.rb
+++ b/spec/components/schedules/card/dose_status_component_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Schedules::Card::DoseStatusComponent, type: :component do
+  let(:person) { create(:person) }
+  let(:medication) { create(:medication, name: 'Ibuprofen', current_supply: 1000, supply_at_last_restock: 1000) }
+  let(:schedule) do
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      dose_amount: 400.0,
+      dose_unit: 'mg',
+      frequency: 'Twice daily',
+      max_daily_doses: 4,
+      notes: 'Take with food',
+      start_date: 1.month.ago,
+      end_date: 1.month.from_now
+    )
+  end
+  let(:presenter) { Schedules::CardPresenter.new(schedule: schedule, todays_takes: [take], current_user: nil, person: person) }
+  let(:take) { create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.current, amount_ml: 400) }
+
+  it 'renders dates, notes, dose count, and today take history' do
+    rendered = render_inline(described_class.new(schedule: schedule, presenter: presenter))
+
+    expect(rendered.text).to include('Take with food')
+    expect(rendered.text).to include("Today's Doses")
+    expect(rendered.text).to include('1/4')
+    expect(rendered.text).to include('400mg')
+  end
+end

--- a/spec/components/schedules/card/header_component_spec.rb
+++ b/spec/components/schedules/card/header_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Schedules::Card::HeaderComponent, type: :component do
+  let(:person) { create(:person) }
+  let(:medication) { create(:medication, name: 'Ibuprofen', current_supply: 1000, supply_at_last_restock: 1000) }
+  let(:schedule) do
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      dose_amount: 400.0,
+      dose_unit: 'mg',
+      frequency: 'Twice daily',
+      start_date: 1.month.ago,
+      end_date: 1.month.from_now
+    )
+  end
+  let(:presenter) { Schedules::CardPresenter.new(schedule: schedule, todays_takes: [], current_user: nil, person: person) }
+
+  it 'renders schedule metadata and stock status' do
+    rendered = render_inline(described_class.new(schedule: schedule, presenter: presenter))
+
+    expect(rendered.text).to include('Ibuprofen')
+    expect(rendered.text).to include('400mg • Twice daily')
+    expect(rendered.text).to include('Ready Now')
+  end
+end


### PR DESCRIPTION
Closes #1038

## Summary
- Split Components::Schedules::Card into HeaderComponent, DoseStatusComponent, and ActionsComponent
- Added Schedules::CardPresenter for stock, timing, dose-count, and action-label decisions
- Added focused component specs and updated REVIEW.md

## Verification
- task rubocop
- task test TEST_FILE=spec/components/schedules
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
