### PR TITLE
feat: time-only dose entry with separate prior-day form

### DIFF
--- a/app/components/medications/dose_recording_helpers.rb
+++ b/app/components/medications/dose_recording_helpers.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    module DoseRecordingHelpers # rubocop:disable Metrics/ModuleLength
+      extend ActiveSupport::Concern
+
+      private
+
+      def render_context
+        div(class: 'rounded-shape-xl border border-border/70 bg-surface-container-low p-4') do
+          dl(class: 'grid gap-3 sm:grid-cols-2') do
+            div(class: 'space-y-1') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.person', default: 'Person')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { person.name }
+            end
+            div(class: 'space-y-1') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.medication', default: 'Medication')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { source.medication.name }
+            end
+            div(class: 'space-y-1 sm:col-span-2') do
+              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
+                t('medications.take_action.dose', default: 'Dose')
+              end
+              dd(class: 'text-sm font-semibold text-foreground') { dose_label }
+            end
+          end
+        end
+      end
+
+      def render_stock_source_selection
+        if available_medications.many?
+          render_stock_source_options
+        elsif available_medications.one?
+          input(type: :hidden, name: 'medication_take[taken_from_medication_id]', value: available_medications.first.id)
+          render_selected_stock_source(available_medications.first)
+        end
+      end
+
+      def render_stock_source_options
+        fieldset(class: 'space-y-2') do
+          legend(class: 'text-sm font-semibold text-foreground') do
+            t('medications.take_action.stock_source', default: 'Stock source')
+          end
+          available_medications.each_with_index do |medication, index|
+            render_stock_source_option(medication, index)
+          end
+        end
+      end
+
+      def render_stock_source_option(medication, index)
+        label(
+          for: stock_source_input_id(medication),
+          class: 'flex flex-col gap-3 rounded-shape-xl border border-border p-4 sm:flex-row ' \
+                 'sm:items-center sm:justify-between'
+        ) do
+          render_stock_source_details(medication)
+          div(class: 'flex items-center gap-3 shrink-0') do
+            Badge(variant: :outlined, class: 'rounded-full text-[10px] whitespace-nowrap justify-center') do
+              inventory_label(medication)
+            end
+            input(
+              type: :radio,
+              id: stock_source_input_id(medication),
+              name: 'medication_take[taken_from_medication_id]',
+              value: medication.id,
+              checked: index.zero?
+            )
+          end
+        end
+      end
+
+      def render_selected_stock_source(medication)
+        div(class: 'space-y-2') do
+          m3_text(variant: :label_medium, class: 'font-semibold text-foreground') do
+            t('medications.take_action.stock_source', default: 'Stock source')
+          end
+          div(class: 'rounded-shape-xl border border-border p-4') do
+            render_stock_source_details(medication)
+          end
+        end
+      end
+
+      def render_stock_source_details(medication)
+        div(class: 'space-y-1 min-w-0') do
+          m3_text(size: '2', weight: 'bold', class: 'text-foreground') { medication.location.name }
+          m3_text(size: '1', class: 'text-on-surface-variant break-words') do
+            medication_description(medication)
+          end
+        end
+      end
+
+      def take_path
+        if source.is_a?(::Schedule)
+          take_medication_person_schedule_path(person, source)
+        else
+          take_medication_person_person_medication_path(person, source)
+        end
+      end
+
+      def offline_source_type
+        source.is_a?(::Schedule) ? 'schedule' : 'person_medication'
+      end
+
+      def available_medications
+        @available_medications ||= stock_source_resolver.available_medications
+      end
+
+      def medication_description(medication)
+        parts = [medication.name]
+        dose = DoseAmount.new(medication.dosage_amount, medication.dosage_unit).to_s
+        parts << dose if dose.present?
+        parts.join(' • ')
+      end
+
+      def inventory_label(medication)
+        if medication.current_supply.blank?
+          return t('medications.take_action.untracked_inventory', default: 'Untracked')
+        end
+
+        stock_label_for(medication)
+      end
+
+      def stock_label_for(medication)
+        if medication.dosage_unit == 'ml'
+          return "#{MedicationStockQuantityFormatter.format(medication.current_supply)} ml"
+        end
+
+        supply = MedicationStockQuantityFormatter.format(medication.current_supply)
+        supply == '1' ? '1 unit' : "#{supply} units"
+      end
+
+      def formatted_amount
+        amount.to_s
+      end
+
+      def dose_label
+        dose = DoseAmount.new(amount, source_dose_unit).to_s
+        dose.presence || formatted_amount
+      end
+
+      def source_dose_unit
+        return source.dose_unit if source.respond_to?(:dose_unit)
+
+        source.medication.dosage_unit
+      end
+
+      def stock_source_input_id(medication)
+        "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}"
+      end
+
+      def stock_source_resolver
+        @stock_source_resolver ||= MedicationStockSourceResolver.new(user: current_user, source: source)
+      end
+    end
+  end
+end

--- a/app/components/medications/prior_day_take_action.rb
+++ b/app/components/medications/prior_day_take_action.rb
@@ -61,18 +61,11 @@ module Components
       private
 
       def render_menu_item_trigger
-        div(
-          role: 'menuitem',
-          tabindex: '-1',
-          class: 'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 ' \
-                 'text-sm outline-none transition-colors hover:bg-tertiary-container ' \
-                 'hover:text-on-tertiary-container focus:bg-tertiary-container ' \
-                 'focus:text-on-tertiary-container',
-          data: {
-            action: 'click->ruby-ui--dropdown-menu#close',
-            testid: testid,
-            test_id: testid
-          }
+        render RubyUI::DropdownMenuItem.new(
+          href: '#',
+          data_action: 'click->ruby-ui--dialog#open:prevent',
+          data_testid: testid,
+          data_test_id: testid
         ) do
           render Icons::Calendar.new(size: 16, aria_hidden: 'true', class: 'mr-2 shrink-0')
           plain t('medications.prior_day_take_action.menu_item', default: 'Log a past dose')

--- a/app/components/medications/prior_day_take_action.rb
+++ b/app/components/medications/prior_day_take_action.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Components
+  module Medications
+    class PriorDayTakeAction < Components::Base
+      include Phlex::Rails::Helpers::FormWith
+      include DoseRecordingHelpers
+
+      attr_reader :source, :person, :current_user, :amount, :testid
+
+      def initialize(source:, context:, amount:, testid:)
+        @source = source
+        @person = context.fetch(:person)
+        @current_user = context.fetch(:current_user)
+        @amount = amount
+        @testid = testid
+        super()
+      end
+
+      def view_template
+        Dialog(class: 'block w-full') do
+          DialogTrigger(class: 'block w-full') { render_menu_item_trigger }
+          DialogContent(size: :md) do
+            DialogHeader do
+              DialogTitle do
+                t('medications.prior_day_take_action.title',
+                  default: 'Record a dose from a previous day')
+              end
+              DialogDescription do
+                t('medications.prior_day_take_action.description',
+                  default: 'Backdate a dose taken before today.')
+              end
+            end
+
+            form_with(url: take_path, method: :post, class: 'contents') do
+              DialogMiddle do
+                div(class: 'space-y-5') do
+                  input(type: :hidden, name: 'dose_amount', value: formatted_amount)
+                  input(type: :hidden, name: 'dose_unit', value: source_dose_unit)
+                  render_context
+                  render_taken_at_field
+                  render_stock_source_selection
+                end
+              end
+
+              DialogFooter(class: 'border-t border-border/70 bg-popover px-8 pb-8 pt-4') do
+                render M3::Button.new(
+                  type: :submit,
+                  variant: :filled,
+                  class: 'w-full rounded-xl sm:w-auto'
+                ) do
+                  plain t('medications.prior_day_take_action.submit',
+                          default: 'Record historical dose')
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def render_menu_item_trigger
+        div(
+          role: 'menuitem',
+          tabindex: '-1',
+          class: 'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 ' \
+                 'text-sm outline-none transition-colors hover:bg-tertiary-container ' \
+                 'hover:text-on-tertiary-container focus:bg-tertiary-container ' \
+                 'focus:text-on-tertiary-container',
+          data: {
+            action: 'click->ruby-ui--dropdown-menu#close',
+            testid: testid,
+            test_id: testid
+          }
+        ) do
+          render Icons::Calendar.new(size: 16, aria_hidden: 'true', class: 'mr-2 shrink-0')
+          plain t('medications.prior_day_take_action.menu_item', default: 'Log a past dose')
+        end
+      end
+
+      def render_taken_at_field
+        div(class: 'space-y-2') do
+          render RubyUI::FormFieldLabel.new(for: taken_at_input_id) do
+            t('medications.prior_day_take_action.taken_at', default: 'Date and time taken')
+          end
+          m3_input(
+            id: taken_at_input_id,
+            type: 'datetime-local',
+            name: 'medication_take[taken_at]',
+            value: taken_at_field_value,
+            max: taken_at_field_value
+          )
+        end
+      end
+
+      def taken_at_input_id
+        @taken_at_input_id ||= "medication_take_taken_at_prior_day_#{source.class.name.underscore}_#{source.id}"
+      end
+
+      def taken_at_field_value
+        @taken_at_field_value ||= Time.current.strftime('%Y-%m-%dT%H:%M')
+      end
+    end
+  end
+end

--- a/app/components/medications/take_action.rb
+++ b/app/components/medications/take_action.rb
@@ -4,6 +4,7 @@ module Components
   module Medications
     class TakeAction < Components::Base
       include Phlex::Rails::Helpers::FormWith
+      include DoseRecordingHelpers
 
       attr_reader :source, :person, :current_user, :amount, :button_label, :button_variant, :button_size,
                   :button_class, :button_icon, :disabled, :disabled_label, :disabled_icon, :testid,
@@ -123,31 +124,6 @@ module Components
         end
       end
 
-      def render_context
-        div(class: 'rounded-shape-xl border border-border/70 bg-surface-container-low p-4') do
-          dl(class: 'grid gap-3 sm:grid-cols-2') do
-            div(class: 'space-y-1') do
-              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
-                t('medications.take_action.person', default: 'Person')
-              end
-              dd(class: 'text-sm font-semibold text-foreground') { person.name }
-            end
-            div(class: 'space-y-1') do
-              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
-                t('medications.take_action.medication', default: 'Medication')
-              end
-              dd(class: 'text-sm font-semibold text-foreground') { source.medication.name }
-            end
-            div(class: 'space-y-1 sm:col-span-2') do
-              dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
-                t('medications.take_action.dose', default: 'Dose')
-              end
-              dd(class: 'text-sm font-semibold text-foreground') { dose_label }
-            end
-          end
-        end
-      end
-
       def render_taken_at_field
         div(class: 'space-y-2') do
           render RubyUI::FormFieldLabel.new(for: taken_at_input_id) do
@@ -155,145 +131,31 @@ module Components
           end
           m3_input(
             id: taken_at_input_id,
-            type: 'datetime-local',
+            type: 'time',
             name: 'medication_take[taken_at]',
-            value: taken_at_field_value,
-            max: taken_at_field_value
+            value: time_field_value,
+            max: time_field_max
           )
         end
-      end
-
-      def render_stock_source_selection
-        if available_medications.many?
-          render_stock_source_options
-        elsif available_medications.one?
-          input(type: :hidden, name: 'medication_take[taken_from_medication_id]', value: available_medications.first.id)
-          render_selected_stock_source(available_medications.first)
-        end
-      end
-
-      def render_stock_source_options
-        fieldset(class: 'space-y-2') do
-          legend(class: 'text-sm font-semibold text-foreground') do
-            t('medications.take_action.stock_source', default: 'Stock source')
-          end
-          available_medications.each_with_index do |medication, index|
-            render_stock_source_option(medication, index)
-          end
-        end
-      end
-
-      def render_stock_source_option(medication, index)
-        label(
-          for: stock_source_input_id(medication),
-          class: 'flex flex-col gap-3 rounded-shape-xl border border-border p-4 sm:flex-row ' \
-                 'sm:items-center sm:justify-between'
-        ) do
-          render_stock_source_details(medication)
-          div(class: 'flex items-center gap-3 shrink-0') do
-            Badge(variant: :outlined, class: 'rounded-full text-[10px] whitespace-nowrap justify-center') do
-              inventory_label(medication)
-            end
-            input(
-              type: :radio,
-              id: stock_source_input_id(medication),
-              name: 'medication_take[taken_from_medication_id]',
-              value: medication.id,
-              checked: index.zero?
-            )
-          end
-        end
-      end
-
-      def render_selected_stock_source(medication)
-        div(class: 'space-y-2') do
-          m3_text(variant: :label_medium, class: 'font-semibold text-foreground') do
-            t('medications.take_action.stock_source', default: 'Stock source')
-          end
-          div(class: 'rounded-shape-xl border border-border p-4') do
-            render_stock_source_details(medication)
-          end
-        end
-      end
-
-      def render_stock_source_details(medication)
-        div(class: 'space-y-1 min-w-0') do
-          m3_text(size: '2', weight: 'bold', class: 'text-foreground') { medication.location.name }
-          m3_text(size: '1', class: 'text-on-surface-variant break-words') do
-            medication_description(medication)
-          end
-        end
-      end
-
-      def take_path
-        if source.is_a?(::Schedule)
-          take_medication_person_schedule_path(person, source)
-        else
-          take_medication_person_person_medication_path(person, source)
-        end
-      end
-
-      def offline_source_type
-        source.is_a?(::Schedule) ? 'schedule' : 'person_medication'
-      end
-
-      def available_medications
-        @available_medications ||= stock_source_resolver.available_medications
-      end
-
-      def medication_description(medication)
-        parts = [medication.name]
-        dose = DoseAmount.new(medication.dosage_amount, medication.dosage_unit).to_s
-        parts << dose if dose.present?
-        parts.join(' • ')
-      end
-
-      def inventory_label(medication)
-        if medication.current_supply.blank?
-          return t('medications.take_action.untracked_inventory', default: 'Untracked')
-        end
-
-        stock_label_for(medication)
-      end
-
-      def stock_label_for(medication)
-        if medication.dosage_unit == 'ml'
-          return "#{MedicationStockQuantityFormatter.format(medication.current_supply)} ml"
-        end
-
-        supply = MedicationStockQuantityFormatter.format(medication.current_supply)
-        supply == '1' ? '1 unit' : "#{supply} units"
-      end
-
-      def formatted_amount
-        amount.to_s
-      end
-
-      def dose_label
-        dose = DoseAmount.new(amount, source_dose_unit).to_s
-        dose.presence || formatted_amount
-      end
-
-      def source_dose_unit
-        return source.dose_unit if source.respond_to?(:dose_unit)
-
-        source.medication.dosage_unit
       end
 
       def taken_at_input_id
         @taken_at_input_id ||= "medication_take_taken_at_#{source.class.name.underscore}_#{source.id}"
       end
 
-      def stock_source_input_id(medication)
-        "taken_from_medication_#{source.class.name.underscore}_#{source.id}_#{medication.id}"
+      def time_field_value
+        @time_field_value ||= Time.current.strftime('%H:%M')
       end
 
-      def taken_at_field_value
-        @taken_at_field_value ||= Time.current.strftime('%Y-%m-%dT%H:%M')
-      end
-
-      def stock_source_resolver
-        @stock_source_resolver ||= MedicationStockSourceResolver.new(user: current_user, source: source)
+      def time_field_max
+        @time_field_max ||= begin
+          upper = Time.current + TakeMedicationGuardable::FUTURE_TOLERANCE
+          if upper.to_date == Date.current
+            upper.strftime('%H:%M')
+          else
+            '23:59'
+          end
+        end
       end
     end
   end

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -277,7 +277,32 @@ module Components
 
           render_take_medication_button if view_context.policy(person_medication).take_medication?
 
+          render_overflow_menu if view_context.policy(person_medication).take_medication?
+
           render_delete_dialog if view_context.policy(person_medication).destroy?
+        end
+      end
+
+      def render_overflow_menu
+        render RubyUI::DropdownMenu.new do
+          render RubyUI::DropdownMenuTrigger.new do
+            m3_button(
+              variant: :text,
+              class: 'w-10 h-10 p-0 rounded-xl text-on-surface-variant hover:text-foreground',
+              data: { testid: "more-actions-person-medication-#{person_medication.id}" },
+              aria_label: t('medications.card.more_actions', default: 'More actions')
+            ) do
+              render Icons::MoreHorizontal.new(size: 18)
+            end
+          end
+          render RubyUI::DropdownMenuContent.new(class: 'w-56') do
+            render Components::Medications::PriorDayTakeAction.new(
+              source: person_medication,
+              context: { person: person, current_user: current_user },
+              amount: person_medication.dose_amount,
+              testid: "log-past-dose-person-medication-#{person_medication.id}"
+            )
+          end
         end
       end
 

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -18,12 +18,36 @@ module Components
           CardFooter(class: 'px-8 pb-8 pt-2') do
             div(class: 'flex items-center gap-2 w-full') do
               render_take_medication_button
+              render_overflow_menu
               render_admin_actions if administrator?
             end
           end
         end
 
         private
+
+        def render_overflow_menu
+          render RubyUI::DropdownMenu.new do
+            render RubyUI::DropdownMenuTrigger.new do
+              m3_button(
+                variant: :text,
+                class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant hover:text-foreground transition-all',
+                data: { testid: "more-actions-schedule-#{schedule.id}" },
+                aria_label: t('medications.card.more_actions', default: 'More actions')
+              ) do
+                render Icons::MoreHorizontal.new(size: 20)
+              end
+            end
+            render RubyUI::DropdownMenuContent.new(class: 'w-56') do
+              render Components::Medications::PriorDayTakeAction.new(
+                source: schedule,
+                context: { person: person, current_user: current_user },
+                amount: schedule.dose_amount,
+                testid: "log-past-dose-schedule-#{schedule.id}"
+              )
+            end
+          end
+        end
 
         def render_take_medication_button
           render Components::Medications::TakeAction.new(

--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -3,6 +3,8 @@
 module TakeMedicationGuardable
   extend ActiveSupport::Concern
 
+  FUTURE_TOLERANCE = 60.minutes
+
   private
 
   # Maps a TakeMedicationService error symbol to the appropriate HTTP response.
@@ -57,7 +59,7 @@ module TakeMedicationGuardable
       return
     end
 
-    if taken_at.future?
+    if taken_at > Time.current + FUTURE_TOLERANCE
       respond_take_medication_error(
         message: t("#{scope}.future_taken_at", default: t('take_medications.future_taken_at'))
       )
@@ -87,12 +89,23 @@ module TakeMedicationGuardable
     raw_taken_at = params.dig(:medication_take, :taken_at).presence
     return Time.current if raw_taken_at.blank?
 
+    return parse_time_only_taken_at(raw_taken_at) if raw_taken_at.match?(/\A\d{2}:\d{2}(:\d{2})?\z/)
+
     medication_taken_at_formats.each do |format|
       return Time.zone.strptime(raw_taken_at, format)
     rescue ArgumentError, TypeError
       next
     end
 
+    nil
+  end
+
+  def parse_time_only_taken_at(raw)
+    format = raw.length == 5 ? '%H:%M' : '%H:%M:%S'
+    parsed = Time.zone.strptime(raw, format)
+    today = Date.current
+    Time.zone.local(today.year, today.month, today.day, parsed.hour, parsed.min, parsed.sec)
+  rescue ArgumentError, TypeError
     nil
   end
 

--- a/app/controllers/offline_controller.rb
+++ b/app/controllers/offline_controller.rb
@@ -31,7 +31,9 @@ class OfflineController < ApplicationController
 
     parsed_taken_at = parse_taken_at(taken_at)
     return render_unprocessable(t('take_medications.invalid_taken_at')) if parsed_taken_at.blank?
-    return render_unprocessable(t('take_medications.future_taken_at')) if parsed_taken_at.future?
+    if parsed_taken_at > Time.current + TakeMedicationGuardable::FUTURE_TOLERANCE
+      return render_unprocessable(t('take_medications.future_taken_at'))
+    end
 
     result = TakeMedicationService.new.call(
       source: source,

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -532,6 +532,14 @@ cy:
       choose_location: "Dewis lleoliad"
       choose_location_description: "Dewiswch pa leoliad i ddidynnu'r dos hwn ohono."
       untracked_inventory: "Heb ei olrhain"
+    prior_day_take_action:
+      menu_item: "Cofnodi dos blaenorol"
+      title: "Cofnodi dos o ddiwrnod blaenorol"
+      description: "Cofnodi dos a gymerwyd cyn heddiw."
+      taken_at: "Dyddiad ac amser"
+      submit: "Cofnodi dos hanesyddol"
+    card:
+      more_actions: "Rhagor o weithredoedd"
     reorder_statuses:
       ordered: "Wedi archebu"
       received: "Wedi derbyn"
@@ -951,7 +959,7 @@ cy:
     failure: "Methwyd â chofnodi cymryd y feddyginiaeth."
     json_success: "Cofnodwyd cymryd y feddyginiaeth yn llwyddiannus."
     invalid_taken_at: "Dewiswch amser dos dilys."
-    future_taken_at: "Ni all amser y dos fod yn y dyfodol."
+    future_taken_at: "Ni all amser y dos fod fwy nag awr yn y dyfodol."
 
   profiles:
     updated: "Diweddarwyd y proffil yn llwyddiannus."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -582,6 +582,14 @@ en:
       choose_location: "Choose location"
       choose_location_description: "Select which location to deduct this dose from."
       untracked_inventory: "Untracked"
+    prior_day_take_action:
+      menu_item: "Log a past dose"
+      title: "Record a dose from a previous day"
+      description: "Backdate a dose taken before today."
+      taken_at: "Date and time taken"
+      submit: "Record historical dose"
+    card:
+      more_actions: "More actions"
     reorder_statuses:
       ordered: "Ordered"
       received: "Received"
@@ -1003,7 +1011,7 @@ en:
     failure: "Failed to record medication taken."
     json_success: "Medication taken successfully."
     invalid_taken_at: "Choose a valid dose time."
-    future_taken_at: "Dose time cannot be in the future."
+    future_taken_at: "Dose time cannot be more than an hour in the future."
 
   barcode_scanner:
     title: "Scan Barcode"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -532,6 +532,14 @@ es:
       choose_location: "Elegir ubicación"
       choose_location_description: "Selecciona de qué ubicación deducir esta dosis."
       untracked_inventory: "Sin seguimiento"
+    prior_day_take_action:
+      menu_item: "Registrar dosis anterior"
+      title: "Registrar una dosis de un día anterior"
+      description: "Retroceda una dosis tomada antes de hoy."
+      taken_at: "Fecha y hora"
+      submit: "Registrar dosis histórica"
+    card:
+      more_actions: "Más acciones"
     reorder_statuses:
       ordered: "Pedido"
       received: "Recibido"
@@ -920,7 +928,7 @@ es:
     failure: "Error al registrar la toma de medicamento."
     json_success: "Toma de medicamento registrada correctamente."
     invalid_taken_at: "Elige una hora de dosis válida."
-    future_taken_at: "La hora de la dosis no puede estar en el futuro."
+    future_taken_at: "La hora de la dosis no puede ser más de una hora en el futuro."
 
   profiles:
     updated: "Perfil actualizado correctamente."

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -532,6 +532,14 @@ ga:
       choose_location: "Roghnaigh suíomh"
       choose_location_description: "Roghnaigh cén suíomh as a dtabharfar an dáileog seo."
       untracked_inventory: "Neamhrianaithe"
+    prior_day_take_action:
+      menu_item: "Logáil dáileog roimhe seo"
+      title: "Cláraigh dáileog ó lá roimhe seo"
+      description: "Cláraigh dáileog a tógadh roimh inniu."
+      taken_at: "Dáta agus am"
+      submit: "Cláraigh dáileog stairiúil"
+    card:
+      more_actions: "Tuilleadh gníomhartha"
     reorder_statuses:
       ordered: "Ordaithe"
       received: "Faighte"
@@ -854,7 +862,7 @@ ga:
     failure: "Theip ar chlárú an leighis tógtha."
     json_success: "Cláraíodh an leigheas tógtha go rathúil."
     invalid_taken_at: "Roghnaigh am dáileoige bailí."
-    future_taken_at: "Ní féidir am na dáileoige a bheith sa todhchaí."
+    future_taken_at: "Ní féidir am na dáileoige a bheith níos mó ná uair an chloig sa todhchaí."
 
   profiles:
     updated: "Nuashonraíodh an phróifíl go rathúil."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -532,6 +532,14 @@ pt:
       choose_location: "Escolha a localização"
       choose_location_description: "Selecione de que localização quer deduzir esta dose."
       untracked_inventory: "Não rastreado"
+    prior_day_take_action:
+      menu_item: "Registar dose anterior"
+      title: "Registar uma dose de um dia anterior"
+      description: "Retroceda uma dose tomada antes de hoje."
+      taken_at: "Data e hora"
+      submit: "Registar dose histórica"
+    card:
+      more_actions: "Mais ações"
     reorder_statuses:
       ordered: "Encomendado"
       received: "Recebido"
@@ -919,7 +927,7 @@ pt:
     failure: "Falha ao registar toma de medicamento."
     json_success: "Toma de medicamento registada com sucesso."
     invalid_taken_at: "Escolha uma hora de dose válida."
-    future_taken_at: "A hora da dose não pode ser no futuro."
+    future_taken_at: "A hora da dose não pode ser mais de uma hora no futuro."
 
   barcode_scanner:
     title: "Ler Código de Barras"

--- a/spec/components/medications/prior_day_take_action_spec.rb
+++ b/spec/components/medications/prior_day_take_action_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::PriorDayTakeAction, type: :component do
+  fixtures :accounts, :locations, :medications, :people, :users
+
+  let(:person) { people(:jane) }
+  let(:user) { users(:admin) }
+  let(:medication) { medications(:ibuprofen) }
+  let(:source) do
+    Schedule.create!(
+      person: person,
+      medication: medication,
+      start_date: Time.zone.today,
+      end_date: Time.zone.today + 30.days,
+      dose_amount: medication.dosage_amount,
+      dose_unit: medication.dosage_unit
+    )
+  end
+
+  it 'renders a datetime-local field defaulted to now with the same max' do
+    travel_to(Time.zone.local(2026, 4, 28, 14, 45)) do
+      build_alternate_medication
+
+      rendered = render_component
+      timestamp_field = rendered.at_css("input[type='datetime-local'][name='medication_take[taken_at]']")
+
+      expect(rendered.text).to include('Record a dose from a previous day')
+      expect(rendered.at_css("form[action='#{take_path}']")).not_to be_nil
+      expect(timestamp_field).not_to be_nil
+      expect(timestamp_field['value']).to eq('2026-04-28T14:45')
+      expect(timestamp_field['max']).to eq('2026-04-28T14:45')
+    end
+  end
+
+  it 'renders a menuitem trigger with the configured testid and a calendar icon' do
+    build_alternate_medication
+    rendered = render_component
+
+    trigger = rendered.at_css("[role='menuitem'][data-testid='log-past-dose-schedule-#{source.id}']")
+    expect(trigger).not_to be_nil
+    expect(trigger.text).to include('Log a past dose')
+    expect(trigger.at_css('svg.lucide-calendar')).not_to be_nil
+  end
+
+  def render_component
+    html = view_context.render(
+      described_class.new(
+        source: source,
+        context: { person: person, current_user: user },
+        amount: source.dose_amount,
+        testid: "log-past-dose-schedule-#{source.id}"
+      )
+    )
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  def take_path
+    Rails.application.routes.url_helpers.take_medication_person_schedule_path(person, source)
+  end
+
+  def build_alternate_medication
+    Medication.create!(
+      name: medication.name,
+      location: locations(:school),
+      category: medication.category,
+      dosage_amount: medication.dosage_amount,
+      dosage_unit: medication.dosage_unit,
+      current_supply: 7,
+      reorder_threshold: 1
+    )
+  end
+end

--- a/spec/components/medications/take_action_spec.rb
+++ b/spec/components/medications/take_action_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Components::Medications::TakeAction, type: :component do
-  fixtures :locations, :medications, :people, :users
+  fixtures :accounts, :locations, :medications, :people, :users
 
   let(:person) { people(:jane) }
   let(:user) { users(:admin) }
@@ -19,18 +19,30 @@ RSpec.describe Components::Medications::TakeAction, type: :component do
     )
   end
 
-  it 'renders a RubyUI location modal with a bounded historical dose timestamp field' do
+  it 'renders a RubyUI location modal with a time field defaulting to now and capped 60 minutes ahead' do
     travel_to(Time.zone.local(2026, 4, 28, 14, 45)) do
       build_alternate_medication
 
       rendered = render_take_action
-      timestamp_field = rendered.at_css("input[type='datetime-local'][name='medication_take[taken_at]']")
+      timestamp_field = rendered.at_css("input[type='time'][name='medication_take[taken_at]']")
 
       expect(rendered.text).to include('Record dose')
       expect(rendered.at_css("form[action='#{take_path}']")).not_to be_nil
       expect(timestamp_field).not_to be_nil
-      expect(timestamp_field['value']).to eq('2026-04-28T14:45')
-      expect(timestamp_field['max']).to eq('2026-04-28T14:45')
+      expect(timestamp_field['value']).to eq('14:45')
+      expect(timestamp_field['max']).to eq('15:45')
+    end
+  end
+
+  it 'clamps the time field max at 23:59 when the 60-minute window crosses midnight' do
+    travel_to(Time.zone.local(2026, 4, 28, 23, 30)) do
+      build_alternate_medication
+
+      rendered = render_take_action
+      timestamp_field = rendered.at_css("input[type='time'][name='medication_take[taken_at]']")
+
+      expect(timestamp_field['value']).to eq('23:30')
+      expect(timestamp_field['max']).to eq('23:59')
     end
   end
 

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     expect(title['class']).to include('break-words')
   end
 
+  it 'renders an overflow menu with a Log a past dose item when the user can take medication' do
+    rendered = render_person_medication_card
+
+    trigger = rendered.at_css("button[data-testid='more-actions-person-medication-#{person_medication.id}']")
+    item = rendered.at_css("[role='menuitem'][data-testid='log-past-dose-person-medication-#{person_medication.id}']")
+
+    expect(trigger).not_to be_nil
+    expect(item).not_to be_nil
+    expect(item.text).to include('Log a past dose')
+  end
+
   def render_person_medication_card
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }

--- a/spec/components/schedules/card/actions_component_spec.rb
+++ b/spec/components/schedules/card/actions_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Components::Schedules::Card::ActionsComponent, type: :component d
   context 'when the schedule is on cooldown' do
     it 'renders a disabled waiting action' do
       allow(MedicationStockSourceResolver).to receive(:new).and_return(
-        instance_double(MedicationStockSourceResolver, blocked_reason: :cooldown)
+        instance_double(MedicationStockSourceResolver, blocked_reason: :cooldown, available_medications: [])
       )
 
       rendered = render_inline(

--- a/spec/components/schedules/card_spec.rb
+++ b/spec/components/schedules/card_spec.rb
@@ -20,11 +20,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
 
   it 'displays dosage unit from schedule, not hardcoded ml' do
     MedicationTake.create!(schedule: schedule, taken_at: Time.current, dose_amount: 400)
-    vc = view_context
-    vc.singleton_class.define_method(:current_user) { nil }
-
-    html = vc.render(described_class.new(schedule: schedule, person: person))
-    rendered = Nokogiri::HTML::DocumentFragment.parse(html)
+    rendered = render_schedule_card
 
     take_text = rendered.text
     expect(take_text).to include('400 mg')
@@ -33,11 +29,7 @@ RSpec.describe Components::Schedules::Card, type: :component do
 
   it 'disables the take button when schedule dose is invalid' do
     schedule.dose_amount = 0
-    vc = view_context
-    vc.singleton_class.define_method(:current_user) { nil }
-
-    html = vc.render(described_class.new(schedule: schedule, person: person))
-    rendered = Nokogiri::HTML::DocumentFragment.parse(html)
+    rendered = render_schedule_card
 
     button = rendered.at_css("button[data-testid='take-schedule-#{schedule.id}-disabled'][disabled]")
     expect(button).not_to be_nil
@@ -57,6 +49,17 @@ RSpec.describe Components::Schedules::Card, type: :component do
     heading = rendered.at_css('h3')
     expect(heading.text).to include(medication.name)
     expect(heading['class']).to include('break-words')
+  end
+
+  it 'renders an overflow menu with a Log a past dose item' do
+    rendered = render_schedule_card
+
+    trigger = rendered.at_css("button[data-testid='more-actions-schedule-#{schedule.id}']")
+    item = rendered.at_css("[role='menuitem'][data-testid='log-past-dose-schedule-#{schedule.id}']")
+
+    expect(trigger).not_to be_nil
+    expect(item).not_to be_nil
+    expect(item.text).to include('Log a past dose')
   end
 
   def render_schedule_card

--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -66,17 +66,42 @@ RSpec.describe 'Medication Timing Restrictions' do
       end
     end
 
-    context 'when submitted taken_at is in the future' do
+    context 'when submitted taken_at is more than an hour in the future' do
       it 'does not create a medication take' do
         travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
           expect do
             post take_medication_person_schedule_path(person, schedule),
-                 params: { medication_take: { taken_at: 1.minute.from_now.strftime('%Y-%m-%dT%H:%M') } }
+                 params: { medication_take: { taken_at: 61.minutes.from_now.strftime('%Y-%m-%dT%H:%M') } }
           end.not_to change(MedicationTake, :count)
         end
 
         expect(response).to redirect_to(person_path(person))
         expect(flash[:alert]).to include('future')
+      end
+    end
+
+    context 'when submitted taken_at is within the 60 minute future tolerance' do
+      it 'creates a medication take' do
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_schedule_path(person, schedule),
+                 params: { medication_take: { taken_at: 30.minutes.from_now.strftime('%Y-%m-%dT%H:%M') } }
+          end.to change(MedicationTake, :count).by(1)
+        end
+      end
+    end
+
+    context 'when submitted taken_at is a HH:MM time-only payload' do
+      it 'records the dose against today at the submitted time' do
+        travel_to(Time.zone.local(2026, 4, 28, 14, 0)) do
+          expect do
+            post take_medication_person_schedule_path(person, schedule),
+                 params: { medication_take: { taken_at: '08:30' } }
+          end.to change(MedicationTake, :count).by(1)
+
+          expect(MedicationTake.order(:id).last.taken_at)
+            .to be_within(1.second).of(Time.zone.local(2026, 4, 28, 8, 30))
+        end
       end
     end
 
@@ -178,17 +203,28 @@ RSpec.describe 'Medication Timing Restrictions' do
       end
     end
 
-    context 'when submitted taken_at is in the future' do
+    context 'when submitted taken_at is more than an hour in the future' do
       it 'does not create a medication take' do
         travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
           expect do
             post take_medication_person_person_medication_path(person, person_medication),
-                 params: { medication_take: { taken_at: 1.minute.from_now.strftime('%Y-%m-%dT%H:%M') } }
+                 params: { medication_take: { taken_at: 61.minutes.from_now.strftime('%Y-%m-%dT%H:%M') } }
           end.not_to change(MedicationTake, :count)
         end
 
         expect(response).to redirect_to(person_path(person))
         expect(flash[:alert]).to include('future')
+      end
+    end
+
+    context 'when submitted taken_at is within the 60 minute future tolerance' do
+      it 'creates a medication take' do
+        travel_to(Time.zone.local(2026, 4, 28, 12, 0)) do
+          expect do
+            post take_medication_person_person_medication_path(person, person_medication),
+                 params: { medication_take: { taken_at: 30.minutes.from_now.strftime('%Y-%m-%dT%H:%M') } }
+          end.to change(MedicationTake, :count).by(1)
+        end
       end
     end
 

--- a/spec/requests/offline_spec.rb
+++ b/spec/requests/offline_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Offline mode' do
 
     it 'returns validation errors without discarding the queued take' do
       post '/offline/medication_takes',
-           params: payload.merge(taken_at: 1.minute.from_now.iso8601),
+           params: payload.merge(taken_at: 61.minutes.from_now.iso8601),
            as: :json
 
       expect(response).to have_http_status(:unprocessable_content)

--- a/spec/system/historical_dose_recording_spec.rb
+++ b/spec/system/historical_dose_recording_spec.rb
@@ -13,26 +13,26 @@ RSpec.describe 'Historical dose recording' do
     sign_in(admin)
   end
 
-  it 'records a historical dose from the take medication dialog' do
+  it 'records a historical dose via the overflow menu prior-day dialog' do
     travel_to(Time.zone.local(2026, 4, 28, 14, 45)) do
       schedule = build_schedule
       build_alternate_medication
       submitted_time = Time.zone.local(2026, 4, 27, 8, 30)
 
       visit person_path(person)
-      find("[data-testid='take-schedule-#{schedule.id}']").click
+      find("[data-testid='more-actions-schedule-#{schedule.id}']").click
+      find("[data-testid='log-past-dose-schedule-#{schedule.id}']").click
 
-      expect(page).to have_text('Record dose')
+      expect(page).to have_text('Record a dose from a previous day')
 
-      field = find("input[name='medication_take[taken_at]']", visible: :all)
-      expect(field[:type]).to eq('datetime-local')
+      field = find("input[name='medication_take[taken_at]'][type='datetime-local']", visible: :all)
       expect(field[:value]).to eq('2026-04-28T14:45')
       expect(field[:max]).to eq('2026-04-28T14:45')
 
       expect do
         within("form[action='#{take_path(schedule)}']") do
-          fill_in 'Taken at', with: submitted_time.strftime('%Y-%m-%dT%H:%M')
-          click_button I18n.t('schedules.card.give')
+          fill_in 'Date and time taken', with: submitted_time.strftime('%Y-%m-%dT%H:%M')
+          click_button I18n.t('medications.prior_day_take_action.submit')
         end
         expect(page).to have_text(I18n.t('schedules.medication_taken'), wait: 10)
       end.to change(MedicationTake, :count).by(1)


### PR DESCRIPTION
The "take dose" dialog now uses a native time picker (assumes today's
date) for nicer mobile UX, accepting times up to 60 minutes ahead so
users can pre-fill just before swallowing the pill. Logging a dose from
a previous day moves into a kebab overflow menu on the medication and
schedule cards, keeping the rare retrospective path off the primary
flow.

https://claude.ai/code/session_018BZFMP1SrvmUy1veN6doZF