### PR TITLE
feat: add global search command palette

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,93 +1,95 @@
-# Code Review - codex/login-page-storyboard-redesign
+# Code Review - codex/global-search-command-palette
 
 **Base Branch**: origin/main
-**Changed Ruby Files**: 24
-**Review Date**: 2026-04-29
-**Ruby LSP**: Not available in this Codex session; fallback `rg`, outlines, targeted reads, RubyCritic/SimpleCov attempts, and tests were used.
+**Changed Files**: 21
+**Changed Ruby Files**: 14
+**Review Date**: 2026-05-06
+**Review Skills**: review-ruby-code, sandi-metz-reviewer, rubycritic availability check, simplecov availability check
 
 ---
 
 ## Summary
 
-This branch redesigns the Rodauth login page with a split auth layout, extracted auth artwork components, passkey/OIDC sign-in options, deferred themed illustration assets, and a login-specific logo/chevron treatment.
+This branch adds a keyboard-first global search command palette backed by a Pundit-scoped Rails service, authenticated `/search` endpoint, PostgreSQL trigram indexes, authenticated chrome triggers, Stimulus keyboard behavior, and request/service/system coverage.
 
-The production Ruby changes are generally well scoped and move the login visual complexity out of `LoginBrandSupport`. The shared `ChevronRight` behavior is restored correctly, login call sites opt into their custom chevron path/stroke, and the breadcrumb separator spec now protects the shared default path.
+The implementation is generally sound: model search goes through policy scopes, wildcard search terms are escaped with `sanitize_sql_like`, query-like params are filtered from logs, and the system specs cover the high-risk keyboard path. I did not find a critical security or authorization issue in the reviewed changes.
 
 ## Critical Issues
 
-No critical issues remain from the focused review pass.
+No critical issues found.
 
 ## Design & Architecture
 
-### OOP Violations
+### OOP / Sandi Metz Findings
 
-No high-impact Sandi Metz/SOLID violations found in the current login extraction.
+Warning: [GlobalSearchQuery is 228 lines and owns search orchestration, five record-specific query builders, result shaping, command matching, scoring, sorting, normalization, and route generation](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L3). This exceeds the Sandi Metz 100-line class rule and is much larger than most existing query objects in this app. The current version is acceptable as an MVP, but the next search expansion should extract per-type searchers or a small registry before adding more result types.
 
-Positive observations:
-
-- [LoginBrandSupport is now a focused composition module](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/views/rodauth/login_brand_support.rb#L5), down from the previous large visual-rendering module.
-- [BenefitIconTile centralizes benefit icon dispatch](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/components/auth/benefit_icon_tile.rb#L5) without leaking icon switch logic back into the login view.
-- [ChevronRight now preserves shared defaults and exposes opt-in overrides](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/components/icons/chevron_right.rb#L8), which addresses the PR review thread without creating a separate login-only icon class.
+Warning: [GlobalSearchQuery#call returns blank-query command results directly](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L37), bypassing the service-level `limit` contract applied by `sort_results`. Today the default command set is small, so the UI is not broken, but `GlobalSearchQuery.new(..., query: '', limit: 2).call` can return more than two results. Add a blank-query limit spec and apply `.first(limit)` or route blank commands through the same sorter.
 
 ### Rails Patterns
 
-No N+1 query, callback, scope, or service-object issues were found in the changed login component code. The changes are view/component oriented and do not introduce database reads beyond existing `oauth_enabled?` and `invite_only?` behavior.
+No N+1 issue found in the added record searches. [Medication results preload location](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L67), and [schedule/person-medication results join and include their display associations](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L97).
 
-### Maintainability Notes
-
-[MtLogo#view_template](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/components/auth/mt_logo.rb#L11) is currently 27 lines because it contains the full inline SVG. This is acceptable for a small, isolated logo component, but if the logo is reused outside login or gains variants, prefer extracting repeated SVG primitives or loading a static asset to keep the component easy to scan.
-
-[MedicationIllustration#illustration_attrs](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/components/auth/medication_illustration.rb#L31) cleanly centralizes the four themed asset paths. The explicit `image_path_resolver` dependency keeps the component testable and avoids reaching into Rails helpers implicitly.
+The service-object shape matches the repo's existing `*Query` naming, but the branch introduces a larger orchestration query than the surrounding patterns. Existing query objects are mostly narrow, so future work should prefer small collaborators such as `GlobalSearch::PeopleSearch` and `GlobalSearch::MedicationsSearch` over continuing to grow this class.
 
 ## Security Concerns
 
-No new security issues found in the reviewed Ruby changes.
+No new security issue found.
 
 Positive observations:
 
-- [MedicationIllustration renders its inline activation script with a CSP nonce](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/app/components/auth/medication_illustration.rb#L59).
-- The login illustration image is decorative (`alt: ''`, `aria_hidden: 'true'`) while the wrapper keeps the localized `role="img"` label.
-- No raw SQL, mass assignment, unescaped user content, or authorization changes were introduced in the reviewed Ruby files.
+- [All record searches route through `Pundit.policy_scope!`](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L196).
+- [Search terms are escaped with `ActiveRecord::Base.sanitize_sql_like`](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/app/services/global_search_query.rb#L225).
+- [The request spec covers unauthenticated JSON access](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/spec/requests/global_search_spec.rb#L10), scoped user results, admin visibility, carer visibility, and wildcard escaping.
+- [Filtered parameters now include `q`, `query`, and `search`](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/config/initializers/filter_parameter_logging.rb#L8).
 
 ## Test Coverage
 
-### Passing Focused Tests
+Focused search tests passed after resetting the stale test stack:
 
-- `task test TEST_FILE=spec/components/icons/chevron_right_spec.rb`
-- `task test TEST_FILE=spec/components/views/rodauth/login_spec.rb`
-- `task test TEST_FILE=spec/components/ruby_ui/breadcrumb_separator_spec.rb`
+- `env COVERAGE=true task test TEST_FILE='spec/services/global_search_query_spec.rb spec/requests/global_search_spec.rb spec/system/global_search_spec.rb'`
+- 16 examples, 0 failures
 
-### Full Suite / Coverage
+Full suite passed after rebuilding the test environment:
 
-`task test` passed after the breadcrumb spec fix during this final push pass:
+- `task test:rebuild`
+- `task test`
+- 2103 examples, 0 failures, 2 pending
 
-- 1983 examples, 0 failures, 2 pending
+RuboCop passed:
 
-### Missing or Stale Test Coverage
+- `task rubocop`
+- 900 files inspected, no offenses detected
 
-[ChevronRight spec covers both default and opt-in variants](file:///Users/damacus/.codex/worktrees/76a4/med-tracker/spec/components/icons/chevron_right_spec.rb#L6), and the breadcrumb separator spec now asserts the shared default path for non-login callers.
+Coverage gap:
+
+- [The limit spec covers a nonblank query](file:///Users/damacus/.codex/worktrees/8e6c/med-tracker/spec/services/global_search_query_spec.rb#L57), but not the blank-query command-shortcut path where the current service bypasses `sort_results`.
 
 ## Tool Reports
 
 ### RubyCritic Summary
 
-RubyCritic could not be run:
+RubyCritic metrics are unavailable in this worktree:
 
-- `rubycritic --format json --no-browser ...` failed because `rubycritic` is not installed as a direct executable.
-- `bundle exec rubycritic --version` failed because the gem executable is not present in the bundle.
-
-RubyCritic metrics are therefore unavailable.
+- `rubycritic --version` failed because `rubycritic` is not installed on PATH.
+- The local RubyCritic helper, `scripts/check_quality.sh`, auto-installs RubyCritic and may modify the Gemfile, so I did not run it during a review-only pass.
 
 ### SimpleCov Summary
 
-SimpleCov metrics are unavailable because the full suite was not run with coverage enabled.
+SimpleCov metrics are unavailable:
+
+- Running focused specs with `COVERAGE=true` produced no `coverage/` directory.
+- No SimpleCov configuration or gem entry was found in the app paths checked during this review.
 
 ## Recommendations
 
-1. If RubyCritic is required as a quality gate, add it to the bundle or document that this review skill cannot run it in the current repo environment.
+1. Fix the blank-query `limit` path in `GlobalSearchQuery#call` and add a service spec for `query: ''`.
+2. Before expanding v2 search, split `GlobalSearchQuery` into small per-type query objects or a result-source registry. That keeps the MVP class from becoming the place every search concern accumulates.
+3. If RubyCritic/SimpleCov reports are required for reviews, add repo-native `task` wrappers that do not auto-edit the Gemfile during analysis.
 
 ## Positive Observations
 
-- The original review findings are addressed: `LoginBrandSupport` is small, the login spec is split into focused examples, and `secondary_sign_in_visible?` names the OIDC visibility policy.
-- The chevron review thread is addressed in production code with the simpler approach: shared defaults are preserved, login call sites opt into the larger path/stroke.
-- The new logo and illustration components isolate visual markup from Rodauth login flow logic.
+- The branch keeps v1 internal search simple: Rails, PostgreSQL, Pundit, and Stimulus only.
+- The keyboard behavior is covered end to end, including Ctrl+K/Cmd+K, focus, arrow navigation, Enter navigation, Escape, and the mobile trigger.
+- The SQL uses static fragments plus bind parameters; I did not find user-controlled SQL interpolation.
+- The implementation avoids searching medication takes, audit logs, notes, and user records in v1.

--- a/app/components/global_search/palette.rb
+++ b/app/components/global_search/palette.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Components
+  module GlobalSearch
+    class Palette < Components::Base
+      def view_template
+        dialog(
+          id: 'global_search_dialog',
+          class: 'w-[min(720px,calc(100vw-2rem))] max-h-[min(680px,calc(100vh-2rem))] p-0 ' \
+                 'overflow-hidden rounded-lg border border-outline-variant bg-surface text-on-surface ' \
+                 'shadow-elevation-4 backdrop:bg-black/40',
+          aria: { label: t('global_search.dialog_label') },
+          data: dialog_data
+        ) do
+          render_search_form
+          render_status
+          div(
+            id: 'global_search_results',
+            class: 'max-h-[520px] overflow-y-auto p-3',
+            data: { global_search_target: 'results' }
+          )
+        end
+      end
+
+      private
+
+      def dialog_data
+        {
+          global_search_target: 'dialog',
+          action: 'cancel->global-search#cancel close->global-search#closed',
+          search_url: search_path(format: :json),
+          translations: translations.to_json
+        }
+      end
+
+      def render_search_form
+        form(action: search_path, method: :get, class: 'border-b border-outline-variant p-3',
+             data: { action: 'submit->global-search#submit' }) do
+          label(class: 'sr-only', for: 'global_search_query') { t('global_search.input_label') }
+          div(class: 'flex items-center gap-3 rounded-md bg-surface-container-low px-3 py-2') do
+            render Icons::Search.new(size: 20, class: 'text-on-surface-variant')
+            input(
+              id: 'global_search_query',
+              name: 'q',
+              type: 'search',
+              autocomplete: 'off',
+              placeholder: t('global_search.placeholder'),
+              class: 'min-h-[44px] flex-1 bg-transparent text-base text-foreground outline-none ' \
+                     'placeholder:text-on-surface-variant',
+              aria: { controls: 'global_search_results' },
+              data: {
+                global_search_target: 'input',
+                action: 'input->global-search#search keydown->global-search#handleKeydown'
+              }
+            )
+            button(
+              type: 'button',
+              class: 'flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant ' \
+                     'hover:bg-surface-container-high focus-visible:outline-none focus-visible:ring-2 ' \
+                     'focus-visible:ring-primary',
+              aria: { label: t('global_search.close') },
+              data: { action: 'global-search#close' }
+            ) do
+              render Icons::X.new(size: 20)
+            end
+          end
+        end
+      end
+
+      def render_status
+        div(
+          class: 'px-4 py-2 text-xs font-bold uppercase tracking-widest text-on-surface-variant',
+          aria: { live: 'polite' },
+          data: { global_search_target: 'status' }
+        )
+      end
+
+      def translations
+        {
+          loading: t('global_search.loading'),
+          no_results: t('global_search.no_results'),
+          result_one: t('global_search.results.one'),
+          result_other: t('global_search.results.other'),
+          type_labels: {
+            command: t('global_search.types.command'),
+            person: t('global_search.types.person'),
+            medication: t('global_search.types.medication'),
+            person_medication: t('global_search.types.person_medication'),
+            schedule: t('global_search.types.schedule'),
+            location: t('global_search.types.location')
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/components/global_search/show_view.rb
+++ b/app/components/global_search/show_view.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Components
+  module GlobalSearch
+    class ShowView < Components::Base
+      attr_reader :query, :results
+
+      def initialize(query:, results:)
+        @query = query
+        @results = results
+        super()
+      end
+
+      def view_template
+        div(class: 'container mx-auto max-w-4xl px-4 py-10 space-y-8') do
+          header(class: 'space-y-2') do
+            m3_heading(variant: :display_small, level: 1) { t('global_search.page_title') }
+            m3_text(class: 'text-on-surface-variant') { t('global_search.page_subtitle') }
+          end
+          render_form
+          render_results
+        end
+      end
+
+      private
+
+      def render_form
+        form(action: search_path, method: :get, class: 'flex gap-3') do
+          label(class: 'sr-only', for: 'search_q') { t('global_search.input_label') }
+          input(
+            id: 'search_q',
+            name: 'q',
+            type: 'search',
+            value: query,
+            class: 'min-h-[44px] flex-1 rounded-md border border-outline-variant bg-surface-container-low px-4',
+            placeholder: t('global_search.placeholder')
+          )
+          m3_button(type: :submit) { t('global_search.page_submit') }
+        end
+      end
+
+      def render_results
+        if results.empty?
+          m3_text(class: 'text-on-surface-variant') { t('global_search.no_results') }
+          return
+        end
+
+        div(class: 'space-y-2') do
+          results.each do |result|
+            link_to result.path,
+                    class: 'block rounded-md border border-outline-variant bg-surface-container-low p-4 ' \
+                           'no-underline hover:border-primary focus-visible:outline-none focus-visible:ring-2 ' \
+                           'focus-visible:ring-primary' do
+              p(class: 'font-bold text-foreground') { result.title }
+              p(class: 'text-sm text-on-surface-variant') { result.subtitle }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/layouts/navigation.rb
+++ b/app/components/layouts/navigation.rb
@@ -54,6 +54,19 @@ module Components
       end
 
       def render_auth_actions
+        if authenticated?
+          button(
+            type: 'button',
+            class: 'flex h-11 w-11 items-center justify-center rounded-full text-on-surface-variant ' \
+                   'hover:bg-surface-container-high focus-visible:outline-none focus-visible:ring-2 ' \
+                   'focus-visible:ring-primary',
+            aria: { label: t('global_search.open') },
+            data: { action: 'global-search#open' }
+          ) do
+            render Icons::Search.new(size: 22)
+          end
+        end
+
         div(class: 'nav__user-menu hidden md:block') do
           if authenticated?
             render Components::Layouts::ProfileMenu.new(current_user: current_user)

--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -17,6 +17,7 @@ module Components
                  'sm:flex flex-col items-center md:items-start py-8 px-4 z-50 transition-all duration-500'
         ) do
           render_brand
+          render_search_trigger
           render_navigation
           render_user_profile
         end
@@ -55,6 +56,24 @@ module Components
           if user_is_admin?
             render_nav_link(admin_root_path, Icons::Settings,
                             t('layouts.sidebar.administration'))
+          end
+        end
+      end
+
+      def render_search_trigger
+        button(
+          type: 'button',
+          class: 'mb-6 flex w-full items-center justify-center gap-3 rounded-md border border-outline-variant ' \
+                 'bg-surface-container px-3 py-3 text-on-surface-variant transition-colors ' \
+                 'hover:border-primary hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 ' \
+                 'focus-visible:ring-primary md:justify-start',
+          aria: { label: t('global_search.open') },
+          data: { action: 'global-search#open' }
+        ) do
+          render Icons::Search.new(size: 20)
+          span(class: 'hidden flex-1 text-left text-sm font-bold md:block') { t('global_search.open_short') }
+          kbd(class: 'hidden rounded border border-outline-variant px-1.5 py-0.5 text-[10px] font-bold md:block') do
+            t('global_search.shortcut_hint')
           end
         end
       end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SearchesController < ApplicationController
+  def show
+    respond_to do |format|
+      format.html { render Components::GlobalSearch::ShowView.new(query: search_query, results: search_results) }
+      format.json { render json: { results: search_results.map(&:as_json) } }
+    end
+  end
+
+  private
+
+  def search_results
+    @search_results ||= GlobalSearchQuery.new(user: current_user, query: search_query).call
+  end
+
+  def search_query
+    params[:q].to_s
+  end
+end

--- a/app/javascript/controllers/global_search_controller.js
+++ b/app/javascript/controllers/global_search_controller.js
@@ -1,0 +1,230 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog", "input", "results", "status", "result"]
+
+  connect() {
+    this.shortcutHandler = this.shortcut.bind(this)
+    window.addEventListener("keydown", this.shortcutHandler)
+    this.activeIndex = -1
+    this.translations = JSON.parse(this.dialogTarget.dataset.translations || "{}")
+  }
+
+  disconnect() {
+    window.removeEventListener("keydown", this.shortcutHandler)
+    this.abortCurrentSearch()
+    clearTimeout(this.searchTimer)
+  }
+
+  shortcut(event) {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault()
+      this.open(event)
+    }
+  }
+
+  open(event) {
+    const opener = event?.currentTarget
+    this.previouslyFocused = opener instanceof Element ? opener : document.activeElement
+
+    if (!this.dialogTarget.open) {
+      this.dialogTarget.showModal()
+    }
+
+    this.inputTarget.value = ""
+    this.resultsTarget.innerHTML = ""
+    this.setStatus("")
+    this.fetchResults("")
+    requestAnimationFrame(() => this.inputTarget.focus())
+  }
+
+  close(event) {
+    if (event) event.preventDefault()
+    if (this.dialogTarget.open) this.dialogTarget.close()
+  }
+
+  cancel(event) {
+    event.preventDefault()
+    this.close()
+  }
+
+  closed() {
+    this.abortCurrentSearch()
+    clearTimeout(this.searchTimer)
+    this.previouslyFocused?.focus?.()
+  }
+
+  search() {
+    clearTimeout(this.searchTimer)
+    this.searchTimer = setTimeout(() => {
+      this.fetchResults(this.inputTarget.value.trim())
+    }, 150)
+  }
+
+  submit(event) {
+    event.preventDefault()
+    const result = this.activeResult || this.resultTargets[0]
+    if (result) window.location.href = result.href
+  }
+
+  handleKeydown(event) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      this.activate(this.activeIndex + 1)
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      this.activate(this.activeIndex - 1)
+    } else if (event.key === "Enter") {
+      this.submit(event)
+    } else if (event.key === "Escape") {
+      this.close(event)
+    }
+  }
+
+  activatePointer(event) {
+    const index = Number.parseInt(event.currentTarget.dataset.index, 10)
+    if (!Number.isNaN(index)) this.activate(index)
+  }
+
+  async fetchResults(query) {
+    this.abortCurrentSearch()
+    this.showLoading()
+
+    this.abortController = new AbortController()
+    const url = new URL(this.dialogTarget.dataset.searchUrl, window.location.origin)
+    url.searchParams.set("q", query)
+
+    try {
+      const response = await fetch(url.toString(), {
+        headers: { "Accept": "application/json" },
+        signal: this.abortController.signal
+      })
+      const data = await response.json()
+      this.renderResults(data.results || [])
+    } catch (error) {
+      if (error.name !== "AbortError") this.renderResults([])
+    }
+  }
+
+  abortCurrentSearch() {
+    if (this.abortController) {
+      this.abortController.abort()
+      this.abortController = null
+    }
+  }
+
+  showLoading() {
+    this.activeIndex = -1
+    this.resultsTarget.innerHTML = `
+      <div class="px-3 py-8 text-center text-sm text-on-surface-variant">
+        ${this.escapeHtml(this.t("loading"))}
+      </div>
+    `
+    this.setStatus(this.t("loading"))
+  }
+
+  renderResults(results) {
+    this.activeIndex = -1
+
+    if (results.length === 0) {
+      this.resultsTarget.innerHTML = `
+        <div class="px-3 py-8 text-center text-sm text-on-surface-variant">
+          ${this.escapeHtml(this.t("no_results"))}
+        </div>
+      `
+      this.setStatus(this.t("no_results"))
+      return
+    }
+
+    this.resultsTarget.innerHTML = this.groupedResultsHtml(results)
+    this.setStatus(this.resultCountText(results.length))
+  }
+
+  groupedResultsHtml(results) {
+    const groups = []
+
+    results.forEach((result, index) => {
+      const group = groups.find((entry) => entry.type === result.type)
+      const item = this.resultHtml(result, index)
+
+      if (group) {
+        group.items.push(item)
+      } else {
+        groups.push({ type: result.type, items: [item] })
+      }
+    })
+
+    return groups.map((group) => `
+      <section class="space-y-1 pb-3">
+        <h2 class="px-2 py-1 text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+          ${this.escapeHtml(this.typeLabel(group.type))}
+        </h2>
+        <div class="space-y-1">${group.items.join("")}</div>
+      </section>
+    `).join("")
+  }
+
+  resultHtml(result, index) {
+    return `
+      <a
+        href="${this.hrefAttribute(result.path)}"
+        class="block rounded-md border border-transparent px-3 py-3 no-underline outline-none transition-colors
+               hover:border-primary hover:bg-surface-container-low
+               focus-visible:border-primary focus-visible:bg-surface-container-low focus-visible:ring-2 focus-visible:ring-primary
+               data-[global-search-active=true]:border-primary data-[global-search-active=true]:bg-surface-container-low"
+        data-global-search-target="result"
+        data-global-search-active="false"
+        data-index="${index}"
+        data-action="mouseenter->global-search#activatePointer"
+      >
+        <span class="block text-sm font-bold text-foreground">${this.escapeHtml(result.title)}</span>
+        <span class="block text-xs text-on-surface-variant">${this.escapeHtml(result.subtitle || "")}</span>
+      </a>
+    `
+  }
+
+  activate(index) {
+    if (this.resultTargets.length === 0) return
+
+    this.activeIndex = (index + this.resultTargets.length) % this.resultTargets.length
+
+    this.resultTargets.forEach((result, resultIndex) => {
+      const active = resultIndex === this.activeIndex
+      result.dataset.globalSearchActive = active ? "true" : "false"
+      if (active) result.scrollIntoView({ block: "nearest" })
+    })
+  }
+
+  get activeResult() {
+    return this.resultTargets[this.activeIndex]
+  }
+
+  setStatus(text) {
+    this.statusTarget.textContent = text
+  }
+
+  typeLabel(type) {
+    return this.translations.type_labels?.[type] || type
+  }
+
+  resultCountText(count) {
+    const template = count === 1 ? this.t("result_one") : this.t("result_other")
+    return template.replace("%{count}", count)
+  }
+
+  t(key) {
+    return this.translations[key] || ""
+  }
+
+  escapeHtml(value) {
+    const div = document.createElement("div")
+    div.appendChild(document.createTextNode(String(value || "")))
+    return div.innerHTML
+  }
+
+  hrefAttribute(url) {
+    const link = document.createElement("a")
+    link.setAttribute("href", String(url || ""))
+    return link.getAttribute("href") || ""
+  }
+}

--- a/app/services/global_search/locations_results_query.rb
+++ b/app/services/global_search/locations_results_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class LocationsResultsQuery < RecordResultsQuery
+    def call
+      scoped(Location)
+        .where('locations.name ILIKE ?', search_term)
+        .order(:name)
+        .limit(limit)
+        .map { |location| result_for(location) }
+    end
+
+    private
+
+    def result_for(location)
+      builder.build(
+        type: 'location',
+        title: location.name,
+        subtitle: I18n.t('global_search.types.location'),
+        path: location_path(location)
+      )
+    end
+  end
+end

--- a/app/services/global_search/medications_results_query.rb
+++ b/app/services/global_search/medications_results_query.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class MedicationsResultsQuery < RecordResultsQuery
+    def call
+      scoped(Medication)
+        .includes(:location)
+        .where(search_sql, term: search_term)
+        .order(:name)
+        .limit(limit)
+        .map { |medication| result_for(medication) }
+    end
+
+    private
+
+    def result_for(medication)
+      builder.build(
+        type: 'medication',
+        title: medication.name,
+        subtitle: subtitle_for(medication),
+        path: medication_path(medication),
+        secondary_values: [medication.category, medication.barcode, medication.dmd_code]
+      )
+    end
+
+    def subtitle_for(medication)
+      [medication.category.presence, medication.location&.name].compact.join(' · ').presence ||
+        I18n.t('global_search.types.medication')
+    end
+
+    def search_sql
+      'medications.name ILIKE :term OR medications.category ILIKE :term OR ' \
+        'medications.barcode ILIKE :term OR medications.dmd_code ILIKE :term'
+    end
+  end
+end

--- a/app/services/global_search/people_results_query.rb
+++ b/app/services/global_search/people_results_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class PeopleResultsQuery < RecordResultsQuery
+    def call
+      scoped(Person)
+        .where('people.name ILIKE ?', search_term)
+        .order(:name)
+        .limit(limit)
+        .map { |person| result_for(person) }
+    end
+
+    private
+
+    def result_for(person)
+      builder.build(
+        type: 'person',
+        title: person.name,
+        subtitle: I18n.t('global_search.types.person'),
+        path: person_path(person)
+      )
+    end
+  end
+end

--- a/app/services/global_search/person_medications_results_query.rb
+++ b/app/services/global_search/person_medications_results_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class PersonMedicationsResultsQuery < RecordResultsQuery
+    def call
+      scoped(PersonMedication)
+        .joins(:person, :medication)
+        .includes(:person, :medication)
+        .where(search_sql, term: search_term)
+        .order('medications.name ASC', 'people.name ASC')
+        .limit(limit)
+        .map { |person_medication| result_for(person_medication) }
+    end
+
+    private
+
+    def result_for(person_medication)
+      builder.build(
+        type: 'person_medication',
+        title: person_medication.medication.name,
+        subtitle: I18n.t('global_search.subtitles.person_medication', person: person_medication.person.name),
+        path: person_path(person_medication.person, anchor: "person_medication_#{person_medication.id}"),
+        secondary_values: [person_medication.person.name]
+      )
+    end
+
+    def search_sql
+      'medications.name ILIKE :term OR people.name ILIKE :term'
+    end
+  end
+end

--- a/app/services/global_search/record_results_query.rb
+++ b/app/services/global_search/record_results_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class RecordResultsQuery
+    include Rails.application.routes.url_helpers
+
+    attr_reader :user, :query, :limit, :builder
+
+    def initialize(user:, query:, limit:, builder:)
+      @user = user
+      @query = query
+      @limit = limit
+      @builder = builder
+    end
+
+    private
+
+    def scoped(model)
+      Pundit.policy_scope!(user, model)
+    end
+
+    def search_term
+      @search_term ||= "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+    end
+  end
+end

--- a/app/services/global_search/result.rb
+++ b/app/services/global_search/result.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  Result = Data.define(:type, :title, :subtitle, :path, :score) do
+    def as_json(*)
+      {
+        type: type,
+        title: title,
+        subtitle: subtitle,
+        path: path,
+        score: score
+      }
+    end
+  end
+end

--- a/app/services/global_search/result_builder.rb
+++ b/app/services/global_search/result_builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class ResultBuilder
+    attr_reader :query
+
+    def initialize(query:)
+      @query = query.to_s.strip
+    end
+
+    def build(type:, title:, subtitle:, path:, secondary_values: [])
+      Result.new(
+        type: type,
+        title: title,
+        subtitle: subtitle,
+        path: path,
+        score: score_for(title, secondary_values)
+      )
+    end
+
+    def rescore(result, secondary_values: [])
+      build(
+        type: result.type,
+        title: result.title,
+        subtitle: result.subtitle,
+        path: result.path,
+        secondary_values: secondary_values
+      )
+    end
+
+    private
+
+    def score_for(title, secondary_values)
+      normalized_title = normalize(title)
+      return 100 if normalized_title == normalized_query
+      return 80 if normalized_title.start_with?(normalized_query)
+      return 60 if normalized_title.include?(normalized_query)
+      return 40 if secondary_values.any? { |value| normalize(value).include?(normalized_query) }
+
+      0
+    end
+
+    def normalize(value)
+      value.to_s.strip.downcase
+    end
+
+    def normalized_query
+      @normalized_query ||= normalize(query)
+    end
+  end
+end

--- a/app/services/global_search/schedules_results_query.rb
+++ b/app/services/global_search/schedules_results_query.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module GlobalSearch
+  class SchedulesResultsQuery < RecordResultsQuery
+    def call
+      scoped(Schedule)
+        .joins(:person, :medication)
+        .includes(:person, :medication)
+        .where(search_sql, term: search_term)
+        .order('medications.name ASC', 'people.name ASC')
+        .limit(limit)
+        .map { |schedule| result_for(schedule) }
+    end
+
+    private
+
+    def result_for(schedule)
+      builder.build(
+        type: 'schedule',
+        title: I18n.t('global_search.result_titles.schedule', medication: schedule.medication.name),
+        subtitle: subtitle_for(schedule),
+        path: person_path(schedule.person, anchor: "schedule_#{schedule.id}"),
+        secondary_values: [schedule.person.name]
+      )
+    end
+
+    def subtitle_for(schedule)
+      I18n.t(
+        'global_search.subtitles.schedule',
+        person: schedule.person.name,
+        frequency: schedule.frequency.presence || I18n.t('global_search.subtitles.no_frequency')
+      )
+    end
+
+    def search_sql
+      'medications.name ILIKE :term OR people.name ILIKE :term'
+    end
+  end
+end

--- a/app/services/global_search_commands_query.rb
+++ b/app/services/global_search_commands_query.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class GlobalSearchCommandsQuery
+  include Rails.application.routes.url_helpers
+
+  attr_reader :user
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def call
+    command_definitions.filter_map do |command|
+      next unless command_allowed?(command)
+
+      GlobalSearchQuery::Result.new(
+        type: 'command',
+        title: command.fetch(:title),
+        subtitle: command.fetch(:subtitle),
+        path: command.fetch(:path),
+        score: 50
+      )
+    end
+  end
+
+  private
+
+  def command_definitions
+    navigation_command_definitions + creation_command_definitions
+  end
+
+  def navigation_command_definitions
+    [
+      command(:medication_finder, medication_finder_path, Medication, :finder?),
+      command(:inventory, medications_path, Medication, :index?),
+      command(:people, people_path, Person, :index?),
+      command(:locations, locations_path, Location, :index?),
+      command(:reports, reports_path, :report, :index?)
+    ]
+  end
+
+  def creation_command_definitions
+    [
+      command(:add_medication, add_medication_path, Medication, :create?),
+      command(:add_person, new_person_path, Person.new, :new?),
+      command(:schedule_workflow, schedules_workflow_path, Schedule.new(person: user.person), :create?)
+    ]
+  end
+
+  def command(key, path, record, action)
+    {
+      title: I18n.t("global_search.commands.#{key}.title"),
+      subtitle: I18n.t("global_search.commands.#{key}.subtitle"),
+      path: path,
+      record: record,
+      action: action
+    }
+  end
+
+  def command_allowed?(command)
+    Pundit.policy!(user, command.fetch(:record)).public_send(command.fetch(:action))
+  rescue Pundit::NotDefinedError
+    false
+  end
+end

--- a/app/services/global_search_query.rb
+++ b/app/services/global_search_query.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 class GlobalSearchQuery
-  include Rails.application.routes.url_helpers
-
-  Result = Data.define(:type, :title, :subtitle, :path, :score) do
-    def as_json(*)
-      {
-        type: type,
-        title: title,
-        subtitle: subtitle,
-        path: path,
-        score: score
-      }
-    end
-  end
+  Result = GlobalSearch::Result
 
   TYPE_ORDER = {
     'command' => 0,
@@ -23,6 +11,14 @@ class GlobalSearchQuery
     'schedule' => 4,
     'location' => 5
   }.freeze
+
+  RECORD_QUERIES = [
+    GlobalSearch::PeopleResultsQuery,
+    GlobalSearch::MedicationsResultsQuery,
+    GlobalSearch::LocationsResultsQuery,
+    GlobalSearch::SchedulesResultsQuery,
+    GlobalSearch::PersonMedicationsResultsQuery
+  ].freeze
 
   attr_reader :user, :query, :limit
 
@@ -34,7 +30,7 @@ class GlobalSearchQuery
 
   def call
     return [] unless user
-    return command_results if query.blank?
+    return command_results.first(limit) if query.blank?
 
     results = matching_command_results
     results.concat(record_results) if query.length >= 2
@@ -44,134 +40,7 @@ class GlobalSearchQuery
   private
 
   def record_results
-    person_results + medication_results + location_results + schedule_results + person_medication_results
-  end
-
-  def person_results
-    scoped(Person)
-      .where('people.name ILIKE ?', search_term)
-      .order(:name)
-      .limit(limit)
-      .map do |person|
-        build_result(
-          type: 'person',
-          title: person.name,
-          subtitle: I18n.t('global_search.types.person'),
-          path: person_path(person)
-        )
-      end
-  end
-
-  def medication_results
-    scoped(Medication)
-      .includes(:location)
-      .where(medication_search_sql, term: search_term)
-      .order(:name)
-      .limit(limit)
-      .map do |medication|
-        build_result(
-          type: 'medication',
-          title: medication.name,
-          subtitle: medication_subtitle(medication),
-          path: medication_path(medication),
-          secondary_values: [medication.category, medication.barcode, medication.dmd_code]
-        )
-      end
-  end
-
-  def location_results
-    scoped(Location)
-      .where('locations.name ILIKE ?', search_term)
-      .order(:name)
-      .limit(limit)
-      .map do |location|
-        build_result(
-          type: 'location',
-          title: location.name,
-          subtitle: I18n.t('global_search.types.location'),
-          path: location_path(location)
-        )
-      end
-  end
-
-  def schedule_results
-    scoped(Schedule)
-      .joins(:person, :medication)
-      .includes(:person, :medication)
-      .where(schedule_search_sql, term: search_term)
-      .order('medications.name ASC', 'people.name ASC')
-      .limit(limit)
-      .map { |schedule| schedule_result(schedule) }
-  end
-
-  def person_medication_results
-    scoped(PersonMedication)
-      .joins(:person, :medication)
-      .includes(:person, :medication)
-      .where(person_medication_search_sql, term: search_term)
-      .order('medications.name ASC', 'people.name ASC')
-      .limit(limit)
-      .map { |person_medication| person_medication_result(person_medication) }
-  end
-
-  def schedule_result(schedule)
-    build_result(
-      type: 'schedule',
-      title: I18n.t('global_search.result_titles.schedule', medication: schedule.medication.name),
-      subtitle: schedule_subtitle(schedule),
-      path: person_path(schedule.person, anchor: "schedule_#{schedule.id}"),
-      secondary_values: [schedule.person.name]
-    )
-  end
-
-  def person_medication_result(person_medication)
-    build_result(
-      type: 'person_medication',
-      title: person_medication.medication.name,
-      subtitle: person_medication_subtitle(person_medication),
-      path: person_path(person_medication.person, anchor: "person_medication_#{person_medication.id}"),
-      secondary_values: [person_medication.person.name]
-    )
-  end
-
-  def medication_search_sql
-    'medications.name ILIKE :term OR medications.category ILIKE :term OR ' \
-      'medications.barcode ILIKE :term OR medications.dmd_code ILIKE :term'
-  end
-
-  def schedule_search_sql
-    'medications.name ILIKE :term OR people.name ILIKE :term'
-  end
-
-  def person_medication_search_sql
-    'medications.name ILIKE :term OR people.name ILIKE :term'
-  end
-
-  def medication_subtitle(medication)
-    [medication.category.presence, medication.location&.name].compact.join(' · ').presence ||
-      I18n.t('global_search.types.medication')
-  end
-
-  def schedule_subtitle(schedule)
-    I18n.t(
-      'global_search.subtitles.schedule',
-      person: schedule.person.name,
-      frequency: schedule.frequency.presence || I18n.t('global_search.subtitles.no_frequency')
-    )
-  end
-
-  def person_medication_subtitle(person_medication)
-    I18n.t('global_search.subtitles.person_medication', person: person_medication.person.name)
-  end
-
-  def build_result(type:, title:, subtitle:, path:, secondary_values: [])
-    Result.new(
-      type: type,
-      title: title,
-      subtitle: subtitle,
-      path: path,
-      score: score_for(title, secondary_values)
-    )
+    RECORD_QUERIES.flat_map { |query_class| record_results_for(query_class) }
   end
 
   def command_results
@@ -180,31 +49,19 @@ class GlobalSearchQuery
 
   def matching_command_results
     command_results.filter_map do |result|
-      score = score_for(result.title, [result.subtitle])
-      next unless score.positive?
+      rescored_result = result_builder.rescore(result, secondary_values: [result.subtitle])
+      next unless rescored_result.score.positive?
 
-      Result.new(
-        type: result.type,
-        title: result.title,
-        subtitle: result.subtitle,
-        path: result.path,
-        score: score
-      )
+      rescored_result
     end
   end
 
-  def scoped(model)
-    Pundit.policy_scope!(user, model)
+  def record_results_for(query_class)
+    query_class.new(user: user, query: query, limit: limit, builder: result_builder).call
   end
 
-  def score_for(title, secondary_values)
-    normalized_title = normalize(title)
-    return 100 if normalized_title == normalized_query
-    return 80 if normalized_title.start_with?(normalized_query)
-    return 60 if normalized_title.include?(normalized_query)
-    return 40 if secondary_values.any? { |value| normalize(value).include?(normalized_query) }
-
-    0
+  def result_builder
+    @result_builder ||= GlobalSearch::ResultBuilder.new(query: query)
   end
 
   def sort_results(results)
@@ -212,17 +69,5 @@ class GlobalSearchQuery
       .select { |result| result.score.positive? }
       .sort_by { |result| [-result.score, TYPE_ORDER.fetch(result.type), result.title.downcase] }
       .first(limit)
-  end
-
-  def normalize(value)
-    value.to_s.strip.downcase
-  end
-
-  def normalized_query
-    @normalized_query ||= normalize(query)
-  end
-
-  def search_term
-    @search_term ||= "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
   end
 end

--- a/app/services/global_search_query.rb
+++ b/app/services/global_search_query.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+class GlobalSearchQuery
+  include Rails.application.routes.url_helpers
+
+  Result = Data.define(:type, :title, :subtitle, :path, :score) do
+    def as_json(*)
+      {
+        type: type,
+        title: title,
+        subtitle: subtitle,
+        path: path,
+        score: score
+      }
+    end
+  end
+
+  TYPE_ORDER = {
+    'command' => 0,
+    'person' => 1,
+    'medication' => 2,
+    'person_medication' => 3,
+    'schedule' => 4,
+    'location' => 5
+  }.freeze
+
+  attr_reader :user, :query, :limit
+
+  def initialize(user:, query:, limit: 12)
+    @user = user
+    @query = query.to_s.strip
+    @limit = limit.to_i.positive? ? limit.to_i : 12
+  end
+
+  def call
+    return [] unless user
+    return command_results if query.blank?
+
+    results = matching_command_results
+    results.concat(record_results) if query.length >= 2
+    sort_results(results)
+  end
+
+  private
+
+  def record_results
+    person_results + medication_results + location_results + schedule_results + person_medication_results
+  end
+
+  def person_results
+    scoped(Person)
+      .where('people.name ILIKE ?', search_term)
+      .order(:name)
+      .limit(limit)
+      .map do |person|
+        build_result(
+          type: 'person',
+          title: person.name,
+          subtitle: I18n.t('global_search.types.person'),
+          path: person_path(person)
+        )
+      end
+  end
+
+  def medication_results
+    scoped(Medication)
+      .includes(:location)
+      .where(medication_search_sql, term: search_term)
+      .order(:name)
+      .limit(limit)
+      .map do |medication|
+        build_result(
+          type: 'medication',
+          title: medication.name,
+          subtitle: medication_subtitle(medication),
+          path: medication_path(medication),
+          secondary_values: [medication.category, medication.barcode, medication.dmd_code]
+        )
+      end
+  end
+
+  def location_results
+    scoped(Location)
+      .where('locations.name ILIKE ?', search_term)
+      .order(:name)
+      .limit(limit)
+      .map do |location|
+        build_result(
+          type: 'location',
+          title: location.name,
+          subtitle: I18n.t('global_search.types.location'),
+          path: location_path(location)
+        )
+      end
+  end
+
+  def schedule_results
+    scoped(Schedule)
+      .joins(:person, :medication)
+      .includes(:person, :medication)
+      .where(schedule_search_sql, term: search_term)
+      .order('medications.name ASC', 'people.name ASC')
+      .limit(limit)
+      .map { |schedule| schedule_result(schedule) }
+  end
+
+  def person_medication_results
+    scoped(PersonMedication)
+      .joins(:person, :medication)
+      .includes(:person, :medication)
+      .where(person_medication_search_sql, term: search_term)
+      .order('medications.name ASC', 'people.name ASC')
+      .limit(limit)
+      .map { |person_medication| person_medication_result(person_medication) }
+  end
+
+  def schedule_result(schedule)
+    build_result(
+      type: 'schedule',
+      title: I18n.t('global_search.result_titles.schedule', medication: schedule.medication.name),
+      subtitle: schedule_subtitle(schedule),
+      path: person_path(schedule.person, anchor: "schedule_#{schedule.id}"),
+      secondary_values: [schedule.person.name]
+    )
+  end
+
+  def person_medication_result(person_medication)
+    build_result(
+      type: 'person_medication',
+      title: person_medication.medication.name,
+      subtitle: person_medication_subtitle(person_medication),
+      path: person_path(person_medication.person, anchor: "person_medication_#{person_medication.id}"),
+      secondary_values: [person_medication.person.name]
+    )
+  end
+
+  def medication_search_sql
+    'medications.name ILIKE :term OR medications.category ILIKE :term OR ' \
+      'medications.barcode ILIKE :term OR medications.dmd_code ILIKE :term'
+  end
+
+  def schedule_search_sql
+    'medications.name ILIKE :term OR people.name ILIKE :term'
+  end
+
+  def person_medication_search_sql
+    'medications.name ILIKE :term OR people.name ILIKE :term'
+  end
+
+  def medication_subtitle(medication)
+    [medication.category.presence, medication.location&.name].compact.join(' · ').presence ||
+      I18n.t('global_search.types.medication')
+  end
+
+  def schedule_subtitle(schedule)
+    I18n.t(
+      'global_search.subtitles.schedule',
+      person: schedule.person.name,
+      frequency: schedule.frequency.presence || I18n.t('global_search.subtitles.no_frequency')
+    )
+  end
+
+  def person_medication_subtitle(person_medication)
+    I18n.t('global_search.subtitles.person_medication', person: person_medication.person.name)
+  end
+
+  def build_result(type:, title:, subtitle:, path:, secondary_values: [])
+    Result.new(
+      type: type,
+      title: title,
+      subtitle: subtitle,
+      path: path,
+      score: score_for(title, secondary_values)
+    )
+  end
+
+  def command_results
+    GlobalSearchCommandsQuery.new(user: user).call
+  end
+
+  def matching_command_results
+    command_results.filter_map do |result|
+      score = score_for(result.title, [result.subtitle])
+      next unless score.positive?
+
+      Result.new(
+        type: result.type,
+        title: result.title,
+        subtitle: result.subtitle,
+        path: result.path,
+        score: score
+      )
+    end
+  end
+
+  def scoped(model)
+    Pundit.policy_scope!(user, model)
+  end
+
+  def score_for(title, secondary_values)
+    normalized_title = normalize(title)
+    return 100 if normalized_title == normalized_query
+    return 80 if normalized_title.start_with?(normalized_query)
+    return 60 if normalized_title.include?(normalized_query)
+    return 40 if secondary_values.any? { |value| normalize(value).include?(normalized_query) }
+
+    0
+  end
+
+  def sort_results(results)
+    results
+      .select { |result| result.score.positive? }
+      .sort_by { |result| [-result.score, TYPE_ORDER.fetch(result.type), result.title.downcase] }
+      .first(limit)
+  end
+
+  def normalize(value)
+    value.to_s.strip.downcase
+  end
+
+  def normalized_query
+    @normalized_query ||= normalize(query)
+  end
+
+  def search_term
+    @search_term ||= "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <% end %>
   </head>
 
-  <body class="bg-background text-foreground transition-colors duration-300">
+  <body class="bg-background text-foreground transition-colors duration-300"<% if current_user %> data-controller="global-search"<% end %>>
     <% hide_signed_out_chrome = !current_user && request.path == "/login" %>
     <% main_classes = ["transition-all duration-500"] %>
     <% main_classes << "sm:ml-20 md:ml-64 pb-24 md:pb-0" if current_user %>
@@ -56,6 +56,7 @@
         <%= yield %>
       </div>
     </main>
+    <%= render Components::GlobalSearch::Palette.new if current_user %>
     <turbo-frame id="modal"></turbo-frame>
   </body>
 </html>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  passw email secret token _key crypt salt certificate otp ssn cvv cvc
+  passw email secret token _key crypt salt certificate otp ssn cvv cvc q query search
 ]

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -35,6 +35,60 @@ cy:
 
   app:
     name: "MedTracker"
+  global_search:
+    dialog_label: "Chwilio byd-eang"
+    open: "Agor chwilio byd-eang"
+    open_short: "Chwilio"
+    shortcut_hint: "Ctrl K"
+    input_label: "Chwilio MedTracker"
+    placeholder: "Chwilio pobl, meddyginiaethau, lleoliadau..."
+    close: "Cau chwilio"
+    loading: "Yn chwilio..."
+    no_results: "Dim canlyniadau"
+    page_title: "Chwilio"
+    page_subtitle: "Dod o hyd i gofnodion a llwybrau byr MedTracker."
+    page_submit: "Chwilio"
+    results:
+      one: "1 canlyniad"
+      other: "%{count} canlyniad"
+    types:
+      command: "Gorchmynion"
+      person: "Pobl"
+      medication: "Meddyginiaethau"
+      person_medication: "Meddyginiaethau person"
+      schedule: "Amserlenni"
+      location: "Lleoliadau"
+    result_titles:
+      schedule: "Amserlen %{medication}"
+    subtitles:
+      schedule: "%{person} · %{frequency}"
+      person_medication: "%{person} · meddyginiaeth heb amserlen"
+      no_frequency: "Dim amlder"
+    commands:
+      add_medication:
+        title: "Ychwanegu meddyginiaeth"
+        subtitle: "Dechrau'r llif meddyginiaeth"
+      medication_finder:
+        title: "Darganfyddwr Meddyginiaeth"
+        subtitle: "Chwilio NHS dm+d a ffynonellau cod bar"
+      inventory:
+        title: "Rhestr"
+        subtitle: "Agor rhestr meddyginiaethau"
+      people:
+        title: "Pobl"
+        subtitle: "Agor pobl"
+      locations:
+        title: "Lleoliadau"
+        subtitle: "Agor lleoliadau"
+      reports:
+        title: "Adroddiadau"
+        subtitle: "Agor adroddiadau"
+      add_person:
+        title: "Ychwanegu person"
+        subtitle: "Creu person dibynnol"
+      schedule_workflow:
+        title: "Llif amserlen"
+        subtitle: "Creu amserlen meddyginiaeth"
   rodauth:
     verify_account:
       subject: "Dilyswch eich cyfrif MedTracker"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,60 @@ en:
   hello: "Hello world"
   app:
     name: "MedTracker"
+  global_search:
+    dialog_label: "Global search"
+    open: "Open global search"
+    open_short: "Search"
+    shortcut_hint: "Ctrl K"
+    input_label: "Search MedTracker"
+    placeholder: "Search people, medications, locations..."
+    close: "Close search"
+    loading: "Searching..."
+    no_results: "No results"
+    page_title: "Search"
+    page_subtitle: "Find MedTracker records and shortcuts."
+    page_submit: "Search"
+    results:
+      one: "1 result"
+      other: "%{count} results"
+    types:
+      command: "Commands"
+      person: "People"
+      medication: "Medications"
+      person_medication: "Person medications"
+      schedule: "Schedules"
+      location: "Locations"
+    result_titles:
+      schedule: "%{medication} schedule"
+    subtitles:
+      schedule: "%{person} · %{frequency}"
+      person_medication: "%{person} · non-scheduled medication"
+      no_frequency: "No frequency"
+    commands:
+      add_medication:
+        title: "Add medication"
+        subtitle: "Start the medication workflow"
+      medication_finder:
+        title: "Medication Finder"
+        subtitle: "Search NHS dm+d and barcode sources"
+      inventory:
+        title: "Inventory"
+        subtitle: "Open medication inventory"
+      people:
+        title: "People"
+        subtitle: "Open people"
+      locations:
+        title: "Locations"
+        subtitle: "Open locations"
+      reports:
+        title: "Reports"
+        subtitle: "Open reports"
+      add_person:
+        title: "Add person"
+        subtitle: "Create a dependent person"
+      schedule_workflow:
+        title: "Schedule workflow"
+        subtitle: "Create a medication schedule"
   ruby_ui:
     common:
       close: "Close"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -35,6 +35,60 @@ es:
 
   app:
     name: "MedTracker"
+  global_search:
+    dialog_label: "Búsqueda global"
+    open: "Abrir búsqueda global"
+    open_short: "Buscar"
+    shortcut_hint: "Ctrl K"
+    input_label: "Buscar en MedTracker"
+    placeholder: "Buscar personas, medicamentos, ubicaciones..."
+    close: "Cerrar búsqueda"
+    loading: "Buscando..."
+    no_results: "Sin resultados"
+    page_title: "Buscar"
+    page_subtitle: "Encuentra registros y accesos directos de MedTracker."
+    page_submit: "Buscar"
+    results:
+      one: "1 resultado"
+      other: "%{count} resultados"
+    types:
+      command: "Comandos"
+      person: "Personas"
+      medication: "Medicamentos"
+      person_medication: "Medicamentos por persona"
+      schedule: "Horarios"
+      location: "Ubicaciones"
+    result_titles:
+      schedule: "Horario de %{medication}"
+    subtitles:
+      schedule: "%{person} · %{frequency}"
+      person_medication: "%{person} · medicamento sin horario"
+      no_frequency: "Sin frecuencia"
+    commands:
+      add_medication:
+        title: "Añadir medicamento"
+        subtitle: "Iniciar el flujo de medicamento"
+      medication_finder:
+        title: "Buscador de medicamentos"
+        subtitle: "Buscar NHS dm+d y fuentes de códigos de barras"
+      inventory:
+        title: "Inventario"
+        subtitle: "Abrir inventario de medicamentos"
+      people:
+        title: "Personas"
+        subtitle: "Abrir personas"
+      locations:
+        title: "Ubicaciones"
+        subtitle: "Abrir ubicaciones"
+      reports:
+        title: "Informes"
+        subtitle: "Abrir informes"
+      add_person:
+        title: "Añadir persona"
+        subtitle: "Crear una persona dependiente"
+      schedule_workflow:
+        title: "Flujo de horario"
+        subtitle: "Crear un horario de medicación"
   rodauth:
     verify_account:
       subject: "Verifica tu cuenta de MedTracker"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -34,6 +34,60 @@ ga:
               taken: "ceangailte cheana le cógas eile sa stórliosta"
   app:
     name: "MedTracker"
+  global_search:
+    dialog_label: "Cuardach domhanda"
+    open: "Oscail cuardach domhanda"
+    open_short: "Cuardaigh"
+    shortcut_hint: "Ctrl K"
+    input_label: "Cuardaigh MedTracker"
+    placeholder: "Cuardaigh daoine, cógais, suíomhanna..."
+    close: "Dún cuardach"
+    loading: "Ag cuardach..."
+    no_results: "Gan torthaí"
+    page_title: "Cuardaigh"
+    page_subtitle: "Aimsigh taifid agus aicearraí MedTracker."
+    page_submit: "Cuardaigh"
+    results:
+      one: "1 toradh"
+      other: "%{count} toradh"
+    types:
+      command: "Orduithe"
+      person: "Daoine"
+      medication: "Cógais"
+      person_medication: "Cógais duine"
+      schedule: "Sceidil"
+      location: "Suíomhanna"
+    result_titles:
+      schedule: "Sceideal %{medication}"
+    subtitles:
+      schedule: "%{person} · %{frequency}"
+      person_medication: "%{person} · cógas gan sceideal"
+      no_frequency: "Gan minicíocht"
+    commands:
+      add_medication:
+        title: "Cuir cógas leis"
+        subtitle: "Tosaigh sreabhadh an chógais"
+      medication_finder:
+        title: "Aimsitheoir Cógais"
+        subtitle: "Cuardaigh NHS dm+d agus foinsí barrachóid"
+      inventory:
+        title: "Stórliosta"
+        subtitle: "Oscail stórliosta cógas"
+      people:
+        title: "Daoine"
+        subtitle: "Oscail daoine"
+      locations:
+        title: "Suíomhanna"
+        subtitle: "Oscail suíomhanna"
+      reports:
+        title: "Tuarascálacha"
+        subtitle: "Oscail tuarascálacha"
+      add_person:
+        title: "Cuir duine leis"
+        subtitle: "Cruthaigh duine spleách"
+      schedule_workflow:
+        title: "Sreabhadh sceidil"
+        subtitle: "Cruthaigh sceideal cógais"
 
   admin:
     invitations:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -35,6 +35,60 @@ pt:
 
   app:
     name: "MedTracker"
+  global_search:
+    dialog_label: "Pesquisa global"
+    open: "Abrir pesquisa global"
+    open_short: "Pesquisar"
+    shortcut_hint: "Ctrl K"
+    input_label: "Pesquisar no MedTracker"
+    placeholder: "Pesquisar pessoas, medicamentos, localizações..."
+    close: "Fechar pesquisa"
+    loading: "A pesquisar..."
+    no_results: "Sem resultados"
+    page_title: "Pesquisar"
+    page_subtitle: "Encontre registos e atalhos do MedTracker."
+    page_submit: "Pesquisar"
+    results:
+      one: "1 resultado"
+      other: "%{count} resultados"
+    types:
+      command: "Comandos"
+      person: "Pessoas"
+      medication: "Medicamentos"
+      person_medication: "Medicamentos por pessoa"
+      schedule: "Horários"
+      location: "Localizações"
+    result_titles:
+      schedule: "Horário de %{medication}"
+    subtitles:
+      schedule: "%{person} · %{frequency}"
+      person_medication: "%{person} · medicamento sem horário"
+      no_frequency: "Sem frequência"
+    commands:
+      add_medication:
+        title: "Adicionar medicamento"
+        subtitle: "Iniciar o fluxo de medicamento"
+      medication_finder:
+        title: "Localizador de medicamentos"
+        subtitle: "Pesquisar NHS dm+d e fontes de códigos de barras"
+      inventory:
+        title: "Inventário"
+        subtitle: "Abrir inventário de medicamentos"
+      people:
+        title: "Pessoas"
+        subtitle: "Abrir pessoas"
+      locations:
+        title: "Localizações"
+        subtitle: "Abrir localizações"
+      reports:
+        title: "Relatórios"
+        subtitle: "Abrir relatórios"
+      add_person:
+        title: "Adicionar pessoa"
+        subtitle: "Criar uma pessoa dependente"
+      schedule_workflow:
+        title: "Fluxo de horário"
+        subtitle: "Criar um horário de medicação"
   rodauth:
     verify_account:
       subject: "Verifique a sua conta MedTracker"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'dashboard#index'
 
+  get 'search', to: 'searches#show'
+
   namespace :admin do
     root to: 'dashboard#index'
     resource :nhs_dmd_import, only: %i[new create]

--- a/db/migrate/20260506123000_add_global_search_trigram_indexes.rb
+++ b/db/migrate/20260506123000_add_global_search_trigram_indexes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddGlobalSearchTrigramIndexes < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension 'pg_trgm' unless extension_enabled?('pg_trgm')
+
+    add_index :people, :name, using: :gin, opclass: :gin_trgm_ops, name: 'index_people_on_name_trigram'
+    add_index :medications, :name, using: :gin, opclass: :gin_trgm_ops, name: 'index_medications_on_name_trigram'
+    add_index :medications, :category, using: :gin, opclass: :gin_trgm_ops, name: 'index_medications_on_category_trigram'
+    add_index :medications, :barcode, using: :gin, opclass: :gin_trgm_ops, name: 'index_medications_on_barcode_trigram'
+    add_index :medications, :dmd_code, using: :gin, opclass: :gin_trgm_ops, name: 'index_medications_on_dmd_code_trigram'
+    add_index :locations, :name, using: :gin, opclass: :gin_trgm_ops, name: 'index_locations_on_name_trigram'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_123000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "account_active_session_keys", id: false, force: :cascade do |t|
     t.bigint "account_id", null: false
@@ -223,6 +224,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_120000) do
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_locations_on_name", unique: true
+    t.index ["name"], name: "index_locations_on_name_trigram", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "medication_takes", force: :cascade do |t|
@@ -269,8 +271,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_120000) do
     t.text "warnings"
     t.index ["barcode"], name: "index_medications_on_barcode", unique: true, where: "((barcode IS NOT NULL) AND ((barcode)::text <> ''::text))"
     t.index ["default_schedule_type"], name: "index_medications_on_default_schedule_type"
+    t.index ["barcode"], name: "index_medications_on_barcode_trigram", opclass: :gin_trgm_ops, using: :gin
+    t.index ["category"], name: "index_medications_on_category_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["dmd_code"], name: "index_medications_on_dmd_code"
+    t.index ["dmd_code"], name: "index_medications_on_dmd_code_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["location_id"], name: "index_medications_on_location_id"
+    t.index ["name"], name: "index_medications_on_name_trigram", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "native_device_tokens", force: :cascade do |t|
@@ -342,6 +348,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_120000) do
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_people_on_account_id"
     t.index ["email"], name: "index_people_on_email_present_unique", unique: true, where: "((email IS NOT NULL) AND (btrim((email)::text) <> ''::text))"
+    t.index ["name"], name: "index_people_on_name_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["person_type"], name: "index_people_on_person_type"
   end
 

--- a/spec/requests/global_search_spec.rb
+++ b/spec/requests/global_search_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Global search' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages,
+           :schedules, :carer_relationships, :person_medications, :medication_takes
+
+  describe 'GET /search.json' do
+    it 'requires authentication' do
+      get search_path(format: :json), params: { q: 'Jane' }
+
+      expect(response).to redirect_to('/login')
+    end
+
+    it 'returns scoped JSON search results for authenticated users' do
+      sign_in(users(:jane))
+
+      get search_path(format: :json), params: { q: 'Vitamin' }
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body.fetch('results')).to include(
+        hash_including('type' => 'medication', 'title' => 'Vitamin D')
+      )
+    end
+
+    it 'does not leak out-of-scope people through JSON search' do
+      sign_in(users(:jane))
+
+      get search_path(format: :json), params: { q: 'John' }
+
+      expect(response).to have_http_status(:ok)
+      titles = response.parsed_body.fetch('results').pluck('title')
+      expect(titles).not_to include('John Doe')
+    end
+
+    it 'returns all matching people for administrators' do
+      sign_in(users(:damacus))
+
+      get search_path(format: :json), params: { q: 'John' }
+
+      expect(response).to have_http_status(:ok)
+      titles = response.parsed_body.fetch('results').pluck('title')
+      expect(titles).to include('John Doe')
+    end
+
+    it 'keeps carer searches inside their assigned person scope' do
+      sign_in(users(:carer))
+
+      get search_path(format: :json), params: { q: 'John' }
+
+      expect(response).to have_http_status(:ok)
+      titles = response.parsed_body.fetch('results').pluck('title')
+      expect(titles).not_to include('John Doe')
+    end
+
+    it 'escapes wildcard query characters' do
+      sign_in(users(:damacus))
+
+      get search_path(format: :json), params: { q: '%' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.fetch('results')).to be_empty
+    end
+  end
+end

--- a/spec/services/global_search_query_spec.rb
+++ b/spec/services/global_search_query_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GlobalSearchQuery do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages,
+           :schedules, :carer_relationships, :person_medications, :medication_takes
+
+  subject(:results) { described_class.new(user: user, query: query, limit: limit).call }
+
+  let(:user) { users(:jane) }
+  let(:query) { 'vitamin' }
+  let(:limit) { 5 }
+
+  it 'returns normalized results across the configured record types' do
+    types = results.map(&:type)
+
+    expect(types).to include('medication')
+    expect(types).to include('person_medication')
+    expect(results).to all(
+      have_attributes(
+        type: a_kind_of(String),
+        title: a_kind_of(String),
+        subtitle: a_kind_of(String),
+        path: a_kind_of(String),
+        score: a_kind_of(Integer)
+      )
+    )
+  end
+
+  it 'ranks exact title matches ahead of broader matches' do
+    ranked = described_class.new(user: users(:damacus), query: 'Vitamin D', limit: 10).call
+
+    expect(ranked.first).to have_attributes(type: 'medication', title: 'Vitamin D')
+  end
+
+  it 'scores exact command title matches as exact matches' do
+    command_match = described_class.new(user: users(:damacus), query: 'Inventory', limit: 10).call.first
+
+    expect(command_match).to have_attributes(type: 'command', title: 'Inventory', score: 100)
+  end
+
+  it 'uses policy scopes for people and schedules' do
+    scoped = described_class.new(user: users(:jane), query: 'John', limit: 10).call
+
+    expect(scoped.map(&:title)).not_to include('John Doe')
+    expect(scoped.map(&:path)).not_to include(Rails.application.routes.url_helpers.person_path(people(:john)))
+  end
+
+  it 'returns authorized command shortcuts when the query is blank' do
+    command_results = described_class.new(user: users(:jane), query: '', limit: 10).call
+
+    expect(command_results.map(&:type)).to all(eq('command'))
+    expect(command_results.map(&:title)).to include('Add medication', 'People')
+  end
+
+  it 'respects the requested result limit' do
+    limited_results = described_class.new(user: users(:jane), query: 'a', limit: 2).call
+
+    expect(limited_results.size).to eq(2)
+  end
+
+  it 'does not search records for one-character queries' do
+    short_query_results = described_class.new(user: users(:jane), query: 'v', limit: 10).call
+
+    expect(short_query_results.map(&:type).uniq).to eq(['command'])
+    expect(short_query_results.map(&:title)).not_to include('Vitamin D')
+  end
+
+  it 'does not search medication take records, notes, audit logs, or user accounts' do
+    sensitive_queries = ['For back pain', users(:john).email_address, 'taken']
+
+    sensitive_queries.each do |sensitive_query|
+      result_titles = described_class.new(user: users(:damacus), query: sensitive_query, limit: 10).call.map(&:title)
+      expect(result_titles).to be_empty
+    end
+  end
+end

--- a/spec/services/global_search_query_spec.rb
+++ b/spec/services/global_search_query_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe GlobalSearchQuery do
     expect(limited_results.size).to eq(2)
   end
 
+  it 'respects the requested result limit for blank command shortcuts' do
+    limited_results = described_class.new(user: users(:jane), query: '', limit: 2).call
+
+    expect(limited_results.size).to eq(2)
+  end
+
   it 'does not search records for one-character queries' do
     short_query_results = described_class.new(user: users(:jane), query: 'v', limit: 10).call
 

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe 'Global search command palette' do
     find_by_id('global_search_query').send_keys(:enter)
     expect(page).to have_current_path(medication_path(medications(:vitamin_d)))
 
-    find('body').send_keys([:control, 'k'])
+    expect(page).to have_css('button[aria-label="Open global search"]')
+    find('button[aria-label="Open global search"]').send_keys([:control, 'k'])
     expect(page).to have_css('dialog[open][aria-label="Global search"]')
 
     find_by_id('global_search_query').send_keys(:escape)

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Global search command palette' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages,
+           :schedules, :carer_relationships, :person_medications
+
+  before do
+    login_as(users(:jane))
+  end
+
+  scenario 'opens with Ctrl+K and Cmd+K, searches, navigates with arrow keys, and closes with Escape' do
+    visit root_path
+
+    page.execute_script('document.querySelector("a[href=\"/people\"]").focus()')
+    expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
+
+    first('a[href="/people"]').send_keys([:control, 'k'])
+
+    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page.evaluate_script('document.activeElement.id')).to eq('global_search_query')
+
+    find_by_id('global_search_query').send_keys(:escape)
+    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+    expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
+
+    page.execute_script(
+      'window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }))'
+    )
+    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+
+    find_by_id('global_search_query').send_keys(:escape)
+    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+    expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
+
+    first('a[href="/people"]').send_keys([:control, 'k'])
+    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+
+    fill_in 'Search MedTracker', with: 'Vitamin D'
+
+    expect(page).to have_link('Vitamin D')
+
+    find_by_id('global_search_query').send_keys(:down)
+    active_title = page.evaluate_script(
+      'document.querySelector("[data-global-search-active=\"true\"]")?.textContent'
+    )
+    expect(active_title).to include('Vitamin D')
+
+    find_by_id('global_search_query').send_keys(:enter)
+    expect(page).to have_current_path(medication_path(medications(:vitamin_d)))
+
+    find('body').send_keys([:control, 'k'])
+    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+
+    find_by_id('global_search_query').send_keys(:escape)
+    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+  end
+
+  scenario 'opens from the mobile trigger' do
+    page.current_window.resize_to(375, 667)
+    visit root_path
+
+    find('button[aria-label="Open global search"]').click
+
+    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page.evaluate_script('document.activeElement.id')).to eq('global_search_query')
+  end
+end


### PR DESCRIPTION
## Summary
- Add authenticated global search across commands, people, medications, locations, schedules, and person medications
- Add keyboard-first command palette UI with Ctrl+K/Cmd+K, arrow navigation, Enter, Escape, and mobile trigger
- Add Pundit-scoped search services, PostgreSQL trigram indexes, filtered search params, and focused request/service/system coverage
- Split global search result sources into smaller service objects after review

Closes #646

## Validation
- task rubocop
- task test