### PR TITLE
🧪 add NhsDmdBarcode model tests and factory

### DIFF
--- a/spec/factories/nhs_dmd_barcodes.rb
+++ b/spec/factories/nhs_dmd_barcodes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nhs_dmd_barcode do
+    gtin { '05016298210989' }
+    code { '13629411000001105' }
+    display { 'Laxido Orange oral powder sachets (Galen Ltd)' }
+    system { 'https://dmd.nhs.uk' }
+    concept_class { 'AMPP' }
+  end
+end

--- a/spec/models/nhs_dmd_barcode_spec.rb
+++ b/spec/models/nhs_dmd_barcode_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NhsDmdBarcode do
+  describe 'validations' do
+    subject { build(:nhs_dmd_barcode) }
+
+    it { is_expected.to validate_presence_of(:gtin) }
+    it { is_expected.to validate_uniqueness_of(:gtin).case_insensitive }
+    it { is_expected.to validate_presence_of(:code) }
+    it { is_expected.to validate_presence_of(:display) }
+    it { is_expected.to validate_presence_of(:system) }
+  end
+
+  describe '.normalize_gtin' do
+    it 'removes non-digit characters' do
+      expect(described_class.normalize_gtin('501-629-821-098-9')).to eq('5016298210989')
+    end
+
+    it 'handles strings that are already normalized' do
+      expect(described_class.normalize_gtin('5016298210989')).to eq('5016298210989')
+    end
+
+    it 'handles nil input' do
+      expect(described_class.normalize_gtin(nil)).to eq('')
+    end
+
+    it 'handles non-string input' do
+      expect(described_class.normalize_gtin(5016298210989)).to eq('5016298210989')
+    end
+  end
+
+  describe 'callbacks' do
+    describe 'after_commit :expire_cache' do
+      let(:barcode) { create(:nhs_dmd_barcode) }
+
+      it 'calls NhsDmd::BarcodeLookup.expire with the gtin' do
+        allow(NhsDmd::BarcodeLookup).to receive(:expire)
+        barcode.update!(display: 'Updated Display')
+        expect(NhsDmd::BarcodeLookup).to have_received(:expire).with(barcode.gtin)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added missing unit tests and factory for the `NhsDmdBarcode` model.

🎯 **What:** The testing gap for `NhsDmdBarcode` was addressed by adding a comprehensive model spec and a factory.
📊 **Coverage:**
- `.normalize_gtin`: Verified that non-digit characters are removed and handles nil/integer inputs correctly.
- Validations: Verified presence of `gtin`, `code`, `display`, and `system`, and uniqueness of `gtin`.
- Callbacks: Verified that `expire_cache` correctly triggers `NhsDmd::BarcodeLookup.expire` after commit.
✨ **Result:** Improved codebase reliability by ensuring the core DM+D barcode model logic is well-tested and documented.

---
*PR created automatically by Jules for task [12994679726829247715](https://jules.google.com/task/12994679726829247715) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->