### PR TITLE
refactor: slim medication controllers

### DIFF
--- a/app/controllers/concerns/medication_refillable.rb
+++ b/app/controllers/concerns/medication_refillable.rb
@@ -27,6 +27,16 @@ module MedicationRefillable
     end
   end
 
+  def render_refill_success
+    respond_to do |format|
+      format.html { redirect_back_or_to @medication, notice: t('medications.refilled') }
+      format.turbo_stream do
+        flash.now[:notice] = t('medications.refilled')
+        render turbo_stream: medication_streams
+      end
+    end
+  end
+
   def medication_streams
     medication = @medication.reload
     [

--- a/app/controllers/concerns/person_medication_form_renderable.rb
+++ b/app/controllers/concerns/person_medication_form_renderable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module PersonMedicationFormRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def prepare_new_person_medication
+    @person_medication = @person.person_medications.build
+    if medication_options_query.include?(params[:medication_id])
+      @person_medication.medication_id = params[:medication_id]
+    end
+    @medications = medication_options_query.call
+  end
+
+  def render_person_medication_form(title:, editing: false, back_path: nil, status: :ok)
+    is_modal = request.headers['Turbo-Frame'] == 'modal'
+
+    respond_to do |format|
+      format.html do
+        if is_modal
+          render person_medication_modal(title: title, editing: editing, back_path: back_path), layout: false, status: status
+        else
+          render person_medication_form_view(editing: editing), status: status
+        end
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          'modal',
+          person_medication_modal(title: title, editing: editing, back_path: back_path)
+        ), status: status
+      end
+    end
+  end
+
+  def person_medication_modal(title:, editing: false, back_path: nil)
+    Components::PersonMedications::Modal.new(
+      person_medication: @person_medication,
+      person: @person,
+      medications: @medications,
+      title: title,
+      editing: editing,
+      back_path: back_path
+    )
+  end
+
+  def person_medication_form_view(editing: false)
+    Components::PersonMedications::FormView.new(
+      person_medication: @person_medication,
+      person: @person,
+      medications: @medications,
+      editing: editing
+    )
+  end
+
+  def save_person_medication?
+    return true if explicit_dose_submitted? && @person_medication.save
+
+    add_explicit_dose_errors unless explicit_dose_submitted?
+    false
+  end
+
+  def render_person_medication_create_failure
+    render_person_medication_form(
+      title: t('person_medications.modal.new_title', person: @person.name),
+      status: :unprocessable_content
+    )
+  end
+
+  def render_person_medication_update_failure
+    render_person_medication_form(
+      title: t('person_medications.modal.edit_title', person: @person.name),
+      editing: true,
+      status: :unprocessable_content
+    )
+  end
+end

--- a/app/controllers/concerns/person_medication_response_renderable.rb
+++ b/app/controllers/concerns/person_medication_response_renderable.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module PersonMedicationResponseRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_person_medication_create_success
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: t('person_medications.created') }
+      format.turbo_stream do
+        flash.now[:notice] = t('person_medications.created')
+        render turbo_stream: [
+          turbo_stream.update('modal', ''),
+          turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_person_medication_update_success
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: t('person_medications.updated') }
+      format.turbo_stream do
+        flash.now[:notice] = t('person_medications.updated')
+        render turbo_stream: [
+          turbo_stream.update('modal', ''),
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_person_medication_destroy_success
+    respond_to do |format|
+      format.html { redirect_back_or_to person_path(@person), notice: t('person_medications.deleted') }
+      format.turbo_stream do
+        flash.now[:notice] = t('person_medications.deleted')
+        render turbo_stream: [
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_person_medication_reorder_success
+    respond_to do |format|
+      format.html { redirect_back_or_to person_path(@person) }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload))
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/person_medication_take_renderable.rb
+++ b/app/controllers/concerns/person_medication_take_renderable.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module PersonMedicationTakeRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def take_person_medication(taken_at)
+    result = TakeMedicationService.new.call(
+      source: @person_medication,
+      amount_override: params[:amount_ml],
+      taken_from_medication_id: requested_taken_from_medication_id,
+      user: current_user,
+      taken_at: taken_at
+    )
+    log_person_medication_invalid_take_attempt if result.error == :invalid_amount
+    result
+  end
+
+  def log_person_medication_invalid_take_attempt
+    log_invalid_take_attempt(source: 'person_medication', amount: nil,
+                             metadata: { person_medication_id: @person_medication.id,
+                                         medication_id: @person_medication.medication_id })
+  end
+
+  def handle_person_medication_take_failure(result)
+    handle_take_medication_failure(result.error, scope: 'person_medications')
+  end
+
+  def render_person_medication_take_success(take)
+    @take = take
+    respond_to do |format|
+      format.html { redirect_back_or_to person_path(@person), notice: t('person_medications.medication_taken') }
+      format.turbo_stream do
+        flash.now[:notice] = t('person_medications.medication_taken')
+        streams = build_timeline_streams_for(@person_medication.reload, @take)
+        streams << turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))
+        render turbo_stream: streams
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/schedule_mutation_renderable.rb
+++ b/app/controllers/concerns/schedule_mutation_renderable.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ScheduleMutationRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_schedule_create_success
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: t('schedules.created') }
+      format.turbo_stream do
+        flash.now[:notice] = t('schedules.created')
+        render turbo_stream: [
+          turbo_stream.update('modal', ''),
+          turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_schedule_create_failure
+    @medications = medication_options_query.call
+    render_new_schedule_form(status: :unprocessable_content)
+  end
+
+  def render_schedule_update_success
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: t('schedules.updated') }
+      format.turbo_stream do
+        flash.now[:notice] = t('schedules.updated')
+        render turbo_stream: [
+          turbo_stream.update('modal', ''),
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_schedule_update_failure
+    @medications = medication_options_query.call
+    render_edit_schedule_form(status: :unprocessable_content)
+  end
+
+  def render_schedule_destroy_success
+    respond_to do |format|
+      format.html { redirect_back_or_to person_path(@person), notice: t('schedules.deleted') }
+      format.turbo_stream do
+        flash.now[:notice] = t('schedules.deleted')
+        render turbo_stream: [
+          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/schedule_take_renderable.rb
+++ b/app/controllers/concerns/schedule_take_renderable.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ScheduleTakeRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def take_schedule(taken_at)
+    result = TakeMedicationService.new.call(
+      source: @schedule,
+      amount_override: params[:amount_ml],
+      taken_from_medication_id: requested_taken_from_medication_id,
+      user: current_user,
+      taken_at: taken_at
+    )
+    log_schedule_invalid_take_attempt if result.error == :invalid_amount
+    result
+  end
+
+  def log_schedule_invalid_take_attempt
+    log_invalid_take_attempt(source: 'schedule', amount: nil,
+                             metadata: { schedule_id: @schedule.id,
+                                         medication_id: @schedule.medication_id })
+  end
+
+  def handle_schedule_take_failure(result)
+    handle_take_medication_failure(result.error, scope: 'schedules')
+  end
+
+  def render_schedule_take_success(take)
+    @take = take
+    respond_to do |format|
+      format.html { redirect_back_or_to person_path(@person), notice: t('schedules.medication_taken') }
+      format.turbo_stream do
+        flash.now[:notice] = t('schedules.medication_taken')
+        streams = build_timeline_streams_for(@schedule.reload, @take)
+        streams << turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))
+        render turbo_stream: streams
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/schedule_workflow_renderable.rb
+++ b/app/controllers/concerns/schedule_workflow_renderable.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module ScheduleWorkflowRenderable
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_schedule_workflow
+    workflow_options = schedule_workflow_query.options
+    @people = workflow_options.people
+    @medications = workflow_options.medications
+    @selected_person_id = params[:person_id]
+    @selected_medication_id = params[:medication_id]
+    @schedule_type = params[:schedule_type]
+    @frequency = params[:frequency]
+
+    render Components::Schedules::WorkflowView.new(
+      people: @people,
+      medications: @medications,
+      selected_person_id: @selected_person_id,
+      selected_medication_id: @selected_medication_id,
+      schedule_type: @schedule_type,
+      frequency: @frequency
+    )
+  end
+
+  def selected_schedule_workflow_path
+    selection = schedule_workflow_query.selection(
+      person_id: params.require(:person_id),
+      medication_id: params.require(:medication_id)
+    )
+
+    new_person_schedule_path(
+      selection.person,
+      medication_id: selection.medication.id,
+      frequency: params[:frequency].to_s,
+      schedule_type: params[:schedule_type].to_s
+    )
+  end
+
+  def prepare_new_schedule
+    @schedule = @person.schedules.build
+    @schedule.medication_id = params[:medication_id] if params[:medication_id].present?
+    @schedule.frequency = params[:frequency] if params[:frequency].present?
+  end
+
+  def render_new_schedule_form(status: :ok)
+    render_schedule_form(
+      schedule: @schedule,
+      medications: @medications,
+      title: t('schedules.modal.new_title', person: @person.name),
+      back_path: modal_back_path(@person),
+      status: status
+    )
+  end
+
+  def render_edit_schedule_form(status: :ok)
+    render_schedule_form(
+      schedule: @schedule,
+      medications: @medications,
+      title: t('schedules.modal.edit_title', person: @person.name),
+      editing: true,
+      status: status
+    )
+  end
+end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -12,18 +12,7 @@ class MedicationsController < ApplicationController
                 only: %i[show nhs_guidance administration edit update destroy refill mark_as_ordered mark_as_received]
 
   def index
-    @current_category = params[:category]
-    base_scope = policy_scope(Medication)
-    locations = accessible_inventory_locations(base_scope)
-    @current_location_id = resolved_inventory_location_id(locations)
-
-    medication_query = MedicationQuery.new(
-      scope: base_scope,
-      category: @current_category,
-      location_id: @current_location_id
-    )
-
-    render_medications_index(medication_query:, locations:)
+    render_medications_index_for_request
   end
 
   def show
@@ -81,7 +70,7 @@ class MedicationsController < ApplicationController
   end
 
   def create
-    @medication = Medication.new(onboarding_builder.merge_create_attributes(medication_params.to_h.deep_symbolize_keys))
+    @medication = build_medication_from_request
     @medication.location_id ||= primary_location&.id
     authorize @medication
 
@@ -89,109 +78,43 @@ class MedicationsController < ApplicationController
 
     result = create_medication_from_request
 
-    if result.success
-      create_success
-    elsif params[:wizard] == 'true'
-      render wizard_wrapper_class.new(
-        medication: @medication,
-        locations: available_locations,
-        people: available_people,
-        current_user: current_user
-      ), status: :unprocessable_content
-    else
-      render Components::Medications::FormView.new(
-        medication: @medication,
-        locations: available_locations,
-        title: t('medications.form.new_title'),
-        subtitle: t('medications.form.new_subtitle')
-      ), status: :unprocessable_content
-    end
+    return create_success if result.success
+
+    render_create_failure
   end
 
   def update
     authorize @medication
     if @medication.update(medication_params)
-      redirect_to safe_redirect_path(params[:return_to]) || @medication, notice: t('medications.updated')
+      redirect_update_success
     else
-      render Components::Medications::FormView.new(
-        medication: @medication,
-        locations: available_locations,
-        title: t('medications.form.edit_title'),
-        subtitle: t('medications.form.edit_subtitle', name: @medication.name),
-        return_to: url_from(params[:return_to])
-      ), status: :unprocessable_content
+      render_update_failure
     end
   end
 
   def destroy
     authorize @medication
-    medication_id = @medication.id
-    @medication.destroy
-    respond_to do |format|
-      format.html { redirect_to medications_url, notice: t('medications.deleted') }
-      format.turbo_stream do
-        flash.now[:notice] = t('medications.deleted')
-        render turbo_stream: [
-          turbo_stream.remove("medication_#{medication_id}"),
-          turbo_stream.remove("medication_show_#{medication_id}"),
-          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-        ]
-      end
-    end
+    destroy_medication
   end
 
   def mark_as_ordered
     authorize @medication
-    @medication.update!(reorder_status: :ordered, ordered_at: Time.current)
-    respond_to do |format|
-      format.html { redirect_back_or_to @medication, notice: t('medications.ordered') }
-      format.turbo_stream do
-        flash.now[:notice] = t('medications.ordered')
-        render turbo_stream: medication_streams
-      end
-    end
+    update_reorder_status(:ordered, notice: t('medications.ordered'))
   end
 
   def mark_as_received
     authorize @medication
-    @medication.update!(reorder_status: :received, reordered_at: Time.current)
-    respond_to do |format|
-      format.html { redirect_back_or_to @medication, notice: t('medications.received') }
-      format.turbo_stream do
-        flash.now[:notice] = t('medications.received')
-        render turbo_stream: medication_streams
-      end
-    end
+    update_reorder_status(:received, notice: t('medications.received'))
   end
 
   def refill
     authorize @medication, :update?
 
-    quantity = refill_quantity
-    restock_date = parse_restock_date
+    result = restock_medication
 
-    if quantity <= 0
-      render_refill_error('Quantity must be greater than 0')
-      return
-    end
+    return render_refill_error(result.error) unless result.success?
 
-    unless restock_date
-      render_refill_error('Restock date is invalid')
-      return
-    end
-
-    @medication.paper_trail_event = "restock (qty: #{quantity}, date: #{restock_date.iso8601})"
-    @medication.restock!(quantity: quantity)
-
-    respond_to do |format|
-      format.html { redirect_back_or_to @medication, notice: t('medications.refilled') }
-      format.turbo_stream do
-        flash.now[:notice] = t('medications.refilled')
-        render turbo_stream: medication_streams
-      end
-    end
-  rescue ActiveRecord::RecordInvalid => e
-    render_refill_error(e.record.errors.full_messages.to_sentence)
+    render_refill_success
   end
 
   def finder
@@ -212,23 +135,98 @@ class MedicationsController < ApplicationController
     @medication = policy_scope(Medication).find(params[:id])
   end
 
-  def create_medication_from_request
-    unless onboarding_schedule?
-      return MedicationOnboardingCreateService::Result.new(
-        success: @medication.save,
-        medication: @medication,
-        schedule: nil
-      )
-    end
+  def render_medications_index_for_request
+    @current_category = params[:category]
+    base_scope = policy_scope(Medication)
+    locations = accessible_inventory_locations(base_scope)
+    @current_location_id = resolved_inventory_location_id(locations)
 
+    render_medications_index(
+      medication_query: medication_query(base_scope),
+      locations: locations
+    )
+  end
+
+  def medication_query(base_scope)
+    MedicationQuery.new(
+      scope: base_scope,
+      category: @current_category,
+      location_id: @current_location_id
+    )
+  end
+
+  def destroy_medication
+    medication_id = @medication.id
+    @medication.destroy
+    render_destroy_success(medication_id)
+  end
+
+  def render_destroy_success(medication_id)
+    respond_to do |format|
+      format.html { redirect_to medications_url, notice: t('medications.deleted') }
+      format.turbo_stream do
+        flash.now[:notice] = t('medications.deleted')
+        render turbo_stream: destroy_medication_streams(medication_id)
+      end
+    end
+  end
+
+  def destroy_medication_streams(medication_id)
+    [
+      turbo_stream.remove("medication_#{medication_id}"),
+      turbo_stream.remove("medication_show_#{medication_id}"),
+      turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+    ]
+  end
+
+  def build_medication_from_request
+    Medication.new(onboarding_builder.merge_create_attributes(medication_params.to_h.deep_symbolize_keys))
+  end
+
+  def redirect_update_success
+    redirect_to safe_redirect_path(params[:return_to]) || @medication, notice: t('medications.updated')
+  end
+
+  def render_update_failure
+    render Components::Medications::FormView.new(
+      medication: @medication,
+      locations: available_locations,
+      title: t('medications.form.edit_title'),
+      subtitle: t('medications.form.edit_subtitle', name: @medication.name),
+      return_to: url_from(params[:return_to])
+    ), status: :unprocessable_content
+  end
+
+  def update_reorder_status(status, notice:)
+    MedicationReorderStatusService.new.call(medication: @medication, status: status)
+    respond_to do |format|
+      format.html { redirect_back_or_to @medication, notice: notice }
+      format.turbo_stream do
+        flash.now[:notice] = notice
+        render turbo_stream: medication_streams
+      end
+    end
+  end
+
+  def restock_medication
+    RestockMedicationService.new.call(
+      medication: @medication,
+      quantity: params.dig(:refill, :quantity),
+      restock_date: params.dig(:refill, :restock_date)
+    )
+  end
+
+  def create_medication_from_request
     MedicationOnboardingCreateService.new(
       medication: @medication,
-      schedule_attributes: onboarding_schedule_params.to_h.deep_symbolize_keys,
+      schedule_attributes: onboarding_schedule_params_for_create,
       people_scope: policy_scope(Person)
     ).call
   end
 
-  def onboarding_schedule?
-    params[:wizard] == 'true' && params[:onboarding_schedule].present?
+  def onboarding_schedule_params_for_create
+    return nil unless params[:wizard] == 'true' && params[:onboarding_schedule].present?
+
+    onboarding_schedule_params.to_h.deep_symbolize_keys
   end
 end

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -3,6 +3,9 @@
 class PersonMedicationsController < ApplicationController
   include TimelineRefreshable
   include PersonViewable
+  include PersonMedicationFormRenderable
+  include PersonMedicationResponseRenderable
+  include PersonMedicationTakeRenderable
   include TakeMedicationGuardable
   include MedicationWorkflowBackPathable
 
@@ -11,47 +14,20 @@ class PersonMedicationsController < ApplicationController
 
   def new
     authorize PersonMedication
-    @person_medication = @person.person_medications.build
-    if medication_options_query.include?(params[:medication_id])
-      @person_medication.medication_id = params[:medication_id]
-    end
-    @medications = medication_options_query.call
-
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
-    back_path = modal_back_path(@person)
-
-    respond_to do |format|
-      format.html do
-        if is_modal
-          render Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.new_title', person: @person.name), back_path: back_path), layout: false
-        else
-          render Components::PersonMedications::FormView.new(person_medication: @person_medication, person: @person, medications: @medications)
-        end
-      end
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace('modal', Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.new_title', person: @person.name), back_path: back_path))
-      end
-    end
+    prepare_new_person_medication
+    render_person_medication_form(
+      title: t('person_medications.modal.new_title', person: @person.name),
+      back_path: modal_back_path(@person)
+    )
   end
 
   def edit
     authorize @person_medication
     @medications = medication_options_query.call
-
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
-
-    respond_to do |format|
-      format.html do
-        if is_modal
-          render Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.edit_title', person: @person.name), editing: true), layout: false
-        else
-          render Components::PersonMedications::FormView.new(person_medication: @person_medication, person: @person, medications: @medications, editing: true)
-        end
-      end
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace('modal', Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.edit_title', person: @person.name), editing: true))
-      end
-    end
+    render_person_medication_form(
+      title: t('person_medications.modal.edit_title', person: @person.name),
+      editing: true
+    )
   end
 
   def create
@@ -59,26 +35,10 @@ class PersonMedicationsController < ApplicationController
     authorize @person_medication
     @medications = medication_options_query.call
 
-    if explicit_dose_submitted? && @person_medication.save
-      respond_to do |format|
-        format.html { redirect_to person_path(@person), notice: t('person_medications.created') }
-        format.turbo_stream do
-          flash.now[:notice] = t('person_medications.created')
-          render turbo_stream: [
-            turbo_stream.update('modal', ''),
-            turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
-            turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-            turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-          ]
-        end
-      end
+    if save_person_medication?
+      render_person_medication_create_success
     else
-      add_explicit_dose_errors unless explicit_dose_submitted?
-
-      respond_to do |format|
-        format.html { render Components::PersonMedications::FormView.new(person_medication: @person_medication, person: @person, medications: @medications), status: :unprocessable_content }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('modal', Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.new_title', person: @person.name))), status: :unprocessable_content }
-      end
+      render_person_medication_create_failure
     end
   end
 
@@ -87,49 +47,22 @@ class PersonMedicationsController < ApplicationController
     @medications = medication_options_query.call
 
     if @person_medication.update(person_medication_update_params)
-      respond_to do |format|
-        format.html { redirect_to person_path(@person), notice: t('person_medications.updated') }
-        format.turbo_stream do
-          flash.now[:notice] = t('person_medications.updated')
-          render turbo_stream: [
-            turbo_stream.update('modal', ''),
-            turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-            turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-          ]
-        end
-      end
+      render_person_medication_update_success
     else
-      respond_to do |format|
-        format.html { render Components::PersonMedications::FormView.new(person_medication: @person_medication, person: @person, medications: @medications, editing: true), status: :unprocessable_content }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('modal', Components::PersonMedications::Modal.new(person_medication: @person_medication, person: @person, medications: @medications, title: t('person_medications.modal.edit_title', person: @person.name), editing: true)), status: :unprocessable_content }
-      end
+      render_person_medication_update_failure
     end
   end
 
   def destroy
     authorize @person_medication
     @person_medication.destroy
-    respond_to do |format|
-      format.html { redirect_back_or_to person_path(@person), notice: t('person_medications.deleted') }
-      format.turbo_stream do
-        flash.now[:notice] = t('person_medications.deleted')
-        render turbo_stream: [
-          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-        ]
-      end
-    end
+    render_person_medication_destroy_success
   end
 
   def reorder
     authorize @person_medication, :update?
-    @person_medication.reorder(params[:direction])
-    respond_to do |format|
-      format.html { redirect_back_or_to person_path(@person) }
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload))
-      end
-    end
+    PersonMedicationReorderService.new.call(person_medication: @person_medication, direction: params[:direction])
+    render_person_medication_reorder_success
   end
 
   def take_medication
@@ -137,32 +70,10 @@ class PersonMedicationsController < ApplicationController
     taken_at = medication_taken_at_or_respond(scope: 'person_medications')
     return unless taken_at
 
-    result = TakeMedicationService.new.call(
-      source: @person_medication,
-      amount_override: params[:amount_ml],
-      taken_from_medication_id: requested_taken_from_medication_id,
-      user: current_user,
-      taken_at: taken_at
-    )
+    result = take_person_medication(taken_at)
+    return handle_person_medication_take_failure(result) unless result.success
 
-    if result.error == :invalid_amount
-      log_invalid_take_attempt(source: 'person_medication', amount: nil,
-                               metadata: { person_medication_id: @person_medication.id,
-                                           medication_id: @person_medication.medication_id })
-    end
-
-    return handle_take_medication_failure(result.error, scope: 'person_medications') unless result.success
-
-    @take = result.take
-    respond_to do |format|
-      format.html { redirect_back_or_to person_path(@person), notice: t('person_medications.medication_taken') }
-      format.turbo_stream do
-        flash.now[:notice] = t('person_medications.medication_taken')
-        streams = build_timeline_streams_for(@person_medication.reload, @take)
-        streams << turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))
-        render turbo_stream: streams
-      end
-    end
+    render_person_medication_take_success(result.take)
   end
 
   private

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -4,6 +4,9 @@ class SchedulesController < ApplicationController
   include TimelineRefreshable
   include PersonViewable
   include ScheduleModalRenderable
+  include ScheduleMutationRenderable
+  include ScheduleTakeRenderable
+  include ScheduleWorkflowRenderable
   include TakeMedicationGuardable
   include ScheduleIndexPersonResolvable
   include ScheduleResourceResolvable
@@ -20,64 +23,25 @@ class SchedulesController < ApplicationController
 
   def workflow
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
-    workflow_options = schedule_workflow_query.options
-    @people = workflow_options.people
-    @medications = workflow_options.medications
-    @selected_person_id = params[:person_id]
-    @selected_medication_id = params[:medication_id]
-    @schedule_type = params[:schedule_type]
-    @frequency = params[:frequency]
-
-    render Components::Schedules::WorkflowView.new(
-      people: @people,
-      medications: @medications,
-      selected_person_id: @selected_person_id,
-      selected_medication_id: @selected_medication_id,
-      schedule_type: @schedule_type,
-      frequency: @frequency
-    )
+    render_schedule_workflow
   end
 
   def start_workflow
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
-    selection = schedule_workflow_query.selection(
-      person_id: params.require(:person_id),
-      medication_id: params.require(:medication_id)
-    )
-    frequency = params[:frequency].to_s
-    schedule_type = params[:schedule_type].to_s
-
-    redirect_to new_person_schedule_path(
-      selection.person,
-      medication_id: selection.medication.id,
-      frequency: frequency,
-      schedule_type: schedule_type
-    )
+    redirect_to selected_schedule_workflow_path
   end
 
   def new
-    @schedule = @person.schedules.build
-    @schedule.medication_id = params[:medication_id] if params[:medication_id].present?
-    @schedule.frequency = params[:frequency] if params[:frequency].present?
+    prepare_new_schedule
     authorize @schedule
     @medications = medication_options_query.call
-    render_schedule_form(
-      schedule: @schedule,
-      medications: @medications,
-      title: t('schedules.modal.new_title', person: @person.name),
-      back_path: modal_back_path(@person)
-    )
+    render_new_schedule_form
   end
 
   def edit
     authorize @schedule
     @medications = medication_options_query.call
-    render_schedule_form(
-      schedule: @schedule,
-      medications: @medications,
-      title: t('schedules.modal.edit_title', person: @person.name),
-      editing: true
-    )
+    render_edit_schedule_form
   end
 
   def create
@@ -86,68 +50,25 @@ class SchedulesController < ApplicationController
     @medications = medication_options_query.call
 
     if @schedule.save
-      respond_to do |format|
-        format.html { redirect_to person_path(@person), notice: t('schedules.created') }
-        format.turbo_stream do
-          flash.now[:notice] = t('schedules.created')
-          render turbo_stream: [
-            turbo_stream.update('modal', ''),
-            turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
-            turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-            turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-          ]
-        end
-      end
+      render_schedule_create_success
     else
-      @medications = medication_options_query.call
-      render_schedule_form(
-        schedule: @schedule,
-        medications: @medications,
-        title: t('schedules.modal.new_title', person: @person.name),
-        status: :unprocessable_content
-      )
+      render_schedule_create_failure
     end
   end
 
   def update
     authorize @schedule
     if @schedule.update(schedule_params)
-      respond_to do |format|
-        format.html { redirect_to person_path(@person), notice: t('schedules.updated') }
-        format.turbo_stream do
-          flash.now[:notice] = t('schedules.updated')
-          render turbo_stream: [
-            turbo_stream.update('modal', ''),
-            turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-            turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-          ]
-        end
-      end
+      render_schedule_update_success
     else
-      @medications = medication_options_query.call
-      render_schedule_form(
-        schedule: @schedule,
-        medications: @medications,
-        title: t('schedules.modal.edit_title', person: @person.name),
-        editing: true,
-        status: :unprocessable_content
-      )
+      render_schedule_update_failure
     end
   end
 
   def destroy
     authorize @schedule
     @schedule.destroy
-    respond_to do |format|
-      format.html { redirect_back_or_to person_path(@person), notice: t('schedules.deleted') }
-      format.turbo_stream do
-        flash.now[:notice] = t('schedules.deleted')
-        render turbo_stream: [
-          turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
-          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
-        ]
-      end
-    end
+    render_schedule_destroy_success
   end
 
   def take_medication
@@ -155,32 +76,10 @@ class SchedulesController < ApplicationController
     taken_at = medication_taken_at_or_respond(scope: 'schedules')
     return unless taken_at
 
-    result = TakeMedicationService.new.call(
-      source: @schedule,
-      amount_override: params[:amount_ml],
-      taken_from_medication_id: requested_taken_from_medication_id,
-      user: current_user,
-      taken_at: taken_at
-    )
+    result = take_schedule(taken_at)
+    return handle_schedule_take_failure(result) unless result.success
 
-    if result.error == :invalid_amount
-      log_invalid_take_attempt(source: 'schedule', amount: nil,
-                               metadata: { schedule_id: @schedule.id,
-                                           medication_id: @schedule.medication_id })
-    end
-
-    return handle_take_medication_failure(result.error, scope: 'schedules') unless result.success
-
-    @take = result.take
-    respond_to do |format|
-      format.html { redirect_back_or_to person_path(@person), notice: t('schedules.medication_taken') }
-      format.turbo_stream do
-        flash.now[:notice] = t('schedules.medication_taken')
-        streams = build_timeline_streams_for(@schedule.reload, @take)
-        streams << turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))
-        render turbo_stream: streams
-      end
-    end
+    render_schedule_take_success(result.take)
   end
 
   private

--- a/app/models/person_medication.rb
+++ b/app/models/person_medication.rb
@@ -35,13 +35,6 @@ class PersonMedication < ApplicationRecord
     dose_amount
   end
 
-  def reorder(direction)
-    adjacent = adjacent_record(direction)
-    return false unless adjacent
-
-    swap_positions_with(adjacent)
-  end
-
   def cycle_period
     DoseCycle.new(dose_cycle).period
   end
@@ -75,24 +68,6 @@ class PersonMedication < ApplicationRecord
     return if position.present?
 
     self.position = person.person_medications.maximum(:position).to_i + 1
-  end
-
-  def adjacent_record(direction)
-    case direction
-    when 'up'
-      person.person_medications.where(position: ...position).order(position: :desc, id: :desc).first
-    when 'down'
-      person.person_medications.where(position: (position + 1)..).order(position: :asc, id: :asc).first
-    end
-  end
-
-  def swap_positions_with(other)
-    self_position = position
-
-    transaction do
-      update!(position: other.position)
-      other.update!(position: self_position)
-    end
   end
 
   def legacy_record_without_resolvable_dose?

--- a/app/services/medication_onboarding_create_service.rb
+++ b/app/services/medication_onboarding_create_service.rb
@@ -5,13 +5,25 @@ class MedicationOnboardingCreateService
 
   attr_reader :medication, :schedule_attributes, :people_scope
 
-  def initialize(medication:, schedule_attributes:, people_scope:)
+  def initialize(medication:, schedule_attributes: nil, people_scope: nil)
     @medication = medication
     @schedule_attributes = schedule_attributes
     @people_scope = people_scope
   end
 
   def call
+    return save_medication unless schedule_requested?
+
+    save_medication_with_schedule
+  end
+
+  private
+
+  def save_medication
+    Result.new(success: medication.save, medication: medication, schedule: nil)
+  end
+
+  def save_medication_with_schedule
     schedule = nil
     success = false
 
@@ -32,7 +44,9 @@ class MedicationOnboardingCreateService
     Result.new(success: success, medication: medication, schedule: schedule)
   end
 
-  private
+  def schedule_requested?
+    schedule_attributes.present? && people_scope.present?
+  end
 
   def build_schedule
     schedule_person.schedules.build(schedule_attributes_for(primary_dosage_option))

--- a/app/services/medication_reorder_status_service.rb
+++ b/app/services/medication_reorder_status_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class MedicationReorderStatusService
+  Result = Data.define(:success, :medication) do
+    def success?
+      success
+    end
+  end
+
+  def call(medication:, status:, at: Time.current)
+    attributes = attributes_for(status, at)
+    return Result.new(success: false, medication: medication) unless attributes
+
+    medication.update!(attributes)
+    Result.new(success: true, medication: medication)
+  end
+
+  private
+
+  def attributes_for(status, at)
+    case status.to_sym
+    when :ordered
+      { reorder_status: :ordered, ordered_at: at }
+    when :received
+      { reorder_status: :received, reordered_at: at }
+    end
+  end
+end

--- a/app/services/person_medication_reorder_service.rb
+++ b/app/services/person_medication_reorder_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class PersonMedicationReorderService
+  Result = Data.define(:success, :person_medication) do
+    def success?
+      success
+    end
+  end
+
+  def call(person_medication:, direction:)
+    adjacent = adjacent_record(person_medication, direction)
+    return Result.new(success: false, person_medication: person_medication) unless adjacent
+
+    swap_positions(person_medication, adjacent)
+    Result.new(success: true, person_medication: person_medication)
+  end
+
+  private
+
+  def adjacent_record(person_medication, direction)
+    case direction
+    when 'up'
+      person_medication.person.person_medications
+                       .where(position: ...person_medication.position)
+                       .order(position: :desc, id: :desc)
+                       .first
+    when 'down'
+      person_medication.person.person_medications
+                       .where(position: (person_medication.position + 1)..)
+                       .order(position: :asc, id: :asc)
+                       .first
+    end
+  end
+
+  def swap_positions(person_medication, adjacent)
+    original_position = person_medication.position
+
+    person_medication.transaction do
+      person_medication.update!(position: adjacent.position)
+      adjacent.update!(position: original_position)
+    end
+  end
+end

--- a/app/services/restock_medication_service.rb
+++ b/app/services/restock_medication_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class RestockMedicationService
+  Result = Data.define(:success, :medication, :error) do
+    def success?
+      success
+    end
+  end
+
+  def call(medication:, quantity:, restock_date:)
+    normalized_quantity = quantity.to_i
+    normalized_date = normalize_date(restock_date)
+
+    return failure(medication, 'Quantity must be greater than 0') if normalized_quantity <= 0
+    return failure(medication, 'Restock date is invalid') unless normalized_date
+
+    medication.paper_trail_event = "restock (qty: #{normalized_quantity}, date: #{normalized_date.iso8601})"
+    medication.restock!(quantity: normalized_quantity)
+
+    Result.new(success: true, medication: medication, error: nil)
+  rescue ActiveRecord::RecordInvalid => e
+    failure(medication, e.record.errors.full_messages.to_sentence)
+  end
+
+  private
+
+  def normalize_date(restock_date)
+    return restock_date if restock_date.respond_to?(:iso8601)
+
+    Date.parse(restock_date.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def failure(medication, error)
+    Result.new(success: false, medication: medication, error: error)
+  end
+end

--- a/spec/controllers/application_controller_controller_action_length_spec.rb
+++ b/spec/controllers/application_controller_controller_action_length_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  let(:action_class) { Data.define(:controller, :name, :line_number, :body_lines) }
+  let(:controllers) do
+    [
+      MedicationsController,
+      PersonMedicationsController,
+      SchedulesController
+    ]
+  end
+
+  it 'keeps each public action under ten nonblank body lines' do
+    oversized_actions = controllers.flat_map { |controller| public_actions_for(controller) }
+                                   .select { |action| action.body_lines > 10 }
+
+    expect(oversized_actions).to eq([])
+  end
+
+  def public_actions_for(controller)
+    lines = controller_source_lines(controller)
+    public_method_lines(lines).filter_map do |line, index|
+      build_action(controller, line, index, lines)
+    end
+  end
+
+  def controller_source_lines(controller)
+    Rails.root.join('app/controllers', controller.name.underscore.concat('.rb')).readlines
+  end
+
+  def public_method_lines(lines)
+    private_line = private_line_number(lines)
+    lines.each_with_index.take_while { |_line, index| index < private_line }
+  end
+
+  def private_line_number(lines)
+    lines.index { |line| line.match?(/^\s*private\s*$/) } || lines.length
+  end
+
+  def build_action(controller, line, index, lines)
+    match = line.match(/^\s*def\s+([a-z_?]+)/)
+    return unless match
+
+    action_class.new(
+      controller: controller.name,
+      name: match[1],
+      line_number: index + 1,
+      body_lines: action_body_line_count(lines, index)
+    )
+  end
+
+  def action_body_line_count(lines, start_index)
+    body_lines_for(lines, start_index).count { |line| line.strip.present? }
+  end
+
+  def body_lines_for(lines, start_index)
+    depth = 0
+    body_lines = []
+
+    lines[(start_index + 1)..].each do |line|
+      depth -= 1 if line.match?(/^\s*end\s*$/)
+      break if depth.negative?
+
+      body_lines << line
+      stripped_line = line.strip
+      depth += 1 if stripped_line.match?(/\A(if|unless|case|begin)\b/) || stripped_line.match?(/\bdo\s*(\|.*\|)?\s*\z/)
+    end
+
+    body_lines
+  end
+end

--- a/spec/services/medication_reorder_status_service_spec.rb
+++ b/spec/services/medication_reorder_status_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationReorderStatusService do
+  describe '#call' do
+    let(:medication) { create(:medication, reorder_status: nil, ordered_at: nil, reordered_at: nil) }
+
+    it 'marks a medication as ordered' do
+      timestamp = Time.zone.local(2026, 5, 5, 9, 30)
+
+      result = described_class.new.call(medication: medication, status: :ordered, at: timestamp)
+
+      expect(result).to be_success
+      expect(medication.reload).to have_attributes(
+        reorder_status: 'ordered',
+        ordered_at: timestamp
+      )
+    end
+
+    it 'marks a medication as received' do
+      timestamp = Time.zone.local(2026, 5, 5, 10, 30)
+
+      result = described_class.new.call(medication: medication, status: :received, at: timestamp)
+
+      expect(result).to be_success
+      expect(medication.reload).to have_attributes(
+        reorder_status: 'received',
+        reordered_at: timestamp
+      )
+    end
+
+    it 'returns false for unsupported statuses' do
+      result = described_class.new.call(medication: medication, status: :cancelled)
+
+      expect(result).not_to be_success
+      expect(medication.reload.reorder_status).to be_nil
+    end
+  end
+end

--- a/spec/services/person_medication_reorder_service_spec.rb
+++ b/spec/services/person_medication_reorder_service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonMedicationReorderService do
+  describe '#call' do
+    let(:person) { create(:person) }
+    let(:first) { create(:person_medication, person: person, position: 1) }
+    let(:second) { create(:person_medication, person: person, position: 2) }
+
+    it 'moves a person medication up by swapping with the previous record' do
+      first
+
+      result = described_class.new.call(person_medication: second, direction: 'up')
+
+      expect(result).to be_success
+      expect(person.person_medications.order(:position, :id)).to eq([second.reload, first.reload])
+    end
+
+    it 'moves a person medication down by swapping with the next record' do
+      second
+
+      result = described_class.new.call(person_medication: first, direction: 'down')
+
+      expect(result).to be_success
+      expect(person.person_medications.order(:position, :id)).to eq([second.reload, first.reload])
+    end
+
+    it 'returns false when there is no adjacent record' do
+      result = described_class.new.call(person_medication: first, direction: 'up')
+
+      expect(result).not_to be_success
+      expect(first.reload.position).to eq(1)
+    end
+
+    it 'returns false for an unsupported direction' do
+      first
+
+      result = described_class.new.call(person_medication: second, direction: 'sideways')
+
+      expect(result).not_to be_success
+      expect(person.person_medications.order(:position, :id)).to eq([first.reload, second.reload])
+    end
+  end
+end

--- a/spec/services/restock_medication_service_spec.rb
+++ b/spec/services/restock_medication_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RestockMedicationService do
+  describe '#call' do
+    let(:medication) do
+      create(
+        :medication,
+        current_supply: 10,
+        supply_at_last_restock: 10,
+        reorder_status: :ordered,
+        ordered_at: 1.day.ago,
+        reordered_at: 1.hour.ago
+      )
+    end
+
+    it 'restocks the medication and records the audit event' do
+      restock_date = Date.current
+
+      result = described_class.new.call(medication: medication, quantity: '12', restock_date: restock_date)
+
+      expect(result).to be_success
+      expect(result.error).to be_nil
+      expect(medication.reload).to have_attributes(
+        current_supply: 22,
+        supply_at_last_restock: 22,
+        reorder_status: nil,
+        ordered_at: nil,
+        reordered_at: nil,
+        paper_trail_event: "restock (qty: 12, date: #{restock_date.iso8601})"
+      )
+    end
+
+    it 'returns an error for a non-positive quantity' do
+      result = described_class.new.call(medication: medication, quantity: '0', restock_date: Date.current)
+
+      expect(result).not_to be_success
+      expect(result.error).to eq('Quantity must be greater than 0')
+      expect(medication.reload.current_supply).to eq(10)
+    end
+
+    it 'returns an error for a missing restock date' do
+      result = described_class.new.call(medication: medication, quantity: '12', restock_date: nil)
+
+      expect(result).not_to be_success
+      expect(result.error).to eq('Restock date is invalid')
+      expect(medication.reload.current_supply).to eq(10)
+    end
+
+    it 'returns validation errors raised by the model command' do
+      allow(medication).to receive(:restock!).and_raise(ActiveRecord::RecordInvalid.new(medication))
+      medication.errors.add(:current_supply, 'is invalid')
+
+      result = described_class.new.call(medication: medication, quantity: '12', restock_date: Date.current)
+
+      expect(result).not_to be_success
+      expect(result.error).to eq('Current supply is invalid')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extract restock and reorder domain operations into service objects.
- Slim MedicationsController, PersonMedicationsController, and SchedulesController public actions behind focused delegators and response concerns.
- Add service specs plus an architecture spec that keeps controller public actions under 10 nonblank body lines.

## Verification
- task test TEST_FILE=spec/controllers/application_controller_controller_action_length_spec.rb
- task rubocop
- task test (2070 examples, 0 failures, 2 pending)

Related: #1040, #1031
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->