### PR TITLE
feat: add username-less passkey login

### DIFF
--- a/app/javascript/auth.js
+++ b/app/javascript/auth.js
@@ -170,9 +170,11 @@ const initPasskeyLogin = () => {
     try {
       await requestCredential();
     } catch (error) {
-      if (!noopError(error)) {
-        setError(trigger.dataset.errorFailed || trigger.dataset.errorUnsupported);
-      }
+      setError(
+        noopError(error)
+          ? trigger.dataset.errorCancelled || trigger.dataset.errorFailed
+          : trigger.dataset.errorFailed || trigger.dataset.errorUnsupported,
+      );
     }
   });
 

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -183,7 +183,16 @@ class RodauthMain < Rodauth::Rails::Auth
 
     webauthn_origin { ENV.fetch('APP_URL', request.base_url) }
     webauthn_user_verification 'required'
+    webauthn_authenticator_selection do
+      {
+        'residentKey' => 'required',
+        'requireResidentKey' => true,
+        'userVerification' => webauthn_user_verification
+      }
+    end
     webauthn_login_user_verification_additional_factor? true
+    webauthn_login_error_flash { I18n.t('sessions.login.passkey_error') }
+    webauthn_invalid_webauthn_id_message { I18n.t('sessions.login.passkey_error') }
 
     # Configure WebAuthn table column mappings for Rails conventions
     webauthn_user_ids_account_id_column :account_id

--- a/app/views/rodauth/login_passkey_ui_support.rb
+++ b/app/views/rodauth/login_passkey_ui_support.rb
@@ -70,6 +70,7 @@ module Views
                  'hover:border-teal-500/60 hover:bg-surface-container-low focus-visible:outline-none ' \
                  'focus-visible:ring-2 focus-visible:ring-teal-500/25 disabled:cursor-not-allowed disabled:opacity-38',
           data_error_unsupported: t('sessions.login.passkey_not_supported'),
+          data_error_cancelled: t('sessions.login.passkey_cancelled'),
           data_error_failed: t('sessions.login.passkey_error')
         }
       end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -870,6 +870,7 @@ cy:
       passkey_helper: "Defnyddiwch Face ID, Touch ID, Windows Hello, neu allwedd ddiogelwch."
       passkey_cta: "Parhau gyda Phasskey"
       passkey_not_supported: "Nid yw passkeys yn cael eu cefnogi yn y porwr hwn."
+      passkey_cancelled: "Cafodd mewngofnodi gyda phasskey ei ganslo. Ceisiwch eto neu defnyddiwch eich cyfrinair."
       passkey_error: "Nid oedd modd eich mewngofnodi gyda'r passkey hwn. Ceisiwch eto neu defnyddiwch eich cyfrinair."
       oauth_continue: "Parhau gyda %{provider}"
       oauth_sso: "Mewngofnodi gyda %{provider} (SSO)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,6 +896,7 @@ en:
       passkey_helper: "Use Face ID, Touch ID, Windows Hello, or a security key."
       passkey_cta: "Continue with Passkey"
       passkey_not_supported: "Passkeys are not supported in this browser."
+      passkey_cancelled: "Passkey sign-in was cancelled. Try again or use your password."
       passkey_error: "We could not sign you in with that passkey. Try again or use your password."
       oauth_continue: "Continue with %{provider}"
       oauth_sso: "Login with %{provider} (SSO)"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -839,6 +839,7 @@ es:
       passkey_helper: "Usa Face ID, Touch ID, Windows Hello o una llave de seguridad."
       passkey_cta: "Continuar con Passkey"
       passkey_not_supported: "Las passkeys no son compatibles con este navegador."
+      passkey_cancelled: "Se canceló el inicio de sesión con passkey. Inténtelo de nuevo o use su contraseña."
       passkey_error: "No pudimos iniciar sesión con esa passkey. Inténtelo de nuevo o use su contraseña."
       oauth_continue: "Continuar con %{provider}"
       oauth_sso: "Iniciar sesión con %{provider} (SSO)"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -773,6 +773,7 @@ ga:
       passkey_helper: "Bain úsáid as Face ID, Touch ID, Windows Hello, nó eochair slándála."
       passkey_cta: "Lean ar aghaidh le Passkey"
       passkey_not_supported: "Ní thacaítear le passkeys sa bhrabhsálaí seo."
+      passkey_cancelled: "Cealaíodh síniú isteach le passkey. Bain triail eile as nó úsáid do phasfhocal."
       passkey_error: "Níorbh fhéidir linn tú a shíniú isteach leis an passkey sin. Bain triail eile as nó úsáid do phasfhocal."
       oauth_continue: "Lean ar aghaidh le %{provider}"
       oauth_sso: "Logáil isteach le %{provider} (SSO)"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -838,6 +838,7 @@ pt:
       passkey_helper: "Use Face ID, Touch ID, Windows Hello ou uma chave de segurança."
       passkey_cta: "Continuar com Passkey"
       passkey_not_supported: "As passkeys não são suportadas neste navegador."
+      passkey_cancelled: "O início de sessão com passkey foi cancelado. Tente novamente ou use a sua palavra-passe."
       passkey_error: "Não foi possível iniciar sessão com essa passkey. Tente novamente ou use a sua palavra-passe."
       oauth_continue: "Continuar com %{provider}"
       oauth_sso: "Iniciar sessão com %{provider} (SSO)"

--- a/spec/features/authentication/passkey_spec.rb
+++ b/spec/features/authentication/passkey_spec.rb
@@ -53,4 +53,14 @@ RSpec.describe 'PASSKEY-001: WebAuthn/Passkey configuration' do
     expect(auth.send(:webauthn_login_user_verification_additional_factor?)).to be(true)
     expect(auth.webauthn_user_verification).to eq('required')
   end
+
+  scenario 'passkey registration requires discoverable credentials' do
+    auth = RodauthApp.rodauth.allocate
+
+    expect(auth.webauthn_authenticator_selection).to include(
+      'residentKey' => 'required',
+      'requireResidentKey' => true,
+      'userVerification' => 'required'
+    )
+  end
 end

--- a/spec/system/passkey_login_spec.rb
+++ b/spec/system/passkey_login_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webauthn/fake_client'
 
 RSpec.describe 'Passkey login', :js do
+  fixtures :accounts, :people, :users
+
   def add_init_script(script)
     page.driver.with_playwright_page do |playwright_page|
       playwright_page.add_init_script(script: script)
@@ -57,6 +60,125 @@ RSpec.describe 'Passkey login', :js do
     JS
   end
 
+  def passkey_browser_stub
+    <<~JS
+      const decode = (value) => {
+        const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+        return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0)).buffer;
+      };
+
+      Object.defineProperty(window, "PublicKeyCredential", {
+        configurable: true,
+        value: class PublicKeyCredential {},
+      });
+      window.PublicKeyCredential.isConditionalMediationAvailable = async () => false;
+
+      Object.defineProperty(window.navigator, "credentials", {
+        configurable: true,
+        value: {
+          get: async () => window.__passkeyCredential,
+        },
+      });
+
+      window.__setPasskeyCredential = (credential) => {
+        window.__passkeyCredential = {
+          type: credential.type,
+          rawId: decode(credential.rawId),
+          response: {
+            authenticatorData: decode(credential.response.authenticatorData),
+            clientDataJSON: decode(credential.response.clientDataJSON),
+            signature: decode(credential.response.signature),
+            userHandle: credential.response.userHandle ? decode(credential.response.userHandle) : undefined,
+          },
+        };
+      };
+    JS
+  end
+
+  def failing_passkey_stub(error_name)
+    <<~JS
+      Object.defineProperty(window, "PublicKeyCredential", {
+        configurable: true,
+        value: class PublicKeyCredential {},
+      });
+      window.PublicKeyCredential.isConditionalMediationAvailable = async () => false;
+
+      Object.defineProperty(window.navigator, "credentials", {
+        configurable: true,
+        value: {
+          get: async () => {
+            throw new DOMException("Passkey failed", "#{error_name}");
+          },
+        },
+      });
+    JS
+  end
+
+  def invalid_passkey_stub
+    <<~JS
+      Object.defineProperty(window, "PublicKeyCredential", {
+        configurable: true,
+        value: class PublicKeyCredential {},
+      });
+      window.PublicKeyCredential.isConditionalMediationAvailable = async () => false;
+
+      Object.defineProperty(window.navigator, "credentials", {
+        configurable: true,
+        value: {
+          get: async () => ({
+            type: "public-key",
+            rawId: Uint8Array.from([1, 2, 3]).buffer,
+            response: {
+              authenticatorData: Uint8Array.from([4, 5, 6]).buffer,
+              clientDataJSON: Uint8Array.from([7, 8, 9]).buffer,
+              signature: Uint8Array.from([10, 11, 12]).buffer,
+            },
+          }),
+        },
+      });
+    JS
+  end
+
+  def current_origin
+    uri = URI.parse(current_url)
+    "#{uri.scheme}://#{uri.host}:#{uri.port}"
+  end
+
+  def configured_webauthn_origin
+    ENV.fetch('APP_URL', current_origin)
+  end
+
+  def create_passkey_for(account, origin)
+    client = WebAuthn::FakeClient.new(origin)
+    user_id = account.account_webauthn_user_ids.create!(webauthn_id: WebAuthn.generate_user_id).webauthn_id
+    credential = WebAuthn::Credential.from_create(client.create)
+
+    key = account.account_webauthn_keys.create!(
+      webauthn_id: credential.id,
+      public_key: credential.public_key,
+      sign_count: credential.sign_count || 0
+    )
+
+    [client, user_id, key]
+  end
+
+  def challenge_value
+    find('#webauthn-login-form input[name$="challenge"]', visible: :all).value
+  end
+
+  def relying_party_for(origin)
+    WebAuthn::RelyingParty.new(
+      allowed_origins: [origin],
+      id: URI.parse(origin).host,
+      name: 'MedTracker'
+    )
+  end
+
+  def prime_passkey_credential(assertion)
+    page.execute_script("window.__setPasskeyCredential(#{assertion.to_json})")
+  end
+
   it 'starts conditional passkey autofill on page load when supported' do
     add_init_script(base_passkey_stub(conditional_available: 'true'))
 
@@ -79,6 +201,51 @@ RSpec.describe 'Passkey login', :js do
     expect(page).to have_css('html[data-passkey-mediation="explicit"]', visible: :all)
     expect(page).to have_css('html[data-passkey-submit-count="1"]', visible: :all)
     expect(find_by_id('webauthn-auth', visible: :all).value).to include('"rawId":"AQID"')
+  end
+
+  it 'signs in with a discoverable passkey without entering an email address' do
+    add_init_script(passkey_browser_stub)
+
+    visit login_path
+
+    origin = configured_webauthn_origin
+    client, user_id, key = create_passkey_for(accounts(:carer), origin)
+    assertion = client.get(challenge: challenge_value, user_verified: true, user_handle: user_id)
+    assertion_credential = WebAuthn::Credential.from_get(assertion, relying_party: relying_party_for(origin))
+
+    expect(
+      assertion_credential.verify(challenge_value, public_key: key.public_key, sign_count: key.sign_count)
+    ).to be(true)
+
+    prime_passkey_credential(assertion)
+
+    click_button 'Continue with Passkey'
+
+    expect(page).to have_current_path('/dashboard')
+  end
+
+  it 'shows a helpful message when explicit passkey sign-in is cancelled' do
+    add_init_script(failing_passkey_stub('NotAllowedError'))
+
+    visit login_path
+    click_button 'Continue with Passkey'
+
+    expect(page).to have_css(
+      '#passkey-login-error',
+      text: 'Passkey sign-in was cancelled. Try again or use your password.'
+    )
+    expect(page).to have_field('email')
+    expect(page).to have_field('password')
+  end
+
+  it 'shows a friendly failure when the selected passkey is unknown' do
+    add_init_script(invalid_passkey_stub)
+
+    visit login_path
+    click_button 'Continue with Passkey'
+
+    expect(page).to have_current_path('/login')
+    expect(page).to have_text('We could not sign you in with that passkey. Try again or use your password.')
   end
 
   it 'keeps the passkey CTA hidden when WebAuthn is unavailable' do


### PR DESCRIPTION
## Summary
- require discoverable WebAuthn credentials for new passkey registrations
- support username-less passkey login from /login with visible explicit-cancel and invalid-credential messaging
- add localized cancellation copy and system coverage for success, cancellation, unsupported, and invalid passkey flows

Closes #807.

## Verification
- task test TEST_FILE=spec/system/passkey_login_spec.rb
- task test TEST_FILE=spec/features/authentication/passkey_spec.rb
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->