### PR TITLE
test: 🧪 Add tests for Passkey default nickname generation

### DIFF
--- a/spec/factories/account_webauthn_keys.rb
+++ b/spec/factories/account_webauthn_keys.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account_webauthn_key do
+    account
+    sequence(:webauthn_id) { |n| "webauthn-id-#{n}" }
+    sequence(:public_key) { |n| "public-key-#{n}" }
+    sign_count { 0 }
+  end
+end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account do
+    sequence(:email) { |n| "account-#{n}@example.com" }
+    status { :verified }
+  end
+end

--- a/spec/models/account_webauthn_key_spec.rb
+++ b/spec/models/account_webauthn_key_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountWebauthnKey do
+  describe 'callbacks' do
+    describe '#set_default_nickname' do
+      let(:account) { create(:account) }
+
+      context 'when nickname is not provided' do
+        it 'sets the default nickname to Passkey 1 for the first key' do
+          key = create(:account_webauthn_key, account: account, nickname: nil)
+          expect(key.nickname).to eq('Passkey 1')
+        end
+
+        it 'sets the default nickname to Passkey 2 for the second key' do
+          create(:account_webauthn_key, account: account)
+          key2 = create(:account_webauthn_key, account: account, nickname: nil)
+          expect(key2.nickname).to eq('Passkey 2')
+        end
+      end
+
+      context 'when nickname is provided' do
+        it 'does not overwrite the provided nickname' do
+          key = create(:account_webauthn_key, account: account, nickname: 'My Custom Key')
+          expect(key.nickname).to eq('My Custom Key')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `set_default_nickname` callback in the `AccountWebauthnKey` model, along with the necessary factories for `Account` and `AccountWebauthnKey`.

📊 **Coverage:** 
- Verified that the first passkey for an account is automatically nicknamed "Passkey 1" if no nickname is provided.
- Verified that subsequent passkeys follow the incrementing naming convention (e.g., "Passkey 2").
- Verified that manually provided nicknames are preserved and not overwritten by the default generator.

✨ **Result:** Improved test reliability and coverage for the WebAuthn authentication flow, ensuring that passkeys are always identifiable even if a user doesn't provide a custom name.

---
*PR created automatically by Jules for task [10927164753696030645](https://jules.google.com/task/10927164753696030645) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->