### PR TITLE
fix: improve dark mode icon contrast

### DIFF
--- a/app/assets/stylesheets/hamburgers.css
+++ b/app/assets/stylesheets/hamburgers.css
@@ -41,7 +41,7 @@
 .hamburger.is-active .hamburger-inner,
 .hamburger.is-active .hamburger-inner::before,
 .hamburger.is-active .hamburger-inner::after {
-  background-color: #000;
+  background-color: currentColor;
 }
 
 .hamburger-box {
@@ -62,7 +62,7 @@
 .hamburger-inner::after {
   width: 24px;
   height: 2px;
-  background-color: #000;
+  background-color: currentColor;
   border-radius: 2px;
   position: absolute;
   transition-property: transform;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -715,9 +715,9 @@
 	--primary: oklch(from #79a4ff l c h) !important;
 	--primary-foreground: oklch(from #102447 l c h) !important;
 	--secondary: oklch(from #1b2a45 l c h) !important;
-	--secondary-foreground: var(--foreground);
+	--secondary-foreground: var(--foreground) !important;
 	--secondary-container: color-mix(in oklab, var(--palette-color) 18%, oklch(from #13223c l c h)) !important;
-	--on-secondary-container: var(--foreground);
+	--on-secondary-container: var(--foreground) !important;
 	--tertiary: oklch(from #21365d l c h) !important;
 	--tertiary-foreground: oklch(from #dce7ff l c h) !important;
 	--tertiary-container: oklch(from #21365d l c h) !important;
@@ -730,13 +730,13 @@
 	--sidebar-primary: var(--primary);
 	--sidebar-primary-foreground: var(--primary-foreground);
 	--sidebar-accent: oklch(from #20314e l c h) !important;
-	--sidebar-accent-foreground: var(--foreground);
+	--sidebar-accent-foreground: var(--foreground) !important;
 	--sidebar-border: oklch(from #2d3d5a l c h) !important;
 	--sidebar-ring: var(--ring);
 	--primary-container: color-mix(in oklab, var(--palette-color) 32%, oklch(from #102447 l c h)) !important;
-	--on-primary-container: var(--foreground);
+	--on-primary-container: var(--foreground) !important;
 	--secondary-container: color-mix(in oklab, var(--palette-color) 18%, oklch(from #13223c l c h)) !important;
-	--on-secondary-container: var(--foreground);
+	--on-secondary-container: var(--foreground) !important;
 	--surface: var(--background);
 	--on-surface: var(--foreground);
 	--on-surface-variant: oklch(from #b0bdd0 l c h) !important;

--- a/app/components/layouts/bottom_nav.rb
+++ b/app/components/layouts/bottom_nav.rb
@@ -23,11 +23,7 @@ module Components
 
       def render_nav_item(path, icon_class, label)
         is_active = current_page?(path)
-        active_icon_classes =
-          if is_active
-            'px-5 py-1 bg-secondary-container rounded-shape-full ' \
-              'text-on-secondary-container'
-          end
+        active_icon_classes = 'bg-secondary-container text-on-secondary-container' if is_active
 
         link_to(
           path,
@@ -36,7 +32,8 @@ module Components
                  "#{is_active ? 'text-primary' : 'text-on-surface-variant hover:text-on-surface'}"
         ) do
           div(
-            class: 'relative flex items-center justify-center transition-all z-10 ' \
+            class: 'relative flex h-8 w-16 shrink-0 items-center justify-center rounded-shape-full ' \
+                   'transition-all z-10 ' \
                    "#{active_icon_classes}"
           ) do
             render icon_class.new(size: 24)

--- a/app/components/layouts/mobile_menu.rb
+++ b/app/components/layouts/mobile_menu.rb
@@ -14,7 +14,9 @@ module Components
             render RubyUI::SheetTrigger.new do
               button(
                 type: 'button',
-                class: 'hamburger hamburger--spring',
+                class: 'hamburger hamburger--spring rounded-full text-on-surface transition-colors ' \
+                       'hover:bg-surface-container-high hover:text-foreground ' \
+                       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
                 aria: { label: t('layouts.mobile_menu.open_menu'), expanded: 'false' }
               ) do
                 span(class: 'hamburger-box') do

--- a/spec/components/layouts/bottom_nav_spec.rb
+++ b/spec/components/layouts/bottom_nav_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe Components::Layouts::BottomNav, type: :component do
                          "Nav link '#{link.text.strip}' missing min-w-[44px] for WCAG 2.2 SC 2.5.8"
     end
   end
+
+  it 'uses stable icon containers to avoid active-state layout shift on mobile' do
+    rendered = render_inline(described_class.new)
+
+    rendered.css('a').each do |link|
+      icon_container = link.css('div').first
+      classes = icon_container['class'] || ''
+
+      expect(classes).to include('h-8')
+      expect(classes).to include('w-16')
+      expect(classes).to include('shrink-0')
+    end
+  end
 end

--- a/spec/components/layouts/mobile_menu_spec.rb
+++ b/spec/components/layouts/mobile_menu_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe Components::Layouts::MobileMenu, type: :component do
       expect(button).to be_present
     end
 
+    it 'renders hamburger button with dark-mode-safe contrast and affordance classes' do
+      rendered = render_inline(described_class.new)
+
+      button = rendered.css('button[aria-label="Open menu"]').first
+      classes = button['class']
+
+      expect(classes).to include('text-on-surface')
+      expect(classes).to include('hover:bg-surface-container-high')
+      expect(classes).to include('focus-visible:ring-2')
+    end
+
+    it 'uses current color for hamburger lines instead of hard-coded black' do
+      css = Rails.root.join('app/assets/stylesheets/hamburgers.css').read
+
+      expect(css).to include('background-color: currentColor')
+      expect(css).not_to include('background-color: #000')
+    end
+
     it 'renders close button with aria-label' do
       rendered = render_inline(described_class.new)
 

--- a/spec/lib/theme_token_contract_spec.rb
+++ b/spec/lib/theme_token_contract_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe ThemeTokenContract do
     expect(palette_definitions).to all(include('oklch('))
   end
 
+  it 'keeps dark signed-in on-container tokens above earlier signed-in overrides' do
+    block = css_block('.dark:root[data-allow-palette="true"]')
+
+    expect(block).to include('--on-primary-container: var(--foreground) !important')
+    expect(block.scan('--on-secondary-container: var(--foreground) !important').count).to eq(2)
+  end
+
   it 'keeps derived theme overrides inside perceptual color spaces' do
     [
       ':root[data-allow-palette="true"][class*="theme-"]',


### PR DESCRIPTION
## Summary
- Fix hamburger line contrast in dark mode by inheriting currentColor.
- Stabilize mobile bottom-nav icon slots to avoid active-state shift.
- Ensure dark signed-in container foreground tokens override light important tokens.

## Verification
- task rubocop
- task test (2127 examples, 0 failures, 2 pending)
- Mobile dark-mode browser audit on /reports