### PR TITLE
feat: elevate OIDC button and restore version identifier on login page

### DIFF
--- a/app/views/rodauth/login.rb
+++ b/app/views/rodauth/login.rb
@@ -33,7 +33,7 @@ module Views
         div(class: 'w-full max-w-5xl text-center space-y-4') do
           render_signup_link
           render_resend_link
-          render_invite_only_oidc_link if invite_only? && oauth_enabled?
+          render_version_display
         end
       end
 
@@ -56,16 +56,9 @@ module Views
         end
       end
 
-      def render_invite_only_oidc_link
-        provider_name = ENV.fetch('OIDC_PROVIDER_NAME', 'OIDC')
-        div(class: 'space-y-2 text-xs text-on-surface-variant font-medium') do
-          p { t('sessions.login.invite_only_oidc_notice') }
-          form(action: view_context.rodauth.omniauth_request_path(:oidc), method: 'post', data: { turbo: 'false' }, class: 'inline-block') do
-            input(type: 'hidden', name: 'authenticity_token', value: view_context.form_authenticity_token)
-            m3_button(type: :submit, variant: :text, size: :sm, class: 'h-auto p-0 font-bold underline') do
-              plain t('sessions.login.invite_only_oidc_cta', provider: provider_name)
-            end
-          end
+      def render_version_display
+        span(class: 'block text-[10px] text-on-surface-variant/50 font-mono font-bold uppercase tracking-widest') do
+          "v#{ENV.fetch('APP_VERSION', MedTracker::VERSION)}"
         end
       end
 

--- a/app/views/rodauth/login_secondary_sign_in_support.rb
+++ b/app/views/rodauth/login_secondary_sign_in_support.rb
@@ -11,19 +11,19 @@ module Views
           p(class: 'text-sm font-semibold text-on-surface-variant') { t('sessions.login.other_sign_in_options') }
           div(class: 'space-y-3') do
             render_passkey_section
-            render_oauth_button if secondary_sign_in_visible?
+            render_oauth_button if oauth_enabled?
           end
         end
       end
 
       def secondary_sign_in_options_attributes
         attrs = { id: 'secondary-sign-in-options', class: 'mt-9 space-y-4' }
-        attrs[:hidden] = true unless secondary_sign_in_visible?
+        attrs[:hidden] = true unless oauth_enabled?
         attrs
       end
 
       def secondary_sign_in_visible?
-        oauth_enabled? && !invite_only?
+        oauth_enabled?
       end
 
       def render_oauth_divider


### PR DESCRIPTION
Show the OIDC provider button as a full-height styled button in the
secondary sign-in section for all modes (including invite-only), replacing
the small footer text link. Also adds the app version identifier to the
login page footer, following the same pattern used on the dashboard.

https://claude.ai/code/session_01XJdg39TWtZmU6a81BCADSb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
