### PR TITLE
feat: add medication assignment flow

### DIFF
--- a/app/components/medication_assignments/form.rb
+++ b/app/components/medication_assignments/form.rb
@@ -1,0 +1,391 @@
+# frozen_string_literal: true
+
+module Components
+  module MedicationAssignments
+    class Form < Components::Base
+      include Phlex::Rails::Helpers::FormWith
+
+      attr_reader :assignment, :person, :medications, :modal, :back_path
+
+      def initialize(assignment:, person:, medications:, modal: false, back_path: nil)
+        @assignment = assignment
+        @person = person
+        @medications = medications
+        @modal = modal
+        @back_path = back_path
+        super()
+      end
+
+      def view_template
+        form_with(
+          scope: :medication_assignment,
+          url: person_medication_assignments_path(person),
+          method: :post,
+          class: 'space-y-6',
+          data: form_data
+        ) do
+          render_errors if assignment.errors.any?
+          render_workflow
+          render_actions
+        end
+      end
+
+      private
+
+      def form_data
+        {
+          controller: 'medication-assignment-form',
+          person_type: person.person_type,
+          medication_assignment_form_options_value: medication_options_payload.to_json,
+          medication_assignment_form_current_step_value: initial_step,
+          medication_assignment_form_start_date_value: start_date.to_s,
+          medication_assignment_form_end_date_value: end_date.to_s,
+          medication_assignment_form_translations_value: translations_payload.to_json
+        }
+      end
+
+      def render_errors
+        Alert(variant: :destructive, class: 'mb-6') do
+          AlertTitle do
+            t('person_medications.form.validation_errors', count: assignment.errors.count)
+          end
+          AlertDescription do
+            ul(class: 'my-2 ml-6 list-disc [&>li]:mt-1') do
+              assignment.errors.full_messages.each do |message|
+                li { message }
+              end
+            end
+          end
+        end
+      end
+
+      def render_workflow
+        div(class: 'space-y-6') do
+          div(class: 'flex items-center justify-center gap-2') do
+            [1, 2, 3].each do |step_number|
+              div(class: workflow_progress_classes(step_number),
+                  data: { medication_assignment_form_target: 'stepIndicator' })
+            end
+          end
+
+          render_workflow_step(
+            1,
+            title: t('person_medications.form.workflow.choose_medication_title'),
+            description: t('person_medications.form.workflow.choose_medication_description')
+          ) do
+            render_medication_field
+          end
+
+          render_workflow_step(
+            2,
+            title: t('person_medications.form.workflow.choose_dose_title'),
+            description: t('schedules.form.choose_one_dose')
+          ) do
+            render_selection_summary
+            render_dose_field
+          end
+
+          render_workflow_step(
+            3,
+            title: t('medication_assignments.form.review_title'),
+            description: t('medication_assignments.form.review_description')
+          ) do
+            render_selection_summary(show_dose: true)
+            render_review_panel
+          end
+        end
+      end
+
+      def render_workflow_step(step_number, title:, description:, &)
+        div(class: workflow_step_classes(step_number),
+            data: { medication_assignment_form_target: 'stepPanel', step: step_number }) do
+          div(class: 'space-y-1') do
+            m3_heading(level: 2, size: '4', class: 'font-semibold') { title }
+            m3_text(size: '2', class: 'text-on-surface-variant') { description }
+          end
+          div(class: 'space-y-4', &)
+        end
+      end
+
+      def render_medication_field
+        FormField do
+          FormFieldLabel(for: 'medication_assignment_medication_id_trigger') do
+            t('person_medications.form.medication')
+          end
+          render RubyUI::Combobox.new(class: 'w-full') do
+            render RubyUI::ComboboxTrigger.new(
+              placeholder: selected_medication_name || t('person_medications.form.select_medication')
+            )
+
+            render RubyUI::ComboboxPopover.new do
+              render RubyUI::ComboboxSearchInput.new(placeholder: t('person_medications.form.search_medications'))
+
+              render RubyUI::ComboboxList.new do
+                render(RubyUI::ComboboxEmptyState.new { t('person_medications.form.no_medications_found') })
+
+                medications.each do |medication|
+                  render RubyUI::ComboboxItem.new do
+                    render RubyUI::ComboboxRadio.new(
+                      name: 'medication_assignment[medication_id]',
+                      id: "medication_assignment_medication_id_#{medication.id}",
+                      value: medication.id,
+                      checked: assignment.medication_id == medication.id,
+                      required: true,
+                      data: {
+                        text: medication.name,
+                        medication_assignment_form_target: 'medicationSelect',
+                        action: 'change->medication-assignment-form#updateMedication'
+                      }
+                    )
+                    span { medication.name }
+                  end
+                end
+              end
+            end
+          end
+          FormFieldHint { t('person_medications.form.medication_hint') }
+        end
+      end
+
+      def render_dose_field
+        FormField do
+          FormFieldLabel(for: 'medication_assignment_dose_option') do
+            plain t('person_medications.form.dose')
+            span(class: 'text-destructive ml-0.5') { ' *' }
+          end
+          input(
+            type: :hidden,
+            name: 'medication_assignment[source_dosage_option_id]',
+            value: assignment.source_dosage_option_id,
+            data: { medication_assignment_form_target: 'sourceDosageOptionIdInput' }
+          )
+          input(
+            type: :hidden,
+            name: 'medication_assignment[dose_amount]',
+            value: decimal_string(assignment.dose_amount),
+            data: { medication_assignment_form_target: 'doseAmountInput' }
+          )
+          input(
+            type: :hidden,
+            name: 'medication_assignment[dose_unit]',
+            value: assignment.dose_unit,
+            data: { medication_assignment_form_target: 'doseUnitInput' }
+          )
+          select(
+            id: 'medication_assignment_dose_option',
+            name: 'medication_assignment[dose_option]',
+            required: true,
+            disabled: assignment.medication_id.blank?,
+            class: 'w-full rounded-md border border-outline bg-background px-3 py-2 text-sm',
+            data: {
+              medication_assignment_form_target: 'doseOptionInput',
+              action: 'change->medication-assignment-form#selectDose'
+            }
+          ) do
+            option(value: '') do
+              if assignment.medication_id.present?
+                t('person_medications.form.select_dose')
+              else
+                t('person_medications.form.select_medication_first')
+              end
+            end
+          end
+          FormFieldHint { t('person_medications.form.dose_hint') }
+        end
+      end
+
+      def render_selection_summary(show_dose: false)
+        div(class: selection_summary_layout_classes(show_dose)) do
+          render_summary_card(
+            t('person_medications.form.medication'),
+            selected_medication_name || t('person_medications.form.workflow.choose_medication_title'),
+            'selectedMedicationName'
+          )
+          if show_dose
+            render_summary_card(
+              t('person_medications.form.dose'),
+              t('person_medications.form.workflow.choose_dose_title'),
+              'selectedDoseName'
+            )
+          end
+        end
+      end
+
+      def render_summary_card(label, value, target)
+        div(class: 'rounded-shape-xl border border-border/60 bg-popover px-4 py-3 shadow-elevation-1') do
+          m3_text(size: '1', weight: 'medium',
+                  class: 'uppercase tracking-[0.2em] text-on-surface-variant') { label }
+          m3_text(size: '3', weight: 'semibold', data: { medication_assignment_form_target: target }) { value }
+        end
+      end
+
+      def render_review_panel
+        div(class: 'grid grid-cols-1 gap-3 md:grid-cols-2') do
+          render_review_item(t('medication_assignments.form.frequency'), 'reviewFrequency')
+          render_review_item(t('schedules.form.max_doses_per_cycle'), 'reviewMaxDoses')
+          render_review_item(t('schedules.form.min_hours_between_doses'), 'reviewMinHours')
+          render_review_item(t('schedules.form.dose_cycle'), 'reviewDoseCycle')
+          render_review_item(t('medication_assignments.form.schedule_type'), 'reviewScheduleType')
+          render_review_item(t('medication_assignments.form.active_dates'), 'reviewActiveDates')
+        end
+      end
+
+      def render_review_item(label, target)
+        div(class: 'rounded-shape-xl border border-outline-variant/60 bg-surface-container-low px-4 py-3') do
+          m3_text(size: '1', weight: 'medium',
+                  class: 'uppercase tracking-[0.2em] text-on-surface-variant') { label }
+          m3_text(size: '2', weight: 'semibold',
+                  data: { medication_assignment_form_target: target }) do
+            t('medication_assignments.form.not_set')
+          end
+        end
+      end
+
+      def render_actions
+        div(class: 'pt-4') do
+          div(class: 'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-6') do
+            div(class: 'order-2 sm:order-1 sm:mr-auto') { render_cancel_action }
+            div(class: 'order-1 flex w-full items-center gap-3 sm:order-2 sm:w-auto') do
+              m3_button(
+                type: :button,
+                variant: :outlined,
+                size: :xl,
+                class: 'hidden min-w-0 flex-1 sm:min-w-28 sm:flex-none',
+                data: {
+                  action: 'click->medication-assignment-form#prevStep',
+                  medication_assignment_form_target: 'prevButton'
+                }
+              ) { t('person_medications.form.back') }
+              m3_button(
+                type: :button,
+                variant: :filled,
+                size: :xl,
+                class: 'min-w-0 flex-1 sm:min-w-28 sm:flex-none',
+                data: {
+                  action: 'click->medication-assignment-form#nextStep',
+                  medication_assignment_form_target: 'nextButton'
+                }
+              ) { t('person_medications.form.next') }
+              m3_button(
+                type: :submit,
+                variant: :filled,
+                size: :xl,
+                class: 'hidden min-w-0 flex-1 sm:min-w-28 sm:flex-none',
+                data: { medication_assignment_form_target: 'submitButton' }
+              ) { t('person_medications.form.add_medication_button') }
+            end
+          end
+        end
+      end
+
+      def render_cancel_action
+        if modal
+          m3_link(
+            href: person_path(person),
+            variant: :text,
+            size: :xl,
+            class: 'w-full justify-center sm:w-auto',
+            data: { turbo_frame: '_top' }
+          ) { t('person_medications.form.cancel') }
+        else
+          m3_link(
+            href: person_path(person),
+            variant: :text,
+            size: :xl,
+            class: 'w-full justify-center sm:w-auto'
+          ) { t('person_medications.form.cancel') }
+        end
+      end
+
+      def medication_options_payload
+        medications.to_h do |medication|
+          [medication.id.to_s, medication_payload(medication)]
+        end
+      end
+
+      def medication_payload(medication)
+        {
+          name: medication.name,
+          default_schedule_type: medication.default_schedule_type,
+          schedule_type_label: schedule_type_label(medication.default_schedule_type),
+          dose_options: dose_options_for(medication)
+        }
+      end
+
+      def dose_options_for(medication)
+        options = medication.dose_options_payload.map(&:deep_stringify_keys)
+        return options if options.any?
+        return [] if medication.dosage_amount.blank? || medication.dosage_unit.blank?
+
+        [
+          {
+            'amount' => decimal_string(medication.dosage_amount),
+            'unit' => medication.dosage_unit,
+            'frequency' => medication.default_schedule_type_prn? ? 'As needed' : 'As directed',
+            'default_dose_cycle' => 'daily',
+            'option_value' => "#{decimal_string(medication.dosage_amount)}|#{medication.dosage_unit}"
+          }
+        ]
+      end
+
+      def schedule_type_label(schedule_type)
+        return t('forms.medications.wizard.dose.schedule_types.prn.title') if schedule_type == 'prn'
+
+        schedule_type.to_s.humanize
+      end
+
+      def translations_payload
+        {
+          chooseMedication: t('person_medications.form.workflow.choose_medication_title'),
+          chooseDose: t('person_medications.form.workflow.choose_dose_title'),
+          selectDose: t('person_medications.form.select_dose'),
+          noDosesAvailable: t('person_medications.form.no_doses_available'),
+          notSet: t('medication_assignments.form.not_set')
+        }
+      end
+
+      def selected_medication_name
+        return nil if assignment.medication_id.blank?
+
+        medications.find { |medication| medication.id == assignment.medication_id }&.name
+      end
+
+      def initial_step
+        return 2 if assignment.errors[:source_dosage_option].any?
+        return 2 if assignment.medication_id.present?
+
+        1
+      end
+
+      def workflow_step_classes(step_number)
+        classes = ['space-y-4']
+        classes << 'hidden' if initial_step != step_number
+        classes.join(' ')
+      end
+
+      def workflow_progress_classes(step_number)
+        classes = %w[h-2 w-10 rounded-full transition-colors]
+        classes << (step_number <= initial_step ? 'bg-foreground' : 'bg-primary/15')
+        classes.join(' ')
+      end
+
+      def selection_summary_layout_classes(show_dose)
+        show_dose ? 'grid grid-cols-1 md:grid-cols-2 gap-3' : 'max-w-md'
+      end
+
+      def decimal_string(value)
+        return if value.blank?
+
+        value.is_a?(BigDecimal) ? value.to_s('F') : value.to_s
+      end
+
+      def start_date
+        Time.zone.today
+      end
+
+      def end_date
+        1.month.from_now.to_date
+      end
+    end
+  end
+end

--- a/app/components/medication_assignments/form_view.rb
+++ b/app/components/medication_assignments/form_view.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Components
+  module MedicationAssignments
+    class FormView < Components::Base
+      attr_reader :assignment, :person, :medications
+
+      def initialize(assignment:, person:, medications:)
+        @assignment = assignment
+        @person = person
+        @medications = medications
+        super()
+      end
+
+      def view_template
+        div(class: 'container mx-auto px-4 py-8 max-w-2xl') do
+          div(class: 'mb-8') do
+            m3_text(size: '2', weight: 'medium',
+                    class: 'uppercase tracking-wide text-on-surface-variant mb-2') do
+              t('person_medications.form.add_medication')
+            end
+            m3_heading(level: 1) do
+              t('person_medications.form.add_medication_for', person: person.name)
+            end
+          end
+          render Form.new(assignment: assignment, person: person, medications: medications)
+        end
+      end
+    end
+  end
+end

--- a/app/components/medication_assignments/modal.rb
+++ b/app/components/medication_assignments/modal.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Components
+  module MedicationAssignments
+    class Modal < Components::Base
+      include Phlex::Rails::Helpers::TurboFrameTag
+      include RubyUI
+
+      attr_reader :assignment, :person, :medications, :back_path
+
+      def initialize(assignment:, person:, medications:, back_path: nil)
+        @assignment = assignment
+        @person = person
+        @medications = medications
+        @back_path = back_path
+        super()
+      end
+
+      def view_template
+        turbo_frame_tag 'modal' do
+          Dialog(open: true) do
+            DialogContent(size: :md) do
+              DialogHeader do
+                render_back_link if back_path
+                DialogTitle { t('person_medications.form.add_medication_for', person: person.name) }
+                DialogDescription { t('medication_assignments.modal.subtitle') }
+              end
+              DialogMiddle do
+                render Form.new(
+                  assignment: assignment,
+                  person: person,
+                  medications: medications,
+                  modal: true,
+                  back_path: back_path
+                )
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def render_back_link
+        a(
+          href: back_path,
+          data: { turbo_frame: 'modal' },
+          class: 'inline-flex items-center text-sm text-on-surface-variant hover:text-foreground ' \
+                 'transition-colors mb-2 no-underline'
+        ) do
+          plain t('medication_workflow.back')
+        end
+      end
+    end
+  end
+end

--- a/app/components/medication_workflow/person_selection.rb
+++ b/app/components/medication_workflow/person_selection.rb
@@ -41,7 +41,7 @@ module Components
         div(class: 'grid grid-cols-1 gap-3 py-2') do
           people.each do |person|
             a(
-              href: add_medication_person_path(person, source: :workflow, medication_id: medication_id),
+              href: new_person_medication_assignment_path(person, source: :workflow, medication_id: medication_id),
               data: { turbo_frame: 'modal' },
               class: 'flex items-center gap-4 w-full rounded-2xl border-2 border-outline p-4 ' \
                      'hover:border-primary hover:bg-primary/5 active:bg-primary/10 ' \
@@ -81,7 +81,11 @@ module Components
                       data: {
                         text: person.name,
                         action: 'change->medication-workflow#navigateToType',
-                        url: add_medication_person_path(person, source: :workflow, medication_id: medication_id)
+                        url: new_person_medication_assignment_path(
+                          person,
+                          source: :workflow,
+                          medication_id: medication_id
+                        )
                       }
                     )
                     span { person.name }

--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -134,7 +134,7 @@ module Components
 
       def render_add_medication_link
         m3_link(
-          href: add_medication_person_path(person),
+          href: new_person_medication_assignment_path(person),
           variant: :filled,
           size: :lg,
           class: 'w-full rounded-xl font-black py-6 shadow-lg shadow-primary/20'

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -134,7 +134,7 @@ module Components
             div(class: 'space-y-3') do
               if can_add_medication?
                 m3_link(
-                  href: add_medication_person_path(person),
+                  href: new_person_medication_assignment_path(person),
                   variant: :tonal,
                   size: :lg,
                   class: 'w-full py-6 rounded-xl font-bold shadow-elevation-1 transition-all',
@@ -191,7 +191,7 @@ module Components
             end
             if can_add_medication?
               m3_link(
-                href: add_medication_person_path(person),
+                href: new_person_medication_assignment_path(person),
                 variant: :filled,
                 size: :lg,
                 class: 'rounded-xl px-8',

--- a/app/controllers/medication_assignments_controller.rb
+++ b/app/controllers/medication_assignments_controller.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+class MedicationAssignmentsController < ApplicationController
+  include PersonViewable
+
+  before_action :set_person
+  before_action :authorize_assignment
+
+  def new
+    @assignment = MedicationAssignment.new(medication_id: preselected_medication_id)
+    @medications = medication_options_query.call
+
+    render_assignment_form
+  end
+
+  def create
+    @assignment = MedicationAssignment.new(assignment_params)
+    ensure_medication_access
+    @medications = medication_options_query.call
+
+    result = MedicationAssignmentCreator.new(
+      person: @person,
+      medication_scope: policy_scope(Medication),
+      assignment: @assignment
+    ).call
+
+    if result.success
+      respond_to do |format|
+        format.html { redirect_to person_path(@person), notice: t('schedules.created') }
+        format.turbo_stream do
+          flash.now[:notice] = t('schedules.created')
+          render turbo_stream: [
+            turbo_stream.update('modal', ''),
+            turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
+            turbo_stream.replace("person_show_#{@person.id}", person_show_view(@person.reload)),
+            turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+          ]
+        end
+      end
+    else
+      @assignment = result.assignment
+      render_assignment_form(status: :unprocessable_content)
+    end
+  end
+
+  private
+
+  def set_person
+    @person = policy_scope(Person).find(params[:person_id])
+    authorize @person, :show?
+  end
+
+  def authorize_assignment
+    return if policy(Schedule.new(person: @person)).create?
+    return if policy(PersonMedication.new(person: @person)).create?
+
+    raise Pundit::NotAuthorizedError
+  end
+
+  def ensure_medication_access
+    return if @assignment.medication_id.blank?
+    return if medication_options_query.include?(@assignment.medication_id)
+
+    raise Pundit::NotAuthorizedError
+  end
+
+  def assignment_params
+    params.expect(
+      medication_assignment: %i[
+        medication_id
+        source_dosage_option_id
+        dose_amount
+        dose_unit
+      ]
+    )
+  end
+
+  def preselected_medication_id
+    return params[:medication_id] if medication_options_query.include?(params[:medication_id])
+
+    nil
+  end
+
+  def medication_options_query
+    @medication_options_query ||= MedicationOptionsQuery.new(scope: policy_scope(Medication))
+  end
+
+  def render_assignment_form(status: :ok)
+    back_path = params[:source] == 'workflow' ? add_medication_path(medication_id: params[:medication_id]) : nil
+    is_modal = request.headers['Turbo-Frame'] == 'modal'
+
+    respond_to do |format|
+      format.html do
+        if is_modal
+          render Components::MedicationAssignments::Modal.new(
+            assignment: @assignment,
+            person: @person,
+            medications: @medications,
+            back_path: back_path
+          ), layout: false, status: status
+        else
+          render Components::MedicationAssignments::FormView.new(
+            assignment: @assignment,
+            person: @person,
+            medications: @medications
+          ), status: status
+        end
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          'modal',
+          Components::MedicationAssignments::Modal.new(
+            assignment: @assignment,
+            person: @person,
+            medications: @medications,
+            back_path: back_path
+          )
+        ), status: status
+      end
+    end
+  end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -132,12 +132,9 @@ class PeopleController < ApplicationController
 
   def add_medication
     authorize @person, :show?
-    back = params[:source] == 'workflow' ? add_medication_path : nil
-    render Components::People::AddMedicationLanding.new(
-      person: @person,
-      can_schedule: policy(Schedule.new(person: @person)).create?,
-      can_person_medication: policy(PersonMedication.new(person: @person)).create?,
-      back_path: back,
+    redirect_to new_person_medication_assignment_path(
+      @person,
+      source: params[:source],
       medication_id: params[:medication_id]
     )
   end

--- a/app/javascript/controllers/medication_assignment_form_controller.js
+++ b/app/javascript/controllers/medication_assignment_form_controller.js
@@ -254,11 +254,11 @@ export default class extends Controller {
   }
 
   #syncReview(medication, dose) {
-    this.#setReviewText("reviewFrequency", dose?.frequency || this.t("notSet"))
-    this.#setReviewText("reviewMaxDoses", dose?.default_max_daily_doses || this.t("notSet"))
-    this.#setReviewText("reviewMinHours", dose?.default_min_hours_between_doses || this.t("notSet"))
-    this.#setReviewText("reviewDoseCycle", dose?.default_dose_cycle || this.t("notSet"))
-    this.#setReviewText("reviewScheduleType", medication?.schedule_type_label || this.t("notSet"))
+    this.#setReviewText("reviewFrequency", dose?.frequency ?? this.t("notSet"))
+    this.#setReviewText("reviewMaxDoses", dose?.default_max_daily_doses ?? this.t("notSet"))
+    this.#setReviewText("reviewMinHours", dose?.default_min_hours_between_doses ?? this.t("notSet"))
+    this.#setReviewText("reviewDoseCycle", dose?.default_dose_cycle ?? this.t("notSet"))
+    this.#setReviewText("reviewScheduleType", medication?.schedule_type_label ?? this.t("notSet"))
     this.#setReviewText("reviewActiveDates", `${this.startDateValue} to ${this.endDateValue}`)
   }
 

--- a/app/javascript/controllers/medication_assignment_form_controller.js
+++ b/app/javascript/controllers/medication_assignment_form_controller.js
@@ -1,0 +1,275 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    currentStep: Number,
+    options: Object,
+    translations: Object,
+    startDate: String,
+    endDate: String
+  }
+
+  static targets = [
+    "medicationSelect", "doseOptionInput", "sourceDosageOptionIdInput",
+    "doseAmountInput", "doseUnitInput", "stepPanel", "stepIndicator",
+    "prevButton", "nextButton", "submitButton", "selectedMedicationName",
+    "selectedDoseName", "reviewFrequency", "reviewMaxDoses", "reviewMinHours",
+    "reviewDoseCycle", "reviewScheduleType", "reviewActiveDates"
+  ]
+
+  connect() {
+    if (!this.hasCurrentStepValue) this.currentStepValue = 1
+    this.updateMedication()
+    this.#refreshWorkflow()
+  }
+
+  updateMedication(event) {
+    const preserveDose = !event
+    const medication = this.#selectedMedicationPayload()
+
+    if (!medication) {
+      this.#renderDoseOptions([])
+      this.#clearDose()
+      this.#syncMedicationSummary()
+      this.#syncDoseSummary(null)
+      this.#syncReview(null, null)
+      this.#refreshWorkflow()
+      return
+    }
+
+    if (!preserveDose) this.#clearDose()
+    this.#renderDoseOptions(medication.dose_options || [])
+
+    const currentValue = preserveDose ? this.#currentDoseOptionValue() : ""
+    const currentOption = this.#doseOptions().find((dose) => this.#optionValue(dose) === currentValue)
+    if (currentOption) {
+      this.doseOptionInputTarget.value = this.#optionValue(currentOption)
+      this.#applyDose(currentOption)
+    }
+
+    if (event && this.currentStepValue === 1) this.currentStepValue = 2
+    this.#syncMedicationSummary()
+    this.#syncDoseSummary(currentOption)
+    this.#syncReview(medication, currentOption)
+    this.#refreshWorkflow()
+  }
+
+  selectDose() {
+    const medication = this.#selectedMedicationPayload()
+    const option = this.#selectedDoseOption()
+
+    if (!option) {
+      this.#clearDose()
+      this.#syncDoseSummary(null)
+      this.#syncReview(medication, null)
+      this.#refreshWorkflow()
+      return
+    }
+
+    this.#applyDose(option)
+    this.#syncDoseSummary(option)
+    this.#syncReview(medication, option)
+    this.#refreshWorkflow()
+  }
+
+  nextStep() {
+    if (!this.#currentStepValid()) return
+    if (this.currentStepValue >= 3) return
+
+    this.currentStepValue += 1
+    this.#refreshWorkflow()
+  }
+
+  prevStep() {
+    if (this.currentStepValue <= 1) return
+
+    this.currentStepValue -= 1
+    this.#refreshWorkflow()
+  }
+
+  cancel(event) {
+    event.preventDefault()
+    const frame = this.element.closest("turbo-frame")
+    if (frame) {
+      frame.removeAttribute("src")
+      frame.innerHTML = ""
+    }
+  }
+
+  #selectedMedication() {
+    return this.medicationSelectTargets.find((target) => target.checked)
+  }
+
+  #selectedMedicationPayload() {
+    const selected = this.#selectedMedication()
+    if (!selected) return null
+
+    return this.optionsValue?.[selected.value] || null
+  }
+
+  #doseOptions() {
+    return this.#selectedMedicationPayload()?.dose_options || []
+  }
+
+  #selectedDoseOption() {
+    if (!this.hasDoseOptionInputTarget || !this.doseOptionInputTarget.value) return null
+
+    return this.#doseOptions().find((dose) => this.#optionValue(dose) === this.doseOptionInputTarget.value) || null
+  }
+
+  #renderDoseOptions(options) {
+    if (!this.hasDoseOptionInputTarget) return
+
+    this.doseOptionInputTarget.innerHTML = ""
+
+    const placeholder = document.createElement("option")
+    placeholder.value = ""
+    placeholder.textContent = options.length > 0 ? this.t("selectDose") : this.t("noDosesAvailable")
+    this.doseOptionInputTarget.appendChild(placeholder)
+    this.doseOptionInputTarget.disabled = options.length === 0
+
+    options.forEach((dose) => {
+      const option = document.createElement("option")
+      option.value = this.#optionValue(dose)
+      option.textContent = this.#doseLabel(dose)
+      if (dose.id) option.dataset.id = dose.id
+      option.dataset.amount = dose.amount
+      option.dataset.unit = dose.unit
+      this.doseOptionInputTarget.appendChild(option)
+    })
+  }
+
+  #applyDose(dose) {
+    if (this.hasSourceDosageOptionIdInputTarget) {
+      this.sourceDosageOptionIdInputTarget.value = dose.id || ""
+    }
+    if (this.hasDoseAmountInputTarget) {
+      this.doseAmountInputTarget.value = dose.amount || ""
+    }
+    if (this.hasDoseUnitInputTarget) {
+      this.doseUnitInputTarget.value = dose.unit || ""
+    }
+  }
+
+  #clearDose() {
+    if (this.hasSourceDosageOptionIdInputTarget) this.sourceDosageOptionIdInputTarget.value = ""
+    if (this.hasDoseAmountInputTarget) this.doseAmountInputTarget.value = ""
+    if (this.hasDoseUnitInputTarget) this.doseUnitInputTarget.value = ""
+    if (this.hasDoseOptionInputTarget) this.doseOptionInputTarget.value = ""
+  }
+
+  #currentDoseOptionValue() {
+    if (this.hasSourceDosageOptionIdInputTarget && this.sourceDosageOptionIdInputTarget.value !== "") {
+      return this.sourceDosageOptionIdInputTarget.value
+    }
+
+    if (this.hasDoseAmountInputTarget && this.hasDoseUnitInputTarget &&
+      this.doseAmountInputTarget.value !== "" && this.doseUnitInputTarget.value !== "") {
+      return `${this.doseAmountInputTarget.value}|${this.doseUnitInputTarget.value}`
+    }
+
+    return null
+  }
+
+  #optionValue(dose) {
+    if (dose.option_value) return String(dose.option_value)
+    if (dose.id) return String(dose.id)
+
+    return `${dose.amount}|${dose.unit}`
+  }
+
+  #doseLabel(dose) {
+    const amount = this.#formatAmount(dose.amount)
+    const description = dose.description ? ` - ${dose.description}` : ""
+    return `${amount} ${dose.unit}${description}`
+  }
+
+  #formatAmount(amount) {
+    const numericAmount = Number.parseFloat(amount)
+    if (Number.isNaN(numericAmount)) return amount
+
+    return Number.isInteger(numericAmount) ? numericAmount.toString() : numericAmount.toString()
+  }
+
+  #refreshWorkflow() {
+    if (!this.hasStepPanelTarget) return
+
+    this.stepPanelTargets.forEach((panel) => {
+      const step = Number.parseInt(panel.dataset.step, 10)
+      panel.classList.toggle("hidden", step !== this.currentStepValue)
+    })
+
+    if (this.hasStepIndicatorTarget) {
+      this.stepIndicatorTargets.forEach((indicator, index) => {
+        const active = index + 1 <= this.currentStepValue
+        indicator.classList.toggle("bg-foreground", active)
+        indicator.classList.toggle("bg-primary/15", !active)
+      })
+    }
+
+    if (this.hasPrevButtonTarget) {
+      const firstStep = this.currentStepValue === 1
+      this.prevButtonTarget.classList.toggle("hidden", firstStep)
+      this.prevButtonTarget.hidden = firstStep
+    }
+
+    if (this.hasNextButtonTarget) {
+      const finalStep = this.currentStepValue === 3
+      this.nextButtonTarget.classList.toggle("hidden", finalStep)
+      this.nextButtonTarget.hidden = finalStep
+      this.nextButtonTarget.disabled = !this.#currentStepValid()
+    }
+
+    if (this.hasSubmitButtonTarget) {
+      const finalStep = this.currentStepValue === 3
+      this.submitButtonTarget.classList.toggle("hidden", !finalStep)
+      this.submitButtonTarget.hidden = !finalStep
+    }
+  }
+
+  #currentStepValid() {
+    if (this.currentStepValue === 1) return !!this.#selectedMedication()
+
+    if (this.currentStepValue === 2) {
+      return this.hasDoseAmountInputTarget && this.hasDoseUnitInputTarget &&
+        this.doseAmountInputTarget.value !== "" && this.doseUnitInputTarget.value !== ""
+    }
+
+    return true
+  }
+
+  #syncMedicationSummary() {
+    if (!this.hasSelectedMedicationNameTarget) return
+
+    const selected = this.#selectedMedication()
+    const label = selected?.dataset.text || this.t("chooseMedication")
+    this.selectedMedicationNameTargets.forEach((target) => { target.textContent = label })
+  }
+
+  #syncDoseSummary(dose) {
+    if (!this.hasSelectedDoseNameTarget) return
+
+    const label = dose ? `${this.#formatAmount(dose.amount)} ${dose.unit}` : this.t("chooseDose")
+    this.selectedDoseNameTargets.forEach((target) => { target.textContent = label })
+  }
+
+  #syncReview(medication, dose) {
+    this.#setReviewText("reviewFrequency", dose?.frequency || this.t("notSet"))
+    this.#setReviewText("reviewMaxDoses", dose?.default_max_daily_doses || this.t("notSet"))
+    this.#setReviewText("reviewMinHours", dose?.default_min_hours_between_doses || this.t("notSet"))
+    this.#setReviewText("reviewDoseCycle", dose?.default_dose_cycle || this.t("notSet"))
+    this.#setReviewText("reviewScheduleType", medication?.schedule_type_label || this.t("notSet"))
+    this.#setReviewText("reviewActiveDates", `${this.startDateValue} to ${this.endDateValue}`)
+  }
+
+  #setReviewText(targetName, value) {
+    const targets = this[`${targetName}Targets`]
+    if (!targets) return
+
+    targets.forEach((target) => { target.textContent = value })
+  }
+
+  t(key) {
+    return this.translationsValue?.[key] || ""
+  }
+}

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -54,6 +54,8 @@ class Medication < ApplicationRecord # :nodoc:
 
   accepts_nested_attributes_for :dosage_records, allow_destroy: true, reject_if: :blank_dosage_record_attributes?
 
+  enum :default_schedule_type, Schedule.schedule_types, prefix: :default_schedule_type
+
   validate :single_dose_switch_requires_no_schedules
   validate :nested_dosage_records_are_valid
   after_commit :sync_dosages, on: :update

--- a/app/models/medication_assignment.rb
+++ b/app/models/medication_assignment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MedicationAssignment
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :medication_id, :integer
+  attribute :source_dosage_option_id, :integer
+  attribute :dose_amount, :decimal
+  attribute :dose_unit, :string
+end

--- a/app/services/medication_assignment_creator.rb
+++ b/app/services/medication_assignment_creator.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+class MedicationAssignmentCreator
+  Result = Data.define(:success, :assignment, :schedule)
+
+  attr_reader :person, :medication_scope, :assignment
+
+  def initialize(person:, medication_scope:, assignment:)
+    @person = person
+    @medication_scope = medication_scope
+    @assignment = assignment
+  end
+
+  def call
+    return failure unless valid_assignment?
+
+    persist_schedule
+  end
+
+  private
+
+  def persist_schedule
+    schedule = person.schedules.build(schedule_attributes)
+    return Result.new(success: true, assignment: assignment, schedule: schedule) if schedule.save
+
+    copy_schedule_errors(schedule)
+    Result.new(success: false, assignment: assignment, schedule: schedule)
+  end
+
+  def copy_schedule_errors(schedule)
+    schedule.errors.full_messages.each { |message| assignment.errors.add(:base, message) }
+  end
+
+  def valid_assignment?
+    medication.present? && selected_dose.present?
+  end
+
+  def medication
+    return @medication if defined?(@medication)
+
+    @medication = medication_scope.find_by(id: assignment.medication_id)
+  end
+
+  def selected_dose
+    @selected_dose ||= selected_dosage_option || selected_legacy_dose
+  end
+
+  def selected_dosage_option
+    return if assignment.source_dosage_option_id.blank?
+
+    dosage = medication&.dosage_records&.find_by(id: assignment.source_dosage_option_id)
+    assignment.errors.add(:source_dosage_option, 'Select a valid predefined dose') if dosage.blank?
+    dosage
+  end
+
+  def selected_legacy_dose
+    return if assignment.source_dosage_option_id.present?
+    return unless legacy_dose_selected?
+
+    MedicationDosage.new(
+      amount: medication.dosage_amount,
+      unit: medication.dosage_unit,
+      frequency: fallback_frequency,
+      description: nil,
+      default_for_adults: false,
+      default_for_children: false,
+      default_max_daily_doses: nil,
+      default_min_hours_between_doses: nil,
+      default_dose_cycle: 'daily'
+    )
+  end
+
+  def legacy_dose_selected?
+    complete_legacy_dose? && submitted_legacy_dose_matches?
+  end
+
+  def complete_legacy_dose?
+    medication.present? &&
+      medication.dosage_amount.present? &&
+      medication.dosage_unit.present? &&
+      assignment.dose_amount.present? &&
+      assignment.dose_unit.present?
+  end
+
+  def submitted_legacy_dose_matches?
+    medication.dosage_amount.to_s == assignment.dose_amount.to_s &&
+      medication.dosage_unit == assignment.dose_unit
+  end
+
+  def schedule_attributes
+    schedule_dose_attributes.merge(schedule_timing_attributes)
+  end
+
+  def schedule_dose_attributes
+    {
+      medication: medication,
+      source_dosage_option: selected_dosage_option,
+      dose_amount: selected_dose.amount,
+      dose_unit: selected_dose.unit,
+      frequency: selected_dose.frequency.presence || fallback_frequency
+    }
+  end
+
+  def schedule_timing_attributes
+    {
+      start_date: Time.zone.today,
+      end_date: 1.month.from_now.to_date,
+      max_daily_doses: selected_dose.default_max_daily_doses,
+      min_hours_between_doses: selected_dose.default_min_hours_between_doses,
+      dose_cycle: selected_dose.default_dose_cycle.presence || 'daily',
+      schedule_type: schedule_type,
+      schedule_config: schedule_config
+    }
+  end
+
+  def schedule_type
+    medication.default_schedule_type.presence || 'multiple_daily'
+  end
+
+  def schedule_config
+    config = medication.default_schedule_config.to_h.deep_dup
+    config['schedule_type'] = schedule_type
+    config['frequency'] = selected_dose.frequency.presence || fallback_frequency
+    config['as_needed'] = true if schedule_type == 'prn'
+    config
+  end
+
+  def fallback_frequency
+    schedule_type == 'prn' ? 'As needed' : 'As directed'
+  end
+
+  def failure
+    add_failure_errors
+    Result.new(success: false, assignment: assignment, schedule: nil)
+  end
+
+  def add_failure_errors
+    assignment.errors.add(:medication, :blank) if medication.blank?
+    assignment.errors.add(:source_dosage_option, 'Select a valid predefined dose') if missing_dose_error?
+  end
+
+  def missing_dose_error?
+    medication.present? &&
+      selected_dose.blank? &&
+      assignment.errors[:source_dosage_option].blank?
+  end
+end

--- a/app/services/medication_assignment_creator.rb
+++ b/app/services/medication_assignment_creator.rb
@@ -83,7 +83,7 @@ class MedicationAssignmentCreator
   end
 
   def submitted_legacy_dose_matches?
-    medication.dosage_amount.to_s == assignment.dose_amount.to_s &&
+    BigDecimal(medication.dosage_amount.to_s) == assignment.dose_amount &&
       medication.dosage_unit == assignment.dose_unit
   end
 

--- a/app/services/medication_onboarding_create_service.rb
+++ b/app/services/medication_onboarding_create_service.rb
@@ -28,6 +28,7 @@ class MedicationOnboardingCreateService
     success = false
 
     ActiveRecord::Base.transaction do
+      assign_medication_schedule_defaults
       raise ActiveRecord::Rollback unless medication.save
 
       schedule = build_schedule
@@ -50,6 +51,11 @@ class MedicationOnboardingCreateService
 
   def build_schedule
     schedule_person.schedules.build(schedule_attributes_for(primary_dosage_option))
+  end
+
+  def assign_medication_schedule_defaults
+    medication.default_schedule_type = schedule_attributes[:schedule_type].presence || 'multiple_daily'
+    medication.default_schedule_config = normalized_schedule_config
   end
 
   def primary_dosage_option

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -711,6 +711,17 @@ cy:
         add_guidance_title: "Ychwanegu arweiniad dewisol"
         add_guidance_description: "Ychwanegwch unrhyw nodiadau neu derfynau dos yr hoffech eu holrhain gyda'r feddyginiaeth hon."
 
+  medication_assignments:
+    modal:
+      subtitle: "Ychwanegwch fanylion meddyginiaeth o'r rhagosodiadau sydd wedi'u cadw"
+    form:
+      review_title: "Adolygu"
+      review_description: "Gwiriwch y dos a ddewiswyd a'r rhagosodiadau amserlen sydd wedi'u cadw."
+      frequency: "Amlder"
+      schedule_type: "Math o amserlen"
+      active_dates: "Dyddiadau gweithredol"
+      not_set: "Heb ei osod"
+
   dosages:
     created: "Ychwanegwyd y dos yn llwyddiannus."
     updated: "Diweddarwyd y dos yn llwyddiannus."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -737,6 +737,17 @@ en:
       add_medication_button: "Add Medication"
       save_changes_button: "Save Changes"
 
+  medication_assignments:
+    modal:
+      subtitle: "Add medication details from saved defaults"
+    form:
+      review_title: "Review"
+      review_description: "Check the selected dose and saved schedule defaults."
+      frequency: "Frequency"
+      schedule_type: "Schedule type"
+      active_dates: "Active dates"
+      not_set: "Not set"
+
   dosages:
     created: "Dosage was successfully added."
     updated: "Dosage was successfully updated."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -707,6 +707,17 @@ es:
         add_guidance_title: "Añade orientación opcional"
         add_guidance_description: "Añade notas o límites de dosis que quieras seguir con este medicamento."
 
+  medication_assignments:
+    modal:
+      subtitle: "Añade detalles del medicamento desde los valores guardados"
+    form:
+      review_title: "Revisar"
+      review_description: "Comprueba la dosis seleccionada y los valores de programación guardados."
+      frequency: "Frecuencia"
+      schedule_type: "Tipo de programación"
+      active_dates: "Fechas activas"
+      not_set: "Sin definir"
+
   schedules:
     created: "Receta creada correctamente."
     updated: "Receta actualizada correctamente."

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -707,6 +707,17 @@ ga:
       add_medication_button: "Cuir Leigheas Leis"
       save_changes_button: "Sábháil Athruithe"
 
+  medication_assignments:
+    modal:
+      subtitle: "Cuir sonraí leighis leis ó na réamhshocruithe sábháilte"
+    form:
+      review_title: "Athbhreithniú"
+      review_description: "Seiceáil an dáileog roghnaithe agus na réamhshocruithe sceidil sábháilte."
+      frequency: "Minicíocht"
+      schedule_type: "Cineál sceidil"
+      active_dates: "Dátaí gníomhacha"
+      not_set: "Gan socrú"
+
   schedules:
     created: "Cruthaíodh an t-oideas leigheasanna go rathúil."
     updated: "Nuashonraíodh an t-oideas leigheasanna go rathúil."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -707,6 +707,17 @@ pt:
       add_medication_button: "Adicionar Medicamento"
       save_changes_button: "Guardar Alterações"
 
+  medication_assignments:
+    modal:
+      subtitle: "Adicione detalhes do medicamento a partir das predefinições guardadas"
+    form:
+      review_title: "Rever"
+      review_description: "Confirme a dose selecionada e as predefinições da agenda guardadas."
+      frequency: "Frequência"
+      schedule_type: "Tipo de agenda"
+      active_dates: "Datas ativas"
+      not_set: "Não definido"
+
   schedules:
     created: "Receita criada com sucesso."
     updated: "Receita atualizada com sucesso."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
         post :take_medication
       end
     end
+    resources :medication_assignments, only: %i[new create]
   end
 
   resource :push_subscription, only: %i[create destroy] do

--- a/db/migrate/20260505120000_add_default_schedule_metadata_to_medications.rb
+++ b/db/migrate/20260505120000_add_default_schedule_metadata_to_medications.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddDefaultScheduleMetadataToMedications < ActiveRecord::Migration[8.0]
+  def up
+    add_column :medications, :default_schedule_type, :integer, null: false, default: 1
+    add_column :medications, :default_schedule_config, :jsonb, null: false, default: {}
+    add_index :medications, :default_schedule_type
+
+    execute <<~SQL.squish
+      UPDATE medications
+      SET default_schedule_type = CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM dosages
+          WHERE dosages.medication_id = medications.id
+          AND lower(trim(dosages.frequency)) = 'as needed'
+        ) THEN 4
+        ELSE 1
+      END
+    SQL
+  end
+
+  def down
+    remove_index :medications, :default_schedule_type
+    remove_column :medications, :default_schedule_config
+    remove_column :medications, :default_schedule_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -249,6 +249,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
     t.datetime "created_at", null: false
     t.integer "current_supply"
     t.text "description"
+    t.jsonb "default_schedule_config", default: {}, null: false
+    t.integer "default_schedule_type", default: 1, null: false
     t.string "dmd_code"
     t.string "dmd_concept_class"
     t.string "dmd_system"
@@ -265,6 +267,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
     t.datetime "updated_at", null: false
     t.text "warnings"
     t.index ["barcode"], name: "index_medications_on_barcode", unique: true, where: "((barcode IS NOT NULL) AND ((barcode)::text <> ''::text))"
+    t.index ["default_schedule_type"], name: "index_medications_on_default_schedule_type"
     t.index ["dmd_code"], name: "index_medications_on_dmd_code"
     t.index ["location_id"], name: "index_medications_on_location_id"
   end

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Person Medications', type: :system do
-  fixtures :accounts, :people, :locations, :medications, :users, :person_medications
+  fixtures :accounts, :people, :locations, :location_memberships, :medications, :users, :person_medications
 
   let(:person) { people(:john) }
   let(:user) { users(:john) }
@@ -13,10 +13,10 @@ RSpec.describe 'Person Medications', type: :system do
     login_as(user)
   end
 
-  describe 'adding a non-schedule medication' do
+  describe 'adding a medication assignment' do
     let(:new_medication) { medications(:vitamin_c) }
 
-    it 'allows adding an as-needed medication without a schedule', :js do
+    it 'allows adding a medication from predefined defaults', :js do
       visit person_path(person)
 
       expect(page).to have_text('Medications')
@@ -24,26 +24,21 @@ RSpec.describe 'Person Medications', type: :system do
       within '[data-testid="quick-actions"]' do
         click_link 'Add Medication'
       end
-      click_link 'As needed'
 
       click_button 'Select a medication'
       find('label', text: new_medication.name).click
 
       expect(page).to have_text('Choose the dose')
-      # Wait for the async fetch to populate the select options
-      expect(page).to have_css('#person_medication_dose_option option', text: '500 mg', visible: :all)
+      expect(page).to have_css('#medication_assignment_dose_option option', text: '500 mg', visible: :all)
       select '500 mg', from: 'Dose'
       click_button 'Next'
 
-      expect(page).to have_text('Add optional guidance')
-      fill_in 'person_medication_notes', with: 'Take with breakfast'
-      fill_in 'person_medication_max_daily_doses', with: '1'
+      expect(page).to have_text('Review')
 
       click_button 'Add Medication'
 
-      expect(page).to have_text('Medication added successfully')
+      expect(page).to have_text('Schedule was successfully created.')
       expect(page).to have_text(new_medication.name)
-      expect(page).to have_text('Take with breakfast')
     end
   end
 

--- a/spec/fixtures/medications.yml
+++ b/spec/fixtures/medications.yml
@@ -5,6 +5,7 @@ paracetamol:
   category: Analgesic
   dosage_amount: 500
   dosage_unit: "mg"
+  default_schedule_type: 4
   current_supply: 80
   supply_at_last_restock: 80
   expiry_date: <%= 2.years.from_now.to_date %>

--- a/spec/requests/dosages_wizard_spec.rb
+++ b/spec/requests/dosages_wizard_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe 'Medication wizard dose option follow-up' do
     expect(body).not_to include('target="dosage-list"')
     expect(medication.current_supply).to eq(10)
     expect(medication.reorder_threshold).to eq(1)
+    expect(medication.default_schedule_type).to eq('multiple_daily')
+    expect(medication.default_schedule_config).to include(
+      'schedule_type' => 'multiple_daily',
+      'frequency' => 'Twice daily',
+      'times' => %w[08:00 20:00]
+    )
     expect(medication.dosage_records.count).to eq(1)
     expect(dosage).to have_attributes(
       amount: BigDecimal('2.5'),

--- a/spec/requests/medication_assignments_spec.rb
+++ b/spec/requests/medication_assignments_spec.rb
@@ -88,6 +88,31 @@ RSpec.describe 'Medication assignments' do
       )
     end
 
+    it 'creates a schedule from a matching legacy dose fallback' do
+      medication = medications(:vitamin_c)
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 dose_amount: '500.0',
+                 dose_unit: 'mg'
+               }
+             }
+      end.to change(Schedule, :count).by(1)
+
+      schedule = Schedule.order(:id).last
+
+      expect(schedule).to have_attributes(
+        medication: medication,
+        source_dosage_option: nil,
+        dose_amount: BigDecimal('500.0'),
+        dose_unit: 'mg',
+        frequency: 'As directed'
+      )
+    end
+
     it 'ignores submitted timing overrides and uses the selected dose defaults' do
       medication = medications(:ibuprofen)
       dosage = dosages(:ibuprofen_child)

--- a/spec/requests/medication_assignments_spec.rb
+++ b/spec/requests/medication_assignments_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medication assignments' do
+  fixtures :accounts, :people, :locations, :location_memberships, :medications, :users, :carer_relationships, :dosages
+
+  let(:person) { people(:child_user_person) }
+  let(:parent) { users(:parent) }
+
+  before { sign_in(parent) }
+
+  describe 'GET /people/:person_id/medication_assignments/new' do
+    it 'renders the unified assignment workflow without the type chooser' do
+      get new_person_medication_assignment_path(person), headers: { 'Turbo-Frame' => 'modal' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Add Medication for')
+      expect(response.body).to include('Choose a medication')
+      expect(response.body).to include('Choose the dose')
+      expect(response.body).to include('Review')
+      expect(response.body).not_to include('Prescribed / Scheduled')
+      expect(response.body).not_to include('How is this medication taken?')
+    end
+  end
+
+  describe 'POST /people/:person_id/medication_assignments' do
+    it 'creates a PRN schedule from medication metadata and the selected predefined dose' do
+      medication = medications(:paracetamol)
+      dosage = dosages(:paracetamol_child)
+      person_medication_count = PersonMedication.count
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 source_dosage_option_id: dosage.id
+               }
+             }
+      end.to change(Schedule, :count).by(1)
+
+      expect(PersonMedication.count).to eq(person_medication_count)
+      expect(response).to redirect_to(person_path(person))
+      schedule = Schedule.order(:id).last
+
+      expect(schedule).to have_attributes(
+        person: person,
+        medication: medication,
+        source_dosage_option: dosage,
+        dose_amount: BigDecimal('250.0'),
+        dose_unit: 'mg',
+        frequency: 'Every 4-6 hours',
+        max_daily_doses: 4,
+        min_hours_between_doses: 4,
+        start_date: Time.zone.today,
+        end_date: 1.month.from_now.to_date
+      )
+      expect(schedule.dose_cycle).to eq('daily')
+      expect(schedule.schedule_type).to eq('prn')
+      expect(schedule.schedule_config).to include('as_needed' => true)
+    end
+
+    it 'creates a non-PRN schedule when medication metadata is not as needed' do
+      medication = medications(:ibuprofen)
+      dosage = dosages(:ibuprofen_child)
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 source_dosage_option_id: dosage.id
+               }
+             }
+      end.to change(Schedule, :count).by(1)
+
+      schedule = Schedule.order(:id).last
+
+      expect(schedule.schedule_type).to eq('multiple_daily')
+      expect(schedule.schedule_config).not_to include('as_needed' => true)
+      expect(schedule).to have_attributes(
+        dose_amount: BigDecimal('200.0'),
+        dose_unit: 'mg',
+        frequency: 'Every 6-8 hours',
+        max_daily_doses: 4,
+        min_hours_between_doses: 6
+      )
+    end
+
+    it 'ignores submitted timing overrides and uses the selected dose defaults' do
+      medication = medications(:ibuprofen)
+      dosage = dosages(:ibuprofen_child)
+
+      post person_medication_assignments_path(person),
+           params: {
+             medication_assignment: {
+               medication_id: medication.id,
+               source_dosage_option_id: dosage.id,
+               max_daily_doses: '99',
+               min_hours_between_doses: '0',
+               dose_cycle: 'monthly'
+             }
+           }
+
+      schedule = Schedule.order(:id).last
+
+      expect(schedule.max_daily_doses).to eq(4)
+      expect(schedule.min_hours_between_doses).to eq(6)
+      expect(schedule.dose_cycle).to eq('daily')
+    end
+
+    it 'rejects a forged inaccessible medication id' do
+      foreign_medication = Medication.create!(
+        name: 'Foreign Household Medication',
+        location: locations(:grandmas),
+        category: 'Analgesic',
+        dosage_amount: 250,
+        dosage_unit: 'mg',
+        current_supply: 10,
+        reorder_threshold: 1
+      )
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: foreign_medication.id
+               }
+             }
+      end.not_to change(Schedule, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'rejects a forged dose option from another medication' do
+      medication = medications(:ibuprofen)
+      forged_dosage = dosages(:paracetamol_child)
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 source_dosage_option_id: forged_dosage.id
+               }
+             }
+      end.not_to change(Schedule, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Select a valid predefined dose')
+    end
+  end
+end

--- a/spec/system/authorization/person_medications_authorization_spec.rb
+++ b/spec/system/authorization/person_medications_authorization_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Person Medications Authorization' do
-  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :carer_relationships
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :carer_relationships
 
   before do |example|
     driven_by(example.metadata[:js] ? :playwright : :rack_test)
@@ -30,21 +30,19 @@ RSpec.describe 'Person Medications Authorization' do
         expect(page).to have_link('Add Medication')
         click_link 'Add Medication'
       end
-      click_link 'As needed'
       click_button 'Select a medication'
       find('label', text: medication.name).click
       expect(page).to have_text('Choose the dose')
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Add optional guidance')
-      fill_in 'person_medication_notes', with: 'Test notes'
+      expect(page).to have_text('Review')
       click_button 'Add Medication'
 
-      expect(page).to have_text('Medication added successfully')
+      expect(page).to have_text('Schedule was successfully created.')
     end
 
-    it 'allows doctors to add scheduled medications but not as-needed medications', :js do
+    it 'allows doctors to open the unified medication assignment flow', :js do
       login_as(doctor)
       visit person_path(assigned_patient)
 
@@ -54,8 +52,9 @@ RSpec.describe 'Person Medications Authorization' do
         click_link 'Add Medication'
       end
 
-      expect(page).to have_text('Prescribed / Scheduled')
-      expect(page).to have_no_text('As needed')
+      expect(page).to have_text('Choose a medication')
+      expect(page).to have_no_text('Prescribed / Scheduled')
+      expect(page).to have_no_text('How is this medication taken?')
     end
 
     it 'denies nurses ability to add medications' do
@@ -93,18 +92,16 @@ RSpec.describe 'Person Medications Authorization' do
         expect(page).to have_link('Add Medication')
         click_link 'Add Medication'
       end
-      click_link 'As needed'
       click_button 'Select a medication'
       find('label', text: medication.name).click
       expect(page).to have_text('Choose the dose')
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Add optional guidance')
-      fill_in 'person_medication_notes', with: 'Parent-added medication'
+      expect(page).to have_text('Review')
       click_button 'Add Medication'
 
-      expect(page).to have_text('Medication added successfully')
+      expect(page).to have_text('Schedule was successfully created.')
       expect(page).to have_text(medication.name)
     end
 

--- a/spec/system/people_spec.rb
+++ b/spec/system/people_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'People' do
       visit people_path
 
       within "#person_#{person.id}" do
-        expect(page).to have_link('Add Medication', href: add_medication_person_path(person))
+        expect(page).to have_link('Add Medication', href: new_person_medication_assignment_path(person))
       end
     end
 

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -79,4 +79,32 @@ RSpec.describe 'Person medication workflow' do
     expect(page).to have_no_text("Add Medication for #{person.name}")
     expect(page).to have_text(person.name)
   end
+
+  it 'shows zero minimum hours as a selected dose default' do
+    medication = medications(:ibuprofen)
+
+    visit person_path(person)
+
+    within '[data-testid="quick-actions"]' do
+      click_link 'Add Medication'
+    end
+
+    click_button 'Select a medication'
+    find('label', text: medication.name).click
+
+    page.execute_script(<<~JS, medication.id)
+      const form = document.querySelector("[data-controller~='medication-assignment-form']")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(form, "medication-assignment-form")
+      const options = controller.optionsValue
+      options[String(arguments[0])].dose_options[0].default_min_hours_between_doses = 0
+      controller.optionsValue = options
+      controller.updateMedication()
+    JS
+
+    select '200 mg - Light adult dose', from: 'Dose'
+    click_button 'Next'
+
+    expect(page).to have_css('[data-medication-assignment-form-target="reviewMinHours"]', text: /\A0\z/)
+    expect(page).to have_no_css('[data-medication-assignment-form-target="reviewMinHours"]', text: 'Not set')
+  end
 end

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Person medication workflow' do
-  fixtures :accounts, :people, :locations, :location_memberships, :medications, :users, :carer_relationships,
-           :person_medications
+  fixtures :accounts, :people, :locations, :location_memberships, :medications, :dosages, :users,
+           :person_medications, :carer_relationships
 
   let(:person) { people(:child_user_person) }
   let(:parent) { users(:parent) }
@@ -14,75 +14,69 @@ RSpec.describe 'Person medication workflow' do
     login_as(parent)
   end
 
-  it 'lets a parent create and administer an as-needed medication for a linked child until the daily limit is hit' do
+  it 'lets a parent add a medication from predefined doses without choosing a medication type' do
     visit person_path(person)
 
     within '[data-testid="quick-actions"]' do
       click_link 'Add Medication'
     end
-    click_link 'As needed'
 
-    expect(page).to have_button('Cancel')
+    expect(page).to have_no_text('Prescribed / Scheduled')
+    expect(page).to have_no_text('How is this medication taken?')
+    expect(page).to have_link('Cancel')
     expect(page).to have_button('Next', disabled: true)
     expect(page).to have_no_button('Back')
     expect(page).to have_no_button('Add Medication')
-    expect(page).to have_button('Next', disabled: true)
 
     click_button 'Select a medication'
-    find('label', text: 'Calpol').click
+    find('label', text: 'Paracetamol').click
 
     expect(page).to have_text('Choose the dose')
-    expect(page).to have_button('Cancel')
+    expect(page).to have_link('Cancel')
     expect(page).to have_button('Back')
-    expect(page).to have_button('Next', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
     expect(page).to have_css('div.max-w-md')
     expect(page).to have_text('Medication')
-    expect(page).to have_text('Calpol')
+    expect(page).to have_text('Paracetamol')
 
-    expect(page).to have_no_text('Standard child dose')
-    expect(page).to have_select('Dose', with_options: ['2.5 ml'])
-    select '2.5 ml', from: 'Dose'
+    expect(page).to have_select('Dose', with_options: ['250 mg - Standard child dose (6-12 years)'])
+    select '250 mg - Standard child dose (6-12 years)', from: 'Dose'
     click_button 'Next'
 
-    expect(page).to have_text('Add optional guidance')
-    expect(page).to have_text('Dose')
-    expect(page).to have_text('2.5 ml')
+    expect(page).to have_text('Review')
+    expect(page).to have_text(/dose/i)
+    expect(page).to have_text('250 mg')
+    expect(page).to have_text('Every 4-6 hours')
+    expect(page).to have_text('As needed')
     expect(page).to have_no_button('Next')
     expect(page).to have_button('Back')
-    expect(page).to have_button('Cancel')
+    expect(page).to have_link('Cancel')
     expect(page).to have_button('Add Medication')
-
-    fill_in 'person_medication_notes', with: 'Workflow test'
-    fill_in 'person_medication_max_daily_doses', with: '1'
 
     click_button 'Add Medication'
 
-    expect(page).to have_text('Medication added successfully')
-    expect(page).to have_text('Workflow test')
+    expect(page).to have_text('Schedule was successfully created.')
+    expect(page).to have_no_text("Add Medication for #{person.name}")
+    expect(page).to have_text(person.name)
+    expect(page).to have_text('Paracetamol')
 
-    created_person_medication = person.person_medications.order(:id).last
-
-    within("#person_medication_#{created_person_medication.id}") do
-      expect(page).to have_button('Give')
-      click_button 'Give'
-    end
-    confirm_record_dose(created_person_medication)
-
-    expect(page).to have_text('Medication taken successfully')
-
-    within("#person_medication_#{created_person_medication.id}") do
-      expect(page).to have_text(/today's doses/i)
-      expect(page).to have_text(/2\.5 ml/i)
-      expect(page).to have_button('Give', disabled: false)
-      expect(page).to have_text('1/1')
-    end
+    created_schedule = person.schedules.order(:id).last
+    expect(created_schedule.schedule_type).to eq('prn')
+    expect(created_schedule.source_dosage_option).to eq(dosages(:paracetamol_child))
   end
 
-  def confirm_record_dose(person_medication)
-    path = take_medication_person_person_medication_path(person, person_medication)
+  it 'does not leave a blank page when cancelled' do
+    visit person_path(person)
 
-    within("form[action='#{path}']") do
-      click_button 'Give'
+    within '[data-testid="quick-actions"]' do
+      click_link 'Add Medication'
     end
+
+    expect(page).to have_text("Add Medication for #{person.name}")
+    click_on 'Cancel'
+
+    expect(page).to have_current_path(person_path(person))
+    expect(page).to have_no_text("Add Medication for #{person.name}")
+    expect(page).to have_text(person.name)
   end
 end

--- a/spec/system/schedules/add_schedule_modal_spec.rb
+++ b/spec/system/schedules/add_schedule_modal_spec.rb
@@ -14,13 +14,9 @@ RSpec.describe 'Add schedule modal flow' do
 
   it 'opens add schedule modal from person page and creates a schedule via turbo' do
     login_as(admin)
-    visit person_path(person)
+    visit new_person_schedule_path(person)
 
-    within '[data-testid="quick-actions"]' do
-      click_on 'Add Medication'
-    end
-    click_on 'Prescribed / Scheduled'
-    expect(page).to have_text("New Schedule for #{person.name}")
+    expect(page).to have_text("Add schedule for #{person.name}")
     expect(page).to have_text('Choose a medication')
 
     find_by_id('medication_trigger').click
@@ -41,25 +37,20 @@ RSpec.describe 'Add schedule modal flow' do
     expect(page).to have_text('Ibuprofen')
   end
 
-  it 'closes the add schedule modal cleanly when cancelled from the details step' do
+  it 'closes the add medication assignment cleanly when cancelled' do
     login_as(admin)
     visit person_path(person)
 
     within '[data-testid="quick-actions"]' do
       click_on 'Add Medication'
     end
-    click_on 'Prescribed / Scheduled'
 
-    find_by_id('medication_trigger').click
-    find('label', text: 'Ibuprofen', visible: :all, wait: 10).click
+    expect(page).to have_text("Add Medication for #{person.name}")
 
-    expect(page).to have_text("New Schedule for #{person.name}")
-    expect(page).to have_text('Schedule details')
-
-    click_on 'Cancel', match: :prefer_exact
+    click_on 'Cancel'
 
     expect(page).to have_current_path(person_path(person))
-    expect(page).to have_no_text("New Schedule for #{person.name}")
+    expect(page).to have_no_text("Add Medication for #{person.name}")
     expect(page).to have_text(person.name)
   end
 end

--- a/spec/system/schedules/dosage_selection_spec.rb
+++ b/spec/system/schedules/dosage_selection_spec.rb
@@ -14,12 +14,7 @@ RSpec.describe 'Schedule dosage selection' do
 
   it 'auto-advances to schedule details after medication selection' do
     login_as(admin)
-    visit person_path(person)
-
-    within '[data-testid="quick-actions"]' do
-      click_on 'Add Medication'
-    end
-    click_on 'Prescribed / Scheduled'
+    visit new_person_schedule_path(person)
 
     expect(page).to have_text('Choose a medication')
 
@@ -51,12 +46,7 @@ RSpec.describe 'Schedule dosage selection' do
     )
 
     login_as(admin)
-    visit person_path(person)
-
-    within '[data-testid="quick-actions"]' do
-      click_on 'Add Medication'
-    end
-    click_on 'Prescribed / Scheduled'
+    visit new_person_schedule_path(person)
 
     find_by_id('medication_trigger').click
     find('label', text: 'Dose-less medication', visible: :all, wait: 10).click

--- a/spec/system/schedules/dose_cycle_defaults_spec.rb
+++ b/spec/system/schedules/dose_cycle_defaults_spec.rb
@@ -30,12 +30,7 @@ RSpec.describe 'Schedule dose cycle defaults' do
   it 'applies and reads the selected dose cycle from the combobox radios' do
     dosage
     login_as(admin)
-    visit person_path(person)
-
-    within '[data-testid="quick-actions"]' do
-      click_on 'Add Medication'
-    end
-    click_on 'Prescribed / Scheduled'
+    visit new_person_schedule_path(person)
 
     find_by_id('medication_trigger').click
     find('label', text: medication.name, visible: :all, wait: 10).click


### PR DESCRIPTION
Summary: Add medication defaults and unified add-to-person Schedule assignment flow; use predefined dose options with read-only review and PRN metadata; fix add/cancel outcomes to avoid blank pages. Tests: task rubocop; task test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->