### PR TITLE
fix: show Zitadel SSO in invite-only login

### DIFF
--- a/app/views/rodauth/login.rb
+++ b/app/views/rodauth/login.rb
@@ -63,11 +63,7 @@ module Views
       end
 
       def oauth_enabled?
-        oidc_configured? && !invite_only?
-      end
-
-      def invite_only_oidc_available?
-        oidc_configured? && invite_only?
+        oidc_configured?
       end
 
       def oidc_configured?

--- a/app/views/rodauth/login_secondary_sign_in_support.rb
+++ b/app/views/rodauth/login_secondary_sign_in_support.rb
@@ -12,7 +12,6 @@ module Views
           div(class: 'space-y-3') do
             render_passkey_section
             render_oauth_button if oauth_enabled?
-            render_invite_only_oidc_notice if invite_only_oidc_available?
           end
         end
       end
@@ -24,13 +23,7 @@ module Views
       end
 
       def secondary_sign_in_visible?
-        oauth_enabled? || invite_only_oidc_available?
-      end
-
-      def render_invite_only_oidc_notice
-        div(class: 'rounded-lg border border-outline-variant bg-surface-container px-4 py-3 text-sm font-medium text-on-surface-variant') do
-          t('sessions.login.invite_only_oidc_notice')
-        end
+        oauth_enabled?
       end
 
       def render_oauth_divider

--- a/spec/views/rodauth/login_spec.rb
+++ b/spec/views/rodauth/login_spec.rb
@@ -105,10 +105,11 @@ RSpec.describe Views::Rodauth::Login do
     expect(rendered.text).to include('Login with OIDC (SSO)')
   end
 
-  it 'hides the OAuth CTA and shows invite-only notice when invite-only is active' do
+  it 'renders the OAuth button when invite-only is active' do
     rendered = render_login(oauth_enabled: true, invite_only: true)
 
-    expect(rendered.text).not_to include('or continue with')
-    expect(rendered.text).to include('Single sign-on is reserved for invited accounts.')
+    expect(rendered.text).to include('Other sign-in options')
+    expect(rendered.text).to include('Login with OIDC (SSO)')
+    expect(rendered.text).not_to include('Single sign-on is reserved for invited accounts.')
   end
 end


### PR DESCRIPTION
## Summary
- show configured OIDC/SSO on the login page even when invite-only registration is active
- remove the invite-only replacement notice from secondary sign-in options
- keep backend invite-only enforcement for first-time OmniAuth account creation

## Tests
- task rubocop
- task test TEST_FILE=spec/views/rodauth/login_spec.rb
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
