### PR TITLE
perf: Bulk load family dashboard dose sources

### DIFF
--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -30,25 +30,22 @@ module FamilyDashboard
     private
 
     def fetch_active_schedules
-      @people.each_with_object({}) do |person, hash|
-        schedules = if person.schedules.loaded?
-                      person.schedules.select(&:active?)
-                    else
-                      person.schedules.active.includes(:medication).to_a
-                    end
-        hash[person.id] = schedules
-      end
+      schedules_by_person_id = Schedule.active
+                                       .where(person_id: @person_ids)
+                                       .includes(:medication)
+                                       .to_a
+                                       .group_by(&:person_id)
+
+      @people.to_h { |person| [person.id, schedules_by_person_id.fetch(person.id, [])] }
     end
 
     def fetch_person_medications
-      @people.each_with_object({}) do |person, hash|
-        pms = if person.person_medications.loaded?
-                person.person_medications.to_a
-              else
-                person.person_medications.includes(:medication).to_a
-              end
-        hash[person.id] = pms
-      end
+      person_medications_by_person_id = PersonMedication.where(person_id: @person_ids)
+                                                        .includes(:medication)
+                                                        .to_a
+                                                        .group_by(&:person_id)
+
+      @people.to_h { |person| [person.id, person_medications_by_person_id.fetch(person.id, [])] }
     end
 
     def preload_takes

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -11,6 +11,29 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
   let(:query) { described_class.new([jane, child]) }
 
   describe '#call' do
+    def count_source_queries(&)
+      counts = Hash.new(0)
+
+      subscriber = lambda do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        counts[:schedules] += 1 if sql.include?('FROM "schedules"') && sql.include?('"schedules"."person_id"')
+        counts[:person_medications] += 1 if sql.include?('FROM "person_medications"') &&
+                                            sql.include?('"person_medications"."person_id"')
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      counts
+    end
+
+    it 'bulk loads dose sources for the dashboard family' do
+      counts = count_source_queries { query.call }
+
+      expect(counts[:schedules]).to eq(1)
+      expect(counts[:person_medications]).to eq(1)
+    end
+
     it 'returns an aggregated list of doses for the person and their dependents' do
       results = query.call
       expect(results).to be_an(Array)


### PR DESCRIPTION
## What changed
- Bulk-load active schedules for all dashboard people in one query, then group by `person_id`.
- Bulk-load person medications for all dashboard people in one query, then group by `person_id`.
- Added a query-count spec around `FamilyDashboard::ScheduleQuery` source loading.

## Why it was a bottleneck
`FamilyDashboard::ScheduleQuery` iterated over each dashboard person and called scoped associations for schedules and person medications. That produced one source query per person, so dashboard query count grew with family size.

## Measurement used
Focused RSpec query-count instrumentation via `ActiveSupport::Notifications` in `spec/services/family_dashboard/schedule_query_spec.rb`. Red run showed 2 schedule source queries for the two-person fixture dashboard; green run requires 1 schedule query and 1 person medication query.

## Expected impact
Dashboard dose source loading is now constant-query for the family instead of scaling with the number of visible people, while preserving the existing dose aggregation behavior.

## Tests run
- `task test TEST_FILE=spec/services/family_dashboard/schedule_query_spec.rb` red before implementation
- `task test TEST_FILE=spec/services/family_dashboard/schedule_query_spec.rb`
- `task rubocop`
- `task test`
- Rebased on latest `origin/main`, then reran `task rubocop` and `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->