### PR TITLE
perf: ⚡ Bolt: optimize member doses generation in ScheduleQuery

### DIFF
--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -93,22 +93,33 @@ module FamilyDashboard
     end
 
     def aggregate_family_doses
+      sources = all_sources
+      all_medications_by_key = MedicationStockSourceResolver.bulk_fetch(current_user, sources)
+
       @people.each_with_object([]) do |member, doses|
         (@all_schedules[member.id] || []).each do |schedule|
-          doses.concat(generate_doses_for(schedule, member))
+          matching = all_medications_by_key[medication_key(schedule.medication)]
+          doses.concat(generate_doses_for(schedule, member, matching_medications: matching))
         end
 
         (@all_person_medications[member.id] || []).each do |pm|
-          doses.concat(generate_doses_for(pm, member))
+          matching = all_medications_by_key[medication_key(pm.medication)]
+          doses.concat(generate_doses_for(pm, member, matching_medications: matching))
         end
       end
+    end
+
+    def medication_key(medication)
+      return [] if medication.blank?
+
+      [medication.name, medication.dosage_amount, medication.dosage_unit]
     end
 
     def generate_member_doses(member)
       self.class.new(member).call
     end
 
-    def generate_doses_for(source, person)
+    def generate_doses_for(source, person, matching_medications: nil)
       now = Time.current
       # 1. Get doses already taken today from our preloaded association
       # This uses the association preloaded in aggregate_family_doses to avoid N+1 queries
@@ -119,7 +130,12 @@ module FamilyDashboard
       # We show the "next available" dose if it falls within today
       next_time = source.next_available_time
       if next_time && next_time <= now + 24.hours
-        status = MedicationStockSourceResolver.new(user: current_user, source: source).blocked_reason || :upcoming
+        resolver = MedicationStockSourceResolver.new(
+          user: current_user,
+          source: source,
+          matching_medications: matching_medications
+        )
+        status = resolver.blocked_reason || :upcoming
         doses << {
           person: person,
           source: source,

--- a/app/services/medication_stock_source_resolver.rb
+++ b/app/services/medication_stock_source_resolver.rb
@@ -3,9 +3,51 @@
 class MedicationStockSourceResolver
   attr_reader :user, :source
 
-  def initialize(user:, source:)
+  def self.bulk_fetch(user, sources)
+    # Filter out sources with nil medication to avoid NoMethodError
+    valid_sources = sources.select { |s| s.medication.present? }
+    return {} if valid_sources.empty?
+
+    # 1. Collect unique medication attributes
+    keys = valid_sources.map do |s|
+      m = s.medication
+      [m.name, m.dosage_amount, m.dosage_unit]
+    end.uniq
+
+    # 2. Build a query that covers all these combinations
+    query = Medication.none
+    keys.each do |key|
+      query = query.or(Medication.where(
+                         name: key[0],
+                         dosage_amount: key[1],
+                         dosage_unit: key[2]
+                       ))
+    end
+
+    # 3. Apply the same scope and ordering as MedicationStockSourceResolver
+    scope = if user.blank?
+              Medication.where(id: valid_sources.map(&:medication_id))
+            else
+              MedicationPolicy::Scope.new(user, Medication.all).resolve
+            end
+
+    all_matching = scope.merge(query)
+                        .joins(:location)
+                        .includes(:location)
+                        .order('locations.name ASC, medications.id ASC')
+                        .to_a
+
+    # 4. Group by key for fast lookup
+    results = all_matching.group_by { |m| [m.name, m.dosage_amount, m.dosage_unit] }
+    # Ensure all requested keys are present in the hash even if no medications were found
+    keys.each { |key| results[key] ||= [] }
+    results
+  end
+
+  def initialize(user:, source:, matching_medications: nil)
     @user = user
     @source = source
+    @matching_medications = matching_medications
   end
 
   def available_medications
@@ -40,6 +82,8 @@ class MedicationStockSourceResolver
   def matching_medications
     @matching_medications ||= begin
       medication = source.medication
+      return [] if medication.blank?
+
       resolved_scope
         .joins(:location)
         .includes(:location)


### PR DESCRIPTION
💡 **What:**
Implemented a bulk-fetching strategy for medication stock information in the `FamilyDashboard::ScheduleQuery` service. This involves a new `bulk_fetch` class method in `MedicationStockSourceResolver` that retrieves all relevant medications for a collection of sources in a single database call, respecting Pundit policy scopes and ordering requirements.

🎯 **Why:**
The previous implementation exhibited a classic N+1 query pattern. For every schedule or person medication rendered on the dashboard, the `MedicationStockSourceResolver` was instantiated and performed its own database query to determine stock availability. This led to significant performance degradation as the number of family members and their medications grew.

📊 **Impact:**
- Drastically reduces the number of database queries required to render the family dashboard.
- Improves response times and reduces server load, especially for large families.
- Centralizes medication lookup logic, improving maintainability.

🧪 **Measurement:**
While environment limitations (missing gems and timeouts) prevented direct RSpec execution, the optimization has been verified through manual code review and syntax validation. The change replaces a linear number of database queries (O(N)) with a single, optimized bulk query (O(1)), addressing the core performance bottleneck.

---
*PR created automatically by Jules for task [6148080935548887452](https://jules.google.com/task/6148080935548887452) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->