### PR TITLE
test: cover inventory race decrements

### DIFF
--- a/app/models/medication_take_stock_decrement.rb
+++ b/app/models/medication_take_stock_decrement.rb
@@ -48,6 +48,7 @@ class MedicationTakeStockDecrement
   end
 
   def decremented_supply(current_supply, dose_unit)
+    # Row locks reload stale records before decrement; the clamp keeps validation-bypass races at zero.
     [current_supply.to_d - stock_decrement_for(dose_unit: dose_unit), BigDecimal('0')].max
   end
 

--- a/spec/models/medication_take_stock_decrement_spec.rb
+++ b/spec/models/medication_take_stock_decrement_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationTakeStockDecrement do
+  subject(:decrementer) { described_class.new(take) }
+
+  let(:take) { instance_double(MedicationTake, dose_amount: 10, dose_unit: 'mg') }
+
+  describe '#call' do
+    it 'serializes stale aggregate inventory decrements from separate sessions' do
+      medication = create(:medication, current_supply: 2, reorder_threshold: 0)
+
+      decrement_stale_inventory(medication)
+      decrement_stale_inventory(medication)
+
+      expect(medication.reload.current_supply).to eq(BigDecimal('0'))
+    end
+
+    it 'does not allow stale aggregate inventory decrements to push supply below zero' do
+      medication = create(:medication, current_supply: 1, reorder_threshold: 0)
+
+      decrement_stale_inventory(medication)
+      decrement_stale_inventory(medication)
+
+      expect(medication.reload.current_supply).to eq(BigDecimal('0'))
+    end
+
+    it 'serializes stale dosage-option decrements and keeps aggregate inventory in sync' do
+      medication = create(:medication, current_supply: 2, reorder_threshold: 0)
+      dosage_option = create(
+        :dosage,
+        medication: medication,
+        amount: 1,
+        unit: 'tablet',
+        current_supply: 2,
+        reorder_threshold: 0
+      )
+
+      decrement_stale_dosage_option(medication: medication, dosage_option: dosage_option)
+      decrement_stale_dosage_option(medication: medication, dosage_option: dosage_option)
+
+      expect(dosage_option.reload.current_supply).to eq(BigDecimal('0'))
+      expect(medication.reload.current_supply).to eq(BigDecimal('0'))
+    end
+  end
+
+  def stock_source_for(inventory:, dosage_option: nil)
+    instance_double(MedicationTakeStockSource, inventory: inventory, dosage_option: dosage_option)
+  end
+
+  def decrement_stale_inventory(medication)
+    decrementer.call(stock_source_for(inventory: stale_medication(medication)))
+  end
+
+  def decrement_stale_dosage_option(medication:, dosage_option:)
+    decrementer.call(
+      stock_source_for(
+        inventory: stale_medication(medication),
+        dosage_option: stale_dosage_option(dosage_option)
+      )
+    )
+  end
+
+  def stale_medication(medication)
+    Medication.find(medication.id)
+  end
+
+  def stale_dosage_option(dosage_option)
+    MedicationDosageOption.find(dosage_option.id)
+  end
+end


### PR DESCRIPTION
Closes #1041.

## Summary
- add focused stale-instance regression coverage for aggregate inventory decrements
- cover zero-clamp behavior and dosage-option inventory sync under stale sessions
- document the lock/clamp concurrency strategy near the decrement calculation

## Verification
- task test TEST_FILE=spec/models/medication_take_stock_decrement_spec.rb
- task test TEST_FILE=spec/models/medication_take_inventory_spec.rb
- task rubocop
- task test