### PR TITLE
feat: anchor global search under sidebar

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,5 +1,18 @@
 @import "tailwindcss";
 
+.global-search-panel {
+  left: 1rem;
+  top: 62px;
+  width: calc(100vw - 2rem);
+}
+
+@media (min-width: 640px) {
+  .global-search-panel {
+    top: 175px;
+    width: 20rem;
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @font-face {

--- a/app/components/global_search/palette.rb
+++ b/app/components/global_search/palette.rb
@@ -4,19 +4,21 @@ module Components
   module GlobalSearch
     class Palette < Components::Base
       def view_template
-        dialog(
-          id: 'global_search_dialog',
-          class: 'w-[min(720px,calc(100vw-2rem))] max-h-[min(680px,calc(100vh-2rem))] p-0 ' \
-                 'overflow-hidden rounded-lg border border-outline-variant bg-surface text-on-surface ' \
-                 'shadow-elevation-4 backdrop:bg-black/40',
-          aria: { label: t('global_search.dialog_label') },
-          data: dialog_data
+        div(
+          id: 'global_search_panel',
+          role: 'search',
+          hidden: true,
+          class: 'global-search-panel fixed z-[70] max-h-[min(560px,calc(100vh-1rem))] origin-top overflow-hidden ' \
+                 'rounded-xl border border-outline-variant/80 bg-surface/95 text-on-surface shadow-elevation-4 ' \
+                 'backdrop-blur-md',
+          aria: { label: t('global_search.dialog_label'), hidden: 'true' },
+          data: panel_data
         ) do
           render_search_form
           render_status
           div(
             id: 'global_search_results',
-            class: 'max-h-[520px] overflow-y-auto p-3',
+            class: 'max-h-[420px] overflow-y-auto p-2',
             data: { global_search_target: 'results' }
           )
         end
@@ -24,20 +26,20 @@ module Components
 
       private
 
-      def dialog_data
+      def panel_data
         {
-          global_search_target: 'dialog',
-          action: 'cancel->global-search#cancel close->global-search#closed',
+          global_search_target: 'panel',
           search_url: search_path(format: :json),
-          translations: translations.to_json
+          translations: translations.to_json,
+          open: 'false'
         }
       end
 
       def render_search_form
-        form(action: search_path, method: :get, class: 'border-b border-outline-variant p-3',
+        form(action: search_path, method: :get, class: 'border-b border-outline-variant p-2',
              data: { action: 'submit->global-search#submit' }) do
           label(class: 'sr-only', for: 'global_search_query') { t('global_search.input_label') }
-          div(class: 'flex items-center gap-3 rounded-md bg-surface-container-low px-3 py-2') do
+          div(class: 'flex items-center gap-3 rounded-lg bg-surface-container-low px-3 py-2') do
             render Icons::Search.new(size: 20, class: 'text-on-surface-variant')
             input(
               id: 'global_search_query',

--- a/app/components/layouts/navigation.rb
+++ b/app/components/layouts/navigation.rb
@@ -60,8 +60,8 @@ module Components
             class: 'flex h-11 w-11 items-center justify-center rounded-full text-on-surface-variant ' \
                    'hover:bg-surface-container-high focus-visible:outline-none focus-visible:ring-2 ' \
                    'focus-visible:ring-primary',
-            aria: { label: t('global_search.open') },
-            data: { action: 'global-search#open' }
+            aria: { label: t('global_search.open'), expanded: 'false', controls: 'global_search_panel' },
+            data: { action: 'global-search#open', global_search_target: 'trigger' }
           ) do
             render Icons::Search.new(size: 22)
           end

--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -67,8 +67,8 @@ module Components
                  'bg-surface-container px-3 py-3 text-on-surface-variant transition-colors ' \
                  'hover:border-primary hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 ' \
                  'focus-visible:ring-primary md:justify-start',
-          aria: { label: t('global_search.open') },
-          data: { action: 'global-search#open' }
+          aria: { label: t('global_search.open'), expanded: 'false', controls: 'global_search_panel' },
+          data: { action: 'global-search#open', global_search_target: 'trigger' }
         ) do
           render Icons::Search.new(size: 20)
           span(class: 'hidden flex-1 text-left text-sm font-bold md:block') { t('global_search.open_short') }

--- a/app/javascript/controllers/global_search_controller.js
+++ b/app/javascript/controllers/global_search_controller.js
@@ -1,18 +1,24 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["dialog", "input", "results", "status", "result"]
+  static targets = ["panel", "input", "results", "status", "result", "trigger"]
 
   connect() {
     this.shortcutHandler = this.shortcut.bind(this)
+    this.pointerDownHandler = this.closeFromOutside.bind(this)
     window.addEventListener("keydown", this.shortcutHandler)
+    document.addEventListener("pointerdown", this.pointerDownHandler)
     this.activeIndex = -1
-    this.translations = JSON.parse(this.dialogTarget.dataset.translations || "{}")
+    this.isOpen = false
+    this.panelAnimation = null
+    this.translations = JSON.parse(this.panelTarget.dataset.translations || "{}")
   }
 
   disconnect() {
     window.removeEventListener("keydown", this.shortcutHandler)
+    document.removeEventListener("pointerdown", this.pointerDownHandler)
     this.abortCurrentSearch()
+    this.cancelPanelAnimation()
     clearTimeout(this.searchTimer)
   }
 
@@ -24,34 +30,38 @@ export default class extends Controller {
   }
 
   open(event) {
-    const opener = event?.currentTarget
-    this.previouslyFocused = opener instanceof Element ? opener : document.activeElement
-
-    if (!this.dialogTarget.open) {
-      this.dialogTarget.showModal()
-    }
+    if (event) event.preventDefault()
+    const opener = event?.currentTarget instanceof Element ? event.currentTarget : this.visibleTrigger
+    this.previouslyFocused = event?.currentTarget instanceof Element ? opener : document.activeElement
+    this.isOpen = true
+    this.panelTarget.hidden = false
+    this.panelTarget.dataset.open = "true"
+    this.panelTarget.setAttribute("aria-hidden", "false")
+    this.updateTriggerState(true)
 
     this.inputTarget.value = ""
     this.resultsTarget.innerHTML = ""
     this.setStatus("")
     this.fetchResults("")
-    requestAnimationFrame(() => this.inputTarget.focus())
+    this.animatePanelOpen()
+    requestAnimationFrame(() => this.inputTarget.focus({ preventScroll: true }))
   }
 
   close(event) {
     if (event) event.preventDefault()
-    if (this.dialogTarget.open) this.dialogTarget.close()
+    if (!this.isOpen) return
+
+    this.isOpen = false
+    this.abortCurrentSearch()
+    clearTimeout(this.searchTimer)
+    this.updateTriggerState(false)
+    this.animatePanelClosed()
+    this.previouslyFocused?.focus?.({ preventScroll: true })
   }
 
   cancel(event) {
     event.preventDefault()
     this.close()
-  }
-
-  closed() {
-    this.abortCurrentSearch()
-    clearTimeout(this.searchTimer)
-    this.previouslyFocused?.focus?.()
   }
 
   search() {
@@ -91,7 +101,7 @@ export default class extends Controller {
     this.showLoading()
 
     this.abortController = new AbortController()
-    const url = new URL(this.dialogTarget.dataset.searchUrl, window.location.origin)
+    const url = new URL(this.panelTarget.dataset.searchUrl, window.location.origin)
     url.searchParams.set("q", query)
 
     try {
@@ -137,6 +147,7 @@ export default class extends Controller {
     }
 
     this.resultsTarget.innerHTML = this.groupedResultsHtml(results)
+    this.animateResultRows()
     this.setStatus(this.resultCountText(results.length))
   }
 
@@ -201,6 +212,98 @@ export default class extends Controller {
 
   setStatus(text) {
     this.statusTarget.textContent = text
+  }
+
+  closeFromOutside(event) {
+    if (!this.isOpen) return
+    if (this.panelTarget.contains(event.target)) return
+    if (this.triggerTargets.some((trigger) => trigger.contains(event.target))) return
+
+    this.close()
+  }
+
+  animatePanelOpen() {
+    this.cancelPanelAnimation()
+
+    if (this.prefersReducedMotion) return
+
+    const animation = this.panelTarget.animate(
+      [
+        { opacity: 0, transform: "translateY(-10px) scaleY(0.96)" },
+        { opacity: 1, transform: "translateY(0) scaleY(1.01)", offset: 0.72 },
+        { opacity: 1, transform: "translateY(0) scaleY(1)" }
+      ],
+      { duration: 240, easing: "cubic-bezier(0.22, 1, 0.36, 1)" }
+    )
+    this.panelAnimation = animation
+    animation.finished.then(() => {
+      if (this.panelAnimation === animation) this.panelAnimation = null
+    }).catch(() => {})
+  }
+
+  animatePanelClosed() {
+    const hide = () => {
+      this.panelTarget.hidden = true
+      this.panelTarget.dataset.open = "false"
+      this.panelTarget.setAttribute("aria-hidden", "true")
+    }
+
+    this.cancelPanelAnimation()
+
+    if (this.prefersReducedMotion) {
+      hide()
+      return
+    }
+
+    const animation = this.panelTarget.animate(
+      [
+        { opacity: 1, transform: "translateY(0) scaleY(1)" },
+        { opacity: 0, transform: "translateY(-6px) scaleY(0.98)" }
+      ],
+      { duration: 120, easing: "ease-out" }
+    )
+    this.panelAnimation = animation
+    animation.finished.then(() => {
+      if (this.panelAnimation !== animation) return
+
+      this.panelAnimation = null
+      if (!this.isOpen) hide()
+    }).catch(() => {})
+  }
+
+  animateResultRows() {
+    if (this.prefersReducedMotion) return
+
+    this.resultTargets.forEach((result, index) => {
+      result.animate(
+        [
+          { opacity: 0, transform: "translateY(-6px)" },
+          { opacity: 1, transform: "translateY(0)" }
+        ],
+        { duration: 190, delay: index * 22, easing: "cubic-bezier(0.22, 1, 0.36, 1)" }
+      )
+    })
+  }
+
+  cancelPanelAnimation() {
+    if (!this.panelAnimation) return
+
+    this.panelAnimation.cancel()
+    this.panelAnimation = null
+  }
+
+  updateTriggerState(expanded) {
+    this.triggerTargets.forEach((trigger) => {
+      trigger.setAttribute("aria-expanded", expanded ? "true" : "false")
+    })
+  }
+
+  get visibleTrigger() {
+    return this.triggerTargets.find((trigger) => trigger.offsetParent !== null) || this.triggerTargets[0]
+  }
+
+  get prefersReducedMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches
   }
 
   typeLabel(type) {

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Global search command palette' do
     login_as(users(:jane))
   end
 
-  scenario 'opens with Ctrl+K and Cmd+K, searches, navigates with arrow keys, and closes with Escape' do
+  scenario 'opens as a left-anchored dropdown with Ctrl+K and Cmd+K, searches, navigates, and closes' do
     visit root_path
 
     page.execute_script('document.querySelector("a[href=\"/people\"]").focus()')
@@ -18,24 +18,37 @@ RSpec.describe 'Global search command palette' do
 
     first('a[href="/people"]').send_keys([:control, 'k'])
 
-    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
+    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
     expect(page.evaluate_script('document.activeElement.id')).to eq('global_search_query')
+    expect(global_search_geometry['panel_left']).to be_within(1).of(global_search_geometry['trigger_left'])
+    expect(global_search_geometry['panel_top']).to be > global_search_geometry['trigger_bottom']
+    expect(global_search_geometry['panel_width']).to be >= global_search_geometry['trigger_width']
 
     find_by_id('global_search_query').send_keys(:escape)
-    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
     expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
+
+    first('a[href="/people"]').send_keys([:control, 'k'])
+    find_by_id('global_search_query').send_keys(:escape)
+    find('aside button[aria-label="Open global search"]').click
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
+    sleep 0.2
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
+    find_by_id('global_search_query').send_keys(:escape)
+    page.execute_script('document.querySelector("a[href=\"/people\"]").focus()')
 
     page.execute_script(
       'window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }))'
     )
-    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     find_by_id('global_search_query').send_keys(:escape)
-    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
     expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
 
     first('a[href="/people"]').send_keys([:control, 'k'])
-    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     fill_in 'Search MedTracker', with: 'Vitamin D'
 
@@ -52,10 +65,10 @@ RSpec.describe 'Global search command palette' do
 
     expect(page).to have_css('button[aria-label="Open global search"]')
     find('button[aria-label="Open global search"]').send_keys([:control, 'k'])
-    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     find_by_id('global_search_query').send_keys(:escape)
-    expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
   end
 
   scenario 'opens from the mobile trigger' do
@@ -64,7 +77,26 @@ RSpec.describe 'Global search command palette' do
 
     find('button[aria-label="Open global search"]').click
 
-    expect(page).to have_css('dialog[open][aria-label="Global search"]')
+    expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
     expect(page.evaluate_script('document.activeElement.id')).to eq('global_search_query')
+  end
+
+  def global_search_geometry
+    page.evaluate_script(<<~JS)
+      (() => {
+        const panel = document.querySelector('#global_search_panel')
+        const panelRect = panel.getBoundingClientRect()
+        const triggerRect = document.querySelector('aside button[aria-label="Open global search"]').getBoundingClientRect()
+
+        return {
+          trigger_left: triggerRect.left,
+          trigger_bottom: triggerRect.bottom,
+          trigger_width: triggerRect.width,
+          panel_left: panelRect.left,
+          panel_top: panelRect.top,
+          panel_width: panelRect.width
+        }
+      })()
+    JS
   end
 end


### PR DESCRIPTION
## Summary
- Replace the global search dialog with a compact sidebar-anchored panel under the search control
- Add vanilla JS open/close and staggered result animations with focus restoration and outside-click dismissal
- Cover left placement and close/reopen animation behavior in the system spec

## Verification
- `task test TEST_FILE=spec/system/global_search_spec.rb`
- `task rubocop`
- `task test` - 2120 examples, 0 failures, 2 pending