### PR TITLE
fix: support decimal dose inventory

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -199,7 +199,7 @@ module Components
       end
 
       def render_supply_item(medication)
-        current = medication.current_supply || 0
+        current = ::Medications::SupplyStatusPresenter.new(medication: medication).inventory_units_label
         percentage = medication.supply_percentage
 
         div(class: 'space-y-3') do

--- a/app/components/dashboard/schedule_helpers.rb
+++ b/app/components/dashboard/schedule_helpers.rb
@@ -16,7 +16,7 @@ module Components
         remaining_supply = schedule.medication&.current_supply
         return '—' if remaining_supply.nil?
 
-        MedicationStockConsumption.format(remaining_supply)
+        MedicationStockQuantityFormatter.format(remaining_supply)
       end
 
       def format_end_date

--- a/app/components/dashboard/schedule_helpers.rb
+++ b/app/components/dashboard/schedule_helpers.rb
@@ -16,7 +16,7 @@ module Components
         remaining_supply = schedule.medication&.current_supply
         return '—' if remaining_supply.nil?
 
-        remaining_supply.to_s
+        MedicationStockConsumption.format(remaining_supply)
       end
 
       def format_end_date

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -118,7 +118,7 @@ module Components
               Badge(variant: :destructive, class: 'shrink-0 whitespace-nowrap justify-center') { 'Low Stock' }
             else
               Badge(variant: :success, class: 'shrink-0 whitespace-nowrap justify-center') do
-                pluralize(medication.current_supply, 'unit')
+                ::Medications::SupplyStatusPresenter.new(medication: medication).inventory_units_label
               end
             end
           end

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -782,7 +782,7 @@ module Components
       def inventory_field_value(value)
         return if value.blank?
 
-        MedicationStockConsumption.format(value)
+        MedicationStockQuantityFormatter.format(value)
       end
     end
   end

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -615,8 +615,9 @@ module Components
             type: :number,
             name: dosage_field_name(index, field),
             id: "medication_dosage_records_attributes_#{index}_#{field}",
-            value: dosage.public_send(field),
-            min: '0'
+            value: inventory_field_value(dosage.public_send(field)),
+            min: '0',
+            step: '0.01'
           )
         end
       end
@@ -728,8 +729,9 @@ module Components
             type: :number,
             name: 'medication[current_supply]',
             id: 'medication_current_supply',
-            value: medication.current_supply,
+            value: inventory_field_value(medication.current_supply),
             min: '0',
+            step: '0.01',
             placeholder: t('forms.medications.current_supply_placeholder', default: 'e.g., 30'),
             class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
@@ -748,8 +750,9 @@ module Components
             type: :number,
             name: 'medication[reorder_threshold]',
             id: 'medication_reorder_threshold',
-            value: medication.reorder_threshold,
+            value: inventory_field_value(medication.reorder_threshold),
             min: '0',
+            step: '0.01',
             placeholder: t('forms.medications.reorder_threshold_placeholder', default: 'e.g., 5'),
             class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
@@ -774,6 +777,12 @@ module Components
                    'placeholder:text-on-error-container/50 font-medium'
           ) { medication.warnings }
         end
+      end
+
+      def inventory_field_value(value)
+        return if value.blank?
+
+        MedicationStockConsumption.format(value)
       end
     end
   end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -101,7 +101,7 @@ module Components
       def quantity_value
         return if quantity.blank?
 
-        MedicationStockConsumption.format(quantity)
+        MedicationStockQuantityFormatter.format(quantity)
       end
     end
   end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -65,8 +65,9 @@ module Components
               type: 'number',
               name: 'refill[quantity]',
               required: true,
-              value: quantity,
-              min: '1',
+              value: quantity_value,
+              min: '0.01',
+              step: '0.01',
               class: 'w-full rounded-shape-sm border border-outline bg-background px-3 py-2 text-sm ' \
                      'focus:ring-2 focus:ring-primary/20 transition-all'
             )
@@ -95,6 +96,12 @@ module Components
 
       def restock_date_value
         restock_date.presence || Date.current.to_s
+      end
+
+      def quantity_value
+        return if quantity.blank?
+
+        MedicationStockConsumption.format(quantity)
       end
     end
   end

--- a/app/components/medications/standard_dosage_component.rb
+++ b/app/components/medications/standard_dosage_component.rb
@@ -49,7 +49,7 @@ module Components
       end
 
       def reorder_threshold_label
-        threshold = MedicationStockConsumption.format(medication.reorder_threshold)
+        threshold = MedicationStockQuantityFormatter.format(medication.reorder_threshold)
         return "#{threshold} ml" if medication.dosage_unit == 'ml'
 
         threshold == '1' ? '1 unit' : "#{threshold} units"

--- a/app/components/medications/standard_dosage_component.rb
+++ b/app/components/medications/standard_dosage_component.rb
@@ -36,7 +36,7 @@ module Components
           div(class: 'pt-4 border-t border-border') do
             render_overview_item(
               t('medications.show.reorder_at_label'),
-              pluralize(medication.reorder_threshold, 'unit')
+              reorder_threshold_label
             )
           end
         end
@@ -46,6 +46,13 @@ module Components
 
       def dosage_specified?
         medication.dosage_amount.present? && medication.dosage_unit.present?
+      end
+
+      def reorder_threshold_label
+        threshold = MedicationStockConsumption.format(medication.reorder_threshold)
+        return "#{threshold} ml" if medication.dosage_unit == 'ml'
+
+        threshold == '1' ? '1 unit' : "#{threshold} units"
       end
 
       def render_overview_item(label, value)

--- a/app/components/medications/supply_status_card.rb
+++ b/app/components/medications/supply_status_card.rb
@@ -19,7 +19,7 @@ module Components
           div(class: 'space-y-4') do
             div(class: 'flex items-baseline gap-2') do
               span(class: "#{presenter.stock_count_class} text-3xl font-black tracking-tight") do
-                presenter.supply_level.current.to_s
+                presenter.formatted_supply_current
               end
               m3_text(variant: :label_large, class: 'text-on-surface-variant font-bold') do
                 presenter.remaining_units_label

--- a/app/components/medications/take_action.rb
+++ b/app/components/medications/take_action.rb
@@ -87,7 +87,8 @@ module Components
             ) do
               DialogMiddle do
                 div(class: 'space-y-5') do
-                  input(type: :hidden, name: 'amount_ml', value: formatted_amount)
+                  input(type: :hidden, name: 'dose_amount', value: formatted_amount)
+                  input(type: :hidden, name: 'dose_unit', value: source_dose_unit)
                   render_context
                   render_taken_at_field
                   render_stock_source_selection
@@ -252,7 +253,14 @@ module Components
           return t('medications.take_action.untracked_inventory', default: 'Untracked')
         end
 
-        pluralize(medication.current_supply, 'unit')
+        stock_label_for(medication)
+      end
+
+      def stock_label_for(medication)
+        return "#{MedicationStockConsumption.format(medication.current_supply)} ml" if medication.dosage_unit == 'ml'
+
+        supply = MedicationStockConsumption.format(medication.current_supply)
+        supply == '1' ? '1 unit' : "#{supply} units"
       end
 
       def formatted_amount

--- a/app/components/medications/take_action.rb
+++ b/app/components/medications/take_action.rb
@@ -257,9 +257,11 @@ module Components
       end
 
       def stock_label_for(medication)
-        return "#{MedicationStockConsumption.format(medication.current_supply)} ml" if medication.dosage_unit == 'ml'
+        if medication.dosage_unit == 'ml'
+          return "#{MedicationStockQuantityFormatter.format(medication.current_supply)} ml"
+        end
 
-        supply = MedicationStockConsumption.format(medication.current_supply)
+        supply = MedicationStockQuantityFormatter.format(medication.current_supply)
         supply == '1' ? '1 unit' : "#{supply} units"
       end
 

--- a/app/components/medications/wizard/field_helpers.rb
+++ b/app/components/medications/wizard/field_helpers.rb
@@ -280,8 +280,9 @@ module Components
               type: :number,
               name: 'medication[current_supply]',
               id: 'medication_current_supply',
-              value: medication.current_supply,
+              value: inventory_field_value(medication.current_supply),
               min: '0',
+              step: '0.01',
               title: 'Starting supply for a new medication',
               placeholder: t('forms.medications.current_supply_placeholder', default: 'e.g., 30'),
               class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
@@ -301,8 +302,9 @@ module Components
               type: :number,
               name: 'medication[reorder_threshold]',
               id: 'medication_reorder_threshold',
-              value: medication.reorder_threshold,
+              value: inventory_field_value(medication.reorder_threshold),
               min: '0',
+              step: '0.01',
               title: 'Reorder when supply falls below this level',
               placeholder: t('forms.medications.reorder_threshold_placeholder', default: 'e.g., 5'),
               class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
@@ -333,6 +335,12 @@ module Components
 
         def dosage_units
           Medication::DOSAGE_UNITS
+        end
+
+        def inventory_field_value(value)
+          return if value.blank?
+
+          MedicationStockConsumption.format(value)
         end
 
         def render_suggested_dosage_records_section

--- a/app/components/medications/wizard/field_helpers.rb
+++ b/app/components/medications/wizard/field_helpers.rb
@@ -340,7 +340,7 @@ module Components
         def inventory_field_value(value)
           return if value.blank?
 
-          MedicationStockConsumption.format(value)
+          MedicationStockQuantityFormatter.format(value)
         end
 
         def render_suggested_dosage_records_section

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -205,10 +205,10 @@ module Components
               end
             end
           end
-          if take.amount_ml.present?
+          if take.dose_amount.present?
             m3_text(size: '1', weight: 'bold',
                     class: 'font-black text-on-surface-variant uppercase tracking-tighter') do
-              DoseAmount.new(take.amount_ml, person_medication.dose_unit).to_s
+              DoseAmount.new(take.dose_amount, take.dose_unit || person_medication.dose_unit).to_s
             end
           end
         end

--- a/app/components/schedules/card/dose_status_component.rb
+++ b/app/components/schedules/card/dose_status_component.rb
@@ -139,7 +139,7 @@ module Components
               end
             end
             m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
-              "#{take.amount_ml.to_i}#{schedule.dose_unit}"
+              DoseAmount.new(take.dose_amount, take.dose_unit || schedule.dose_unit).to_s
             end
           end
         end

--- a/app/components/shared/stock_badge.rb
+++ b/app/components/shared/stock_badge.rb
@@ -32,13 +32,20 @@ module Components
       end
 
       def badge_text
-        count = medication.current_supply.to_i
+        count = formatted_supply
 
         case stock_status
         when :out_of_stock then "Out of Stock (#{count})"
         when :low_stock then "Low Stock (#{count})"
         else "#{count} left"
         end
+      end
+
+      def formatted_supply
+        value = MedicationStockConsumption.format(medication.current_supply)
+        return "#{value} ml" if medication.dosage_unit == 'ml'
+
+        value
       end
 
       def stock_status

--- a/app/components/shared/stock_badge.rb
+++ b/app/components/shared/stock_badge.rb
@@ -42,7 +42,7 @@ module Components
       end
 
       def formatted_supply
-        value = MedicationStockConsumption.format(medication.current_supply)
+        value = MedicationStockQuantityFormatter.format(medication.current_supply)
         return "#{value} ml" if medication.dosage_unit == 'ml'
 
         value

--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -74,7 +74,7 @@ module TakeMedicationGuardable
         controller: self.class.name,
         source: source,
         person_id: @person.id,
-        attempted_amount_ml: amount&.to_s
+        attempted_dose_amount: amount&.to_s
       }.merge(metadata).to_json
     )
   end

--- a/app/controllers/offline_controller.rb
+++ b/app/controllers/offline_controller.rb
@@ -18,7 +18,7 @@ class OfflineController < ApplicationController
     source_type = attributes[:source_type]
     source_id = attributes[:source_id]
     taken_at = attributes[:taken_at]
-    amount_ml = attributes[:amount_ml]
+    dose_amount = attributes[:dose_amount]
     taken_from_medication_id = attributes[:taken_from_medication_id]
 
     if client_uuid.present?
@@ -35,7 +35,7 @@ class OfflineController < ApplicationController
 
     result = TakeMedicationService.new.call(
       source: source,
-      amount_override: amount_ml,
+      amount_override: dose_amount,
       taken_from_medication_id: taken_from_medication_id,
       user: current_user,
       taken_at: parsed_taken_at,
@@ -78,7 +78,8 @@ class OfflineController < ApplicationController
   end
 
   def queued_take_params
-    params.permit(:client_uuid, :source_type, :source_id, :taken_at, :amount_ml, :taken_from_medication_id)
+    params.permit(:client_uuid, :source_type, :source_id, :taken_at, :dose_amount, :dose_unit,
+                  :taken_from_medication_id)
   end
 
   def offline_take_source(source_type, source_id)

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -218,7 +218,7 @@ class PersonMedicationsController < ApplicationController
   def take_person_medication(taken_at)
     result = TakeMedicationService.new.call(
       source: @person_medication,
-      amount_override: params[:amount_ml],
+      amount_override: params[:dose_amount],
       taken_from_medication_id: requested_taken_from_medication_id,
       user: current_user,
       taken_at: taken_at

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -260,7 +260,7 @@ class SchedulesController < ApplicationController
   def take_schedule(taken_at)
     result = TakeMedicationService.new.call(
       source: @schedule,
-      amount_override: params[:amount_ml],
+      amount_override: params[:dose_amount],
       taken_from_medication_id: requested_taken_from_medication_id,
       user: current_user,
       taken_at: taken_at

--- a/app/javascript/controllers/offline_shell_controller.js
+++ b/app/javascript/controllers/offline_shell_controller.js
@@ -66,7 +66,8 @@ export default class extends Controller {
     const button = event.currentTarget
     const sourceType = button.dataset.sourceType
     const sourceId = Number(button.dataset.sourceId)
-    const amountMl = button.dataset.amountMl
+    const doseAmount = button.dataset.doseAmount
+    const doseUnit = button.dataset.doseUnit
     const snapshot = await getSnapshot()
     const data = snapshot?.payload?.data || {}
     const source = this.sourceFor(data, sourceType, sourceId)
@@ -74,11 +75,12 @@ export default class extends Controller {
 
     if (!source || !medication) return
 
-    const inventory = this.inventoryFor(data, medication)
+    const inventory = this.inventoryFor(data, medication, [], source)
     const take = await queueTake({
       source_type: sourceType,
       source_id: sourceId,
-      amount_ml: amountMl,
+      dose_amount: doseAmount,
+      dose_unit: doseUnit,
       taken_at: new Date().toISOString(),
       taken_from_medication_id: inventory?.id || medication.id
     })
@@ -121,9 +123,9 @@ export default class extends Controller {
       const person = this.byId(data.people, source.person_id)
       const medication = this.byId(data.medications, source.medication_id)
       const pending = queued.filter((take) => take.source_type === sourceType && Number(take.source_id) === source.id)
-      const inventory = medication ? this.inventoryFor(data, medication, queued) : null
+      const inventory = medication ? this.inventoryFor(data, medication, queued, source) : null
       const stockMedication = inventory || medication
-      const disabled = !medication || this.locallyOutOfStock(stockMedication, queued)
+      const disabled = !medication || this.locallyOutOfStock(stockMedication, queued, source)
       const label = pending.length > 0 ? `${pending.length} pending` : "Take now"
 
       return `
@@ -140,7 +142,8 @@ export default class extends Controller {
               data-action="offline-shell#queue"
               data-source-type="${this.escape(sourceType)}"
               data-source-id="${source.id}"
-              data-amount-ml="${this.escape(source.dose_amount || medication?.dosage_amount || "")}"
+              data-dose-amount="${this.escape(source.dose_amount || medication?.dosage_amount || "")}"
+              data-dose-unit="${this.escape(source.dose_unit || medication?.dosage_unit || "")}"
               ${disabled ? "disabled" : ""}
             >${this.escape(disabled ? "Out of stock" : label)}</button>
           </div>
@@ -195,32 +198,49 @@ export default class extends Controller {
     return source ? this.byId(data.medications, source.medication_id) : null
   }
 
-  inventoryFor(data, medication, queued = []) {
+  inventoryFor(data, medication, queued = [], source = null) {
     return (data.medications || []).find((candidate) =>
       candidate.name === medication.name &&
       String(candidate.dosage_amount) === String(medication.dosage_amount) &&
       candidate.dosage_unit === medication.dosage_unit &&
-      !this.locallyOutOfStock(candidate, queued)
+      !this.locallyOutOfStock(candidate, queued, source)
     )
   }
 
-  locallyOutOfStock(medication, queued) {
+  locallyOutOfStock(medication, queued, source = null) {
     if (!medication) return true
 
     const supply = this.localSupply(medication, queued)
-    return supply === null ? medication.out_of_stock : supply <= 0
+    const consumption = this.stockConsumptionFor({
+      dose_amount: source?.dose_amount || medication.dosage_amount,
+      dose_unit: source?.dose_unit || medication.dosage_unit
+    })
+
+    return supply === null ? medication.out_of_stock : supply < consumption
   }
 
   localSupplyLabel(medication, queued) {
     const supply = this.localSupply(medication, queued)
-    return supply === null ? "Untracked" : supply
+    if (supply === null) return "Untracked"
+
+    return medication.dosage_unit === "ml" ? `${this.formatQuantity(supply)} ml` : this.formatQuantity(supply)
   }
 
   localSupply(medication, queued) {
     if (medication.current_supply === null || medication.current_supply === undefined) return null
 
-    const pending = queued.filter((take) => Number(take.taken_from_medication_id) === Number(medication.id)).length
+    const pending = queued
+      .filter((take) => Number(take.taken_from_medication_id) === Number(medication.id))
+      .reduce((total, take) => total + this.stockConsumptionFor(take), 0)
     return Math.max(Number(medication.current_supply) - pending, 0)
+  }
+
+  stockConsumptionFor(take) {
+    return take.dose_unit === "ml" ? Number(take.dose_amount || 0) : 1
+  }
+
+  formatQuantity(quantity) {
+    return Number(quantity).toLocaleString(undefined, { maximumFractionDigits: 2 })
   }
 
   byId(collection, id) {

--- a/app/javascript/controllers/optimistic_take_controller.js
+++ b/app/javascript/controllers/optimistic_take_controller.js
@@ -25,7 +25,8 @@ export default class extends Controller {
         const take = await queueTake({
             source_type: this.element.dataset.offlineSourceType,
             source_id: this.element.dataset.offlineSourceId,
-            amount_ml: formData.get("amount_ml"),
+            dose_amount: formData.get("dose_amount"),
+            dose_unit: formData.get("dose_unit"),
             taken_at: this.takenAtValue(formData),
             taken_from_medication_id: formData.get("medication_take[taken_from_medication_id]")
         });

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -69,9 +69,9 @@ class Medication < ApplicationRecord # :nodoc:
   validates :category, inclusion: { in: CATEGORIES }, allow_blank: true
   validates :dosage_amount, numericality: { greater_than: 0 }, allow_nil: true
   validates :dosage_unit, inclusion: { in: DOSAGE_UNITS }, allow_blank: true
-  validates :current_supply, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :supply_at_last_restock, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :reorder_threshold, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :current_supply, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :supply_at_last_restock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :reorder_threshold, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   delegate :low_stock?, :out_of_stock?, to: :supply_level
 
@@ -107,11 +107,11 @@ class Medication < ApplicationRecord # :nodoc:
   end
 
   def restock!(quantity:) # rubocop:disable Naming/PredicateMethod
-    increment = quantity.to_i
+    increment = BigDecimal(quantity.to_s)
     return false if increment <= 0
 
     with_lock do
-      new_supply = current_supply.to_i + increment
+      new_supply = current_supply.to_d + increment
       update!(
         current_supply: new_supply,
         supply_at_last_restock: new_supply,
@@ -134,19 +134,7 @@ class Medication < ApplicationRecord # :nodoc:
     # ⚡ Bolt Optimization: Use Enumerable#select instead of ActiveRecord#active
     # to filter schedules in-memory. This prevents N+1 queries when calculating
     # daily consumption for a collection of eager-loaded medications.
-    schedule_rate = schedules.select(&:active?).sum do |schedule|
-      next 0.0 if schedule.max_daily_doses.blank?
-
-      schedule.max_daily_doses.to_f / (schedule.cycle_period / 1.day)
-    end
-
-    pm_rate = person_medications.sum do |pm|
-      next 0.0 if pm.max_daily_doses.blank?
-
-      pm.max_daily_doses.to_f
-    end
-
-    @estimated_daily_consumption = schedule_rate + pm_rate
+    @estimated_daily_consumption = MedicationDailyConsumption.new(self).call
   end
 
   def forecast_available?

--- a/app/models/medication_daily_consumption.rb
+++ b/app/models/medication_daily_consumption.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MedicationDailyConsumption
+  def initialize(medication)
+    @medication = medication
+  end
+
+  def call
+    schedule_rate + person_medication_rate
+  end
+
+  private
+
+  attr_reader :medication
+
+  def schedule_rate
+    medication.schedules.select(&:active?).sum do |schedule|
+      next 0.0 if schedule.max_daily_doses.blank?
+
+      daily_rate(schedule) * consumption_for(
+        schedule.effective_dose_amount(Time.zone.today),
+        schedule.effective_dose_unit(Time.zone.today)
+      )
+    end
+  end
+
+  def person_medication_rate
+    medication.person_medications.sum do |person_medication|
+      next 0.0 if person_medication.max_daily_doses.blank?
+
+      person_medication.max_daily_doses.to_f * consumption_for(
+        person_medication.default_dose_amount,
+        person_medication.dose_unit
+      )
+    end
+  end
+
+  def daily_rate(schedule)
+    schedule.max_daily_doses.to_f / (schedule.cycle_period / 1.day)
+  end
+
+  def consumption_for(dose_amount, dose_unit)
+    MedicationStockConsumption.quantity_for(dose_amount: dose_amount, dose_unit: dose_unit).to_f
+  end
+end

--- a/app/models/medication_dosage_option.rb
+++ b/app/models/medication_dosage_option.rb
@@ -21,8 +21,8 @@ class MedicationDosageOption < ApplicationRecord
   validates :default_max_daily_doses, presence: true, numericality: { greater_than: 0 }
   validates :default_min_hours_between_doses, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :default_dose_cycle, presence: true
-  validates :current_supply, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :reorder_threshold, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :current_supply, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :reorder_threshold, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   delegate :selection_key, to: :to_value
 

--- a/app/models/medication_stock_consumption.rb
+++ b/app/models/medication_stock_consumption.rb
@@ -19,11 +19,4 @@ class MedicationStockConsumption
   def self.volume_unit?(unit)
     VOLUME_UNITS.include?(unit.to_s)
   end
-
-  def self.format(quantity)
-    decimal = BigDecimal(quantity.to_s)
-    value = decimal.frac.zero? ? decimal.to_i.to_s : decimal.to_s('F')
-
-    value.include?('.') ? value.sub(/\.?0+\z/, '') : value
-  end
 end

--- a/app/models/medication_stock_consumption.rb
+++ b/app/models/medication_stock_consumption.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MedicationStockConsumption
+  VOLUME_UNITS = %w[ml].freeze
+
+  def self.quantity_for(dose_amount:, dose_unit:)
+    return BigDecimal('0') if dose_amount.blank?
+    return BigDecimal(dose_amount.to_s) if volume_unit?(dose_unit)
+
+    BigDecimal('1')
+  end
+
+  def self.sufficient?(current_supply:, dose_amount:, dose_unit:)
+    return true if current_supply.nil?
+
+    BigDecimal(current_supply.to_s) >= quantity_for(dose_amount: dose_amount, dose_unit: dose_unit)
+  end
+
+  def self.volume_unit?(unit)
+    VOLUME_UNITS.include?(unit.to_s)
+  end
+
+  def self.format(quantity)
+    decimal = BigDecimal(quantity.to_s)
+    value = decimal.frac.zero? ? decimal.to_i.to_s : decimal.to_s('F')
+
+    value.include?('.') ? value.sub(/\.?0+\z/, '') : value
+  end
+end

--- a/app/models/medication_stock_quantity_formatter.rb
+++ b/app/models/medication_stock_quantity_formatter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class MedicationStockQuantityFormatter
+  def self.format(quantity)
+    new(quantity).format
+  end
+
+  def initialize(quantity)
+    @quantity = quantity
+  end
+
+  def format
+    value.include?('.') ? value.sub(/\.?0+\z/, '') : value
+  end
+
+  private
+
+  attr_reader :quantity
+
+  def value
+    decimal.frac.zero? ? decimal.to_i.to_s : decimal.to_s('F')
+  end
+
+  def decimal
+    @decimal ||= BigDecimal(quantity.to_s)
+  end
+end

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -17,7 +17,8 @@ class MedicationTake < ApplicationRecord
   has_paper_trail
 
   validates :taken_at, presence: true
-  validates :amount_ml, presence: true, numericality: { greater_than: 0 }
+  validates :dose_amount, presence: true, numericality: { greater_than: 0 }
+  validates :dose_unit, presence: true
   validates :client_uuid, uniqueness: true, allow_blank: true
   validate :exactly_one_source
   validate :taken_from_medication_matches_source
@@ -26,6 +27,7 @@ class MedicationTake < ApplicationRecord
   validate :taken_from_medication_is_in_stock
 
   before_validation :assign_taken_from_location
+  before_validation :assign_dose_snapshot
   after_create :decrement_medication_stock
   after_commit :publish_low_stock_threshold_reached, on: :create
 
@@ -61,14 +63,10 @@ class MedicationTake < ApplicationRecord
   private
 
   def decrement_medication_stock
-    inventory = inventory_medication
-    return unless inventory
-    return if inventory.current_supply.blank? && matching_inventory_dosage_option(inventory).blank?
+    stock_change = stock_mutation.decrement
+    return unless stock_change
 
-    stock_row = decrement_inventory_stock(inventory)
-    return unless stock_row
-
-    remember_low_stock_threshold_crossing(inventory:, stock_row:)
+    remember_low_stock_threshold_crossing(inventory: stock_change.inventory, stock_row: stock_change.stock_row)
   end
 
   def exactly_one_source
@@ -93,8 +91,7 @@ class MedicationTake < ApplicationRecord
 
   def taken_from_medication_matches_selected_dose
     return if taken_from_medication.blank?
-    return unless inventory_dosage_option_resolver(taken_from_medication).tracked_inventory?
-    return if matching_inventory_dosage_option(taken_from_medication).present?
+    return if stock_mutation.inventory_matches_selected_dose?(taken_from_medication)
 
     errors.add(:taken_from_medication, 'must include stock for the selected dose')
   end
@@ -107,38 +104,44 @@ class MedicationTake < ApplicationRecord
   end
 
   def taken_from_medication_is_in_stock
-    return if taken_from_medication.blank?
-    return if tracked_inventory_dosage_option_missing?(taken_from_medication)
-    return if inventory_option_in_stock?(taken_from_medication)
-
-    if tracked_inventory_dosage_option(taken_from_medication)&.current_supply.present?
-      errors.add(:taken_from_medication, 'must be in stock')
-      return
-    end
-    return unless taken_from_medication.out_of_stock?
+    return if stock_mutation.inventory_in_stock?
 
     errors.add(:taken_from_medication, 'must be in stock')
   end
 
   # Custom OpenTelemetry span attributes for medication tracking
   def otel_span_attributes(operation)
-    attrs = {
+    attrs = otel_base_span_attributes(operation)
+
+    # Add source-specific attributes
+    attrs.merge(otel_source_span_attributes).merge(taken_from_span_attributes)
+  end
+
+  def otel_base_span_attributes(operation)
+    {
       'model.name' => self.class.name,
       'model.id' => id.to_s,
       'model.operation' => operation,
-      'medication_take.taken_at' => taken_at&.iso8601
+      'medication_take.taken_at' => taken_at&.iso8601,
+      'medication_take.dose_amount' => dose_amount&.to_s,
+      'medication_take.dose_unit' => dose_unit
     }
+  end
 
-    # Add source-specific attributes
+  def otel_source_span_attributes
     if schedule_id
-      attrs['medication_take.source_type'] = 'schedule'
-      attrs['medication_take.schedule_id'] = schedule_id.to_s
+      {
+        'medication_take.source_type' => 'schedule',
+        'medication_take.schedule_id' => schedule_id.to_s
+      }
     elsif person_medication_id
-      attrs['medication_take.source_type'] = 'person_medication'
-      attrs['medication_take.person_medication_id'] = person_medication_id.to_s
+      {
+        'medication_take.source_type' => 'person_medication',
+        'medication_take.person_medication_id' => person_medication_id.to_s
+      }
+    else
+      {}
     end
-
-    attrs.merge(taken_from_span_attributes)
   end
 
   def taken_from_span_attributes
@@ -147,49 +150,6 @@ class MedicationTake < ApplicationRecord
     attrs = { 'medication_take.taken_from_medication_id' => taken_from_medication_id.to_s }
     attrs['medication_take.taken_from_location_id'] = taken_from_location_id.to_s if taken_from_location_id
     attrs
-  end
-
-  def decrement_inventory_stock(inventory)
-    dosage_option = matching_inventory_dosage_option(inventory)
-    return decrement_dosage_option_stock(inventory, dosage_option) if dosage_option&.current_supply.present?
-
-    inventory.with_lock do
-      previous_current_supply = inventory.current_supply
-      current_supply = [previous_current_supply.to_i - 1, 0].max
-
-      inventory.update!(current_supply: current_supply)
-
-      {
-        'previous_current_supply' => previous_current_supply,
-        'current_supply' => current_supply,
-        'reorder_threshold' => inventory.reorder_threshold
-      }
-    end
-  end
-
-  def decrement_dosage_option_stock(inventory, dosage_option)
-    decrement_dosage_option_current_supply(dosage_option)
-
-    inventory.with_lock do
-      previous_current_supply = inventory.current_supply
-
-      inventory.sync_inventory_from_dosage_records!
-      inventory.reload
-
-      {
-        'previous_current_supply' => previous_current_supply,
-        'current_supply' => inventory.current_supply,
-        'reorder_threshold' => inventory.reorder_threshold
-      }
-    end
-  end
-
-  def decrement_dosage_option_current_supply(dosage_option)
-    dosage_option.with_lock do
-      dosage_option.with_inventory_sync_suppressed do
-        dosage_option.update!(current_supply: [dosage_option.current_supply.to_i - 1, 0].max)
-      end
-    end
   end
 
   def remember_low_stock_threshold_crossing(inventory:, stock_row:)
@@ -231,26 +191,30 @@ class MedicationTake < ApplicationRecord
     }
   end
 
-  def matching_inventory_dosage_option(inventory)
-    inventory_dosage_option_resolver(inventory).call
+  def stock_mutation
+    @stock_mutation ||= MedicationTakeStockMutation.new(self)
   end
 
-  def inventory_option_in_stock?(inventory)
-    dosage_option = tracked_inventory_dosage_option(inventory)
-    return true if dosage_option.blank? || dosage_option.current_supply.blank?
-
-    dosage_option.current_supply.to_i.positive?
+  def assign_dose_snapshot
+    self.dose_amount ||= source_dose_amount
+    self.dose_unit ||= source_dose_unit
   end
 
-  def tracked_inventory_dosage_option(inventory)
-    matching_inventory_dosage_option(inventory) if inventory_dosage_option_resolver(inventory).tracked_inventory?
+  def source_dose_amount
+    return source.effective_dose_amount(effective_date) if source.respond_to?(:effective_dose_amount)
+
+    source&.default_dose_amount
   end
 
-  def tracked_inventory_dosage_option_missing?(inventory)
-    inventory_dosage_option_resolver(inventory).tracked_inventory? && tracked_inventory_dosage_option(inventory).blank?
+  def source_dose_unit
+    return source.effective_dose_unit(effective_date) if source.respond_to?(:effective_dose_unit)
+
+    source&.dose_unit
   end
 
-  def inventory_dosage_option_resolver(inventory)
-    InventoryDosageOptionResolver.new(inventory: inventory, source: source, effective_date: taken_at&.to_date)
+  def effective_date
+    return taken_at.to_date if taken_at.respond_to?(:to_date)
+
+    Time.zone.today
   end
 end

--- a/app/models/medication_take_stock_decrement.rb
+++ b/app/models/medication_take_stock_decrement.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class MedicationTakeStockDecrement
+  def initialize(take)
+    @take = take
+  end
+
+  def call(stock_source)
+    dosage_option = stock_source.dosage_option
+    return decrement_dosage_option(stock_source.inventory, dosage_option) if dosage_option&.current_supply.present?
+
+    decrement_inventory(stock_source.inventory, take.dose_unit)
+  end
+
+  private
+
+  attr_reader :take
+
+  def decrement_inventory(inventory, dose_unit)
+    inventory.with_lock do
+      previous_current_supply = inventory.current_supply
+      current_supply = decremented_supply(previous_current_supply, dose_unit)
+      inventory.update!(current_supply: current_supply)
+      stock_row(inventory, previous_current_supply)
+    end
+  end
+
+  def decrement_dosage_option(inventory, dosage_option)
+    decrement_dosage_option_current_supply(dosage_option)
+    sync_inventory(inventory)
+  end
+
+  def decrement_dosage_option_current_supply(dosage_option)
+    dosage_option.with_lock do
+      dosage_option.with_inventory_sync_suppressed do
+        dosage_option.update!(current_supply: decremented_supply(dosage_option.current_supply, dosage_option.unit))
+      end
+    end
+  end
+
+  def sync_inventory(inventory)
+    inventory.with_lock do
+      previous_current_supply = inventory.current_supply
+      inventory.sync_inventory_from_dosage_records!
+      inventory.reload
+      stock_row(inventory, previous_current_supply)
+    end
+  end
+
+  def decremented_supply(current_supply, dose_unit)
+    [current_supply.to_d - stock_decrement_for(dose_unit: dose_unit), BigDecimal('0')].max
+  end
+
+  def stock_row(inventory, previous_current_supply)
+    {
+      'previous_current_supply' => previous_current_supply,
+      'current_supply' => inventory.current_supply,
+      'reorder_threshold' => inventory.reorder_threshold
+    }
+  end
+
+  def stock_decrement_for(dose_unit:)
+    MedicationStockConsumption.quantity_for(dose_amount: take.dose_amount, dose_unit: dose_unit)
+  end
+end

--- a/app/models/medication_take_stock_mutation.rb
+++ b/app/models/medication_take_stock_mutation.rb
@@ -3,119 +3,34 @@
 class MedicationTakeStockMutation
   StockChange = Data.define(:inventory, :stock_row)
 
-  def initialize(take)
+  def initialize(take, decrementer: MedicationTakeStockDecrement.new(take))
     @take = take
+    @decrementer = decrementer
   end
 
   def decrement
-    inventory = take.inventory_medication
-    return if inventory.blank?
-    return if inventory.current_supply.blank? && matching_inventory_dosage_option(inventory).blank?
+    return unless stock_source.tracked?
 
-    StockChange.new(inventory: inventory, stock_row: decrement_inventory_stock(inventory))
+    StockChange.new(inventory: stock_source.inventory, stock_row: decrementer.call(stock_source))
   end
 
   def inventory_matches_selected_dose?(inventory)
-    return true unless inventory_dosage_option_resolver(inventory).tracked_inventory?
-
-    matching_inventory_dosage_option(inventory).present?
+    stock_source_for(inventory).selected_dose?
   end
 
   def inventory_in_stock?
-    inventory = take.inventory_medication
-    return true if inventory.blank?
-    return true if tracked_inventory_dosage_option_missing?(inventory)
-
-    dosage_option = tracked_inventory_dosage_option(inventory)
-    return inventory_option_in_stock?(inventory) if dosage_option&.current_supply.present?
-    return true if inventory.current_supply.blank?
-
-    MedicationStockConsumption.sufficient?(
-      current_supply: inventory.current_supply,
-      dose_amount: take.dose_amount,
-      dose_unit: take.dose_unit
-    )
+    stock_source.in_stock?
   end
 
   private
 
-  attr_reader :take
+  attr_reader :take, :decrementer
 
-  def decrement_inventory_stock(inventory)
-    dosage_option = matching_inventory_dosage_option(inventory)
-    return decrement_dosage_option_stock(inventory, dosage_option) if dosage_option&.current_supply.present?
-
-    inventory.with_lock do
-      previous_current_supply = inventory.current_supply
-      decrement = stock_decrement_for(dose_unit: take.dose_unit)
-      current_supply = [previous_current_supply.to_d - decrement, BigDecimal('0')].max
-
-      inventory.update!(current_supply: current_supply)
-
-      {
-        'previous_current_supply' => previous_current_supply,
-        'current_supply' => current_supply,
-        'reorder_threshold' => inventory.reorder_threshold
-      }
-    end
+  def stock_source
+    @stock_source ||= stock_source_for(take.inventory_medication)
   end
 
-  def decrement_dosage_option_stock(inventory, dosage_option)
-    decrement_dosage_option_current_supply(dosage_option)
-
-    inventory.with_lock do
-      previous_current_supply = inventory.current_supply
-
-      inventory.sync_inventory_from_dosage_records!
-      inventory.reload
-
-      {
-        'previous_current_supply' => previous_current_supply,
-        'current_supply' => inventory.current_supply,
-        'reorder_threshold' => inventory.reorder_threshold
-      }
-    end
-  end
-
-  def decrement_dosage_option_current_supply(dosage_option)
-    dosage_option.with_lock do
-      dosage_option.with_inventory_sync_suppressed do
-        decrement = stock_decrement_for(dose_unit: dosage_option.unit)
-        current_supply = [dosage_option.current_supply.to_d - decrement, BigDecimal('0')].max
-
-        dosage_option.update!(current_supply: current_supply)
-      end
-    end
-  end
-
-  def matching_inventory_dosage_option(inventory)
-    inventory_dosage_option_resolver(inventory).call
-  end
-
-  def inventory_option_in_stock?(inventory)
-    dosage_option = tracked_inventory_dosage_option(inventory)
-    return true if dosage_option.blank? || dosage_option.current_supply.blank?
-
-    MedicationStockConsumption.sufficient?(
-      current_supply: dosage_option.current_supply,
-      dose_amount: take.dose_amount,
-      dose_unit: dosage_option.unit
-    )
-  end
-
-  def tracked_inventory_dosage_option(inventory)
-    matching_inventory_dosage_option(inventory) if inventory_dosage_option_resolver(inventory).tracked_inventory?
-  end
-
-  def tracked_inventory_dosage_option_missing?(inventory)
-    inventory_dosage_option_resolver(inventory).tracked_inventory? && tracked_inventory_dosage_option(inventory).blank?
-  end
-
-  def inventory_dosage_option_resolver(inventory)
-    InventoryDosageOptionResolver.new(inventory: inventory, source: take.source, effective_date: take.taken_at&.to_date)
-  end
-
-  def stock_decrement_for(dose_unit:)
-    MedicationStockConsumption.quantity_for(dose_amount: take.dose_amount, dose_unit: dose_unit)
+  def stock_source_for(inventory)
+    MedicationTakeStockSource.new(take: take, inventory: inventory)
   end
 end

--- a/app/models/medication_take_stock_mutation.rb
+++ b/app/models/medication_take_stock_mutation.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+class MedicationTakeStockMutation
+  StockChange = Data.define(:inventory, :stock_row)
+
+  def initialize(take)
+    @take = take
+  end
+
+  def decrement
+    inventory = take.inventory_medication
+    return if inventory.blank?
+    return if inventory.current_supply.blank? && matching_inventory_dosage_option(inventory).blank?
+
+    StockChange.new(inventory: inventory, stock_row: decrement_inventory_stock(inventory))
+  end
+
+  def inventory_matches_selected_dose?(inventory)
+    return true unless inventory_dosage_option_resolver(inventory).tracked_inventory?
+
+    matching_inventory_dosage_option(inventory).present?
+  end
+
+  def inventory_in_stock?
+    inventory = take.inventory_medication
+    return true if inventory.blank?
+    return true if tracked_inventory_dosage_option_missing?(inventory)
+
+    dosage_option = tracked_inventory_dosage_option(inventory)
+    return inventory_option_in_stock?(inventory) if dosage_option&.current_supply.present?
+    return true if inventory.current_supply.blank?
+
+    MedicationStockConsumption.sufficient?(
+      current_supply: inventory.current_supply,
+      dose_amount: take.dose_amount,
+      dose_unit: take.dose_unit
+    )
+  end
+
+  private
+
+  attr_reader :take
+
+  def decrement_inventory_stock(inventory)
+    dosage_option = matching_inventory_dosage_option(inventory)
+    return decrement_dosage_option_stock(inventory, dosage_option) if dosage_option&.current_supply.present?
+
+    inventory.with_lock do
+      previous_current_supply = inventory.current_supply
+      decrement = stock_decrement_for(dose_unit: take.dose_unit)
+      current_supply = [previous_current_supply.to_d - decrement, BigDecimal('0')].max
+
+      inventory.update!(current_supply: current_supply)
+
+      {
+        'previous_current_supply' => previous_current_supply,
+        'current_supply' => current_supply,
+        'reorder_threshold' => inventory.reorder_threshold
+      }
+    end
+  end
+
+  def decrement_dosage_option_stock(inventory, dosage_option)
+    decrement_dosage_option_current_supply(dosage_option)
+
+    inventory.with_lock do
+      previous_current_supply = inventory.current_supply
+
+      inventory.sync_inventory_from_dosage_records!
+      inventory.reload
+
+      {
+        'previous_current_supply' => previous_current_supply,
+        'current_supply' => inventory.current_supply,
+        'reorder_threshold' => inventory.reorder_threshold
+      }
+    end
+  end
+
+  def decrement_dosage_option_current_supply(dosage_option)
+    dosage_option.with_lock do
+      dosage_option.with_inventory_sync_suppressed do
+        decrement = stock_decrement_for(dose_unit: dosage_option.unit)
+        current_supply = [dosage_option.current_supply.to_d - decrement, BigDecimal('0')].max
+
+        dosage_option.update!(current_supply: current_supply)
+      end
+    end
+  end
+
+  def matching_inventory_dosage_option(inventory)
+    inventory_dosage_option_resolver(inventory).call
+  end
+
+  def inventory_option_in_stock?(inventory)
+    dosage_option = tracked_inventory_dosage_option(inventory)
+    return true if dosage_option.blank? || dosage_option.current_supply.blank?
+
+    MedicationStockConsumption.sufficient?(
+      current_supply: dosage_option.current_supply,
+      dose_amount: take.dose_amount,
+      dose_unit: dosage_option.unit
+    )
+  end
+
+  def tracked_inventory_dosage_option(inventory)
+    matching_inventory_dosage_option(inventory) if inventory_dosage_option_resolver(inventory).tracked_inventory?
+  end
+
+  def tracked_inventory_dosage_option_missing?(inventory)
+    inventory_dosage_option_resolver(inventory).tracked_inventory? && tracked_inventory_dosage_option(inventory).blank?
+  end
+
+  def inventory_dosage_option_resolver(inventory)
+    InventoryDosageOptionResolver.new(inventory: inventory, source: take.source, effective_date: take.taken_at&.to_date)
+  end
+
+  def stock_decrement_for(dose_unit:)
+    MedicationStockConsumption.quantity_for(dose_amount: take.dose_amount, dose_unit: dose_unit)
+  end
+end

--- a/app/models/medication_take_stock_source.rb
+++ b/app/models/medication_take_stock_source.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class MedicationTakeStockSource
+  attr_reader :take, :inventory
+
+  def initialize(take:, inventory:)
+    @take = take
+    @inventory = inventory
+  end
+
+  def tracked?
+    inventory.present? && (inventory.current_supply.present? || dosage_option.present?)
+  end
+
+  def selected_dose?
+    return true if inventory.blank?
+    return true unless tracked_dosage_inventory?
+
+    dosage_option.present?
+  end
+
+  def in_stock?
+    return true if inventory.blank?
+    return true if missing_tracked_dose?
+    return option_in_stock? if dosage_option&.current_supply.present?
+    return true if inventory.current_supply.blank?
+
+    sufficient?(inventory.current_supply, take.dose_unit)
+  end
+
+  def dosage_option
+    return @dosage_option if defined?(@dosage_option)
+
+    @dosage_option = resolver.call
+  end
+
+  private
+
+  def option_in_stock?
+    sufficient?(dosage_option.current_supply, dosage_option.unit)
+  end
+
+  def missing_tracked_dose?
+    tracked_dosage_inventory? && dosage_option.blank?
+  end
+
+  def tracked_dosage_inventory?
+    resolver.tracked_inventory?
+  end
+
+  def sufficient?(current_supply, dose_unit)
+    MedicationStockConsumption.sufficient?(
+      current_supply: current_supply,
+      dose_amount: take.dose_amount,
+      dose_unit: dose_unit
+    )
+  end
+
+  def resolver
+    @resolver ||= InventoryDosageOptionResolver.new(
+      inventory: inventory,
+      source: take.source,
+      effective_date: take.taken_at&.to_date
+    )
+  end
+end

--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -5,12 +5,12 @@ class SupplyLevel
 
   def initialize(current:, reorder_threshold:, last_restock:)
     @raw_current = current
-    @reorder_threshold = reorder_threshold.to_i
+    @reorder_threshold = BigDecimal((reorder_threshold || 0).to_s)
     @last_restock = last_restock
   end
 
   def current
-    raw_current || 0
+    raw_current || BigDecimal('0')
   end
 
   def tracked?
@@ -34,7 +34,7 @@ class SupplyLevel
     return false unless tracked?
     return false if previous_current.nil?
 
-    previous_current.to_i > reorder_threshold && current <= reorder_threshold
+    BigDecimal(previous_current.to_s) > reorder_threshold && current <= reorder_threshold
   end
 
   def out_of_stock?

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -61,7 +61,7 @@ module Medications
     end
 
     def formatted_supply_current
-      MedicationStockConsumption.format(supply_level.current)
+      MedicationStockQuantityFormatter.format(supply_level.current)
     end
 
     def forecast_items

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -49,11 +49,19 @@ module Medications
     end
 
     def remaining_units_label
+      return 'ml remaining' if volume_stock?
+
       supply_level.current == 1 ? 'unit remaining' : 'units remaining'
     end
 
     def inventory_units_label
-      ActionController::Base.helpers.pluralize(supply_level.current, 'unit')
+      return "#{formatted_supply_current} ml" if volume_stock?
+
+      formatted_supply_current == '1' ? '1 unit' : "#{formatted_supply_current} units"
+    end
+
+    def formatted_supply_current
+      MedicationStockConsumption.format(supply_level.current)
     end
 
     def forecast_items
@@ -86,6 +94,10 @@ module Medications
     end
 
     private
+
+    def volume_stock?
+      MedicationStockConsumption.volume_unit?(medication.dosage_unit)
+    end
 
     def low_stock_forecast
       return unless medication.days_until_low_stock&.positive?

--- a/app/serializers/api/v1/medication_take_serializer.rb
+++ b/app/serializers/api/v1/medication_take_serializer.rb
@@ -32,7 +32,8 @@ module Api
 
       def event_data
         {
-          amount_ml: medication_take.amount_ml&.to_f,
+          dose_amount: medication_take.dose_amount&.to_f,
+          dose_unit: medication_take.dose_unit,
           taken_at: medication_take.taken_at&.iso8601,
           updated_at: medication_take.updated_at.iso8601
         }

--- a/app/services/reports/index_query.rb
+++ b/app/services/reports/index_query.rb
@@ -98,7 +98,16 @@ module Reports
       dates = inventory_projection_dates_for(schedule)
       return 0 if dates.empty?
 
-      dates.sum { |date| schedule.expected_doses_on(date) }.to_f / dates.size
+      dates.sum do |date|
+        schedule.expected_doses_on(date) * stock_consumption_for(schedule, date).to_f
+      end.to_f / dates.size
+    end
+
+    def stock_consumption_for(schedule, date)
+      MedicationStockConsumption.quantity_for(
+        dose_amount: schedule.effective_dose_amount(date),
+        dose_unit: schedule.effective_dose_unit(date)
+      )
     end
 
     def inventory_projection_dates_for(schedule)

--- a/app/services/restock_medication_service.rb
+++ b/app/services/restock_medication_service.rb
@@ -16,7 +16,7 @@ class RestockMedicationService
     end
     return failure(medication, 'Restock date is invalid') unless normalized_date
 
-    medication.paper_trail_event = "restock (qty: #{MedicationStockConsumption.format(normalized_quantity)}, " \
+    medication.paper_trail_event = "restock (qty: #{MedicationStockQuantityFormatter.format(normalized_quantity)}, " \
                                    "date: #{normalized_date.iso8601})"
     medication.restock!(quantity: normalized_quantity)
 

--- a/app/services/restock_medication_service.rb
+++ b/app/services/restock_medication_service.rb
@@ -8,13 +8,16 @@ class RestockMedicationService
   end
 
   def call(medication:, quantity:, restock_date:)
-    normalized_quantity = quantity.to_i
+    normalized_quantity = normalize_quantity(quantity)
     normalized_date = normalize_date(restock_date)
 
-    return failure(medication, 'Quantity must be greater than 0') if normalized_quantity <= 0
+    if normalized_quantity.blank? || normalized_quantity <= 0
+      return failure(medication, 'Quantity must be greater than 0')
+    end
     return failure(medication, 'Restock date is invalid') unless normalized_date
 
-    medication.paper_trail_event = "restock (qty: #{normalized_quantity}, date: #{normalized_date.iso8601})"
+    medication.paper_trail_event = "restock (qty: #{MedicationStockConsumption.format(normalized_quantity)}, " \
+                                   "date: #{normalized_date.iso8601})"
     medication.restock!(quantity: normalized_quantity)
 
     Result.new(success: true, medication: medication, error: nil)
@@ -23,6 +26,12 @@ class RestockMedicationService
   end
 
   private
+
+  def normalize_quantity(quantity)
+    BigDecimal(quantity.to_s)
+  rescue ArgumentError
+    nil
+  end
 
   def normalize_date(restock_date)
     return restock_date if restock_date.respond_to?(:iso8601)

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -8,7 +8,7 @@
 # @example
 #   result = TakeMedicationService.new.call(
 #     source: @schedule,
-#     amount_override: params[:amount_ml],
+#     amount_override: params[:dose_amount],
 #     taken_from_medication_id: params[:taken_from_medication_id],
 #     user: current_user,
 #     taken_at: params[:taken_at] || Time.current   # optional, defaults to now
@@ -19,7 +19,7 @@
 #                   #    :selection_required | :invalid_source | :create_failed
 class TakeMedicationService
   Result = Data.define(:success, :take, :error)
-  PreparedTake = Data.define(:source, :amount, :medication, :taken_at, :client_uuid, :error)
+  PreparedTake = Data.define(:source, :amount, :unit, :medication, :taken_at, :client_uuid, :error)
 
   def call(source:, amount_override:, taken_from_medication_id:, user:, **options)
     prepared_take = prepare_take(
@@ -31,7 +31,7 @@ class TakeMedicationService
     )
     return failure(prepared_take.error) if prepared_take.error
 
-    take = record_take(**prepared_take.to_h.except(:error))
+    take = record_take(prepared_take)
     return failure(:create_failed) unless take.persisted?
 
     success(take)
@@ -59,11 +59,26 @@ class TakeMedicationService
     error, medication = resolve_stock_source(resolver, taken_from_medication_id)
     return prepared_error(error) if error
 
-    PreparedTake.new(source:, amount:, medication:, taken_at:, client_uuid: options[:client_uuid], error: nil)
+    prepared_success(source:, amount:, medication:, taken_at:, options:)
   end
 
   def prepared_error(error)
-    PreparedTake.new(source: nil, amount: nil, medication: nil, taken_at: nil, client_uuid: nil, error: error)
+    PreparedTake.new(
+      source: nil, amount: nil, unit: nil, medication: nil,
+      taken_at: nil, client_uuid: nil, error: error
+    )
+  end
+
+  def prepared_success(source:, amount:, medication:, taken_at:, options:)
+    PreparedTake.new(
+      source: source,
+      amount: amount,
+      unit: default_dose_unit_for(source, taken_at),
+      medication: medication,
+      taken_at: taken_at,
+      client_uuid: options[:client_uuid],
+      error: nil
+    )
   end
 
   def resolve_stock_source(resolver, taken_from_medication_id)
@@ -75,13 +90,14 @@ class TakeMedicationService
     [nil, medication]
   end
 
-  def record_take(source:, amount:, medication:, taken_at:, client_uuid:)
-    source.medication_takes.create(
-      taken_at: taken_at,
-      amount_ml: amount,
-      client_uuid: client_uuid,
-      taken_from_medication: medication,
-      taken_from_location: medication.location
+  def record_take(prepared_take)
+    prepared_take.source.medication_takes.create(
+      taken_at: prepared_take.taken_at,
+      dose_amount: prepared_take.amount,
+      dose_unit: prepared_take.unit,
+      client_uuid: prepared_take.client_uuid,
+      taken_from_medication: prepared_take.medication,
+      taken_from_location: prepared_take.medication.location
     )
   end
 
@@ -97,6 +113,12 @@ class TakeMedicationService
     return source.effective_dose_amount(effective_date(taken_at)) if source.respond_to?(:effective_dose_amount)
 
     source.default_dose_amount
+  end
+
+  def default_dose_unit_for(source, taken_at)
+    return source.effective_dose_unit(effective_date(taken_at)) if source.respond_to?(:effective_dose_unit)
+
+    source.dose_unit
   end
 
   def effective_date(taken_at)
@@ -122,7 +144,8 @@ class TakeMedicationService
       medication_id: take.medication&.id,
       inventory_medication_id: take.inventory_medication&.id,
       inventory_location_id: take.inventory_location&.id,
-      amount_ml: take.amount_ml&.to_f,
+      dose_amount: take.dose_amount&.to_f,
+      dose_unit: take.dose_unit,
       taken_at: take.taken_at
     }
   end

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -19,7 +19,24 @@
 #                   #    :selection_required | :invalid_source | :create_failed
 class TakeMedicationService
   Result = Data.define(:success, :take, :error)
-  PreparedTake = Data.define(:source, :amount, :unit, :medication, :taken_at, :client_uuid, :error)
+  PreparedTake = Data.define(:source, :amount, :unit, :medication, :taken_at, :client_uuid, :error) do
+    def record
+      source.medication_takes.create(medication_take_attributes)
+    end
+
+    private
+
+    def medication_take_attributes
+      {
+        taken_at: taken_at,
+        dose_amount: amount,
+        dose_unit: unit,
+        client_uuid: client_uuid,
+        taken_from_medication: medication,
+        taken_from_location: medication.location
+      }
+    end
+  end
 
   def call(source:, amount_override:, taken_from_medication_id:, user:, **options)
     prepared_take = prepare_take(
@@ -31,7 +48,7 @@ class TakeMedicationService
     )
     return failure(prepared_take.error) if prepared_take.error
 
-    take = record_take(prepared_take)
+    take = prepared_take.record
     return failure(:create_failed) unless take.persisted?
 
     success(take)
@@ -88,17 +105,6 @@ class TakeMedicationService
     return [:invalid_source, nil] if medication.blank?
 
     [nil, medication]
-  end
-
-  def record_take(prepared_take)
-    prepared_take.source.medication_takes.create(
-      taken_at: prepared_take.taken_at,
-      dose_amount: prepared_take.amount,
-      dose_unit: prepared_take.unit,
-      client_uuid: prepared_take.client_uuid,
-      taken_from_medication: prepared_take.medication,
-      taken_from_location: prepared_take.medication.location
-    )
   end
 
   def normalize_amount(raw)

--- a/db/migrate/20260506120000_rename_medication_take_amount_and_decimal_inventory.rb
+++ b/db/migrate/20260506120000_rename_medication_take_amount_and_decimal_inventory.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RenameMedicationTakeAmountAndDecimalInventory < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :medication_takes, :amount_ml, :dose_amount
+    add_column :medication_takes, :dose_unit, :string
+    change_column :medication_takes, :dose_amount, :decimal, precision: 10, scale: 2
+
+    change_column :medications, :current_supply, :decimal, precision: 10, scale: 2
+    change_column :medications, :reorder_threshold, :decimal, precision: 10, scale: 2, default: 10, null: false
+    change_column :medications, :supply_at_last_restock, :decimal, precision: 10, scale: 2
+
+    change_column :dosages, :current_supply, :decimal, precision: 10, scale: 2
+    change_column :dosages, :reorder_threshold, :decimal, precision: 10, scale: 2
+  end
+
+  def down
+    change_column :dosages, :reorder_threshold, :integer
+    change_column :dosages, :current_supply, :integer
+
+    change_column :medications, :supply_at_last_restock, :integer
+    change_column :medications, :reorder_threshold, :integer, default: 10, null: false
+    change_column :medications, :current_supply, :integer
+
+    change_column :medication_takes, :dose_amount, :decimal
+    remove_column :medication_takes, :dose_unit
+    rename_column :medication_takes, :dose_amount, :amount_ml
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -179,7 +179,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
   create_table "dosages", force: :cascade do |t|
     t.decimal "amount"
     t.datetime "created_at", null: false
-    t.integer "current_supply"
+    t.decimal "current_supply", precision: 10, scale: 2
     t.integer "default_dose_cycle"
     t.boolean "default_for_adults", default: false, null: false
     t.boolean "default_for_children", default: false, null: false
@@ -188,7 +188,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
     t.string "description"
     t.string "frequency"
     t.bigint "medication_id", null: false
-    t.integer "reorder_threshold"
+    t.decimal "reorder_threshold", precision: 10, scale: 2
     t.string "unit"
     t.datetime "updated_at", null: false
     t.index ["medication_id"], name: "index_dosages_on_medication_id"
@@ -226,7 +226,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
   end
 
   create_table "medication_takes", force: :cascade do |t|
-    t.decimal "amount_ml"
+    t.decimal "dose_amount", precision: 10, scale: 2
+    t.string "dose_unit"
     t.string "client_uuid"
     t.datetime "created_at", null: false
     t.bigint "person_medication_id"
@@ -247,7 +248,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
     t.string "barcode"
     t.string "category"
     t.datetime "created_at", null: false
-    t.integer "current_supply"
+    t.decimal "current_supply", precision: 10, scale: 2
     t.text "description"
     t.jsonb "default_schedule_config", default: {}, null: false
     t.integer "default_schedule_type", default: 1, null: false
@@ -261,9 +262,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120000) do
     t.string "name"
     t.datetime "ordered_at"
     t.integer "reorder_status"
-    t.integer "reorder_threshold", default: 10, null: false
+    t.decimal "reorder_threshold", precision: 10, scale: 2, default: "10.0", null: false
     t.datetime "reordered_at"
-    t.integer "supply_at_last_restock"
+    t.decimal "supply_at_last_restock", precision: 10, scale: 2
     t.datetime "updated_at", null: false
     t.text "warnings"
     t.index ["barcode"], name: "index_medications_on_barcode", unique: true, where: "((barcode IS NOT NULL) AND ((barcode)::text <> ''::text))"

--- a/spec/components/dashboard/schedule_card_spec.rb
+++ b/spec/components/dashboard/schedule_card_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Components::Dashboard::ScheduleCard, type: :component do
     it 'renders the medication quantity' do
       rendered = render_inline(described_class.new(person: person, schedule: schedule))
 
-      expect(rendered.text).to include(MedicationStockConsumption.format(schedule.medication.current_supply))
+      expect(rendered.text).to include(MedicationStockQuantityFormatter.format(schedule.medication.current_supply))
     end
 
     it 'renders the take action with a pill icon' do

--- a/spec/components/dashboard/schedule_card_spec.rb
+++ b/spec/components/dashboard/schedule_card_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Components::Dashboard::ScheduleCard, type: :component do
     it 'renders the medication quantity' do
       rendered = render_inline(described_class.new(person: person, schedule: schedule))
 
-      expect(rendered.text).to include(schedule.medication.current_supply.to_s)
+      expect(rendered.text).to include(MedicationStockConsumption.format(schedule.medication.current_supply))
     end
 
     it 'renders the take action with a pill icon' do

--- a/spec/components/dashboard/schedule_row_spec.rb
+++ b/spec/components/dashboard/schedule_row_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Components::Dashboard::ScheduleRow, type: :component do
 
   it 'renders the medication quantity' do
     rendered = render_inline(row)
-    expect(rendered.text).to include(schedule.medication.current_supply.to_s)
+    expect(rendered.text).to include(MedicationStockConsumption.format(schedule.medication.current_supply))
   end
 
   it 'renders the person avatar with an SVG icon instead of emoji' do

--- a/spec/components/dashboard/schedule_row_spec.rb
+++ b/spec/components/dashboard/schedule_row_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Components::Dashboard::ScheduleRow, type: :component do
 
   it 'renders the medication quantity' do
     rendered = render_inline(row)
-    expect(rendered.text).to include(MedicationStockConsumption.format(schedule.medication.current_supply))
+    expect(rendered.text).to include(MedicationStockQuantityFormatter.format(schedule.medication.current_supply))
   end
 
   it 'renders the person avatar with an SVG icon instead of emoji' do

--- a/spec/components/person_medications/card_countdown_spec.rb
+++ b/spec/components/person_medications/card_countdown_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
 
   describe 'countdown notice styling' do
     before do
-      MedicationTake.create!(person_medication: person_medication, taken_at: 1.hour.ago, amount_ml: 10.0)
+      MedicationTake.create!(person_medication: person_medication, taken_at: 1.hour.ago, dose_amount: 10.0)
       allow(person_medication).to receive_messages(can_take_now?: false, countdown_display: '3 hours')
     end
 

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     MedicationTake.create!(
       person_medication: person_medication,
       taken_at: Time.current,
-      amount_ml: 1,
+      dose_amount: 1,
       taken_from_medication: alternate_medication,
       taken_from_location: alternate_location
     )

--- a/spec/components/person_medications/card_todays_takes_spec.rb
+++ b/spec/components/person_medications/card_todays_takes_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
   end
 
   describe 'pre-loaded todays_takes' do
-    let(:take) { MedicationTake.create!(person_medication: person_medication, taken_at: Time.current, amount_ml: 10.0) }
+    let(:take) do
+      MedicationTake.create!(person_medication: person_medication, taken_at: Time.current, dose_amount: 10.0)
+    end
 
     it 'displays takes from pre-loaded collection' do
       rendered = render_card(todays_takes: [take])

--- a/spec/components/schedules/card/dose_status_component_spec.rb
+++ b/spec/components/schedules/card/dose_status_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Components::Schedules::Card::DoseStatusComponent, type: :componen
     )
   end
   let(:presenter) { Schedules::CardPresenter.new(schedule: schedule, todays_takes: [take], current_user: nil, person: person) }
-  let(:take) { create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.current, amount_ml: 400) }
+  let(:take) { create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.current, dose_amount: 400) }
 
   it 'renders dates, notes, dose count, and today take history', :aggregate_failures do
     rendered = render_inline(described_class.new(schedule: schedule, presenter: presenter))
@@ -27,7 +27,7 @@ RSpec.describe Components::Schedules::Card::DoseStatusComponent, type: :componen
     expect(rendered.text).to include('Take with food')
     expect(rendered.text).to include("Today's Doses")
     expect(rendered.text).to include('1/4')
-    expect(rendered.text).to include('400mg')
+    expect(rendered.text).to include('400 mg')
     expect(rendered.text).not_to match(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/)
     expect(rendered.css('svg.lucide-calendar')).to be_present
     expect(rendered.css('svg.lucide-file-text')).to be_present

--- a/spec/components/schedules/card_spec.rb
+++ b/spec/components/schedules/card_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
   end
 
   it 'displays dosage unit from schedule, not hardcoded ml' do
-    MedicationTake.create!(schedule: schedule, taken_at: Time.current, amount_ml: 400)
+    MedicationTake.create!(schedule: schedule, taken_at: Time.current, dose_amount: 400)
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }
 
@@ -27,7 +27,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
     rendered = Nokogiri::HTML::DocumentFragment.parse(html)
 
     take_text = rendered.text
-    expect(take_text).to include('400mg')
+    expect(take_text).to include('400 mg')
     expect(take_text).not_to match(/400\s*ml/i)
   end
 
@@ -78,7 +78,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
     MedicationTake.create!(
       schedule: schedule,
       taken_at: Time.current,
-      amount_ml: 400,
+      dose_amount: 400,
       taken_from_medication: alternate_medication,
       taken_from_location: alternate_location
     )

--- a/spec/components/schedules/card_todays_takes_spec.rb
+++ b/spec/components/schedules/card_todays_takes_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Components::Schedules::Card, type: :component do
   end
 
   describe 'pre-loaded todays_takes' do
-    let(:take) { MedicationTake.create!(schedule: schedule, taken_at: Time.current, amount_ml: 400) }
+    let(:take) { MedicationTake.create!(schedule: schedule, taken_at: Time.current, dose_amount: 400) }
 
     it 'displays takes from pre-loaded collection' do
       rendered = render_card(todays_takes: [take])
-      expect(rendered.text).to include('400mg')
+      expect(rendered.text).to include('400 mg')
     end
 
     it 'shows no doses message when pre-loaded takes is empty' do
@@ -57,7 +57,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
     it 'falls back to querying when todays_takes is not provided' do
       take
       rendered = render_card
-      expect(rendered.text).to include('400mg')
+      expect(rendered.text).to include('400 mg')
     end
 
     it 'reuses one medication_takes load for the dose badge and list' do

--- a/spec/components/shared/stock_badge_spec.rb
+++ b/spec/components/shared/stock_badge_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Components::Shared::StockBadge, type: :component do
 
   let(:supply_level) { instance_double(SupplyLevel, status: status) }
   let(:medication) do
-    instance_double(Medication, current_supply: current_supply, supply_level: supply_level)
+    instance_double(Medication, current_supply: current_supply, dosage_unit: dosage_unit, supply_level: supply_level)
   end
   let(:current_supply) { 100 }
+  let(:dosage_unit) { 'mg' }
   let(:status) { :in_stock }
 
   describe '#view_template' do
@@ -36,6 +37,16 @@ RSpec.describe Components::Shared::StockBadge, type: :component do
 
         expect(badge['class']).to include('whitespace-nowrap')
         expect(badge['class']).to include('shrink-0')
+      end
+    end
+
+    context 'when medication is volume tracked' do
+      let(:current_supply) { BigDecimal('97.5') }
+      let(:dosage_unit) { 'ml' }
+
+      it 'renders the decimal volume count' do
+        result = render_inline(component)
+        expect(result.text).to include('97.5 ml left')
       end
     end
 

--- a/spec/factories/medication_takes.rb
+++ b/spec/factories/medication_takes.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :medication_take do
     taken_at { Time.current }
-    amount_ml { 1.0 }
+    dose_amount { schedule&.dose_amount || person_medication&.dose_amount || 1.0 }
+    dose_unit { schedule&.dose_unit || person_medication&.dose_unit || 'mg' }
 
     trait :for_person_medication do
       person_medication

--- a/spec/features/admin/audit_logs_spec.rb
+++ b/spec/features/admin/audit_logs_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe 'Admin Audit Logs', type: :system do
         MedicationTake.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0
         )
       end
 
@@ -289,7 +289,7 @@ RSpec.describe 'Admin Audit Logs', type: :system do
         MedicationTake.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0
         )
       end
 

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Person Medications', type: :system do
         MedicationTake.create!(
           person_medication: person_medication,
           taken_at: Time.current,
-          amount_ml: 5
+          dose_amount: 5
         )
       end
 
@@ -88,7 +88,7 @@ RSpec.describe 'Person Medications', type: :system do
       MedicationTake.create!(
         person_medication: person_medication,
         taken_at: 2.hours.ago,
-        amount_ml: 5
+        dose_amount: 5
       )
 
       visit person_path(person)
@@ -111,7 +111,7 @@ RSpec.describe 'Person Medications', type: :system do
       MedicationTake.create!(
         person_medication: person_medication,
         taken_at: Time.current,
-        amount_ml: 5
+        dose_amount: 5
       )
     end
 

--- a/spec/features/schedules/schedule_card_spec.rb
+++ b/spec/features/schedules/schedule_card_spec.rb
@@ -12,11 +12,10 @@ RSpec.describe 'Schedule Card', type: :system do
 
   before do
     login_as(admin_user)
-    visit person_path(person)
   end
 
   it 'allows taking a dose from the card and updates the card state' do
-    schedule.medication_takes.destroy_all
+    schedule.medication_takes.delete_all
     visit person_path(person)
 
     within("#schedule_#{schedule.id}") do
@@ -33,6 +32,8 @@ RSpec.describe 'Schedule Card', type: :system do
   end
 
   it 'opens the edit modal from the schedule card' do
+    visit person_path(person)
+
     within("#schedule_#{schedule.id}") do
       find("a[href='#{edit_person_schedule_path(person, schedule)}']").click
     end
@@ -42,6 +43,8 @@ RSpec.describe 'Schedule Card', type: :system do
   end
 
   it 'updates the persisted dose when changing the selected dose in the edit modal' do
+    visit person_path(person)
+
     within("#schedule_#{schedule.id}") do
       find("a[href='#{edit_person_schedule_path(person, schedule)}']").click
     end

--- a/spec/fixtures/medication_takes.yml
+++ b/spec/fixtures/medication_takes.yml
@@ -2,34 +2,41 @@
 john_morning_paracetamol:
   schedule: john_paracetamol
   taken_at: <%= Time.current.beginning_of_day + 8.hours %>
-  amount_ml: 1000.0
+  dose_amount: 1000.0
+  dose_unit: mg
 
 john_afternoon_paracetamol:
   schedule: john_paracetamol
   taken_at: <%= Time.current.beginning_of_day + 14.hours %>
-  amount_ml: 1000.0
+  dose_amount: 1000.0
+  dose_unit: mg
 
 jane_morning_ibuprofen:
   schedule: jane_ibuprofen
   taken_at: <%= Time.current.beginning_of_day + 8.hours %>
-  amount_ml: 400.0
+  dose_amount: 400.0
+  dose_unit: mg
 
 jane_evening_ibuprofen:
   schedule: jane_ibuprofen
   taken_at: <%= Time.current.beginning_of_day + 20.hours %>
-  amount_ml: 400.0
+  dose_amount: 400.0
+  dose_unit: mg
 
 bob_morning_aspirin:
   schedule: bob_aspirin
   taken_at: <%= Time.current.beginning_of_day + 7.hours %>
-  amount_ml: 75.0
+  dose_amount: 75.0
+  dose_unit: mg
 
 john_vitamin_d_today:
   person_medication: john_vitamin_d
   taken_at: <%= Time.current.beginning_of_day + 8.hours %>
-  amount_ml: 1000.0
+  dose_amount: 1000.0
+  dose_unit: mg
 
 bob_vitamin_c_recent:
   person_medication: bob_vitamin_c
   taken_at: <%= 2.hours.ago %>
-  amount_ml: 500.0
+  dose_amount: 500.0
+  dose_unit: mg

--- a/spec/models/medication_dosage_option_spec.rb
+++ b/spec/models/medication_dosage_option_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe MedicationDosageOption do
       expect(dosage_option).to be_valid
     end
 
+    it 'allows decimal inventory values' do
+      dosage_option = build(:dosage, current_supply: 97.5, reorder_threshold: 12.5)
+
+      expect(dosage_option).to be_valid
+    end
+
     it 'validates non-negative tracked inventory values' do
       dosage_option = build(:dosage, current_supply: -1, reorder_threshold: -1)
 

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -98,14 +98,10 @@ RSpec.describe Medication do
     it { is_expected.to allow_value('pad').for(:dosage_unit) }
     it { is_expected.to validate_numericality_of(:dosage_amount).is_greater_than(0).allow_nil }
 
-    it do
-      expect(medication).to validate_numericality_of(:current_supply)
-        .only_integer
-        .is_greater_than_or_equal_to(0)
-        .allow_nil
-    end
-
-    it { is_expected.to validate_numericality_of(:reorder_threshold).only_integer.is_greater_than_or_equal_to(0) }
+    it { is_expected.to allow_value(97.5).for(:current_supply) }
+    it { is_expected.to allow_value(2.5).for(:reorder_threshold) }
+    it { is_expected.to validate_numericality_of(:current_supply).is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_numericality_of(:reorder_threshold).is_greater_than_or_equal_to(0) }
 
     it { is_expected.to allow_value('Analgesic').for(:category) }
     it { is_expected.to allow_value('Osmotic Laxative').for(:category) }
@@ -190,6 +186,22 @@ RSpec.describe Medication do
 
     it 'increments current_supply by the given quantity' do
       expect { medication.restock!(quantity: 20) }.to change { medication.reload.current_supply }.from(10).to(30)
+    end
+
+    it 'increments current_supply by a decimal quantity' do
+      medication.update!(dosage_unit: 'ml', current_supply: 100, supply_at_last_restock: 100, reorder_threshold: 10)
+
+      expect do
+        medication.restock!(quantity: BigDecimal('12.5'))
+      end.to change { medication.reload.current_supply }.from(100).to(BigDecimal('112.5'))
+    end
+
+    it 'treats a nil current_supply as zero' do
+      medication.update!(current_supply: nil, supply_at_last_restock: nil)
+
+      expect do
+        medication.restock!(quantity: BigDecimal('12.5'))
+      end.to change { medication.reload.current_supply }.from(nil).to(BigDecimal('12.5'))
     end
 
     it 'sets supply_at_last_restock to the new current_supply' do

--- a/spec/models/medication_stock_quantity_formatter_spec.rb
+++ b/spec/models/medication_stock_quantity_formatter_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationStockQuantityFormatter do
+  describe '.format' do
+    it 'formats whole quantities without a decimal point' do
+      expect(described_class.format(BigDecimal('10.0'))).to eq('10')
+    end
+
+    it 'preserves meaningful decimal quantities' do
+      expect(described_class.format(BigDecimal('97.5'))).to eq('97.5')
+    end
+
+    it 'strips trailing zeroes from decimal quantities' do
+      expect(described_class.format(BigDecimal('12.50'))).to eq('12.5')
+    end
+  end
+end

--- a/spec/models/medication_take_inventory_spec.rb
+++ b/spec/models/medication_take_inventory_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe MedicationTake do
     )
     lock_order = record_lock_order(inventory: alternate_medication, dosage_option: inventory_options[:evening])
 
-    build_taken_from_schedule(schedule: schedule, taken_from_medication: alternate_medication).send(
+    take = build_taken_from_schedule(schedule: schedule, taken_from_medication: alternate_medication)
+
+    MedicationTakeStockMutation.new(take).send(
       :decrement_dosage_option_stock,
       alternate_medication,
       inventory_options[:evening]
@@ -185,7 +187,7 @@ RSpec.describe MedicationTake do
     described_class.create!(
       schedule: schedule,
       taken_at: Time.current,
-      amount_ml: 10.0,
+      dose_amount: 10.0,
       taken_from_medication: taken_from_medication,
       taken_from_location: taken_from_medication.location
     )
@@ -195,7 +197,7 @@ RSpec.describe MedicationTake do
     described_class.new(
       schedule: schedule,
       taken_at: Time.current,
-      amount_ml: 10.0,
+      dose_amount: 10.0,
       taken_from_medication: taken_from_medication,
       taken_from_location: taken_from_medication.location
     )

--- a/spec/models/medication_take_inventory_spec.rb
+++ b/spec/models/medication_take_inventory_spec.rb
@@ -53,11 +53,9 @@ RSpec.describe MedicationTake do
 
     take = build_taken_from_schedule(schedule: schedule, taken_from_medication: alternate_medication)
 
-    MedicationTakeStockMutation.new(take).send(
-      :decrement_dosage_option_stock,
-      alternate_medication,
-      inventory_options[:evening]
-    )
+    stock_source = MedicationTakeStockSource.new(take: take, inventory: alternate_medication)
+    allow(stock_source).to receive(:dosage_option).and_return(inventory_options[:evening])
+    MedicationTakeStockDecrement.new(take).call(stock_source)
 
     expect(lock_order).to eq(%i[dosage inventory])
   end

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MedicationTake do
-  subject(:medication_take) { described_class.new(schedule: schedule, taken_at: Time.current, amount_ml: 10.0) }
+  subject(:medication_take) { described_class.new(schedule: schedule, taken_at: Time.current, dose_amount: 10.0) }
 
   let(:medication) do
     Medication.create!(
@@ -22,14 +22,31 @@ RSpec.describe MedicationTake do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:taken_at) }
-    it { is_expected.to validate_presence_of(:amount_ml) }
-    it { is_expected.to validate_numericality_of(:amount_ml).is_greater_than(0) }
+    it { is_expected.to validate_numericality_of(:dose_amount).is_greater_than(0) }
+
+    it 'requires a dose amount snapshot' do
+      take = described_class.new(taken_at: Time.current, dose_unit: 'mg')
+
+      take.valid?
+
+      expect(take.errors[:dose_amount]).to include("can't be blank")
+    end
+
+    it 'requires a dose unit snapshot' do
+      take = described_class.new(taken_at: Time.current, dose_amount: 10)
+
+      take.valid?
+
+      expect(take.errors[:dose_unit]).to include("can't be blank")
+    end
 
     it 'allows blank client UUIDs but rejects duplicates when present' do
       uuid = SecureRandom.uuid
-      described_class.create!(schedule: schedule, taken_at: 1.hour.ago, amount_ml: 10.0, client_uuid: uuid)
+      described_class.create!(schedule: schedule, taken_at: 1.hour.ago, dose_amount: 10.0, dose_unit: 'mg',
+                              client_uuid: uuid)
 
-      duplicate = described_class.new(schedule: schedule, taken_at: Time.current, amount_ml: 10.0, client_uuid: uuid)
+      duplicate = described_class.new(schedule: schedule, taken_at: Time.current, dose_amount: 10.0, dose_unit: 'mg',
+                                      client_uuid: uuid)
 
       expect(duplicate).not_to be_valid
       expect(duplicate.errors[:client_uuid]).to include('has already been taken')
@@ -65,7 +82,7 @@ RSpec.describe MedicationTake do
 
   describe 'source validation' do
     context 'when neither schedule nor person_medication is set' do
-      subject(:medication_take) { described_class.new(taken_at: Time.current, amount_ml: 10.0) }
+      subject(:medication_take) { described_class.new(taken_at: Time.current, dose_amount: 10.0, dose_unit: 'mg') }
 
       it 'is invalid' do
         expect(medication_take).not_to be_valid
@@ -81,7 +98,8 @@ RSpec.describe MedicationTake do
           schedule: schedule,
           person_medication: person_medication,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0,
+          dose_unit: 'mg'
         )
       end
 
@@ -98,7 +116,8 @@ RSpec.describe MedicationTake do
         described_class.new(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0,
+          dose_unit: 'mg'
         )
       end
 
@@ -112,7 +131,8 @@ RSpec.describe MedicationTake do
         described_class.new(
           person_medication: person_medication,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0,
+          dose_unit: 'mg'
         )
       end
 
@@ -142,9 +162,40 @@ RSpec.describe MedicationTake do
           described_class.create!(
             schedule: schedule,
             taken_at: Time.current,
-            amount_ml: 10.0
+            dose_amount: 10.0,
+            dose_unit: 'mg'
           )
         end.to change { medication.reload.current_supply }.from(100).to(99)
+      end
+
+      it 'deducts the dose amount from ml stock' do
+        medication.update!(dosage_amount: 2.5, dosage_unit: 'ml', current_supply: 100, reorder_threshold: 10)
+        liquid_schedule = create_schedule_for(person: person, medication: medication,
+                                              dosage: default_dosage_for(medication))
+
+        expect do
+          described_class.create!(
+            schedule: liquid_schedule,
+            taken_at: Time.current,
+            dose_amount: 2.5,
+            dose_unit: 'ml'
+          )
+        end.to change { medication.reload.current_supply }.from(100).to(BigDecimal('97.5'))
+      end
+
+      it 'rejects a volume dose when stock is below the dose amount' do
+        medication.update!(dosage_amount: 2.5, dosage_unit: 'ml', current_supply: 2, reorder_threshold: 10)
+        liquid_schedule = create_schedule_for(person: person, medication: medication,
+                                              dosage: default_dosage_for(medication))
+        take = described_class.new(
+          schedule: liquid_schedule,
+          taken_at: Time.current,
+          dose_amount: 2.5,
+          dose_unit: 'ml'
+        )
+
+        expect(take).not_to be_valid
+        expect(take.errors[:taken_from_medication]).to include('must be in stock')
       end
     end
 
@@ -154,7 +205,8 @@ RSpec.describe MedicationTake do
           described_class.create!(
             person_medication: person_medication,
             taken_at: Time.current,
-            amount_ml: 10.0
+            dose_amount: 10.0,
+            dose_unit: 'mg'
           )
         end.to change { medication.reload.current_supply }.from(100).to(99)
       end
@@ -296,7 +348,7 @@ RSpec.describe MedicationTake do
         described_class.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0
         )
       end
 
@@ -310,7 +362,7 @@ RSpec.describe MedicationTake do
         described_class.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0
         )
       end
 
@@ -324,7 +376,7 @@ RSpec.describe MedicationTake do
         described_class.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 10.0
+          dose_amount: 10.0
         )
       end
 
@@ -411,7 +463,7 @@ RSpec.describe MedicationTake do
         described_class.create!(
           schedule: schedule,
           taken_at: Time.current,
-          amount_ml: 5.0
+          dose_amount: 5.0
         )
       end.to change(PaperTrail::Version.where(item_type: 'MedicationTake'), :count).by(1)
 
@@ -424,11 +476,11 @@ RSpec.describe MedicationTake do
       take = described_class.create!(
         schedule: schedule,
         taken_at: Time.current,
-        amount_ml: 5.0
+        dose_amount: 5.0
       )
 
       expect do
-        take.update!(amount_ml: 10.0)
+        take.update!(dose_amount: 10.0)
       end.to change(PaperTrail::Version, :count).by(1)
 
       version = take.versions.last
@@ -441,7 +493,7 @@ RSpec.describe MedicationTake do
       take = described_class.create!(
         schedule: schedule,
         taken_at: original_time,
-        amount_ml: 5.0
+        dose_amount: 5.0
       )
 
       new_time = 1.hour.ago
@@ -456,7 +508,7 @@ RSpec.describe MedicationTake do
       take = described_class.create!(
         schedule: schedule,
         taken_at: Time.current,
-        amount_ml: 5.0
+        dose_amount: 5.0
       )
       expect(take.versions.last.whodunnit).to eq(admin.id.to_s)
     end
@@ -467,7 +519,7 @@ RSpec.describe MedicationTake do
       take = described_class.create!(
         schedule: schedule,
         taken_at: Time.current,
-        amount_ml: 5.0
+        dose_amount: 5.0
       )
 
       expect(take.versions.last.ip).to eq('192.168.1.100')
@@ -491,8 +543,8 @@ RSpec.describe MedicationTake do
   def default_dosage_for(medication)
     Dosage.create!(
       medication: medication,
-      amount: 10,
-      unit: 'mg',
+      amount: medication.dosage_amount || 10,
+      unit: medication.dosage_unit || 'mg',
       frequency: 'daily',
       default_max_daily_doses: 1,
       default_min_hours_between_doses: 24,
@@ -602,7 +654,7 @@ RSpec.describe MedicationTake do
     described_class.create!(
       schedule: schedule,
       taken_at: Time.current,
-      amount_ml: 10.0,
+      dose_amount: 10.0,
       taken_from_medication: taken_from_medication,
       taken_from_location: taken_from_location
     )
@@ -612,7 +664,7 @@ RSpec.describe MedicationTake do
     described_class.new(
       schedule: schedule,
       taken_at: Time.current,
-      amount_ml: 10.0,
+      dose_amount: 10.0,
       taken_from_medication: taken_from_medication,
       taken_from_location: taken_from_location
     )

--- a/spec/models/person_medication_spec.rb
+++ b/spec/models/person_medication_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe PersonMedication do
     end
 
     context 'when both on cooldown and out of stock' do
-      let(:medication) { create(:medication, current_supply: 0) }
+      let(:medication) { create(:medication, current_supply: 1) }
       let(:person_medication) { create(:person_medication, medication: medication, min_hours_between_doses: 4) }
 
       it 'returns false' do
@@ -281,7 +281,7 @@ RSpec.describe PersonMedication do
     end
 
     context 'when both on cooldown and out of stock' do
-      let(:medication) { create(:medication, current_supply: 0) }
+      let(:medication) { create(:medication, current_supply: 1) }
       let(:person_medication) { create(:person_medication, medication: medication, min_hours_between_doses: 4) }
 
       it 'returns :out_of_stock (stock takes priority)' do

--- a/spec/presenters/medications/supply_status_presenter_spec.rb
+++ b/spec/presenters/medications/supply_status_presenter_spec.rb
@@ -125,6 +125,13 @@ RSpec.describe Medications::SupplyStatusPresenter do
 
       expect(presenter.remaining_units_label).to eq('units remaining')
     end
+
+    it 'returns ml label for volume stock' do
+      medication = create(:medication, dosage_unit: 'ml', current_supply: 97.5, reorder_threshold: 10)
+      presenter = described_class.new(medication:)
+
+      expect(presenter.remaining_units_label).to eq('ml remaining')
+    end
   end
 
   describe '#inventory_units_label' do
@@ -140,6 +147,13 @@ RSpec.describe Medications::SupplyStatusPresenter do
       presenter = described_class.new(medication:)
 
       expect(presenter.inventory_units_label).to eq('5 units')
+    end
+
+    it 'returns decimal ml label for volume stock' do
+      medication = create(:medication, dosage_unit: 'ml', current_supply: 97.5, reorder_threshold: 10)
+      presenter = described_class.new(medication:)
+
+      expect(presenter.inventory_units_label).to eq('97.5 ml')
     end
   end
 

--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Medication Timing Restrictions' do
           MedicationTake.create!(
             schedule: schedule,
             taken_at: Time.current,
-            amount_ml: 10
+            dose_amount: 10
           )
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe 'Medication Timing Restrictions' do
         MedicationTake.create!(
           schedule: schedule,
           taken_at: 1.hour.ago,
-          amount_ml: 10
+          dose_amount: 10
         )
       end
 
@@ -123,7 +123,7 @@ RSpec.describe 'Medication Timing Restrictions' do
     context 'when schedule dose is invalid' do
       it 'does not create a medication take and shows a friendly alert' do
         expect do
-          post take_medication_person_schedule_path(person, schedule), params: { amount_ml: 0 }
+          post take_medication_person_schedule_path(person, schedule), params: { dose_amount: 0 }
         end.not_to change(MedicationTake, :count)
 
         expect(response).to redirect_to(person_path(person))
@@ -198,7 +198,7 @@ RSpec.describe 'Medication Timing Restrictions' do
           MedicationTake.create!(
             person_medication: person_medication,
             taken_at: Time.current,
-            amount_ml: 10
+            dose_amount: 10
           )
         end
       end
@@ -218,7 +218,7 @@ RSpec.describe 'Medication Timing Restrictions' do
         MedicationTake.create!(
           person_medication: person_medication,
           taken_at: 1.hour.ago,
-          amount_ml: 10
+          dose_amount: 10
         )
       end
 
@@ -235,7 +235,7 @@ RSpec.describe 'Medication Timing Restrictions' do
     context 'when medication dose is invalid' do
       it 'does not create a medication take and shows a friendly alert' do
         expect do
-          post take_medication_person_person_medication_path(person, person_medication), params: { amount_ml: 0 }
+          post take_medication_person_person_medication_path(person, person_medication), params: { dose_amount: 0 }
         end.not_to change(MedicationTake, :count)
 
         expect(response).to redirect_to(person_path(person))

--- a/spec/requests/offline_spec.rb
+++ b/spec/requests/offline_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Offline mode' do
         source_type: 'schedule',
         source_id: schedule.id,
         taken_at: taken_at.iso8601,
-        amount_ml: '300',
+        dose_amount: '300',
         taken_from_medication_id: medication.id
       }
     end

--- a/spec/requests/toast_notifications_spec.rb
+++ b/spec/requests/toast_notifications_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Toast notifications for async actions' do
 
       it 'returns turbo_stream response with flash update when dose is invalid' do
         post take_medication_person_schedule_path(person, schedule),
-             params: { amount_ml: 0 },
+             params: { dose_amount: 0 },
              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
         expect(response).to have_http_status(:ok)
@@ -95,7 +95,7 @@ RSpec.describe 'Toast notifications for async actions' do
 
       it 'returns turbo_stream response with flash update when dose is invalid' do
         post take_medication_person_person_medication_path(person, person_medication),
-             params: { amount_ml: 0 },
+             params: { dose_amount: 0 },
              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
         expect(response).to have_http_status(:ok)

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
 
       before do
-        MedicationTake.create!(schedule: schedule, taken_at: 1.hour.ago, amount_ml: 400)
+        MedicationTake.create!(schedule: schedule, taken_at: 1.hour.ago, dose_amount: 400)
       end
 
       it 'emits a row with :cooldown status' do
@@ -162,7 +162,7 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
 
       before do
-        2.times { MedicationTake.create!(schedule: schedule, taken_at: Time.current, amount_ml: 500) }
+        2.times { MedicationTake.create!(schedule: schedule, taken_at: Time.current, dose_amount: 500) }
       end
 
       it 'does not emit an :upcoming row when daily max is reached' do

--- a/spec/services/reports/index_query_spec.rb
+++ b/spec/services/reports/index_query_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Reports::IndexQuery do
-  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :schedules, :medication_takes
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :schedules,
+           :person_medications, :medication_takes
 
   let(:people_scope) { Person.where(id: [people(:john).id, people(:jane).id]) }
   let(:start_date) { Time.zone.today - 1.day }
@@ -151,5 +152,50 @@ RSpec.describe Reports::IndexQuery do
 
       expect(result.inventory_alerts.pluck(:medication_name)).to contain_exactly('Daily low stock')
     end
+
+    it 'uses ml dose amounts for inventory alerts' do
+      report_date = Time.zone.today
+      person = create(:person)
+      medication = create_ml_report_schedule(person, report_date)
+
+      result = described_class.new(
+        people: Person.where(id: person.id),
+        start_date: report_date,
+        end_date: report_date
+      ).call
+
+      expect(result.inventory_alerts).to contain_exactly(
+        include(medication_name: medication.name, days_left: 2, doses_left: BigDecimal('10.0'))
+      )
+    end
+  end
+
+  def create_ml_report_schedule(person, report_date)
+    medication = create_ml_report_medication
+    dosage = create(:dosage, medication: medication, amount: 2.5, unit: 'ml')
+    create(
+      :schedule,
+      person: person,
+      medication: medication,
+      dosage: dosage,
+      dose_amount: 2.5,
+      dose_unit: 'ml',
+      max_daily_doses: 2,
+      start_date: report_date,
+      end_date: report_date
+    )
+    medication
+  end
+
+  def create_ml_report_medication
+    create(
+      :medication,
+      name: 'Calpol',
+      dosage_amount: 2.5,
+      dosage_unit: 'ml',
+      current_supply: 10,
+      supply_at_last_restock: 10,
+      reorder_threshold: 2
+    )
   end
 end

--- a/spec/services/restock_medication_service_spec.rb
+++ b/spec/services/restock_medication_service_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe RestockMedicationService do
       )
     end
 
+    it 'restocks with a decimal quantity' do
+      medication.update!(dosage_unit: 'ml', current_supply: 100, supply_at_last_restock: 100)
+      restock_date = Date.current
+
+      result = described_class.new.call(medication: medication, quantity: '12.5', restock_date: restock_date)
+
+      expect(result).to be_success
+      expect(medication.reload).to have_attributes(
+        current_supply: BigDecimal('112.5'),
+        supply_at_last_restock: BigDecimal('112.5'),
+        paper_trail_event: "restock (qty: 12.5, date: #{restock_date.iso8601})"
+      )
+    end
+
     it 'returns an error for a non-positive quantity' do
       result = described_class.new.call(medication: medication, quantity: '0', restock_date: Date.current)
 

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TakeMedicationService do
     end
 
     it 'records the correct amount' do
-      expect(result.take.amount_ml).to eq(BigDecimal(expected_amount.to_s))
+      expect(result.take.dose_amount).to eq(BigDecimal(expected_amount.to_s))
     end
 
     it 'records no error' do
@@ -98,7 +98,7 @@ RSpec.describe TakeMedicationService do
         # Create a recent take to trigger the cooldown
         schedule.medication_takes.create!(
           taken_at: 1.minute.ago,
-          amount_ml: schedule.default_dose_amount,
+          dose_amount: schedule.default_dose_amount,
           taken_from_medication: schedule.medication,
           taken_from_location: schedule.medication.location
         )
@@ -378,7 +378,7 @@ RSpec.describe TakeMedicationService do
       )
       result = take_schedule_at(schedule: schedule, travel_date: tablet_date, taken_at: capsule_date.noon)
 
-      expect(result.take.amount_ml).to eq(BigDecimal('1'))
+      expect(result.take.dose_amount).to eq(BigDecimal('1'))
       expect_inventory_supply(tablet: 56, capsule: 27, medication: 83)
     end
   end
@@ -411,7 +411,7 @@ RSpec.describe TakeMedicationService do
       payloads
     end
 
-    def expect_dose_taken_payload(payloads, result:, source:, amount_ml:, source_type:)
+    def expect_dose_taken_payload(payloads, result:, source:, dose_amount:, source_type:)
       expect(payloads).to contain_exactly(
         include(
           take_id: result.take.id,
@@ -421,7 +421,8 @@ RSpec.describe TakeMedicationService do
           medication_id: source.medication_id,
           inventory_medication_id: source.medication_id,
           inventory_location_id: source.medication.location_id,
-          amount_ml: amount_ml,
+          dose_amount: dose_amount,
+          dose_unit: source.dose_unit,
           taken_at: result.take.taken_at
         )
       )
@@ -440,7 +441,7 @@ RSpec.describe TakeMedicationService do
           payloads,
           result: result,
           source: schedule,
-          amount_ml: 750.0,
+          dose_amount: 750.0,
           source_type: 'schedule'
         )
       end
@@ -458,7 +459,7 @@ RSpec.describe TakeMedicationService do
         payloads,
         result: result,
         source: person_medication,
-        amount_ml: 1000.0,
+        dose_amount: 1000.0,
         source_type: 'person_medication'
       )
     end
@@ -480,7 +481,7 @@ RSpec.describe TakeMedicationService do
       travel_to Time.current.end_of_day - 1.minute do
         schedule.medication_takes.create!(
           taken_at: 1.minute.ago,
-          amount_ml: schedule.default_dose_amount,
+          dose_amount: schedule.default_dose_amount,
           taken_from_medication: schedule.medication,
           taken_from_location: schedule.medication.location
         )


### PR DESCRIPTION
## Summary
- rename pill-count inventory fields to stock/current supply semantics
- support decimal stock quantities for volume-based medicines such as Calpol 2.5ml doses
- split stock mutation, stock source resolution, decrementing, and quantity formatting responsibilities

Closes #665

## Verification
- task rubocop
- task test