### PR TITLE
feat: add turbo streams for CRUD flows

### DIFF
--- a/app/components/locations/index_view.rb
+++ b/app/components/locations/index_view.rb
@@ -14,7 +14,8 @@ module Components
       end
 
       def view_template
-        div(class: 'container mx-auto px-4 py-12 max-w-6xl', data: { testid: 'locations-list' }) do
+        div(id: 'locations_index', class: 'container mx-auto px-4 py-12 max-w-6xl',
+            data: { testid: 'locations-list' }) do
           render_header
           render_locations_grid
         end

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -12,7 +12,7 @@ module Components
       end
 
       def view_template
-        div(class: 'container mx-auto px-4 py-12 max-w-6xl space-y-12') do
+        div(id: "location_show_#{location.id}", class: 'container mx-auto px-4 py-12 max-w-6xl space-y-12') do
           render_notice if notice.present?
           render_header
 

--- a/app/components/medications/index_view.rb
+++ b/app/components/medications/index_view.rb
@@ -5,31 +5,41 @@ module Components
     class IndexView < Components::Base
       include Phlex::Rails::Helpers::TurboFrameTag
 
-      attr_reader :medications, :current_category, :categories, :locations, :current_location_id, :wizard_variant
+      attr_reader :medications, :current_category, :categories, :locations, :current_location_id, :wizard_variant,
+                  :frame_only
 
       def initialize(medications:, current_category: nil, categories: [], locations: [], # rubocop:disable Metrics/ParameterLists
-                     current_location_id: nil, wizard_variant: 'fullpage')
+                     current_location_id: nil, wizard_variant: 'fullpage', frame_only: false)
         @medications = medications
         @current_category = current_category
         @categories = categories
         @locations = locations
         @current_location_id = current_location_id
         @wizard_variant = wizard_variant
+        @frame_only = frame_only
         super()
       end
 
       def view_template
+        return render_inventory_frame if frame_only
+
         div(class: 'container mx-auto px-4 py-12 max-w-6xl', data: { testid: 'medications-list' }) do
           render_header
-          div(class: header_content_offset_class, data: { testid: 'medications-content' }) do
-            render_filters_section
-            render_medications_grid
-          end
+          render_inventory_frame
           turbo_frame_tag 'modal'
         end
       end
 
       private
+
+      def render_inventory_frame
+        turbo_frame_tag 'medications_inventory',
+                        class: header_content_offset_class,
+                        data: { testid: 'medications-content' } do
+          render_filters_section
+          render_medications_grid
+        end
+      end
 
       def render_header
         div(class: 'flex flex-col md:flex-row md:items-end justify-between gap-6 pb-8 border-b border-border mb-12') do

--- a/app/components/medications/search_component.rb
+++ b/app/components/medications/search_component.rb
@@ -19,7 +19,8 @@ module Components
         return if locations.empty? && categories.empty?
 
         div(class: 'mb-12 grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl') do
-          form_with(url: medications_path, method: :get, class: 'contents', data: { controller: 'form-submit' }) do
+          form_with(url: medications_path, method: :get, class: 'contents',
+                    data: { controller: 'form-submit', turbo_frame: 'medications_inventory' }) do
             render_filter(location_filter_config) if locations.any?
             render_filter(category_filter_config) if categories.any?
           end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,7 +41,7 @@ module Admin
       create_user_with_account!
       respond_to do |format|
         format.html { redirect_to admin_users_path, notice: t('users.created') }
-        format.turbo_stream { redirect_to admin_users_path, notice: t('users.created') }
+        format.turbo_stream { render_users_index_turbo(t('users.created')) }
       end
     rescue ActiveRecord::RecordInvalid => e
       handle_record_invalid_error(e)
@@ -58,7 +58,7 @@ module Admin
       respond_to do |format|
         if @user.update(user_params)
           format.html { redirect_to admin_users_path, notice: t('users.updated') }
-          format.turbo_stream { redirect_to admin_users_path, notice: t('users.updated') }
+          format.turbo_stream { render_users_index_turbo(t('users.updated')) }
         else
           format.html do
             render Components::Admin::Users::FormView.new(user: @user, locations: load_locations), status: :unprocessable_content
@@ -174,6 +174,23 @@ module Admin
 
     def render_user_form_with_errors
       render Components::Admin::Users::FormView.new(user: @user, locations: load_locations), status: :unprocessable_content
+    end
+
+    def render_users_index_turbo(message)
+      flash.now[:notice] = message
+      render turbo_stream: [
+        turbo_stream.replace('main-content', admin_users_index_view),
+        turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+      ]
+    end
+
+    def admin_users_index_view
+      users = Admin::UsersIndexQuery.new(
+        scope: policy_scope(User),
+        filters: search_params.to_h.symbolize_keys
+      ).call
+      @pagy, users = pagy(:offset, users)
+      Components::Admin::Users::IndexView.new(users: users, search_params: search_params, current_user: current_user, pagy: @pagy)
     end
 
     def search_params

--- a/app/controllers/concerns/inventory_location_filterable.rb
+++ b/app/controllers/concerns/inventory_location_filterable.rb
@@ -34,4 +34,17 @@ module InventoryLocationFilterable
       nil
     end
   end
+
+  def render_medications_index(medication_query:, locations:)
+    frame_only = request.headers['Turbo-Frame'] == 'medications_inventory'
+    render Components::Medications::IndexView.new(
+      medications: medication_query.call,
+      current_category: @current_category,
+      categories: medication_query.categories,
+      locations: locations,
+      current_location_id: @current_location_id,
+      wizard_variant: current_user.wizard_variant,
+      frame_only: frame_only
+    ), layout: !frame_only
+  end
 end

--- a/app/controllers/concerns/medication_refillable.rb
+++ b/app/controllers/concerns/medication_refillable.rb
@@ -28,9 +28,19 @@ module MedicationRefillable
   end
 
   def medication_streams
+    medication = @medication.reload
     [
-      turbo_stream.replace("medication_show_#{@medication.id}", Components::Medications::ShowView.new(medication: @medication.reload)),
+      turbo_stream.replace("medication_show_#{medication.id}", Components::Medications::ShowView.new(medication: medication)),
+      turbo_stream.replace("medication_#{medication.id}", medication_list_item(medication)),
       turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
     ]
+  end
+
+  def medication_list_item(medication)
+    Components::Medications::ListItemComponent.new(
+      medication: medication,
+      inventory_query_params: {},
+      can_manage: policy(medication).update?
+    )
   end
 end

--- a/app/controllers/location_memberships_controller.rb
+++ b/app/controllers/location_memberships_controller.rb
@@ -8,9 +8,21 @@ class LocationMembershipsController < ApplicationController
     @person = policy_scope(Person).find(params[:location_membership][:person_id])
 
     if LocationMembership.create(location: @location, person: @person)
-      redirect_to @location, notice: t('.success', name: @person.name, location: @location.name)
+      respond_to do |format|
+        format.html { redirect_to @location, notice: t('.success', name: @person.name, location: @location.name) }
+        format.turbo_stream do
+          flash.now[:notice] = t('.success', name: @person.name, location: @location.name)
+          render turbo_stream: location_show_streams
+        end
+      end
     else
-      redirect_to @location, alert: t('.failure')
+      respond_to do |format|
+        format.html { redirect_to @location, alert: t('.failure') }
+        format.turbo_stream do
+          flash.now[:alert] = t('.failure')
+          render turbo_stream: location_show_streams, status: :unprocessable_content
+        end
+      end
     end
   end
 
@@ -20,9 +32,21 @@ class LocationMembershipsController < ApplicationController
     @person = @membership.person
 
     if @membership.destroy
-      redirect_to @location, notice: t('.success', name: @person.name, location: @location.name)
+      respond_to do |format|
+        format.html { redirect_to @location, notice: t('.success', name: @person.name, location: @location.name) }
+        format.turbo_stream do
+          flash.now[:notice] = t('.success', name: @person.name, location: @location.name)
+          render turbo_stream: location_show_streams
+        end
+      end
     else
-      redirect_to @location, alert: t('.failure')
+      respond_to do |format|
+        format.html { redirect_to @location, alert: t('.failure') }
+        format.turbo_stream do
+          flash.now[:alert] = t('.failure')
+          render turbo_stream: location_show_streams, status: :unprocessable_content
+        end
+      end
     end
   end
 
@@ -30,5 +54,12 @@ class LocationMembershipsController < ApplicationController
 
   def set_location
     @location = policy_scope(Location).find(params[:location_id])
+  end
+
+  def location_show_streams
+    [
+      turbo_stream.replace("location_show_#{@location.id}", Components::Locations::ShowView.new(location: @location.reload)),
+      turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+    ]
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,8 +4,7 @@ class LocationsController < ApplicationController
   before_action :set_location, only: %i[show edit update destroy]
 
   def index
-    locations = locations_query.index
-    render Components::Locations::IndexView.new(locations: locations)
+    render locations_index_view
   end
 
   def show
@@ -39,34 +38,60 @@ class LocationsController < ApplicationController
     authorize @location
 
     if @location.save
-      redirect_to @location, notice: t('locations.created')
+      respond_to do |format|
+        format.html { redirect_to @location, notice: t('locations.created') }
+        format.turbo_stream do
+          flash.now[:notice] = t('locations.created')
+          render turbo_stream: location_main_content_streams(@location.reload)
+        end
+      end
     else
-      render Components::Locations::FormView.new(
-        location: @location,
-        title: 'New Location',
-        subtitle: 'Add a new medication storage location'
-      ), status: :unprocessable_content
+      respond_to do |format|
+        format.html { render new_location_form, status: :unprocessable_content }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('main-content', new_location_form),
+                 status: :unprocessable_content
+        end
+      end
     end
   end
 
   def update
     authorize @location
     if @location.update(location_params)
-      redirect_to safe_redirect_path(params[:return_to]) || @location, notice: t('locations.updated')
+      respond_to do |format|
+        format.html { redirect_to safe_redirect_path(params[:return_to]) || @location, notice: t('locations.updated') }
+        format.turbo_stream do
+          flash.now[:notice] = t('locations.updated')
+          render turbo_stream: location_main_content_streams(@location.reload)
+        end
+      end
     else
-      render Components::Locations::FormView.new(
-        location: @location,
-        title: 'Edit Location',
-        subtitle: @location.name,
-        return_to: url_from(params[:return_to])
-      ), status: :unprocessable_content
+      respond_to do |format|
+        format.html { render edit_location_form, status: :unprocessable_content }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('main-content', edit_location_form),
+                 status: :unprocessable_content
+        end
+      end
     end
   end
 
   def destroy
     authorize @location
+    location_id = @location.id
     @location.destroy
-    redirect_to locations_url, notice: t('locations.deleted')
+    respond_to do |format|
+      format.html { redirect_to locations_url, notice: t('locations.deleted') }
+      format.turbo_stream do
+        flash.now[:notice] = t('locations.deleted')
+        render turbo_stream: [
+          turbo_stream.remove("location_#{location_id}"),
+          turbo_stream.remove("location_show_#{location_id}"),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
   end
 
   private
@@ -81,5 +106,33 @@ class LocationsController < ApplicationController
 
   def locations_query
     LocationsQuery.new(scope: policy_scope(Location))
+  end
+
+  def locations_index_view
+    Components::Locations::IndexView.new(locations: locations_query.index)
+  end
+
+  def new_location_form
+    Components::Locations::FormView.new(
+      location: @location,
+      title: 'New Location',
+      subtitle: 'Add a new medication storage location'
+    )
+  end
+
+  def edit_location_form
+    Components::Locations::FormView.new(
+      location: @location,
+      title: 'Edit Location',
+      subtitle: @location.name,
+      return_to: url_from(params[:return_to])
+    )
+  end
+
+  def location_main_content_streams(location)
+    [
+      turbo_stream.replace('main-content', Components::Locations::ShowView.new(location: location)),
+      turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+    ]
   end
 end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -23,14 +23,7 @@ class MedicationsController < ApplicationController
       location_id: @current_location_id
     )
 
-    render Components::Medications::IndexView.new(
-      medications: medication_query.call,
-      current_category: @current_category,
-      categories: medication_query.categories,
-      locations: locations,
-      current_location_id: @current_location_id,
-      wizard_variant: current_user.wizard_variant
-    )
+    render_medications_index(medication_query:, locations:)
   end
 
   def show
@@ -132,8 +125,19 @@ class MedicationsController < ApplicationController
 
   def destroy
     authorize @medication
+    medication_id = @medication.id
     @medication.destroy
-    redirect_to medications_url, notice: t('medications.deleted')
+    respond_to do |format|
+      format.html { redirect_to medications_url, notice: t('medications.deleted') }
+      format.turbo_stream do
+        flash.now[:notice] = t('medications.deleted')
+        render turbo_stream: [
+          turbo_stream.remove("medication_#{medication_id}"),
+          turbo_stream.remove("medication_show_#{medication_id}"),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
   end
 
   def mark_as_ordered

--- a/app/controllers/notification_preferences_controller.rb
+++ b/app/controllers/notification_preferences_controller.rb
@@ -5,9 +5,21 @@ class NotificationPreferencesController < ApplicationController
     @preference = current_user.person.notification_preference ||
                   current_user.person.build_notification_preference
     if @preference.update(preference_params)
-      redirect_to profile_path, notice: t('notification_preferences.updated')
+      respond_to do |format|
+        format.html { redirect_to profile_path, notice: t('notification_preferences.updated') }
+        format.turbo_stream do
+          flash.now[:notice] = t('notification_preferences.updated')
+          render turbo_stream: notification_preference_streams
+        end
+      end
     else
-      redirect_to profile_path, alert: t('notification_preferences.update_failed')
+      respond_to do |format|
+        format.html { redirect_to profile_path, alert: t('notification_preferences.update_failed') }
+        format.turbo_stream do
+          flash.now[:alert] = t('notification_preferences.update_failed')
+          render turbo_stream: notification_preference_streams, status: :unprocessable_content
+        end
+      end
     end
   end
 
@@ -15,5 +27,12 @@ class NotificationPreferencesController < ApplicationController
 
   def preference_params
     params.expect(notification_preference: %i[enabled morning_time afternoon_time evening_time night_time])
+  end
+
+  def notification_preference_streams
+    [
+      turbo_stream.replace('notifications-card', Views::Profiles::NotificationsCard.new(person: current_user.person.reload)),
+      turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+    ]
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -65,7 +65,13 @@ class ProfilesController < ApplicationController
         end
       end
     else
-      redirect_to profile_path, alert: t('profiles.no_changes')
+      respond_to do |format|
+        format.html { redirect_to profile_path, alert: t('profiles.no_changes') }
+        format.turbo_stream do
+          flash.now[:alert] = t('profiles.no_changes')
+          render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
+        end
+      end
     end
   end
 

--- a/app/views/profiles/notifications_card.rb
+++ b/app/views/profiles/notifications_card.rb
@@ -21,7 +21,7 @@ module Views
       end
 
       def view_template
-        Card do
+        Card(id: 'notifications-card') do
           render CardHeader.new do
             render(CardTitle.new { t('profiles.notifications.title') })
             render(CardDescription.new { t('profiles.notifications.description') })

--- a/spec/components/views/profiles/notifications_card_spec.rb
+++ b/spec/components/views/profiles/notifications_card_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Views::Profiles::NotificationsCard, type: :component do
   it 'renders a hidden test notification button wired to the push notification controller' do
     rendered = render_inline(described_class.new(person: people(:one)))
 
+    expect(rendered.at_css('#notifications-card')).to be_present
+
     test_button = rendered.at_css('button[data-push-notification-target="testButton"]')
 
     expect(test_button).to be_present

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Admin create and update turbo flows' do
   end
 
   describe 'POST /admin/users' do
-    it 'follows turbo redirect to index on success' do
+    it 'returns turbo_stream and replaces users index and flash on success' do
       post admin_users_path,
            params: {
              user: {
@@ -100,8 +100,12 @@ RSpec.describe 'Admin create and update turbo flows' do
            },
            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(admin_users_path)
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include('target="main-content"')
+      expect(response.body).to include('id="admin-users-frame"')
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include('Turbo New User')
     end
 
     it 'returns unprocessable content on validation failure' do
@@ -130,7 +134,7 @@ RSpec.describe 'Admin create and update turbo flows' do
   end
 
   describe 'PATCH /admin/users/:id' do
-    it 'follows turbo redirect to index on success' do
+    it 'returns turbo_stream and replaces users index and flash on success' do
       patch admin_user_path(users(:jane)),
             params: {
               user: {
@@ -146,8 +150,12 @@ RSpec.describe 'Admin create and update turbo flows' do
             },
             headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(admin_users_path)
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include('target="main-content"')
+      expect(response.body).to include('id="admin-users-frame"')
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include('Jane Turbo Update')
       expect(users(:jane).person.reload.name).to eq('Jane Turbo Update')
     end
   end

--- a/spec/requests/location_memberships_turbo_spec.rb
+++ b/spec/requests/location_memberships_turbo_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Location memberships turbo streams' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  let(:admin) { users(:admin) }
+  let(:location) { locations(:school) }
+
+  before { sign_in(admin) }
+
+  describe 'POST /locations/:location_id/location_memberships' do
+    it 'returns turbo_stream and replaces the location show container and flash' do
+      person = people(:john)
+
+      expect do
+        post location_location_memberships_path(location),
+             params: { location_membership: { person_id: person.id } },
+             headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end.to change(LocationMembership, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include("target=\"location_show_#{location.id}\"")
+      expect(response.body).to include(person.name)
+      expect(response.body).to include('target="flash"')
+    end
+  end
+
+  describe 'DELETE /locations/:location_id/location_memberships/:id' do
+    it 'returns turbo_stream and replaces the location show container and flash' do
+      membership = location_memberships(:jane_school)
+
+      expect do
+        delete location_location_membership_path(location, membership),
+               headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end.to change(LocationMembership, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include("target=\"location_show_#{location.id}\"")
+      expect(response.body).to include('target="flash"')
+    end
+  end
+end

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Locations' do
       it 'returns HTTP success' do
         get locations_path
         expect(response).to have_http_status(:success)
+        expect(response.body).to include('id="locations_index"')
       end
     end
 
@@ -57,6 +58,7 @@ RSpec.describe 'Locations' do
       it 'returns HTTP success' do
         get location_path(location)
         expect(response).to have_http_status(:success)
+        expect(response.body).to include("id=\"location_show_#{location.id}\"")
       end
     end
 
@@ -131,6 +133,20 @@ RSpec.describe 'Locations' do
         expect(response).to redirect_to(location_path(Location.last))
       end
 
+      it 'returns turbo_stream and replaces main content and flash on success' do
+        expect do
+          post locations_path,
+               params: { location: { name: 'Turbo Office', description: 'Work office' } },
+               headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+        end.to change(Location, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include('target="main-content"')
+        expect(response.body).to include("id=\"location_show_#{Location.last.id}\"")
+        expect(response.body).to include('target="flash"')
+      end
+
       it 'renders form with invalid params' do
         post locations_path, params: { location: { name: '' } }
         expect(response).to have_http_status(:unprocessable_content)
@@ -148,6 +164,19 @@ RSpec.describe 'Locations' do
         patch location_path(location), params: { location: { name: 'Updated Home' } }
         expect(response).to redirect_to(location_path(location))
         expect(location.reload.name).to eq('Updated Home')
+      end
+
+      it 'returns turbo_stream and replaces main content and flash on success' do
+        patch location_path(location),
+              params: { location: { name: 'Turbo Updated Home' } },
+              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include('target="main-content"')
+        expect(response.body).to include("id=\"location_show_#{location.id}\"")
+        expect(response.body).to include('Turbo Updated Home')
+        expect(response.body).to include('target="flash"')
       end
 
       it 'renders form with invalid params' do
@@ -169,6 +198,18 @@ RSpec.describe 'Locations' do
         end.to change(Location, :count).by(-1)
 
         expect(response).to redirect_to(locations_path)
+      end
+
+      it 'returns turbo_stream and removes location targets and updates flash' do
+        expect do
+          delete location_path(location), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+        end.to change(Location, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include("target=\"location_#{location.id}\"")
+        expect(response.body).to include("target=\"location_show_#{location.id}\"")
+        expect(response.body).to include('target="flash"')
       end
     end
 

--- a/spec/requests/medications_category_filter_spec.rb
+++ b/spec/requests/medications_category_filter_spec.rb
@@ -22,9 +22,22 @@ RSpec.describe 'Medications category filter' do
     get medications_path
 
     expect(response).to have_http_status(:ok)
+    expect(response.body).to include('id="medications_inventory"')
+    expect(response.body).to include('data-turbo-frame="medications_inventory"')
     expect(response.body).to include('data-controller="ruby-ui--combobox"')
     expect(response.body).to include('name="category"')
     expect(response.body).to include(I18n.t('medications.index.all'))
+  end
+
+  it 'returns only the inventory frame when filtering from the Turbo frame' do
+    get medications_path(category: 'Vitamin'), headers: { 'Turbo-Frame' => 'medications_inventory' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('id="medications_inventory"')
+    expect(response.body).to include('Vitamin D')
+    expect(response.body).to include('Vitamin C')
+    expect(response.body).not_to include('data-testid="medications-list"')
+    expect(response.body).not_to include('Paracetamol')
   end
 
   it 'filters medications by category and keeps selected value' do

--- a/spec/requests/medications_destroy_turbo_spec.rb
+++ b/spec/requests/medications_destroy_turbo_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medications destroy with turbo_stream' do
+  fixtures :accounts, :people, :users, :locations, :medications
+
+  let(:admin) { users(:admin) }
+  let(:medication) { medications(:vitamin_c) }
+
+  before { sign_in(admin) }
+
+  describe 'DELETE /medications/:id' do
+    it 'returns turbo_stream and removes medication targets and updates flash' do
+      expect do
+        delete medication_path(medication), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end.to change(Medication, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include("target=\"medication_#{medication.id}\"")
+      expect(response.body).to include("target=\"medication_show_#{medication.id}\"")
+      expect(response.body).to include('target="flash"')
+    end
+  end
+end

--- a/spec/requests/medications_refill_spec.rb
+++ b/spec/requests/medications_refill_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Medications refill' do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"medication_show_#{medication.id}\"")
+      expect(response.body).to include("target=\"medication_#{medication.id}\"")
       expect(response.body).to include('target="flash"')
     end
 
@@ -58,6 +59,7 @@ RSpec.describe 'Medications refill' do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"medication_show_#{medication.id}\"")
+      expect(response.body).to include("target=\"medication_#{medication.id}\"")
       expect(response.body).to include('target="flash"')
     end
   end

--- a/spec/requests/medications_reorder_status_turbo_spec.rb
+++ b/spec/requests/medications_reorder_status_turbo_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Medications reorder status with turbo_stream' do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"medication_show_#{medication.id}\"")
+      expect(response.body).to include("target=\"medication_#{medication.id}\"")
       expect(response.body).to include('target="flash"')
       expect(medication.reload.reorder_status).to eq('ordered')
     end
@@ -31,6 +32,7 @@ RSpec.describe 'Medications reorder status with turbo_stream' do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"medication_show_#{medication.id}\"")
+      expect(response.body).to include("target=\"medication_#{medication.id}\"")
       expect(response.body).to include('target="flash"')
       expect(medication.reload.reorder_status).to eq('received')
     end

--- a/spec/requests/notification_preferences_turbo_spec.rb
+++ b/spec/requests/notification_preferences_turbo_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Notification preferences turbo streams' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:damacus) }
+
+  before { sign_in(user) }
+
+  describe 'PATCH /notification_preference' do
+    it 'returns turbo_stream and replaces the notifications card and flash' do
+      patch notification_preference_path,
+            params: {
+              notification_preference: {
+                enabled: '0',
+                morning_time: '07:30',
+                afternoon_time: '13:30',
+                evening_time: '18:30',
+                night_time: '22:30'
+              }
+            },
+            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include('target="notifications-card"')
+      expect(response.body).to include('target="flash"')
+      expect(user.person.notification_preference.reload).not_to be_enabled
+    end
+  end
+end

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -73,4 +73,15 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include('Remove')
     end
   end
+
+  describe 'PATCH /profile' do
+    it 'returns turbo_stream and updates flash when no changes are submitted' do
+      patch profile_path, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include(I18n.t('profiles.no_changes'))
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add Turbo frame-only filtering for the medication inventory list
- Add Turbo Stream updates for medication, location, membership, profile notification, and admin user CRUD flows
- Preserve existing HTML fallbacks while adding request/component coverage for the new Turbo targets

Closes #694

## Verification
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->