### PR TITLE
feat: Add paid AI medication help guardrails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'bootsnap', require: false
 # Use Phlex for views [https://github.com/phlex-rb/phlex-rails]
 gem 'csv'
 gem 'phlex-rails'
+gem 'ruby_llm', require: false
 gem 'ruby_ui', require: false
 gem 'tailwindcss-rails'
 gem 'tailwind_merge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -147,8 +148,12 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -230,6 +235,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.3)
@@ -554,6 +560,17 @@ GEM
     ruby-lsp-rails (0.4.8)
       ruby-lsp (>= 0.26.0, < 0.27.0)
     ruby-progressbar (1.13.0)
+    ruby_llm (1.14.1)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.3.0)
     ruby_ui (1.2.0)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
@@ -718,6 +735,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-lsp (~> 0.26.9)
   ruby-lsp-rails (~> 0.4.8)
+  ruby_llm
   ruby_ui
   sequel-activerecord_connection
   shoulda-matchers

--- a/app/components/medications/wizard/full_page_wrapper.rb
+++ b/app/components/medications/wizard/full_page_wrapper.rb
@@ -4,12 +4,13 @@ module Components
   module Medications
     module Wizard
       class FullPageWrapper < Components::Base
-        attr_reader :medication, :locations, :people, :variant
+        attr_reader :medication, :locations, :people, :current_user, :variant
 
-        def initialize(medication:, locations:, people:)
+        def initialize(medication:, locations:, people:, current_user: nil)
           @medication = medication
           @locations = locations
           @people = people
+          @current_user = current_user
           @variant = 'fullpage'
           super()
         end
@@ -24,6 +25,7 @@ module Components
                   medication: medication,
                   locations: locations,
                   people: people,
+                  current_user: current_user,
                   variant: variant
                 )
               end

--- a/app/components/medications/wizard/modal_wrapper.rb
+++ b/app/components/medications/wizard/modal_wrapper.rb
@@ -6,12 +6,13 @@ module Components
       class ModalWrapper < Components::Base
         include Phlex::Rails::Helpers::TurboFrameTag
 
-        attr_reader :medication, :locations, :people, :variant
+        attr_reader :medication, :locations, :people, :current_user, :variant
 
-        def initialize(medication:, locations:, people:)
+        def initialize(medication:, locations:, people:, current_user: nil)
           @medication = medication
           @locations = locations
           @people = people
+          @current_user = current_user
           @variant = 'modal'
           super()
         end
@@ -50,6 +51,7 @@ module Components
                   medication: medication,
                   locations: locations,
                   people: people,
+                  current_user: current_user,
                   variant: variant
                 )
               end

--- a/app/components/medications/wizard/slide_over_wrapper.rb
+++ b/app/components/medications/wizard/slide_over_wrapper.rb
@@ -6,12 +6,13 @@ module Components
       class SlideOverWrapper < Components::Base
         include Phlex::Rails::Helpers::TurboFrameTag
 
-        attr_reader :medication, :locations, :people, :variant
+        attr_reader :medication, :locations, :people, :current_user, :variant
 
-        def initialize(medication:, locations:, people:)
+        def initialize(medication:, locations:, people:, current_user: nil)
           @medication = medication
           @locations = locations
           @people = people
+          @current_user = current_user
           @variant = 'slideover'
           super()
         end
@@ -38,6 +39,7 @@ module Components
                   medication: medication,
                   locations: locations,
                   people: people,
+                  current_user: current_user,
                   variant: variant
                 )
               end

--- a/app/components/medications/wizard/step_basic_info.rb
+++ b/app/components/medications/wizard/step_basic_info.rb
@@ -6,11 +6,12 @@ module Components
       class StepBasicInfo < Components::Base
         include FieldHelpers
 
-        attr_reader :medication, :locations
+        attr_reader :medication, :locations, :ai_medication_help_enabled
 
-        def initialize(medication:, locations:)
+        def initialize(medication:, locations:, ai_medication_help_enabled: false)
           @medication = medication
           @locations = locations
+          @ai_medication_help_enabled = ai_medication_help_enabled
           super()
         end
 
@@ -26,9 +27,41 @@ module Components
             end
 
             render_location_field
+            render_ai_medication_help if ai_medication_help_enabled
             render_name_field
             render_category_field
             render_description_field
+          end
+        end
+
+        private
+
+        def render_ai_medication_help
+          div(
+            class: 'rounded-3xl border border-primary/20 bg-primary/5 p-4 space-y-3',
+            data: { 'ai-medication-help-target': 'panel' }
+          ) do
+            div(class: 'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between') do
+              div(class: 'space-y-1') do
+                m3_heading(level: 4, size: '4', class: 'font-bold text-foreground') { 'Help fill from trusted sources' }
+                m3_text(size: '2', class: 'text-on-surface-variant') do
+                  'We can look for packet or leaflet guidance and draft fields for you to check.'
+                end
+              end
+              m3_button(
+                type: :button,
+                variant: :outlined,
+                class: 'w-full shrink-0 sm:w-auto',
+                data: {
+                  action: 'click->ai-medication-help#suggest',
+                  'ai-medication-help-target': 'button'
+                }
+              ) { 'Help fill this in' }
+            end
+            div(
+              class: 'hidden rounded-2xl border border-outline-variant/60 bg-surface-container-low p-3 text-sm',
+              data: { 'ai-medication-help-target': 'status' }
+            )
           end
         end
       end

--- a/app/components/medications/wizard/step_content.rb
+++ b/app/components/medications/wizard/step_content.rb
@@ -6,12 +6,13 @@ module Components
       class StepContent < Components::Base
         include Phlex::Rails::Helpers::FormWith
 
-        attr_reader :medication, :locations, :people, :variant
+        attr_reader :medication, :locations, :people, :current_user, :variant
 
-        def initialize(medication:, locations:, people:, variant: 'fullpage')
+        def initialize(medication:, locations:, people:, current_user: nil, variant: 'fullpage')
           @medication = medication
           @locations = locations
           @people = people
+          @current_user = current_user
           @variant = variant
           super()
         end
@@ -20,8 +21,9 @@ module Components
           div(
             id: 'wizard-content',
             data: {
-              controller: 'wizard',
-              wizard_current_value: 0
+              controller: ai_medication_help_enabled? ? 'wizard ai-medication-help' : 'wizard',
+              wizard_current_value: 0,
+              ai_medication_help_url_value: ai_medication_suggestions_path
             }
           ) do
             render StepIndicator.new
@@ -34,6 +36,14 @@ module Components
             ) do |_form|
               render_errors if medication.errors.any?
               input(type: 'hidden', name: 'wizard', value: 'true')
+              if ai_medication_help_enabled?
+                input(
+                  type: 'hidden',
+                  name: 'ai_medication_suggestion_applied',
+                  value: '',
+                  data: { 'ai-medication-help-target': 'appliedField' }
+                )
+              end
               if medication.barcode.present?
                 input(type: 'hidden', name: 'medication[barcode]', value: medication.barcode)
               end
@@ -80,7 +90,11 @@ module Components
 
         def render_step_panels
           div(data: { wizard_target: 'step' }) do
-            render StepBasicInfo.new(medication: medication, locations: locations)
+            render StepBasicInfo.new(
+              medication: medication,
+              locations: locations,
+              ai_medication_help_enabled: ai_medication_help_enabled?
+            )
           end
 
           div(class: 'hidden', data: { wizard_target: 'step' }) do
@@ -92,8 +106,15 @@ module Components
           end
 
           div(class: 'hidden', data: { wizard_target: 'step' }) do
-            render StepWarnings.new(medication: medication)
+            render StepWarnings.new(
+              medication: medication,
+              ai_medication_help_enabled: ai_medication_help_enabled?
+            )
           end
+        end
+
+        def ai_medication_help_enabled?
+          PaidFeature.enabled?(:ai_medication_help, user: current_user)
         end
 
         def render_navigation

--- a/app/components/medications/wizard/step_warnings.rb
+++ b/app/components/medications/wizard/step_warnings.rb
@@ -6,11 +6,12 @@ module Components
       class StepWarnings < Components::Base
         include FieldHelpers
 
-        attr_reader :medication, :locations
+        attr_reader :medication, :locations, :ai_medication_help_enabled
 
-        def initialize(medication:, locations: [])
+        def initialize(medication:, locations: [], ai_medication_help_enabled: false)
           @medication = medication
           @locations = locations
+          @ai_medication_help_enabled = ai_medication_help_enabled
           super()
         end
 
@@ -29,6 +30,7 @@ module Components
             end
 
             render_warnings_field
+            render_ai_medication_confirmation if ai_medication_help_enabled
 
             div(class: 'rounded-shape-xl bg-warning-container border border-warning p-4') do
               div(class: 'flex gap-3') do
@@ -40,6 +42,35 @@ module Components
               end
             end
           end
+        end
+
+        private
+
+        def render_ai_medication_confirmation
+          div(
+            class: 'hidden rounded-3xl border border-primary/30 bg-primary/5 p-4 space-y-3',
+            data: { 'ai-medication-help-target': 'confirmationPanel' }
+          ) do
+            div(class: 'space-y-1') do
+              m3_heading(level: 4, size: '4', class: 'font-bold text-foreground') { 'Review AI suggestions' }
+              m3_text(size: '2', class: 'text-on-surface-variant') { ai_medication_confirmation_text }
+            end
+            div(class: 'space-y-2', data: { 'ai-medication-help-target': 'sourceList' })
+            label(class: 'flex items-start gap-3 text-sm font-semibold text-foreground') do
+              input(
+                type: 'checkbox',
+                name: 'ai_medication_suggestion_confirmed',
+                value: '1',
+                class: 'mt-1 rounded border-outline',
+                data: { 'ai-medication-help-target': 'confirmationInput' }
+              )
+              span { 'I checked these suggestions against the packet, leaflet, or linked guidance.' }
+            end
+          end
+        end
+
+        def ai_medication_confirmation_text
+          'Suggested from trusted source text. Check against the packet, leaflet, or linked guidance before saving.'
         end
       end
     end

--- a/app/controllers/ai_medication_suggestions_controller.rb
+++ b/app/controllers/ai_medication_suggestions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AiMedicationSuggestionsController < ApplicationController
+  def create
+    head :not_found unless PaidFeature.enabled?(:ai_medication_help, user: current_user)
+    return if performed?
+
+    authorize Medication, :finder?
+
+    suggestion = AiMedication::SuggestionService.new.call(
+      medication_identity: medication_identity_params.to_h.deep_symbolize_keys,
+      user: current_user
+    )
+
+    render json: suggestion.as_json
+  end
+
+  private
+
+  def medication_identity_params
+    return ActionController::Parameters.new if params[:medication].blank?
+
+    params.expect(
+      medication: %i[name barcode dmd_code dmd_system dmd_concept_class category description]
+    )
+  end
+end

--- a/app/controllers/concerns/medication_ai_suggestion_confirmation.rb
+++ b/app/controllers/concerns/medication_ai_suggestion_confirmation.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module MedicationAiSuggestionConfirmation
+  extend ActiveSupport::Concern
+
+  private
+
+  def reject_unconfirmed_ai_medication_suggestion?
+    return false unless unconfirmed_ai_medication_suggestion?
+
+    @medication.errors.add(:base, ai_medication_suggestion_confirmation_message)
+    render_create_failure
+    true
+  end
+
+  def unconfirmed_ai_medication_suggestion?
+    params[:ai_medication_suggestion_applied].present? && params[:ai_medication_suggestion_confirmed] != '1'
+  end
+
+  def ai_medication_suggestion_confirmation_message
+    'Check AI suggestions against the packet, leaflet, or linked guidance before saving.'
+  end
+
+  def render_create_failure
+    if params[:wizard] == 'true'
+      render wizard_wrapper_class.new(
+        medication: @medication,
+        locations: available_locations,
+        people: available_people,
+        current_user: current_user
+      ), status: :unprocessable_content
+    else
+      render Components::Medications::FormView.new(
+        medication: @medication,
+        locations: available_locations,
+        title: t('medications.form.new_title'),
+        subtitle: t('medications.form.new_subtitle')
+      ), status: :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -2,6 +2,7 @@
 
 class MedicationsController < ApplicationController
   include InventoryLocationFilterable
+  include MedicationAiSuggestionConfirmation
   include MedicationAdministrationOptions
   include MedicationFormContext
   include MedicationRefillable
@@ -69,7 +70,8 @@ class MedicationsController < ApplicationController
     render wizard_wrapper_class.new(
       medication: @medication,
       locations: available_locations,
-      people: available_people
+      people: available_people,
+      current_user: current_user
     )
   end
 
@@ -90,6 +92,8 @@ class MedicationsController < ApplicationController
     @medication.location_id ||= primary_location&.id
     authorize @medication
 
+    return if reject_unconfirmed_ai_medication_suggestion?
+
     result = create_medication_from_request
 
     if result.success
@@ -98,7 +102,8 @@ class MedicationsController < ApplicationController
       render wizard_wrapper_class.new(
         medication: @medication,
         locations: available_locations,
-        people: available_people
+        people: available_people,
+        current_user: current_user
       ), status: :unprocessable_content
     else
       render Components::Medications::FormView.new(

--- a/app/javascript/controllers/ai_medication_help_controller.js
+++ b/app/javascript/controllers/ai_medication_help_controller.js
@@ -1,0 +1,145 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "button",
+    "status",
+    "appliedField",
+    "confirmationPanel",
+    "confirmationInput",
+    "sourceList"
+  ]
+
+  static values = { url: String }
+
+  async suggest(event) {
+    event.preventDefault()
+
+    this.setBusy(true)
+    this.showStatus("Looking for trusted source guidance...")
+
+    try {
+      const response = await fetch(this.urlValue, {
+        method: "POST",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          "X-CSRF-Token": this.csrfToken()
+        },
+        body: JSON.stringify({ medication: this.medicationIdentity() })
+      })
+
+      if (!response.ok) throw new Error("request_failed")
+
+      const suggestion = await response.json()
+      if (!this.applySuggestion(suggestion)) {
+        this.showStatus("No trusted source guidance was found for this medication.")
+      }
+    } catch (_error) {
+      this.showStatus("Medication help is temporarily unavailable.")
+    } finally {
+      this.setBusy(false)
+    }
+  }
+
+  applySuggestion(suggestion) {
+    const medication = suggestion.medication || {}
+    const doses = suggestion.doses || []
+    const sources = suggestion.sources || []
+
+    if (Object.keys(medication).length === 0 && doses.length === 0) return false
+
+    this.applyMedicationFields(medication)
+    this.applyPrimaryDose(doses[0])
+    this.showSources(sources)
+    this.markApplied()
+    this.showStatus("Suggested fields were added. Check them before saving.")
+    return true
+  }
+
+  applyMedicationFields(medication) {
+    this.setFieldValue("medication_name", medication.name, { onlyIfBlank: true })
+    this.setFieldValue("medication_description", medication.description, { onlyIfBlank: true })
+    this.setFieldValue("medication_warnings", medication.warnings, { onlyIfBlank: true })
+  }
+
+  applyPrimaryDose(dose) {
+    if (!dose) return
+
+    this.setFieldValue("wizard_dose_amount", dose.amount)
+    this.setFieldValue("wizard_dose_unit", dose.unit)
+
+    const event = new Event("input", { bubbles: true })
+    this.element.querySelector("#wizard_dose_amount")?.dispatchEvent(event)
+    this.element.querySelector("#wizard_dose_unit")?.dispatchEvent(new Event("change", { bubbles: true }))
+  }
+
+  showSources(sources) {
+    if (!this.hasSourceListTarget || sources.length === 0) return
+
+    this.sourceListTarget.replaceChildren()
+    sources.forEach((source) => {
+      const link = document.createElement("a")
+      link.href = source.url
+      link.target = "_blank"
+      link.rel = "noopener noreferrer"
+      link.className = "block rounded-2xl border border-outline-variant/60 bg-surface px-3 py-2 text-sm font-semibold text-primary"
+      link.textContent = source.title || source.url
+      this.sourceListTarget.append(link)
+    })
+  }
+
+  markApplied() {
+    if (this.hasAppliedFieldTarget) this.appliedFieldTarget.value = "1"
+    if (this.hasConfirmationPanelTarget) this.confirmationPanelTarget.classList.remove("hidden")
+    if (this.hasConfirmationInputTarget) this.confirmationInputTarget.required = true
+  }
+
+  setFieldValue(id, value, options = {}) {
+    if (value === undefined || value === null || value === "") return
+
+    const field = this.element.querySelector(`#${id}`)
+    if (!field) return
+    if (options.onlyIfBlank && field.value) return
+
+    field.value = value
+    field.dispatchEvent(new Event("input", { bubbles: true }))
+    field.dispatchEvent(new Event("change", { bubbles: true }))
+  }
+
+  medicationIdentity() {
+    return {
+      name: this.valueOf("medication_name"),
+      barcode: this.valueOfName("medication[barcode]"),
+      dmd_code: this.valueOfName("medication[dmd_code]"),
+      dmd_system: this.valueOfName("medication[dmd_system]"),
+      dmd_concept_class: this.valueOfName("medication[dmd_concept_class]"),
+      description: this.valueOf("medication_description")
+    }
+  }
+
+  valueOf(id) {
+    return this.element.querySelector(`#${id}`)?.value || ""
+  }
+
+  valueOfName(name) {
+    return this.element.querySelector(`[name="${name}"]`)?.value || ""
+  }
+
+  showStatus(message) {
+    if (!this.hasStatusTarget) return
+
+    this.statusTarget.textContent = message
+    this.statusTarget.classList.remove("hidden")
+  }
+
+  setBusy(busy) {
+    if (!this.hasButtonTarget) return
+
+    this.buttonTarget.disabled = busy
+  }
+
+  csrfToken() {
+    return document.querySelector("meta[name='csrf-token']")?.content || ""
+  }
+}

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,6 +4,7 @@ class Account < ApplicationRecord
   include Rodauth::Rails.model
 
   enum :status, { unverified: 1, verified: 2, closed: 3 }
+  enum :subscription_plan, { free: 'free', family_plus: 'family_plus' }, validate: true
 
   has_one :person, dependent: :nullify
   has_many :api_sessions, dependent: :destroy

--- a/app/services/ai_medication/audit_logger.rb
+++ b/app/services/ai_medication/audit_logger.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AiMedication
+  class AuditLogger
+    def record(user:, medication_identity:, suggestion:)
+      Rails.logger.info(
+        {
+          event: 'ai_medication_suggestion',
+          user_id: user&.id,
+          medication_identity_keys: medication_identity.keys,
+          source_count: suggestion.sources.size,
+          dose_count: suggestion.doses.size,
+          error_count: suggestion.errors.size
+        }.to_json
+      )
+    end
+  end
+end

--- a/app/services/ai_medication/ruby_llm_assistant.rb
+++ b/app/services/ai_medication/ruby_llm_assistant.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module AiMedication
+  class RubyLlmAssistant
+    MODEL_ENV = 'MEDTRACKER_AI_MEDICATION_HELP_MODEL'
+
+    def call(medication_identity:)
+      return Suggestion.new(errors: ['ruby_llm_unavailable']) unless ruby_llm_available?
+      return Suggestion.new(errors: ['ruby_llm_unconfigured']) unless configured?
+
+      response = chat.ask(prompt_for(medication_identity))
+      suggestion_from(response.content)
+    end
+
+    private
+
+    def ruby_llm_available?
+      defined?(RubyLLM)
+    end
+
+    def configured?
+      %w[
+        OPENAI_API_KEY
+        ANTHROPIC_API_KEY
+        GEMINI_API_KEY
+        AZURE_API_KEY
+        OPENROUTER_API_KEY
+      ].any? { |key| ENV.fetch(key, nil).present? }
+    end
+
+    def chat
+      model = ENV.fetch(MODEL_ENV, nil).presence
+      base = (model ? RubyLLM.chat(model: model) : RubyLLM.chat).with_instructions(instructions)
+      return base unless base.respond_to?(:with_tools)
+
+      base.with_tools(
+        Tools::SearchMedicationSources.new,
+        Tools::FetchMedicationSource.new,
+        Tools::ExtractMedicationGuidance.new
+      )
+    end
+
+    def instructions
+      'Help fill medication onboarding fields only from trusted source tool results. ' \
+        'Return JSON with medication, doses, and sources. Do not guess missing dose guidance.'
+    end
+
+    def prompt_for(medication_identity)
+      {
+        task: 'Find trusted source evidence and draft medication onboarding fields.',
+        medication_identity: medication_identity
+      }.to_json
+    end
+
+    def suggestion_from(content)
+      payload = content.is_a?(Hash) ? content : JSON.parse(content.to_s)
+      Suggestion.new(
+        medication: payload.fetch('medication', {}),
+        doses: payload.fetch('doses', []),
+        sources: payload.fetch('sources', []),
+        errors: payload.fetch('errors', [])
+      )
+    rescue JSON::ParserError
+      Suggestion.new(errors: ['invalid_model_response'])
+    end
+  end
+end

--- a/app/services/ai_medication/source_page.rb
+++ b/app/services/ai_medication/source_page.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module AiMedication
+  SourcePage = Data.define(:url, :title, :text)
+end

--- a/app/services/ai_medication/source_page_client.rb
+++ b/app/services/ai_medication/source_page_client.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+
+module AiMedication
+  class SourcePageClient
+    TIMEOUT_SECONDS = 5
+    MAX_TEXT_LENGTH = 30_000
+    NETWORK_ERRORS = [
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      EOFError,
+      SocketError,
+      OpenSSL::SSL::SSLError
+    ].freeze
+
+    def fetch(url)
+      uri = URI.parse(url)
+      response = perform_request(uri)
+      raise "Source returned #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      SourcePage.new(
+        url: url,
+        title: title_from(response.body),
+        text: text_from(response.body)
+      )
+    rescue URI::InvalidURIError, *NETWORK_ERRORS => e
+      raise "Source fetch failed: #{e.message}"
+    end
+
+    private
+
+    def perform_request(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = TIMEOUT_SECONDS
+      http.read_timeout = TIMEOUT_SECONDS
+      http.request(Net::HTTP::Get.new(uri))
+    end
+
+    def title_from(html)
+      html.to_s[%r{<title[^>]*>(.*?)</title>}im, 1].to_s.squish
+    end
+
+    def text_from(html)
+      ActionController::Base.helpers.strip_tags(html.to_s).squish.first(MAX_TEXT_LENGTH)
+    end
+  end
+end

--- a/app/services/ai_medication/suggestion.rb
+++ b/app/services/ai_medication/suggestion.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AiMedication
+  class Suggestion
+    attr_reader :medication, :doses, :sources, :errors
+
+    def initialize(medication: {}, doses: [], sources: [], errors: [])
+      @medication = medication.deep_stringify_keys
+      @doses = doses.map(&:deep_stringify_keys)
+      @sources = sources.map(&:deep_stringify_keys)
+      @errors = errors
+    end
+
+    def empty?
+      medication.blank? && doses.blank?
+    end
+
+    def as_json(*)
+      {
+        medication: medication,
+        doses: doses,
+        sources: sources,
+        errors: errors
+      }
+    end
+  end
+end

--- a/app/services/ai_medication/suggestion_service.rb
+++ b/app/services/ai_medication/suggestion_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AiMedication
+  class SuggestionService
+    def initialize(assistant: RubyLlmAssistant.new, validator: SuggestionValidator.new, audit_logger: AuditLogger.new)
+      @assistant = assistant
+      @validator = validator
+      @audit_logger = audit_logger
+    end
+
+    def call(medication_identity:, user:)
+      raw_suggestion = @assistant.call(medication_identity: medication_identity)
+      suggestion = @validator.call(raw_suggestion)
+      @audit_logger.record(user: user, medication_identity: medication_identity, suggestion: suggestion)
+      suggestion
+    rescue StandardError => e
+      Rails.logger.warn("AI medication suggestion failed: #{e.class}: #{e.message}")
+      Suggestion.new(errors: ['suggestion_unavailable'])
+    end
+  end
+end

--- a/app/services/ai_medication/suggestion_validator.rb
+++ b/app/services/ai_medication/suggestion_validator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module AiMedication
+  class SuggestionValidator
+    def call(suggestion)
+      Suggestion.new(
+        medication: valid_medication_attributes(suggestion.medication),
+        doses: valid_doses(suggestion.doses),
+        sources: valid_sources(suggestion.sources),
+        errors: suggestion.errors
+      )
+    end
+
+    private
+
+    def valid_medication_attributes(attributes)
+      attributes.slice('name', 'category', 'description', 'warnings')
+    end
+
+    def valid_doses(doses)
+      doses.select { |dose| valid_dose?(dose) }
+    end
+
+    def valid_sources(sources)
+      sources.select { |source| source['url'].present? && source['title'].present? }
+    end
+
+    def valid_dose?(dose)
+      dose_evidence_valid?(dose['evidence']) &&
+        positive_number?(dose['amount']) &&
+        Medication::DOSAGE_UNITS.include?(dose['unit'].to_s) &&
+        positive_integer?(dose['default_max_daily_doses']) &&
+        non_negative_number?(dose['default_min_hours_between_doses']) &&
+        MedicationDosageOption.default_dose_cycles.key?(dose['default_dose_cycle'].to_s)
+    end
+
+    def dose_evidence_valid?(evidence)
+      evidence.is_a?(Hash) &&
+        evidence['url'].present? &&
+        evidence['title'].present? &&
+        evidence['text'].present?
+    end
+
+    def positive_number?(value)
+      BigDecimal(value.to_s).positive?
+    rescue ArgumentError
+      false
+    end
+
+    def non_negative_number?(value)
+      BigDecimal(value.to_s) >= 0
+    rescue ArgumentError
+      false
+    end
+
+    def positive_integer?(value)
+      value.to_s.match?(/\A\d+\z/) && value.to_i.positive?
+    end
+  end
+end

--- a/app/services/ai_medication/suggestion_validator.rb
+++ b/app/services/ai_medication/suggestion_validator.rb
@@ -2,6 +2,10 @@
 
 module AiMedication
   class SuggestionValidator
+    def initialize(allowlist: TrustedSourceAllowlist.new)
+      @allowlist = allowlist
+    end
+
     def call(suggestion)
       Suggestion.new(
         medication: valid_medication_attributes(suggestion.medication),
@@ -13,6 +17,8 @@ module AiMedication
 
     private
 
+    attr_reader :allowlist
+
     def valid_medication_attributes(attributes)
       attributes.slice('name', 'category', 'description', 'warnings')
     end
@@ -22,7 +28,11 @@ module AiMedication
     end
 
     def valid_sources(sources)
-      sources.select { |source| source['url'].present? && source['title'].present? }
+      sources.select { |source| source_valid?(source) }
+    end
+
+    def source_valid?(source)
+      source['url'].present? && source['title'].present? && allowlist.allowed?(source['url'])
     end
 
     def valid_dose?(dose)
@@ -38,7 +48,8 @@ module AiMedication
       evidence.is_a?(Hash) &&
         evidence['url'].present? &&
         evidence['title'].present? &&
-        evidence['text'].present?
+        evidence['text'].present? &&
+        allowlist.allowed?(evidence['url'])
     end
 
     def positive_number?(value)

--- a/app/services/ai_medication/tools/extract_medication_guidance.rb
+++ b/app/services/ai_medication/tools/extract_medication_guidance.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module AiMedication
+  module Tools
+    class ExtractMedicationGuidance < (defined?(RubyLLM::Tool) ? RubyLLM::Tool : Object)
+      if respond_to?(:description)
+        description 'Accepts source-linked structured medication guidance extracted by the model'
+      end
+
+      if respond_to?(:params)
+        params do
+          object :suggestion, description: 'Source-linked medication suggestion payload'
+        end
+      end
+
+      def execute(suggestion:)
+        SuggestionValidator.new.call(
+          Suggestion.new(
+            medication: suggestion.fetch('medication', {}),
+            doses: suggestion.fetch('doses', []),
+            sources: suggestion.fetch('sources', [])
+          )
+        ).as_json
+      rescue StandardError => e
+        { error: 'invalid_suggestion', message: e.message }
+      end
+    end
+  end
+end

--- a/app/services/ai_medication/tools/fetch_medication_source.rb
+++ b/app/services/ai_medication/tools/fetch_medication_source.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AiMedication
+  module Tools
+    class FetchMedicationSource < (defined?(RubyLLM::Tool) ? RubyLLM::Tool : Object)
+      if respond_to?(:description)
+        description 'Fetches a trusted medication guidance source after URL allowlist validation'
+      end
+
+      if respond_to?(:params)
+        params do
+          string :url, description: 'Trusted medication guidance URL'
+        end
+      end
+
+      def initialize(allowlist: TrustedSourceAllowlist.new, client: SourcePageClient.new)
+        super()
+        @allowlist = allowlist
+        @client = client
+      end
+
+      def execute(url:)
+        return { error: 'source_not_allowed' } unless @allowlist.allowed?(url)
+
+        page = @client.fetch(url)
+        { url: page.url, title: page.title, text: page.text }
+      rescue StandardError => e
+        { error: 'source_fetch_failed', message: e.message }
+      end
+    end
+  end
+end

--- a/app/services/ai_medication/tools/search_medication_sources.rb
+++ b/app/services/ai_medication/tools/search_medication_sources.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module AiMedication
+  module Tools
+    class SearchMedicationSources < (defined?(RubyLLM::Tool) ? RubyLLM::Tool : Object)
+      description 'Searches configured trusted medication guidance source seeds' if respond_to?(:description)
+
+      if respond_to?(:params)
+        params do
+          string :query, description: 'Medication source search query'
+        end
+      end
+
+      def initialize(allowlist: TrustedSourceAllowlist.new)
+        super()
+        @allowlist = allowlist
+      end
+
+      def execute(query:)
+        tokens = query_tokens(query)
+        @allowlist.seed_urls.filter_map do |source|
+          next unless source_allowed?(source)
+          next unless source_matches?(source, tokens)
+
+          {
+            url: source.fetch('url'),
+            title: source.fetch('title'),
+            matched_keywords: matching_keywords(source, tokens)
+          }
+        end
+      end
+
+      private
+
+      def source_allowed?(source)
+        @allowlist.allowed?(source.fetch('url'))
+      end
+
+      def source_matches?(source, tokens)
+        matching_keywords(source, tokens).any?
+      end
+
+      def matching_keywords(source, tokens)
+        Array(source.fetch('keywords', [])).select do |keyword|
+          keyword_tokens = query_tokens(keyword)
+          keyword_tokens.any? { |token| tokens.include?(token) }
+        end
+      end
+
+      def query_tokens(value)
+        value.to_s.downcase.scan(/[[:alnum:]]+/).reject { |token| token.length < 3 }
+      end
+    end
+  end
+end

--- a/app/services/ai_medication/trusted_source_allowlist.rb
+++ b/app/services/ai_medication/trusted_source_allowlist.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module AiMedication
+  class TrustedSourceAllowlist
+    Entry = Data.define(:name, :domains, :path_patterns, :seed_urls)
+
+    def initialize(config_path: Rails.root.join('config/ai_medication_sources.yml'))
+      @config_path = config_path
+    end
+
+    def allowed?(url)
+      uri = parse_url(url)
+      return false unless uri
+      return false unless uri.is_a?(URI::HTTPS)
+
+      entries.any? { |entry| host_allowed?(uri.host, entry.domains) && path_allowed?(uri.path, entry.path_patterns) }
+    end
+
+    def seed_urls
+      entries.flat_map(&:seed_urls)
+    end
+
+    private
+
+    attr_reader :config_path
+
+    def entries
+      @entries ||= begin
+        payload = YAML.safe_load_file(config_path, aliases: false) || {}
+        Array(payload.fetch('sources', [])).map do |source|
+          Entry.new(
+            name: source.fetch('name'),
+            domains: Array(source.fetch('domains', [])),
+            path_patterns: Array(source.fetch('path_patterns', [])).map { |pattern| Regexp.new(pattern) },
+            seed_urls: Array(source.fetch('seed_urls', []))
+          )
+        end
+      end
+    end
+
+    def parse_url(url)
+      URI.parse(url.to_s)
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def host_allowed?(host, domains)
+      normalized_host = host.to_s.downcase
+
+      domains.any? do |domain|
+        normalized_domain = domain.to_s.downcase
+        normalized_host == normalized_domain || normalized_host.end_with?(".#{normalized_domain}")
+      end
+    end
+
+    def path_allowed?(path, patterns)
+      patterns.any? { |pattern| path.to_s.match?(pattern) }
+    end
+  end
+end

--- a/app/services/paid_feature.rb
+++ b/app/services/paid_feature.rb
@@ -5,6 +5,10 @@ class PaidFeature
     ai_medication_help: 'MEDTRACKER_AI_MEDICATION_HELP_ENABLED'
   }.freeze
 
+  PLAN_FEATURES = {
+    'family_plus' => %i[ai_medication_help]
+  }.freeze
+
   TRUE_VALUES = %w[1 true yes on].freeze
 
   def self.enabled?(feature, user: nil)
@@ -16,9 +20,26 @@ class PaidFeature
   end
 
   def enabled?(feature)
-    flag = ENV_FLAGS[feature.to_sym]
+    feature = feature.to_sym
+    flag = ENV_FLAGS[feature]
     return false if flag.blank?
+    return false unless global_flag_enabled?(flag)
 
+    account_entitled?(feature)
+  end
+
+  private
+
+  attr_reader :user
+
+  def global_flag_enabled?(flag)
     TRUE_VALUES.include?(ENV.fetch(flag, 'false').to_s.downcase)
+  end
+
+  def account_entitled?(feature)
+    account = user&.person&.account
+    return false unless account
+
+    PLAN_FEATURES.fetch(account.subscription_plan, []).include?(feature)
   end
 end

--- a/app/services/paid_feature.rb
+++ b/app/services/paid_feature.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class PaidFeature
+  ENV_FLAGS = {
+    ai_medication_help: 'MEDTRACKER_AI_MEDICATION_HELP_ENABLED'
+  }.freeze
+
+  TRUE_VALUES = %w[1 true yes on].freeze
+
+  def self.enabled?(feature, user: nil)
+    new(user: user).enabled?(feature)
+  end
+
+  def initialize(user: nil)
+    @user = user
+  end
+
+  def enabled?(feature)
+    flag = ENV_FLAGS[feature.to_sym]
+    return false if flag.blank?
+
+    TRUE_VALUES.include?(ENV.fetch(flag, 'false').to_s.downcase)
+  end
+end

--- a/app/views/rodauth/login.rb
+++ b/app/views/rodauth/login.rb
@@ -63,6 +63,14 @@ module Views
       end
 
       def oauth_enabled?
+        oidc_configured? && !invite_only?
+      end
+
+      def invite_only_oidc_available?
+        oidc_configured? && invite_only?
+      end
+
+      def oidc_configured?
         return false unless view_context.rodauth.respond_to?(:omniauth_request_path)
 
         oidc_client_id = Rails.application.credentials.dig(:oidc, :client_id) || ENV.fetch('OIDC_CLIENT_ID', nil)

--- a/app/views/rodauth/login_secondary_sign_in_support.rb
+++ b/app/views/rodauth/login_secondary_sign_in_support.rb
@@ -12,18 +12,25 @@ module Views
           div(class: 'space-y-3') do
             render_passkey_section
             render_oauth_button if oauth_enabled?
+            render_invite_only_oidc_notice if invite_only_oidc_available?
           end
         end
       end
 
       def secondary_sign_in_options_attributes
         attrs = { id: 'secondary-sign-in-options', class: 'mt-9 space-y-4' }
-        attrs[:hidden] = true unless oauth_enabled?
+        attrs[:hidden] = true unless secondary_sign_in_visible?
         attrs
       end
 
       def secondary_sign_in_visible?
-        oauth_enabled?
+        oauth_enabled? || invite_only_oidc_available?
+      end
+
+      def render_invite_only_oidc_notice
+        div(class: 'rounded-lg border border-outline-variant bg-surface-container px-4 py-3 text-sm font-medium text-on-surface-variant') do
+          t('sessions.login.invite_only_oidc_notice')
+        end
       end
 
       def render_oauth_divider

--- a/config/ai_medication_sources.yml
+++ b/config/ai_medication_sources.yml
@@ -1,0 +1,30 @@
+sources:
+  - name: calpol
+    domains:
+      - calpol.co.uk
+      - www.calpol.co.uk
+    path_patterns:
+      - "^/our-products/"
+    seed_urls:
+      - url: "https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol"
+        title: "CALPOL SixPlus Oral Suspension"
+        keywords:
+          - calpol
+          - sixplus
+          - six plus
+          - paracetamol
+          - oral suspension
+  - name: medicines_org_uk
+    domains:
+      - medicines.org.uk
+      - www.medicines.org.uk
+    path_patterns:
+      - "^/emc/"
+    seed_urls: []
+  - name: nhs
+    domains:
+      - nhs.uk
+      - www.nhs.uk
+    path_patterns:
+      - "^/medicines/"
+    seed_urls: []

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -49,6 +49,17 @@ module Rack
       end
     end
 
+    throttle('ai_medication_suggestions/ip', limit: 10, period: 1.minute) do |req|
+      req.ip if req.path == '/ai-medication-suggestions' && req.post?
+    end
+
+    throttle('ai_medication_suggestions/user', limit: 20, period: 1.hour) do |req|
+      if req.path == '/ai-medication-suggestions' && req.post?
+        session = req.env['rack.session']
+        session && session['account_id']
+      end
+    end
+
     self.throttled_responder = lambda do |request|
       match_data = request.env['rack.attack.match_data']
       now = match_data[:epoch_time]

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+begin
+  require 'ruby_llm'
+rescue LoadError
+  nil
+end
+
+if defined?(RubyLLM)
+  RubyLLM.configure do |config|
+    config.openai_api_key = ENV.fetch('OPENAI_API_KEY', nil)
+    config.anthropic_api_key = ENV.fetch('ANTHROPIC_API_KEY', nil)
+    config.gemini_api_key = ENV.fetch('GEMINI_API_KEY', nil)
+    config.openrouter_api_key = ENV.fetch('OPENROUTER_API_KEY', nil)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   end
   get 'medication-finder', to: 'medications#finder', as: :medication_finder
   get 'medication-finder/search', to: 'medications#search', as: :medication_finder_search
+  post 'ai-medication-suggestions', to: 'ai_medication_suggestions#create', as: :ai_medication_suggestions
 
   # Authentication - Rodauth handles /login, /logout, /create-account via middleware
 

--- a/db/migrate/20260429120000_add_subscription_plan_to_accounts.rb
+++ b/db/migrate/20260429120000_add_subscription_plan_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSubscriptionPlanToAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :accounts, :subscription_plan, :string, null: false, default: 'free'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_28_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_100000) do
     t.citext "email", null: false
     t.string "password_hash"
     t.integer "status", default: 1, null: false
+    t.string "subscription_plan", default: "free", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
   end

--- a/spec/requests/ai_medication_suggestions_spec.rb
+++ b/spec/requests/ai_medication_suggestions_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AI medication suggestions' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  before { sign_in(users(:admin)) }
+
+  it 'is unavailable when the paid feature is disabled' do
+    allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: users(:admin)).and_return(false)
+
+    post ai_medication_suggestions_path, params: { medication: { name: 'Calpol Six Plus' } }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'returns source-linked draft suggestions when enabled' do
+    suggestion = AiMedication::Suggestion.new(
+      medication: { description: 'Paracetamol pain and fever relief', warnings: 'Contains paracetamol' },
+      doses: [
+        {
+          amount: 5,
+          unit: 'ml',
+          description: 'Children 6-8 years',
+          default_max_daily_doses: 4,
+          default_min_hours_between_doses: 4,
+          default_dose_cycle: 'daily',
+          evidence: {
+            url: 'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol',
+            title: 'CALPOL SixPlus',
+            text: 'Children 6-8 years 5ml Up to 4 times in 24 hours'
+          }
+        }
+      ],
+      sources: [
+        {
+          url: 'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol',
+          title: 'CALPOL SixPlus'
+        }
+      ]
+    )
+    service = instance_double(AiMedication::SuggestionService, call: suggestion)
+
+    allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: users(:admin)).and_return(true)
+    allow(AiMedication::SuggestionService).to receive(:new).and_return(service)
+
+    post ai_medication_suggestions_path, params: { medication: { name: 'Calpol Six Plus' } }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('doses', 0, 'evidence', 'url')).to eq(
+      'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol'
+    )
+  end
+end

--- a/spec/requests/ai_medication_suggestions_spec.rb
+++ b/spec/requests/ai_medication_suggestions_spec.rb
@@ -7,8 +7,17 @@ RSpec.describe 'AI medication suggestions' do
 
   before { sign_in(users(:admin)) }
 
-  it 'is unavailable when the paid feature is disabled' do
-    allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: users(:admin)).and_return(false)
+  it 'is unavailable when the environment flag is disabled' do
+    users(:admin).person.account.update!(subscription_plan: 'family_plus')
+    allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('false')
+
+    post ai_medication_suggestions_path, params: { medication: { name: 'Calpol Six Plus' } }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'is unavailable when the account plan is not entitled' do
+    allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
 
     post ai_medication_suggestions_path, params: { medication: { name: 'Calpol Six Plus' } }
 
@@ -42,7 +51,8 @@ RSpec.describe 'AI medication suggestions' do
     )
     service = instance_double(AiMedication::SuggestionService, call: suggestion)
 
-    allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: users(:admin)).and_return(true)
+    users(:admin).person.account.update!(subscription_plan: 'family_plus')
+    allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
     allow(AiMedication::SuggestionService).to receive(:new).and_return(service)
 
     post ai_medication_suggestions_path, params: { medication: { name: 'Calpol Six Plus' } }

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe 'Medication creation scope' do
     end
 
     it 'shows the AI medication help action when the paid feature is enabled' do
-      allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: parent_user).and_return(true)
+      parent_user.person.account.update!(subscription_plan: 'family_plus')
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
 
       get new_medication_path
 

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe 'Medication creation scope' do
       expect(response.body).to include('name="medication[reorder_threshold]"')
       expect(response.body).to include('Supply setup')
       expect(response.body).not_to include('Dosage &amp; Supply')
+      expect(response.body).not_to include('Help fill this in')
+    end
+
+    it 'shows the AI medication help action when the paid feature is enabled' do
+      allow(PaidFeature).to receive(:enabled?).with(:ai_medication_help, user: parent_user).and_return(true)
+
+      get new_medication_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Help fill this in')
+      expect(response.body).to include('data-controller="wizard ai-medication-help"')
     end
 
     it 'shows only authorized locations in the form' do
@@ -409,6 +420,34 @@ RSpec.describe 'Medication creation scope' do
       end.not_to change(Medication, :count)
 
       expect(response).to redirect_to(root_path)
+    end
+
+    it 'rejects unconfirmed AI medication help suggestions' do
+      expect do
+        post medications_path, params: {
+          ai_medication_suggestion_applied: '1',
+          medication: {
+            name: 'Calpol Six Plus 250mg/5ml oral suspension (McNeil Products Ltd)',
+            category: 'Analgesic',
+            location_id: locations(:home).id,
+            dosage_records_attributes: {
+              '0' => {
+                amount: '5',
+                unit: 'ml',
+                frequency: 'Children 6-8 years',
+                default_max_daily_doses: '4',
+                default_min_hours_between_doses: '4',
+                default_dose_cycle: 'daily'
+              }
+            }
+          }
+        }
+      end.not_to change(Medication, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(
+        'Check AI suggestions against the packet, leaflet, or linked guidance before saving.'
+      )
     end
   end
 end

--- a/spec/services/ai_medication/suggestion_service_spec.rb
+++ b/spec/services/ai_medication/suggestion_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AiMedication::SuggestionService do
+  fixtures :accounts, :people, :users
+
+  it 'keeps valid source-linked dose suggestions' do
+    suggestion = call_service(valid_suggestion)
+
+    expect(suggestion.doses.first).to include('amount' => 5, 'unit' => 'ml')
+    expect(suggestion.doses.first.dig('evidence', 'url')).to eq(calpol_sixplus_url)
+  end
+
+  it 'drops invalid dose suggestions before rendering' do
+    suggestion = call_service(invalid_suggestion)
+
+    expect(suggestion.doses).to be_empty
+  end
+
+  def call_service(raw_suggestion)
+    assistant = instance_double(AiMedication::RubyLlmAssistant, call: raw_suggestion)
+    audit_logger = instance_double(AiMedication::AuditLogger, record: true)
+
+    described_class.new(assistant: assistant, audit_logger: audit_logger).call(
+      medication_identity: { name: 'Calpol Six Plus' },
+      user: users(:admin)
+    )
+  end
+
+  def valid_suggestion
+    AiMedication::Suggestion.new(
+      medication: { description: 'Paracetamol pain and fever relief' },
+      doses: [valid_dose],
+      sources: [{ url: calpol_sixplus_url, title: 'CALPOL SixPlus' }]
+    )
+  end
+
+  def invalid_suggestion
+    AiMedication::Suggestion.new(
+      doses: [
+        valid_dose.merge(amount: -1),
+        valid_dose.except(:evidence)
+      ]
+    )
+  end
+
+  def valid_dose
+    {
+      amount: 5,
+      unit: 'ml',
+      description: 'Children 6-8 years',
+      default_max_daily_doses: 4,
+      default_min_hours_between_doses: 4,
+      default_dose_cycle: 'daily',
+      evidence: {
+        url: calpol_sixplus_url,
+        title: 'CALPOL SixPlus',
+        text: 'Children 6-8 years 5ml Up to 4 times in 24 hours'
+      }
+    }
+  end
+
+  def calpol_sixplus_url
+    'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol'
+  end
+end

--- a/spec/services/ai_medication/suggestion_validator_spec.rb
+++ b/spec/services/ai_medication/suggestion_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AiMedication::SuggestionValidator do
+  let(:allowlist) { instance_double(AiMedication::TrustedSourceAllowlist) }
+  let(:validator) { described_class.new(allowlist: allowlist) }
+
+  before do
+    allow(allowlist).to receive(:allowed?).with(calpol_sixplus_url).and_return(true)
+    allow(allowlist).to receive(:allowed?).with(disallowed_url).and_return(false)
+  end
+
+  it 'drops source links that are not allowlisted' do
+    suggestion = validator.call(
+      AiMedication::Suggestion.new(
+        sources: [
+          { url: calpol_sixplus_url, title: 'CALPOL SixPlus' },
+          { url: disallowed_url, title: 'Lookalike source' }
+        ]
+      )
+    )
+
+    expect(suggestion.sources).to contain_exactly(
+      include('url' => calpol_sixplus_url, 'title' => 'CALPOL SixPlus')
+    )
+  end
+
+  it 'drops dose suggestions with evidence from non-allowlisted URLs' do
+    suggestion = validator.call(
+      AiMedication::Suggestion.new(
+        doses: [
+          valid_dose,
+          valid_dose.merge(evidence: valid_dose[:evidence].merge(url: disallowed_url))
+        ]
+      )
+    )
+
+    expect(suggestion.doses).to contain_exactly(include('amount' => 5, 'unit' => 'ml'))
+  end
+
+  def valid_dose
+    {
+      amount: 5,
+      unit: 'ml',
+      description: 'Children 6-8 years',
+      default_max_daily_doses: 4,
+      default_min_hours_between_doses: 4,
+      default_dose_cycle: 'daily',
+      evidence: {
+        url: calpol_sixplus_url,
+        title: 'CALPOL SixPlus',
+        text: 'Children 6-8 years 5ml Up to 4 times in 24 hours'
+      }
+    }
+  end
+
+  def calpol_sixplus_url
+    'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol'
+  end
+
+  def disallowed_url
+    'https://calpol.example.com/unsafe-dose-guidance'
+  end
+end

--- a/spec/services/ai_medication/tools/fetch_medication_source_spec.rb
+++ b/spec/services/ai_medication/tools/fetch_medication_source_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AiMedication::Tools::FetchMedicationSource do
+  let(:allowlist) { instance_double(AiMedication::TrustedSourceAllowlist) }
+  let(:client) { instance_double(AiMedication::SourcePageClient) }
+
+  it 'rejects disallowed URLs before fetching' do
+    allow(allowlist).to receive(:allowed?).with('https://example.com/unsafe').and_return(false)
+    allow(client).to receive(:fetch)
+
+    result = described_class.new(allowlist: allowlist, client: client).execute(url: 'https://example.com/unsafe')
+
+    expect(result).to include(error: 'source_not_allowed')
+    expect(client).not_to have_received(:fetch)
+  end
+
+  it 'fetches allowed URLs' do
+    page = AiMedication::SourcePage.new(
+      url: 'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol',
+      title: 'CALPOL SixPlus',
+      text: 'Children 6-8 years 5ml Up to 4 times in 24 hours'
+    )
+    allow(allowlist).to receive(:allowed?).with(page.url).and_return(true)
+    allow(client).to receive(:fetch).with(page.url).and_return(page)
+
+    result = described_class.new(allowlist: allowlist, client: client).execute(url: page.url)
+
+    expect(result).to include(url: page.url, title: 'CALPOL SixPlus')
+    expect(result[:text]).to include('Children 6-8 years')
+  end
+end

--- a/spec/services/ai_medication/trusted_source_allowlist_spec.rb
+++ b/spec/services/ai_medication/trusted_source_allowlist_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AiMedication::TrustedSourceAllowlist do
+  subject(:allowlist) { described_class.new }
+
+  it 'allows configured trusted medication guidance URLs' do
+    expect(allowlist.allowed?(calpol_sixplus_url)).to be(true)
+    expect(allowlist.allowed?('https://www.medicines.org.uk/emc/product/13866/pil')).to be(true)
+  end
+
+  it 'rejects lookalike and unrelated URLs' do
+    expect(allowlist.allowed?("https://www.calpol.co.uk.evil.example#{calpol_sixplus_path}")).to be(false)
+    expect(allowlist.allowed?('https://example.com/calpol-sixplus-oral-suspension-paracetamol')).to be(false)
+    expect(allowlist.allowed?('javascript:alert(1)')).to be(false)
+  end
+
+  def calpol_sixplus_url
+    "https://www.calpol.co.uk#{calpol_sixplus_path}"
+  end
+
+  def calpol_sixplus_path
+    '/our-products/calpol-sixplus-oral-suspension-paracetamol'
+  end
+end

--- a/spec/services/paid_feature_spec.rb
+++ b/spec/services/paid_feature_spec.rb
@@ -12,10 +12,24 @@ RSpec.describe PaidFeature do
       expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(false)
     end
 
-    it 'enables AI medication help when the environment flag is true' do
+    it 'keeps AI medication help disabled for free accounts when the environment flag is true' do
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
+
+      expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(false)
+    end
+
+    it 'enables AI medication help when the environment flag is true and the account plan includes it' do
+      users(:admin).person.account.update!(subscription_plan: 'family_plus')
       allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
 
       expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(true)
+    end
+
+    it 'keeps AI medication help disabled for entitled accounts when the environment flag is false' do
+      users(:admin).person.account.update!(subscription_plan: 'family_plus')
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('false')
+
+      expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(false)
     end
 
     it 'disables unknown paid features' do

--- a/spec/services/paid_feature_spec.rb
+++ b/spec/services/paid_feature_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaidFeature do
+  fixtures :accounts, :people, :users
+
+  describe '.enabled?' do
+    it 'keeps AI medication help disabled by default' do
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('false')
+
+      expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(false)
+    end
+
+    it 'enables AI medication help when the environment flag is true' do
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
+
+      expect(described_class.enabled?(:ai_medication_help, user: users(:admin))).to be(true)
+    end
+
+    it 'disables unknown paid features' do
+      expect(described_class.enabled?(:unknown, user: users(:admin))).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Summary: Adds the off-by-default paid AI medication helper with deterministic source allowlist checks, RubyLLM tools, guarded endpoint/UI, confirmation-before-save, rate limiting, validation, audit logging, and account-plan entitlement gating.

Closes #1144.

Verification: task rubocop; task test (2014 examples, 0 failures, 2 expected pending).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->