### PR TITLE
fix: harden medication wizard against premature & duplicate submits

### DIFF
--- a/app/components/medications/wizard/step_content.rb
+++ b/app/components/medications/wizard/step_content.rb
@@ -118,7 +118,10 @@ module Components
         end
 
         def render_navigation
-          div(class: 'flex items-center justify-between pt-6 border-t border-outline-variant/30') do
+          div(
+            class: 'flex flex-col-reverse gap-3 pt-6 border-t border-outline-variant/30 ' \
+                   'sm:flex-row sm:items-center sm:justify-between sm:gap-4'
+          ) do
             div(class: 'flex items-center gap-3') do
               m3_button(
                 type: :button,
@@ -144,12 +147,12 @@ module Components
               end
             end
 
-            div(class: 'flex gap-3') do
+            div(class: 'flex flex-col gap-3 sm:flex-row sm:gap-3') do
               m3_button(
                 type: :button,
                 variant: :filled,
                 size: :lg,
-                class: 'px-8 rounded-shape-xl shadow-lg shadow-primary/20',
+                class: 'w-full sm:w-auto sm:px-8 rounded-shape-xl shadow-lg shadow-primary/20',
                 data: {
                   wizard_target: 'nextButton',
                   action: 'click->wizard#next'
@@ -162,8 +165,11 @@ module Components
                 type: :submit,
                 variant: :filled,
                 size: :lg,
-                class: 'px-8 rounded-shape-xl shadow-lg shadow-primary/20 hidden',
-                data: { wizard_target: 'submitButton' }
+                class: 'w-full sm:w-auto sm:px-8 rounded-shape-xl shadow-lg shadow-primary/20 hidden',
+                data: {
+                  wizard_target: 'submitButton',
+                  turbo_submits_with: t('forms.medications.saving')
+                }
               ) do
                 plain t('forms.medications.save_medication')
               end

--- a/app/components/medications/wizard/step_dosages.rb
+++ b/app/components/medications/wizard/step_dosages.rb
@@ -57,11 +57,14 @@ module Components
         end
 
         def render_actions
-          div(class: 'flex items-center justify-between pt-6 border-t border-border') do
+          div(
+            class: 'flex flex-col-reverse gap-3 pt-6 border-t border-border ' \
+                   'sm:flex-row sm:items-center sm:justify-between sm:gap-4'
+          ) do
             Link(
               href: edit_medication_path(medication, return_to: medication_path(medication)),
               variant: :outlined,
-              class: 'font-bold',
+              class: 'w-full sm:w-auto justify-center font-bold',
               data: { turbo_frame: '_top' }
             ) { 'Manage dose options' }
 
@@ -69,7 +72,7 @@ module Components
               href: medication_path(medication),
               variant: :filled,
               size: :lg,
-              class: 'px-8 rounded-shape-xl shadow-lg shadow-primary/20',
+              class: 'w-full sm:w-auto justify-center sm:px-8 rounded-shape-xl shadow-lg shadow-primary/20',
               data: { turbo_frame: '_top' }
             ) { 'Done' }
           end

--- a/app/components/medications/wizard/step_dose_schedule.rb
+++ b/app/components/medications/wizard/step_dose_schedule.rb
@@ -21,6 +21,7 @@ module Components
             class: 'space-y-8',
             data: {
               controller: 'medication-schedule-wizard',
+              action: 'wizard:validate@window->medication-schedule-wizard#validateReviewed',
               'medication-schedule-wizard-schedule-type-value': default_schedule_type
             }
           ) do
@@ -445,13 +446,13 @@ module Components
         def render_review_panel
           section(class: 'space-y-3 rounded-3xl bg-primary/5 border border-primary/20 p-5') do
             div(class: 'flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between') do
-              div(class: 'space-y-1') do
+              div(class: 'space-y-1 min-w-0') do
                 m3_heading(level: 4, size: '4', class: 'font-bold tracking-tight text-foreground') do
                   t('forms.medications.wizard.dose.review_title')
                 end
                 m3_text(
                   size: '2',
-                  class: 'text-on-surface-variant',
+                  class: 'text-on-surface-variant break-words',
                   data: { 'medication-schedule-wizard-target': 'reviewText' }
                 ) do
                   t('forms.medications.wizard.dose.review_placeholder')
@@ -466,16 +467,22 @@ module Components
                 t('forms.medications.wizard.dose.review_button')
               end
             end
+            div(
+              class: 'hidden rounded-2xl border border-error/40 bg-error-container/50 px-4 py-3 ' \
+                     'text-sm font-semibold text-on-error-container',
+              data: { 'medication-schedule-wizard-target': 'reviewWarning' },
+              role: 'alert'
+            ) do
+              t('forms.medications.wizard.dose.review_required')
+            end
             input(
               type: 'text',
               id: 'medication_schedule_review_complete',
               name: 'medication_schedule_review_complete',
-              required: true,
               tabindex: '-1',
               aria_hidden: 'true',
               class: 'sr-only',
-              data: { 'medication-schedule-wizard-target': 'reviewCompleteInput' },
-              title: t('forms.medications.wizard.dose.review_required')
+              data: { 'medication-schedule-wizard-target': 'reviewCompleteInput' }
             )
           end
         end

--- a/app/javascript/controllers/medication_schedule_wizard_controller.js
+++ b/app/javascript/controllers/medication_schedule_wizard_controller.js
@@ -41,7 +41,8 @@ export default class extends Controller {
     "doseCycleField",
     "scheduleConfigField",
     "reviewText",
-    "reviewCompleteInput"
+    "reviewCompleteInput",
+    "reviewWarning"
   ]
 
   static values = { scheduleType: { type: String, default: "multiple_daily" } }
@@ -107,6 +108,25 @@ export default class extends Controller {
     this.updateHiddenFields()
     this.reviewTextTarget.textContent = this.reviewSentence()
     this.reviewCompleteInputTarget.value = "reviewed"
+    this.hideReviewWarning()
+  }
+
+  validateReviewed(event) {
+    // Only enforce when this step is the visible one — multiple wizard steps stay
+    // in the DOM concurrently, just hidden via class.
+    if (this.element.offsetParent === null) return
+    if (this.reviewCompleteInputTarget.value === "reviewed") return
+
+    event.preventDefault()
+    this.showReviewWarning()
+  }
+
+  showReviewWarning() {
+    if (this.hasReviewWarningTarget) this.reviewWarningTarget.classList.remove("hidden")
+  }
+
+  hideReviewWarning() {
+    if (this.hasReviewWarningTarget) this.reviewWarningTarget.classList.add("hidden")
   }
 
   updateHiddenFields() {
@@ -150,6 +170,7 @@ export default class extends Controller {
 
   clearReview() {
     if (this.hasReviewCompleteInputTarget) this.reviewCompleteInputTarget.value = ""
+    this.hideReviewWarning()
   }
 
   timingDefaults() {

--- a/app/javascript/controllers/wizard_controller.js
+++ b/app/javascript/controllers/wizard_controller.js
@@ -6,6 +6,24 @@ export default class extends Controller {
 
   connect() {
     this.showStep()
+    this.formElement = this.element.querySelector("form")
+    if (this.formElement) {
+      this.boundHandleSubmit = this.handleSubmit.bind(this)
+      this.formElement.addEventListener("submit", this.boundHandleSubmit)
+    }
+  }
+
+  disconnect() {
+    if (this.formElement && this.boundHandleSubmit) {
+      this.formElement.removeEventListener("submit", this.boundHandleSubmit)
+    }
+  }
+
+  handleSubmit(event) {
+    if (this.currentValue < this.stepTargets.length - 1) {
+      event.preventDefault()
+      this.next()
+    }
   }
 
   next() {
@@ -88,12 +106,20 @@ export default class extends Controller {
     const currentStepEl = this.stepTargets[this.currentValue]
     if (!currentStepEl) return true
 
+    // Let step-level controllers run their own validators and cancel progress
+    const validateEvent = new CustomEvent("wizard:validate", { bubbles: true, cancelable: true })
+    currentStepEl.dispatchEvent(validateEvent)
+    if (validateEvent.defaultPrevented) return false
+
     let valid = true
 
-    // Validate visible text/number/etc inputs (not radios — they live inside combobox popovers)
+    // Validate visible text/number/etc inputs (not radios — they live inside combobox popovers).
+    // Skip elements that aren't currently rendered: reportValidity() on a clipped/hidden
+    // element can't position its popup, so the user sees nothing happen.
     currentStepEl.querySelectorAll(
       "input[required]:not([type=radio]):not([type=hidden]), select[required], textarea[required]"
     ).forEach((input) => {
+      if (input.offsetParent === null) return
       if (!input.checkValidity()) {
         input.reportValidity()
         valid = false

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1119,6 +1119,7 @@ cy:
       warnings: "Rhybuddion"
       warnings_placeholder: "Unrhyw sgîl-effeithiau neu rybuddion defnyddio?"
       save_medication: "Cadw Meddyginiaeth"
+      saving: "Yn cadw..."
       back_to_medications: "Yn ôl i Feddyginiaethau"
       back: "Yn ôl"
       select_location: "Dewiswch leoliad..."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1256,6 +1256,7 @@ en:
       warnings: "Warnings"
       warnings_placeholder: "Any side effects or usage warnings?"
       save_medication: "Save Medication"
+      saving: "Saving..."
       back_to_medications: "Back to Medications"
       back: "Back"
       select_location: "Select a location..."
@@ -1327,7 +1328,7 @@ en:
           review_title: "Plain-English review"
           review_placeholder: "Review the dose schedule before continuing."
           review_button: "Review dose schedule"
-          review_required: "Review the dose schedule before continuing."
+          review_required: "Tap \"Review dose schedule\" before continuing."
         supply:
           title: "Supply setup"
           description: "Track how much you have in the pack and when to reorder."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1089,6 +1089,7 @@ es:
       warnings: "Advertencias"
       warnings_placeholder: "¿Algún efecto secundario o advertencia de uso?"
       save_medication: "Guardar Medicamento"
+      saving: "Guardando..."
       back_to_medications: "Volver a Medicamentos"
       back: "Volver"
       select_location: "Seleccione una ubicación..."

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1056,6 +1056,7 @@ ga:
       warnings: "Rabhaidh"
       warnings_placeholder: "Aon fo-iarsmaí nó rabhaidh úsáide?"
       save_medication: "Sábháil Leigheas"
+      saving: "Á shábháil..."
       back_to_medications: "Ar Ais go Leigheasanna"
       back: "Ar Ais"
       select_location: "Roghnaigh suíomh..."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1225,6 +1225,7 @@ pt:
       warnings: "Avisos"
       warnings_placeholder: "Algum efeito secundário ou aviso de utilização?"
       save_medication: "Guardar Medicamento"
+      saving: "A guardar..."
       back_to_medications: "Voltar aos Medicamentos"
       back: "Voltar"
       select_location: "Selecione uma localização..."


### PR DESCRIPTION
Pressing Enter in any text input was implicit-submitting the wizard via
its hidden submit button, and double-clicking Save sent two POSTs — both
slipping past the dedup matcher (which is gated on stock). The dose-
schedule "Review" gate also relied on a required sr-only input whose
validation popup browsers can't position, leaving users silently stuck.

- Intercept form submit in wizard controller; only allow on the final step
- Dispatch a cancelable wizard:validate event so step controllers can gate
  progress with a visible warning instead of an invisible HTML5 popup
- Skip non-rendered required inputs in step validation
- Add data-turbo-submits-with on Save to disable the button during submit
- Stack wizard nav and success-step actions on mobile so labels don't
  overflow the row

https://claude.ai/code/session_01Dy8dN2VGxfRETvdVqspa2S