### PR TITLE
refactor: 🧹 remove unused methods from CarerRelationships::IndexView

### DIFF
--- a/app/components/admin/carer_relationships/index_view.rb
+++ b/app/components/admin/carer_relationships/index_view.rb
@@ -89,60 +89,6 @@ module Components
           render Row.new(relationship: relationship)
         end
 
-        def render_status_badge(relationship)
-          if relationship.active?
-            render RubyUI::Badge.new(variant: :success) { t('admin.carer_relationships.index.active') }
-          else
-            render RubyUI::Badge.new(variant: :destructive) { t('admin.carer_relationships.index.inactive') }
-          end
-        end
-
-        def render_activation_button(relationship)
-          if relationship.active?
-            render_deactivate_dialog(relationship)
-          else
-            form_with(
-              url: "/admin/carer_relationships/#{relationship.id}/activate",
-              method: :post,
-              class: 'inline-block'
-            ) do
-              m3_button(
-                type: :submit,
-                variant: :success_outline,
-                size: :sm
-              ) { t('admin.carer_relationships.index.activate') }
-            end
-          end
-        end
-
-        def render_deactivate_dialog(relationship)
-          render RubyUI::AlertDialog.new do
-            render RubyUI::AlertDialogTrigger.new do
-              m3_button(variant: :destructive_outline, size: :sm) do
-                t('admin.carer_relationships.index.deactivate')
-              end
-            end
-            render RubyUI::AlertDialogContent.new do
-              render RubyUI::AlertDialogHeader.new do
-                render(RubyUI::AlertDialogTitle.new { t('admin.carer_relationships.index.deactivate_dialog.title') })
-                render RubyUI::AlertDialogDescription.new do
-                  t('admin.carer_relationships.index.deactivate_dialog.confirm',
-                    carer: relationship.carer.name,
-                    patient: relationship.patient.name)
-                end
-              end
-              render RubyUI::AlertDialogFooter.new do
-                render(RubyUI::AlertDialogCancel.new { t('admin.carer_relationships.index.deactivate_dialog.cancel') })
-                form_with(url: "/admin/carer_relationships/#{relationship.id}", method: :delete, class: 'inline') do
-                  m3_button(variant: :destructive, type: :submit) do
-                    t('admin.carer_relationships.index.deactivate_dialog.submit')
-                  end
-                end
-              end
-            end
-          end
-        end
-
         def render_pagination
           div(
             class: 'flex items-center justify-between border-t border-border ' \


### PR DESCRIPTION
### 🎯 Why
The `CarerRelationships::IndexView` component contained several private methods (`render_status_badge`, `render_activation_button`, and `render_deactivate_dialog`) that were no longer used after the row rendering logic was refactored into a dedicated `Row` component.

### 💡 What
- Removed `render_status_badge(relationship)`
- Removed `render_activation_button(relationship)`
- Removed `render_deactivate_dialog(relationship)`
- Cleaned up the `IndexView` class to focus on its primary responsibility: rendering the table structure and pagination.

### ✅ Verification
- Performed a syntax check using `ruby -c` on the modified component.
- Used `grep` to confirm that the removed methods were not being called anywhere else within `IndexView`.
- Confirmed that the `Row` component correctly implements its own versions of these methods.

### ✨ Result
Improved maintainability and readability of the `CarerRelationships::IndexView` component by removing dead code.

---
*PR created automatically by Jules for task [15166303079437586928](https://jules.google.com/task/15166303079437586928) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->