### PR TITLE
feat: split dashboard medication timing

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -34,11 +34,15 @@ module Components
       private
 
       delegate :people, :active_schedules, :upcoming_schedules,
-               :current_user, :doses, :next_dose_time, :compliance_percentage, to: :presenter
+               :current_user, :doses, :next_dose_time, :routine_tasks_due?,
+               :routine_tasks_by_person, :as_needed_by_person, :compliance_percentage, to: :presenter
 
       def next_dose_value
         time = next_dose_time
-        time ? time.strftime('%H:%M') : t('dashboard.stats.no_upcoming_doses')
+        return time.strftime('%H:%M') if time
+        return t('dashboard.stats.due_today') if routine_tasks_due?
+
+        t('dashboard.stats.no_upcoming_doses')
       end
 
       def render_header
@@ -116,10 +120,16 @@ module Components
             end
           end
 
-          if doses.any?
+          task_people = people_with_dashboard_items
+          if task_people.any?
             div(class: 'space-y-4') do
-              doses.each do |dose|
-                render Components::Dashboard::TimelineItem.new(dose: dose, current_user: current_user)
+              task_people.each do |person|
+                render Components::Dashboard::PersonTaskCard.new(
+                  person: person,
+                  routine_tasks: routine_tasks_by_person.fetch(person, []),
+                  as_needed_items: as_needed_by_person.fetch(person, []),
+                  current_user: current_user
+                )
               end
             end
           else
@@ -131,6 +141,12 @@ module Components
               end
             end
           end
+        end
+      end
+
+      def people_with_dashboard_items
+        people.select do |person|
+          routine_tasks_by_person.fetch(person, []).any? || as_needed_by_person.fetch(person, []).any?
         end
       end
 

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+module Components
+  module Dashboard
+    class PersonTaskCard < Components::Base
+      attr_reader :person, :routine_tasks, :as_needed_items, :current_user
+
+      def initialize(person:, routine_tasks:, as_needed_items:, current_user: nil)
+        @person = person
+        @routine_tasks = routine_tasks
+        @as_needed_items = as_needed_items
+        @current_user = current_user
+        super()
+      end
+
+      def view_template
+        m3_card(
+          variant: :elevated,
+          class: 'border-none bg-surface-container-low p-5 rounded-[2rem] shadow-elevation-1'
+        ) do
+          render_header
+          render_routine_tasks
+          render_as_needed_items
+        end
+      end
+
+      private
+
+      def render_header
+        div(class: 'flex items-start justify-between gap-4 pb-4') do
+          div(class: 'min-w-0') do
+            m3_heading(variant: :title_large, level: 3, class: 'font-black tracking-tight') { person.name }
+            m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') { routine_summary }
+          end
+          m3_badge(variant: remaining_routine_count.positive? ? :filled : :tonal,
+                   class: 'shrink-0 px-3 py-1 text-[10px] font-black uppercase tracking-wider') do
+            remaining_routine_count.positive? ? remaining_routine_count.to_s : t('dashboard.routine.done_short')
+          end
+        end
+      end
+
+      def render_routine_tasks
+        if routine_tasks.any?
+          div(class: 'space-y-3') do
+            routine_tasks.each { |task| render_task_row(task, routine: true) }
+          end
+        else
+          div(class: 'rounded-shape-xl border border-dashed border-outline-variant/70 p-4') do
+            m3_text(variant: :body_medium, class: 'text-on-surface-variant italic') do
+              t('dashboard.routine.empty')
+            end
+          end
+        end
+      end
+
+      def render_as_needed_items
+        return if as_needed_items.empty?
+
+        details(class: 'mt-4 rounded-shape-xl border border-border bg-surface-container',
+                data: { testid: 'dashboard-as-needed-person' }) do
+          summary(class: as_needed_summary_classes) do
+            t('dashboard.as_needed.title')
+          end
+          div(class: 'space-y-3 border-t border-border px-4 py-4') do
+            as_needed_items.each { |item| render_task_row(item, routine: false) }
+          end
+        end
+      end
+
+      def render_task_row(row, routine:)
+        div(
+          id: timeline_dom_id(row[:source]),
+          class: task_row_classes(row),
+          data: { testid: routine ? 'dashboard-routine-task' : 'dashboard-as-needed-task' }
+        ) do
+          div(class: 'flex min-w-0 items-start gap-4') do
+            div(class: 'w-16 shrink-0 pt-0.5 text-xs font-black uppercase tracking-widest text-on-surface-variant') do
+              leading_label(row, routine:)
+            end
+            div(class: 'min-w-0') do
+              m3_text(variant: :title_medium, class: 'font-bold tracking-tight break-words') do
+                row[:source].medication.name
+              end
+              m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium') { dose_label(row[:source]) }
+            end
+          end
+          div(class: 'flex shrink-0 items-center gap-2 sm:justify-end') do
+            render_action(row)
+            render_status_badge(row)
+          end
+        end
+      end
+
+      def render_action(row)
+        return unless %i[upcoming available].include?(row[:status])
+
+        render Components::Medications::TakeAction.new(
+          source: row[:source],
+          context: { person: person, current_user: current_user },
+          amount: row[:source].dose_amount,
+          button: {
+            label: take_label,
+            variant: row[:status] == :available ? :outlined : :filled,
+            size: :md,
+            icon: Icons::Pill,
+            testid: "take-dose-#{dose_id(row[:source])}",
+            form_class: nil
+          }
+        )
+      end
+
+      def render_status_badge(row)
+        m3_badge(variant: status_badge_variant(row[:status]),
+                 class: 'px-3 py-1 text-[10px] font-black uppercase tracking-wider') do
+          status_label(row)
+        end
+      end
+
+      def routine_summary
+        if remaining_routine_count.positive?
+          t('dashboard.routine.left_today', count: remaining_routine_count)
+        else
+          t('dashboard.routine.done_today')
+        end
+      end
+
+      def remaining_routine_count
+        @remaining_routine_count ||= routine_tasks.count { |task| task[:status] != :taken }
+      end
+
+      def row_classes(row)
+        case row[:status]
+        when :taken then 'border-success/30 bg-success-container/30'
+        when :upcoming, :available then 'border-primary/30 bg-surface-container-high'
+        when :cooldown, :max_reached then 'border-warning/30 bg-warning-container/30'
+        when :out_of_stock then 'border-error/30 bg-error-container/30'
+        else 'border-border bg-surface-container-high'
+        end
+      end
+
+      def leading_label(row, routine:)
+        return row[:taken_at].strftime('%H:%M') if row[:status] == :taken && row[:taken_at]
+        return row[:scheduled_at].strftime('%H:%M') if routine && row[:scheduled_at]
+
+        routine ? t('dashboard.routine.anytime') : ''
+      end
+
+      def as_needed_summary_classes
+        'cursor-pointer px-4 py-3 text-sm font-black uppercase tracking-widest text-on-surface-variant'
+      end
+
+      def task_row_classes(row)
+        [
+          'flex flex-col gap-3 rounded-shape-xl border p-4 sm:flex-row sm:items-center sm:justify-between',
+          row_classes(row)
+        ].join(' ')
+      end
+
+      def status_label(row)
+        case row[:status]
+        when :taken then t('dashboard.statuses.taken')
+        when :upcoming then t('dashboard.statuses.upcoming')
+        when :available then t('dashboard.statuses.available_now')
+        when :cooldown then cooldown_label(row)
+        when :max_reached then t('dashboard.statuses.max_reached')
+        when :out_of_stock then t('dashboard.statuses.out_of_stock')
+        else t("dashboard.statuses.#{row[:status]}")
+        end
+      end
+
+      def cooldown_label(row)
+        return t('dashboard.statuses.available_at', time: row[:scheduled_at].strftime('%H:%M')) if row[:scheduled_at]
+        return t('dashboard.statuses.cooldown') unless row[:source].respond_to?(:countdown_display)
+
+        "#{t('dashboard.statuses.cooldown')} (#{row[:source].countdown_display})"
+      end
+
+      def status_badge_variant(status)
+        case status
+        when :taken then :tonal
+        when :upcoming, :available then :filled
+        when :out_of_stock then :destructive
+        else :outlined
+        end
+      end
+
+      def dose_label(source)
+        source.dose_display.presence || DoseAmount.new(source.dose_amount, source.dose_unit).to_s
+      end
+
+      def own_dose?
+        return true if current_user.nil?
+
+        current_user.person == person
+      end
+
+      def take_label
+        own_dose? ? t('person_medications.card.take') : t('person_medications.card.give')
+      end
+
+      def dose_id(source)
+        "#{source.class.name.downcase}_#{source.id}"
+      end
+
+      def timeline_dom_id(source)
+        "timeline_#{source.class.name.underscore}_#{source.id}"
+      end
+    end
+  end
+end

--- a/app/components/person_medications/form_fields.rb
+++ b/app/components/person_medications/form_fields.rb
@@ -22,6 +22,7 @@ module Components
           div(class: 'space-y-4') do
             render_medication_field
             render_dose_field
+            render_administration_kind_field
             render_notes_field
             render_timing_fields
           end
@@ -62,6 +63,7 @@ module Components
             description: t('person_medications.form.workflow.add_guidance_description')
           ) do
             render_selection_summary(show_dose: true)
+            render_administration_kind_field
             render_notes_field
             render_timing_fields
           end
@@ -208,6 +210,45 @@ module Components
         end
       end
 
+      def render_administration_kind_field
+        fieldset(class: 'space-y-3') do
+          legend(class: 'text-sm font-semibold text-foreground') do
+            t('person_medications.form.administration_kind')
+          end
+          div(class: 'grid grid-cols-1 gap-3 md:grid-cols-2') do
+            PersonMedication.administration_kinds.each_key do |kind|
+              render_administration_kind_option(kind)
+            end
+          end
+          m3_text(size: '1', class: 'text-on-surface-variant') do
+            t('person_medications.form.administration_kind_hint')
+          end
+        end
+      end
+
+      def render_administration_kind_option(kind)
+        label(
+          for: "person_medication_administration_kind_#{kind}",
+          class: administration_kind_option_classes(kind)
+        ) do
+          input(
+            type: :radio,
+            name: 'person_medication[administration_kind]',
+            id: "person_medication_administration_kind_#{kind}",
+            value: kind,
+            checked: administration_kind_value == kind,
+            data: {
+              person_medication_form_target: 'administrationKindInput',
+              action: 'change->person-medication-form#administrationKindChanged'
+            }
+          )
+          span(class: 'font-semibold') { t("person_medications.form.administration_kinds.#{kind}.label") }
+          span(class: 'text-sm text-on-surface-variant') do
+            t("person_medications.form.administration_kinds.#{kind}.description")
+          end
+        end
+      end
+
       def render_timing_fields
         div(class: 'grid grid-cols-1 md:grid-cols-3 gap-4') do
           render_max_daily_doses_field
@@ -308,6 +349,19 @@ module Components
 
       def workflow_error_attributes
         person_medication.errors.attribute_names.map(&:to_sym).uniq
+      end
+
+      def administration_kind_value
+        person_medication.administration_kind.presence || 'as_needed'
+      end
+
+      def administration_kind_option_classes(kind)
+        classes = [
+          'flex flex-col gap-1 rounded-shape-xl border bg-surface-container-low p-4',
+          'has-[:checked]:border-primary has-[:checked]:bg-primary-container/40'
+        ]
+        classes << (administration_kind_value == kind ? 'border-primary' : 'border-border')
+        classes.join(' ')
       end
 
       def render_dose_cycle_field

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -257,6 +257,7 @@ class PersonMedicationsController < ApplicationController
         dose_amount
         dose_unit
         source_dosage_option_id
+        administration_kind
         notes
         max_daily_doses
         min_hours_between_doses
@@ -271,6 +272,7 @@ class PersonMedicationsController < ApplicationController
         dose_amount
         dose_unit
         source_dosage_option_id
+        administration_kind
         notes
         max_daily_doses
         min_hours_between_doses

--- a/app/javascript/controllers/person_medication_form_controller.js
+++ b/app/javascript/controllers/person_medication_form_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static values = { currentStep: Number, translations: Object, doseOptions: Object }
   static targets = [
     "medicationSelect", "doseOptionInput", "doseAmountInput", "doseUnitInput",
-    "sourceDosageOptionIdInput",
+    "sourceDosageOptionIdInput", "administrationKindInput",
     "maxDosesInput", "minHoursInput", "doseCycleInput", "stepPanel",
     "stepIndicator", "prevButton", "nextButton", "submitButton",
     "selectedMedicationName", "selectedDoseName"
@@ -76,9 +76,10 @@ export default class extends Controller {
         if (this.hasMaxDosesInputTarget && !this.maxDosesInputTarget.value) {
           this.maxDosesInputTarget.value = defaultDosage.default_max_daily_doses || ''
         }
-        if (this.hasMinHoursInputTarget && !this.minHoursInputTarget.value) {
+        if (this.hasMinHoursInputTarget && !this.minHoursInputTarget.value && !this.#routineSelected()) {
           this.minHoursInputTarget.value = defaultDosage.default_min_hours_between_doses || ''
         }
+        this.#clearRoutineDefaultInterval()
         if (this.hasDoseCycleInputTarget && !this.doseCycleInputTarget.value && defaultDosage.default_dose_cycle !== null) {
           const cycleMap = { 0: 'daily', 1: 'weekly', 2: 'monthly' }
           const cycleValue = typeof defaultDosage.default_dose_cycle === 'number'
@@ -92,6 +93,10 @@ export default class extends Controller {
     } catch (error) {
       console.error('Error loading dose options:', error)
     }
+  }
+
+  administrationKindChanged() {
+    this.#clearRoutineDefaultInterval()
   }
 
   selectDose() {
@@ -270,6 +275,20 @@ export default class extends Controller {
     }
 
     return true
+  }
+
+  #routineSelected() {
+    if (!this.hasAdministrationKindInputTarget) return false
+
+    return this.administrationKindInputTargets.some((target) => target.checked && target.value === 'routine')
+  }
+
+  #clearRoutineDefaultInterval() {
+    if (!this.#routineSelected() || !this.hasMaxDosesInputTarget || !this.hasMinHoursInputTarget) return
+
+    if (this.maxDosesInputTarget.value === '1' && this.minHoursInputTarget.value === '24') {
+      this.minHoursInputTarget.value = ''
+    }
   }
 
   #syncMedicationSummary() {

--- a/app/models/person_medication.rb
+++ b/app/models/person_medication.rb
@@ -12,6 +12,7 @@ class PersonMedication < ApplicationRecord
   has_many :medication_takes, dependent: :destroy
 
   enum :dose_cycle, { daily: 0, weekly: 1, monthly: 2 }, prefix: :dose
+  enum :administration_kind, { routine: 0, as_needed: 1 }
 
   # CRITICAL: Audit trail for person-medication links
   # Tracks: which medications are assigned to which people, and their non-scheduled dosing rules
@@ -21,6 +22,7 @@ class PersonMedication < ApplicationRecord
   scope :ordered, -> { order(:position, :id) }
 
   before_validation :assign_default_dose
+  before_validation :clear_routine_default_interval
   before_validation :assign_position, on: :create
 
   validates :person_id, uniqueness: { scope: :medication_id }
@@ -98,6 +100,13 @@ class PersonMedication < ApplicationRecord
 
   def child_person_type?
     %w[minor dependent_adult].include?(person&.person_type.to_s)
+  end
+
+  def clear_routine_default_interval
+    return unless routine?
+    return unless max_daily_doses.to_i == 1 && min_hours_between_doses.to_i == 24
+
+    self.min_hours_between_doses = nil
   end
 
   def source_dosage_option_matches_medication

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -2,6 +2,8 @@
 
 # Presenter for the dashboard view that encapsulates data preparation logic
 class DashboardPresenter
+  delegate :routine_tasks_by_person, :as_needed_by_person, to: :dashboard_schedule
+
   attr_reader :current_user
 
   def initialize(current_user:)
@@ -24,12 +26,16 @@ class DashboardPresenter
   end
 
   def doses
-    @doses ||= FamilyDashboard::ScheduleQuery.new(people, current_user: current_user).call
+    dashboard_schedule.routine_tasks
+  end
+
+  def routine_tasks_due?
+    doses.any? { |d| d[:status] == :upcoming }
   end
 
   def next_dose_time
     upcoming = doses.select { |d| d[:status] == :upcoming }
-    upcoming.min_by { |d| d[:scheduled_at] }&.dig(:scheduled_at)
+    upcoming.filter_map { |d| d[:scheduled_at] }.min
   end
 
   def compliance_percentage
@@ -84,5 +90,9 @@ class DashboardPresenter
 
   def full_access?
     current_user.administrator? || current_user.doctor? || current_user.nurse?
+  end
+
+  def dashboard_schedule
+    @dashboard_schedule ||= FamilyDashboard::ScheduleQuery.new(people, current_user: current_user).tap(&:call)
   end
 end

--- a/app/serializers/api/v1/person_medication_serializer.rb
+++ b/app/serializers/api/v1/person_medication_serializer.rb
@@ -32,6 +32,7 @@ module Api
       def schedule_data
         {
           dose_cycle: person_medication.dose_cycle,
+          administration_kind: person_medication.administration_kind,
           notes: person_medication.notes,
           position: person_medication.position,
           updated_at: person_medication.updated_at.iso8601

--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -3,6 +3,10 @@
 module FamilyDashboard
   # Query object to fetch a 24-hour medication schedule for a person and their dependents
   class ScheduleQuery
+    Result = Data.define(:routine_tasks, :routine_tasks_by_person, :as_needed_by_person)
+
+    delegate :routine_tasks, :routine_tasks_by_person, :as_needed_by_person, to: :result
+
     attr_reader :current_user
 
     def initialize(people, current_user: nil)
@@ -11,6 +15,16 @@ module FamilyDashboard
     end
 
     def call
+      result.routine_tasks
+    end
+
+    private
+
+    def result
+      @result ||= build_result
+    end
+
+    def build_result
       # 1. Fetch all active schedules and person_medications for these people first
       # to get the IDs for take preloading
       @person_ids = @people.map(&:id)
@@ -21,13 +35,16 @@ module FamilyDashboard
       preload_takes
 
       # 3. Aggregate all doses
-      doses = aggregate_family_doses
+      routine_tasks = sort_rows(aggregate_family_doses)
+      as_needed_items = sort_rows(aggregate_family_as_needed_items)
 
       # 4. Sort by time and return
-      doses.sort_by { |d| d[:scheduled_at] }
+      Result.new(
+        routine_tasks: routine_tasks,
+        routine_tasks_by_person: group_rows_by_person(routine_tasks),
+        as_needed_by_person: group_rows_by_person(as_needed_items)
+      )
     end
-
-    private
 
     def fetch_active_schedules
       schedules_by_person_id = Schedule.active
@@ -90,43 +107,67 @@ module FamilyDashboard
     end
 
     def aggregate_family_doses
-      @people.each_with_object([]) do |member, doses|
-        (@all_schedules[member.id] || []).each do |schedule|
-          doses.concat(generate_doses_for(schedule, member))
-        end
+      aggregate_rows { |source, member| generate_doses_for(source, member) }
+    end
 
-        (@all_person_medications[member.id] || []).each do |pm|
-          doses.concat(generate_doses_for(pm, member))
-        end
+    def aggregate_family_as_needed_items
+      aggregate_rows { |source, member| generate_as_needed_rows_for(source, member) }
+    end
+
+    def aggregate_rows
+      @people.each_with_object([]) do |member, rows|
+        sources_for(member).each { |source| rows.concat(yield(source, member)) }
       end
     end
 
-    def generate_member_doses(member)
-      self.class.new(member).call
+    def sources_for(member)
+      (@all_schedules[member.id] || []) + (@all_person_medications[member.id] || [])
     end
 
     def generate_doses_for(source, person)
-      now = Time.current
+      return [] if as_needed_source?(source)
+
       # 1. Get doses already taken today from our preloaded association
       # This uses the association preloaded in aggregate_family_doses to avoid N+1 queries
-      takes = source.medication_takes.select { |t| Time.current.all_day.cover?(t.taken_at) }
+      takes = todays_takes(source)
       doses = generate_taken_doses(takes, source, person)
 
       # 2. Determine if an upcoming dose should be shown
       # We show the "next available" dose if it falls within today
-      next_time = source.next_available_time
-      if next_time && next_time <= now + 24.hours
-        status = MedicationStockSourceResolver.new(user: current_user, source: source).blocked_reason || :upcoming
-        doses << {
-          person: person,
-          source: source,
-          scheduled_at: next_time,
-          taken_at: nil,
-          status: status
-        }
-      end
-
+      doses << build_upcoming_row(source, person, takes) if upcoming_routine_row?(source)
       doses
+    end
+
+    def todays_takes(source)
+      source.medication_takes.select { |take| Time.current.all_day.cover?(take.taken_at) }
+    end
+
+    def upcoming_routine_row?(source)
+      expected_doses = expected_routine_doses_for(source)
+      expected_doses.positive? && taken_count_for_cycle(source, Time.current) < expected_doses
+    end
+
+    def build_upcoming_row(source, person, takes)
+      {
+        person: person,
+        source: source,
+        scheduled_at: routine_scheduled_at(source, takes.length),
+        taken_at: nil,
+        status: MedicationStockSourceResolver.new(user: current_user, source: source).blocked_reason || :upcoming
+      }
+    end
+
+    def generate_as_needed_rows_for(source, person)
+      return [] unless as_needed_source?(source)
+
+      status = as_needed_status_for(source)
+      [{
+        person: person,
+        source: source,
+        scheduled_at: as_needed_scheduled_at(source, status),
+        taken_at: nil,
+        status: status
+      }]
     end
 
     def generate_taken_doses(takes, source, person)
@@ -140,6 +181,100 @@ module FamilyDashboard
           taken_from_location_name: take.inventory_location&.name
         }
       end
+    end
+
+    def expected_routine_doses_for(source)
+      return expected_schedule_doses_for(source) if source.is_a?(Schedule)
+
+      source.max_daily_doses.presence || 1
+    end
+
+    def expected_schedule_doses_for(schedule)
+      return 0 unless schedule.applies_on?(Date.current)
+
+      expected = schedule.expected_doses_on(Date.current)
+      return expected unless expected == 1 && schedule.effective_max_daily_doses.blank?
+      return expected if schedule.effective_min_hours_between_doses.blank?
+
+      (24 / schedule.effective_min_hours_between_doses.to_f).ceil
+    end
+
+    def taken_count_for_cycle(source, now)
+      cycle = source_cycle(source)
+      source.medication_takes.count { |take| cycle.range_for(now).cover?(take.taken_at) }
+    end
+
+    def as_needed_status_for(source)
+      blocked_reason = MedicationStockSourceResolver.new(user: current_user, source: source).blocked_reason
+      return :available if blocked_reason.blank?
+      return :max_reached if blocked_reason == :cooldown && daily_limit_reached?(source)
+
+      blocked_reason
+    end
+
+    def as_needed_scheduled_at(source, status)
+      return Time.current if status == :available
+      return source.next_available_time if %i[cooldown max_reached].include?(status)
+
+      nil
+    end
+
+    def daily_limit_reached?(source)
+      source.dose_constraints.would_exceed_daily_limit?(
+        takes: source.medication_takes.to_a,
+        cycle: source_cycle(source),
+        check_time: Time.current
+      )
+    end
+
+    def source_cycle(source)
+      DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
+    end
+
+    def as_needed_source?(source)
+      return schedule_as_needed?(source) if source.is_a?(Schedule)
+
+      source.as_needed?
+    end
+
+    def schedule_as_needed?(schedule)
+      schedule.schedule_type_prn? || schedule_config_as_needed?(schedule) || frequency_as_needed?(schedule)
+    end
+
+    def schedule_config_as_needed?(schedule) = schedule.schedule_config.to_h['as_needed'] == true
+
+    def frequency_as_needed?(schedule) = schedule.frequency.to_s.casecmp('as needed').zero?
+
+    def routine_scheduled_at(source, taken_count)
+      return unless source.is_a?(Schedule)
+
+      configured_time_at(source, taken_count)
+    end
+
+    def configured_time_at(schedule, index)
+      raw_time = Array(schedule.schedule_config.to_h['times']).compact_blank[index]
+      return if raw_time.blank?
+
+      current_day_at(*configured_hour_and_minute(raw_time))
+    end
+
+    def configured_hour_and_minute(raw_time)
+      raw_time.to_s.split(':').map(&:to_i)
+    end
+
+    def current_day_at(hour, minute)
+      date = Date.current
+      Time.zone.local(date.year, date.month, date.day, hour, minute)
+    end
+
+    def sort_rows(rows)
+      rows.sort_by { |row| [row[:scheduled_at] || Time.current.end_of_day, row[:source].id] }
+    end
+
+    def group_rows_by_person(rows)
+      grouped = @people.index_with { [] }
+      rows.each { |row| grouped[row[:person]] << row }
+      grouped
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -711,7 +711,7 @@ cy:
     modal:
       new_title: "Ychwanegu Meddyginiaeth ar gyfer %{person}"
       edit_title: "Golygu Meddyginiaeth ar gyfer %{person}"
-      subtitle: "Ychwanegu meddyginiaeth yn ôl yr angen"
+      subtitle: "Ychwanegu meddyginiaeth reolaidd neu yn ôl yr angen"
     card:
       notes: "Nodiadau:"
       timing_restrictions: "Cyfyngiadau Amseru:"
@@ -750,7 +750,7 @@ cy:
       dose: "Dos"
       select_dose: "Dewis dos"
       no_doses_available: "Dim dosau ar gael"
-      dose_hint: "Mae angen dos ar bob meddyginiaeth yn ôl yr angen"
+      dose_hint: "Mae angen dos ar bob meddyginiaeth"
       notes: "Nodiadau"
       notes_placeholder: "Ychwanegwch unrhyw gyfarwyddiadau neu nodiadau arbennig"
       notes_hint: "Ychwanegwch unrhyw gyfarwyddiadau neu nodiadau arbennig"
@@ -761,6 +761,15 @@ cy:
       dose_cycle: "Cylch dos"
       default_dose_cycle: "Dyddiol"
       dose_cycle_hint: "Cyfnod ailosod cylch"
+      administration_kind: "Math o feddyginiaeth"
+      administration_kind_hint: "Mae tasgau rheolaidd yn cyfrif ar gyfer heddiw; dim ond pan ellir ei rhoi y dangosir meddyginiaeth yn ôl yr angen."
+      administration_kinds:
+        routine:
+          label: "Rheolaidd"
+          description: "Tasg ddyddiol i'w chwblhau pan fydd y cylch yn ailosod"
+        as_needed:
+          label: "Yn ôl yr angen"
+          description: "Dim ond pan fydd symptomau neu gyfarwyddyd yn galw amdani y caiff ei defnyddio"
       no_options: "Dim opsiynau."
       optional: "Dewisol"
       next: "Nesaf"
@@ -769,7 +778,7 @@ cy:
         choose_medication_title: "Dewiswch feddyginiaeth"
         choose_medication_description: "Dechreuwch trwy ddewis y feddyginiaeth rydych am ei hychwanegu."
         choose_dose_title: "Dewiswch y dos"
-        choose_dose_description: "Mae angen dos ar bob meddyginiaeth yn ôl yr angen cyn i chi barhau."
+        choose_dose_description: "Dewiswch y dos cyn i chi barhau."
         add_guidance_title: "Ychwanegu arweiniad dewisol"
         add_guidance_description: "Ychwanegwch unrhyw nodiadau neu derfynau dos yr hoffech eu holrhain gyda'r feddyginiaeth hon."
 
@@ -1231,17 +1240,29 @@ cy:
     add_schedules_hint: "Ychwanegwch bresgripsiynau i'w gweld yma"
     dose_taken_at: "%{person} • Cymerwyd am %{time}"
     empty_state: "Dim meddyginiaethau wedi'u trefnu ar gyfer heddiw."
+    routine:
+      anytime: "Unrhyw bryd"
+      done_short: "Wedi gorffen"
+      done_today: "Tasgau rheolaidd wedi'u cwblhau heddiw"
+      empty: "Dim tasgau rheolaidd i'w gwneud heddiw"
+      left_today:
+        one: "1 dasg reolaidd ar ôl heddiw"
+        other: "%{count} tasg reolaidd ar ôl heddiw"
     stats:
       people: "Pobl"
       active_schedules: "Presgripsiynau Gweithredol"
       compliance: "Cydymffurfiaeth"
       next_dose: "Dos nesaf"
+      due_today: "Heddiw"
       no_upcoming_doses: "Dim un heddiw"
     statuses:
       taken: "Wedi cymryd"
       upcoming: "Ar ddod"
+      available_now: "Ar gael nawr"
+      available_at: "Ar gael am %{time}"
       cooldown: "Aros"
       missed: "Wedi colli"
+      max_reached: "Uchafswm dyddiol wedi'i gyrraedd"
       out_of_stock: "Allan o Stoc"
     table:
       person: "Person"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -763,7 +763,7 @@ en:
     modal:
       new_title: "Add Medication for %{person}"
       edit_title: "Edit Medication for %{person}"
-      subtitle: "Add an as-needed medication"
+      subtitle: "Add a routine or as-needed medication"
     card:
       notes: "Notes:"
       timing_restrictions: "Timing Restrictions:"
@@ -800,7 +800,7 @@ en:
       select_dose: "Select a dose"
       select_medication_first: "Select a medication first"
       no_doses_available: "No doses available"
-      dose_hint: "All as-needed medications require a dose"
+      dose_hint: "Every medication requires a dose"
       notes: "Notes"
       notes_placeholder: "Add any special instructions or notes"
       notes_hint: "Add any special instructions or notes"
@@ -811,6 +811,15 @@ en:
       dose_cycle: "Dose cycle"
       default_dose_cycle: "Daily"
       dose_cycle_hint: "Cycle reset period"
+      administration_kind: "Medication type"
+      administration_kind_hint: "Routine tasks count against today; as-needed medication only shows when it can be given."
+      administration_kinds:
+        routine:
+          label: "Routine"
+          description: "A daily task to complete once the cycle resets"
+        as_needed:
+          label: "As needed"
+          description: "Only used when symptoms or guidance call for it"
       no_options: "No options."
       optional: "Optional"
       back: "Back"
@@ -819,7 +828,7 @@ en:
         choose_medication_title: "Choose a medication"
         choose_medication_description: "Start by choosing the medication you want to add."
         choose_dose_title: "Choose the dose"
-        choose_dose_description: "Every as-needed medication needs a dose before you continue."
+        choose_dose_description: "Choose the dose before you continue."
         add_guidance_title: "Add optional guidance"
         add_guidance_description: "Add any notes or dose limits you want to track with this medication."
       add_medication_button: "Add Medication"
@@ -1368,13 +1377,21 @@ en:
     subtitle: "Your family's medication schedule for today."
     todays_schedule: "Today's Schedule"
     as_needed:
-      title: "Take as Needed"
+      title: "As needed"
     overdue_alert: "Overdue: %{medication} for %{person} (scheduled at %{time})"
     out_of_stock_alert: "Out of Stock: %{medication}. Cannot record doses for %{person}."
     no_active_schedules: "No active schedules found"
     add_schedules_hint: "Add schedules to see them here"
     dose_taken_at: "%{person} • Taken at %{time}"
     empty_state: "No medications scheduled for today."
+    routine:
+      anytime: "Anytime"
+      done_short: "Done"
+      done_today: "Routine tasks done today"
+      empty: "No routine tasks due today"
+      left_today:
+        one: "1 routine task left today"
+        other: "%{count} routine tasks left today"
     insights:
       title: "Smart Insights"
       pattern_detected: "Pattern detected"
@@ -1389,12 +1406,16 @@ en:
       active_schedules: "Active Schedules"
       compliance: "Compliance"
       next_dose: "Next Dose"
+      due_today: "Today"
       no_upcoming_doses: "None today"
     statuses:
       taken: "Taken"
       upcoming: "Upcoming"
+      available_now: "Available now"
+      available_at: "Available at %{time}"
       cooldown: "Wait"
       missed: "Missed"
+      max_reached: "Daily max reached"
       out_of_stock: "Out of Stock"
     table:
       person: "Person"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -706,7 +706,7 @@ es:
     invalid_dose_configured: "La dosis configurada no es válida. Actualiza la dosis del medicamento antes de tomarlo."
     modal:
       new_title: "Agregar Medicamento para %{person}"
-      subtitle: "Agregar un medicamento según sea necesario"
+      subtitle: "Agregar un medicamento rutinario o según necesidad"
       edit_title: "Editar medicamento para %{person}"
     card:
       notes: "Notas:"
@@ -745,7 +745,7 @@ es:
       select_dose: "Selecciona una dosis"
       select_medication_first: "Selecciona primero un medicamento"
       no_doses_available: "No hay dosis disponibles"
-      dose_hint: "Todos los medicamentos según sea necesario requieren una dosis"
+      dose_hint: "Todo medicamento requiere una dosis"
       notes: "Notas"
       notes_placeholder: "Añade cualquier instrucción especial o nota"
       notes_hint: "Añade cualquier instrucción especial o nota"
@@ -756,6 +756,15 @@ es:
       dose_cycle: "Ciclo de dosis"
       default_dose_cycle: "Diario"
       dose_cycle_hint: "Periodo de reinicio del ciclo"
+      administration_kind: "Tipo de medicamento"
+      administration_kind_hint: "Las tareas rutinarias cuentan para hoy; los medicamentos según necesidad solo se muestran cuando se pueden administrar."
+      administration_kinds:
+        routine:
+          label: "Rutina"
+          description: "Una tarea diaria para completar cuando se reinicia el ciclo"
+        as_needed:
+          label: "Según necesidad"
+          description: "Solo se usa cuando los síntomas o las indicaciones lo requieren"
       no_options: "No hay opciones."
       optional: "Opcional"
       back: "Volver"
@@ -765,7 +774,7 @@ es:
         choose_medication_title: "Elige un medicamento"
         choose_medication_description: "Empieza eligiendo el medicamento que quieres añadir."
         choose_dose_title: "Elige la dosis"
-        choose_dose_description: "Todo medicamento según sea necesario necesita una dosis antes de continuar."
+        choose_dose_description: "Elige la dosis antes de continuar."
         add_guidance_title: "Añade orientación opcional"
         add_guidance_description: "Añade notas o límites de dosis que quieras seguir con este medicamento."
 
@@ -1192,6 +1201,14 @@ es:
     overdue_alert: "Atrasado: %{medication} para %{person} (programado a las %{time})"
     out_of_stock_alert: "Sin stock: %{medication}. No se pueden registrar dosis para %{person}."
     empty_state: "No hay medicamentos programados para hoy."
+    routine:
+      anytime: "En cualquier momento"
+      done_short: "Hecho"
+      done_today: "Tareas rutinarias completadas hoy"
+      empty: "No hay tareas rutinarias pendientes hoy"
+      left_today:
+        one: "1 tarea rutinaria pendiente hoy"
+        other: "%{count} tareas rutinarias pendientes hoy"
     insights:
       title: "Información inteligente"
       pattern_detected: "Patrón detectado"
@@ -1207,6 +1224,7 @@ es:
       no_upcoming_doses: "Ninguna hoy"
       compliance: "Adherencia"
       next_dose: "Próxima dosis"
+      due_today: "Hoy"
     person_schedule:
       age: "Edad"
       dosage: "Dosis"
@@ -1228,8 +1246,11 @@ es:
     statuses:
       taken: "Tomado"
       upcoming: "Próximo"
+      available_now: "Disponible ahora"
+      available_at: "Disponible a las %{time}"
       cooldown: "Esperar"
       missed: "Perdido"
+      max_reached: "Máximo diario alcanzado"
       out_of_stock: "Sin Stock"
     table:
       person: "Persona"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -707,7 +707,7 @@ ga:
     modal:
       new_title: "Cuir Leigheas Leis do %{person}"
       edit_title: "Cuir Leigheas in Eagar do %{person}"
-      subtitle: "Cuir leigheas de réir mar is gá leis"
+      subtitle: "Cuir cógas rialta nó de réir mar is gá leis"
     card:
       notes: "Nótaí:"
       timing_restrictions: "Srianta Ama:"
@@ -744,7 +744,7 @@ ga:
       select_dose: "Roghnaigh dáileog"
       select_medication_first: "Roghnaigh leigheas ar dtús"
       no_doses_available: "Níl aon dáileoga ar fáil"
-      dose_hint: "Teastaíonn dáileog ó gach leigheas de réir mar is gá"
+      dose_hint: "Teastaíonn dáileog ó gach cógas"
       notes: "Nótaí"
       notes_placeholder: "Cuir aon treoracha speisialta nó nótaí leis"
       notes_hint: "Cuir aon treoracha speisialta nó nótaí leis"
@@ -755,6 +755,15 @@ ga:
       dose_cycle: "Timthriall dáileoige"
       default_dose_cycle: "Laethúil"
       dose_cycle_hint: "Tréimhse athshocraithe an timthrialla"
+      administration_kind: "Cineál cógais"
+      administration_kind_hint: "Áirítear tascanna rialta don lá inniu; ní thaispeántar cógas de réir mar is gá ach nuair is féidir é a thabhairt."
+      administration_kinds:
+        routine:
+          label: "Rialta"
+          description: "Tasc laethúil le críochnú nuair a athshocraíonn an timthriall"
+        as_needed:
+          label: "De réir mar is gá"
+          description: "Ní úsáidtear é ach nuair a éilíonn comharthaí nó treoir é"
       no_options: "Níl aon roghanna ann."
       optional: "Roghnach"
       back: "Ar Ais"
@@ -763,7 +772,7 @@ ga:
         choose_medication_title: "Roghnaigh leigheas"
         choose_medication_description: "Tosaigh trí roghnú an leighis is mian leat a chur leis."
         choose_dose_title: "Roghnaigh an dáileog"
-        choose_dose_description: "Teastaíonn dáileog ó gach leigheas de réir mar is gá sula leanann tú ar aghaidh."
+        choose_dose_description: "Roghnaigh an dáileog sula leanann tú ar aghaidh."
         add_guidance_title: "Cuir treoir roghnach leis"
         add_guidance_description: "Cuir nótaí nó teorainneacha dáileoige leis ar mian leat a rianú leis an leigheas seo."
       add_medication_button: "Cuir Leigheas Leis"
@@ -1159,6 +1168,14 @@ ga:
     add_schedules_hint: "Cuir oideas leigheasanna leis chun iad a fheiceáil anseo"
     dose_taken_at: "%{person} • Tógtha ag %{time}"
     empty_state: "Gan leigheasanna sceidealta inniu."
+    routine:
+      anytime: "Am ar bith"
+      done_short: "Déanta"
+      done_today: "Tascanna rialta déanta inniu"
+      empty: "Níl aon tascanna rialta le déanamh inniu"
+      left_today:
+        one: "1 tasc rialta fágtha inniu"
+        other: "%{count} tasc rialta fágtha inniu"
     insights:
       title: "Léarchéal Cliste"
       pattern_detected: "Patrún aimsithe"
@@ -1173,6 +1190,7 @@ ga:
       active_schedules: "Oideas Leigheasanna Gníomhacha"
       compliance: "Comhlíonadh"
       next_dose: "An Chéad Dháileog Eile"
+      due_today: "Inniu"
       no_upcoming_doses: "Níl ceann ar bith inniu"
     quick_stats:
       title: "Staitisticí Tapa"
@@ -1181,8 +1199,11 @@ ga:
     statuses:
       taken: "Tógtha"
       upcoming: "Ag Teacht"
+      available_now: "Ar fáil anois"
+      available_at: "Ar fáil ag %{time}"
       cooldown: "Fan"
       missed: "Caillte"
+      max_reached: "Uasmhéid laethúil bainte amach"
       out_of_stock: "As Stoc"
     table:
       person: "Duine"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -707,7 +707,7 @@ pt:
     modal:
       new_title: "Adicionar Medicamento para %{person}"
       edit_title: "Editar Medicamento para %{person}"
-      subtitle: "Adicionar um medicamento conforme necessário"
+      subtitle: "Adicionar uma medicação de rotina ou conforme necessário"
     card:
       notes: "Notas:"
       timing_restrictions: "Restrições de Tempo:"
@@ -744,7 +744,7 @@ pt:
       select_dose: "Selecionar uma dose"
       select_medication_first: "Selecione primeiro um medicamento"
       no_doses_available: "Não existem doses disponíveis"
-      dose_hint: "Todos os medicamentos conforme necessário requerem uma dose"
+      dose_hint: "Todos os medicamentos requerem uma dose"
       notes: "Notas"
       notes_placeholder: "Adicione quaisquer instruções ou notas especiais"
       notes_hint: "Adicione quaisquer instruções ou notas especiais"
@@ -755,6 +755,15 @@ pt:
       dose_cycle: "Ciclo de dose"
       default_dose_cycle: "Diário"
       dose_cycle_hint: "Período de reinício do ciclo"
+      administration_kind: "Tipo de medicação"
+      administration_kind_hint: "As tarefas de rotina contam para hoje; a medicação conforme necessário só aparece quando pode ser administrada."
+      administration_kinds:
+        routine:
+          label: "Rotina"
+          description: "Uma tarefa diária para concluir quando o ciclo reinicia"
+        as_needed:
+          label: "Conforme necessário"
+          description: "Usada apenas quando os sintomas ou as orientações o exigem"
       no_options: "Sem opções."
       optional: "Opcional"
       back: "Voltar"
@@ -763,7 +772,7 @@ pt:
         choose_medication_title: "Escolha um medicamento"
         choose_medication_description: "Comece por escolher o medicamento que quer adicionar."
         choose_dose_title: "Escolha a dose"
-        choose_dose_description: "Cada medicamento conforme necessário precisa de uma dose antes de continuar."
+        choose_dose_description: "Escolha a dose antes de continuar."
         add_guidance_title: "Adicionar orientação opcional"
         add_guidance_description: "Adicione notas ou limites de dose que queira acompanhar com este medicamento."
       add_medication_button: "Adicionar Medicamento"
@@ -1328,6 +1337,14 @@ pt:
     add_schedules_hint: "Adicione prescrições para vê-las aqui"
     dose_taken_at: "%{person} • Tomado às %{time}"
     empty_state: "Nenhum medicamento agendado para hoje."
+    routine:
+      anytime: "A qualquer momento"
+      done_short: "Feito"
+      done_today: "Tarefas de rotina concluídas hoje"
+      empty: "Nenhuma tarefa de rotina pendente hoje"
+      left_today:
+        one: "1 tarefa de rotina pendente hoje"
+        other: "%{count} tarefas de rotina pendentes hoje"
     insights:
       title: "Informações inteligentes"
       pattern_detected: "Padrão detetado"
@@ -1342,12 +1359,16 @@ pt:
       active_schedules: "Prescrições Ativas"
       compliance: "Conformidade"
       next_dose: "Próxima dose"
+      due_today: "Hoje"
       no_upcoming_doses: "Nenhuma hoje"
     statuses:
       taken: "Tomado"
       upcoming: "Próximo"
+      available_now: "Disponível agora"
+      available_at: "Disponível às %{time}"
       cooldown: "Aguardar"
       missed: "Perdido"
+      max_reached: "Máximo diário atingido"
       out_of_stock: "Sem Stock"
     table:
       person: "Pessoa"

--- a/db/migrate/20260510120000_add_administration_kind_to_person_medications.rb
+++ b/db/migrate/20260510120000_add_administration_kind_to_person_medications.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AddAdministrationKindToPersonMedications < ActiveRecord::Migration[8.1]
+  def up
+    add_column :person_medications, :administration_kind, :integer, default: 1, null: false
+    add_index :person_medications, :administration_kind
+
+    execute <<~SQL.squish
+      UPDATE person_medications
+      SET administration_kind = 0,
+          min_hours_between_doses = CASE
+            WHEN max_daily_doses = 1 AND min_hours_between_doses = 24 THEN NULL
+            ELSE min_hours_between_doses
+          END
+      WHERE COALESCE(dose_cycle, 0) = 0
+        AND max_daily_doses IS NOT NULL
+        AND (
+          min_hours_between_doses IS NULL OR
+          (max_daily_doses = 1 AND min_hours_between_doses = 24)
+        )
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE schedules
+      SET schedule_type = 4
+      WHERE schedule_type <> 4
+        AND (
+          LOWER(COALESCE(frequency, '')) = 'as needed' OR
+          schedule_config @> '{"as_needed": true}'::jsonb
+        )
+    SQL
+  end
+
+  def down
+    remove_index :person_medications, :administration_kind
+    remove_column :person_medications, :administration_kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -360,6 +360,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000000) do
   end
 
   create_table "person_medications", force: :cascade do |t|
+    t.integer "administration_kind", default: 1, null: false
     t.datetime "created_at", null: false
     t.decimal "dose_amount", precision: 10, scale: 2
     t.integer "dose_cycle"
@@ -372,6 +373,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000000) do
     t.integer "position", null: false
     t.bigint "source_dosage_option_id"
     t.datetime "updated_at", null: false
+    t.index ["administration_kind"], name: "index_person_medications_on_administration_kind"
     t.index ["medication_id"], name: "index_person_medications_on_medication_id"
     t.index ["person_id", "medication_id"], name: "index_person_medications_on_person_id_and_medication_id", unique: true
     t.index ["person_id", "position"], name: "index_person_medications_on_person_id_and_position"

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Components::Dashboard::IndexView, type: :component do
-  fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules,
+  fixtures :accounts, :account_otp_keys, :people, :users, :locations, :medications, :dosages, :schedules,
            :person_medications, :medication_takes
 
   subject(:dashboard_view) do
@@ -161,6 +161,33 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
+  describe 'person task cards' do
+    it 'renders a routine task card with a collapsed as-needed disclosure' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter))
+      details = rendered.at_css('details[data-testid="dashboard-as-needed-person"]')
+
+      expect(rendered.text).to include('Vitamin D')
+      expect(details).to be_present
+      expect(details['open']).to be_nil
+    end
+
+    it 'renders as-needed availability inside the disclosure' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter))
+      details = rendered.at_css('details[data-testid="dashboard-as-needed-person"]')
+
+      expect(details.text).to include('As needed')
+      expect(details.text).to include('Paracetamol')
+      expect(details.text).to include('Available now')
+    end
+
+    it 'counts blocked routine rows as remaining tasks' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter(routine_status: :out_of_stock)))
+
+      expect(rendered.text).to include('1 routine task left today')
+      expect(rendered.text).not_to include('Routine tasks done today')
+    end
+  end
+
   context 'when there are no active schedules or person medications' do
     before do
       MedicationTake.delete_all
@@ -172,5 +199,40 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(dashboard_view)
       expect(rendered.text).to include('No medications scheduled for today')
     end
+  end
+
+  def person_task_presenter(routine_status: :upcoming)
+    person = people(:john)
+    instance_double(
+      DashboardPresenter,
+      people: [person],
+      active_schedules: [],
+      current_user: admin_user,
+      compliance_percentage: 85,
+      next_dose_time: nil,
+      routine_tasks_due?: true,
+      routine_tasks_by_person: { person => [routine_dashboard_row(person, status: routine_status)] },
+      as_needed_by_person: { person => [as_needed_dashboard_row(person)] }
+    )
+  end
+
+  def routine_dashboard_row(person, status: :upcoming)
+    {
+      person: person,
+      source: person_medications(:john_vitamin_d),
+      scheduled_at: nil,
+      taken_at: nil,
+      status: status
+    }
+  end
+
+  def as_needed_dashboard_row(person)
+    {
+      person: person,
+      source: schedules(:john_paracetamol),
+      scheduled_at: Time.current,
+      taken_at: nil,
+      status: :available
+    }
   end
 end

--- a/spec/components/person_medications/form_view_spec.rb
+++ b/spec/components/person_medications/form_view_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe Components::PersonMedications::FormView, type: :component do
     end
   end
 
+  it 'renders an administration kind choice' do
+    person_medication = PersonMedication.new
+    person = instance_double(Person, name: 'John Doe', person_type: 'adult')
+
+    rendered = render_inline(
+      described_class.new(
+        person_medication: person_medication,
+        person: person,
+        medications: []
+      )
+    )
+
+    expect(rendered.text).to include('Routine')
+    expect(rendered.text).to include('As needed')
+    expect(rendered.css("input[name='person_medication[administration_kind]'][value='routine']")).to be_present
+    expect(rendered.css("input[name='person_medication[administration_kind]'][value='as_needed']")).to be_present
+  end
+
   it 'renders medication dose options for the Stimulus controller' do
     person_medication = PersonMedication.new
     person = instance_double(Person, name: 'John Doe', person_type: 'adult')

--- a/spec/factories/person_medications.rb
+++ b/spec/factories/person_medications.rb
@@ -24,8 +24,17 @@ FactoryBot.define do
     dose_amount { dosage&.amount || medication.dosage_amount }
     dose_unit { dosage&.unit || medication.dosage_unit }
     notes { nil }
+    administration_kind { :as_needed }
     max_daily_doses { nil }
     min_hours_between_doses { nil }
+
+    trait :routine do
+      administration_kind { :routine }
+    end
+
+    trait :as_needed do
+      administration_kind { :as_needed }
+    end
 
     trait :with_max_doses do
       max_daily_doses { 3 }

--- a/spec/features/dashboard_authorization_spec.rb
+++ b/spec/features/dashboard_authorization_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe 'Dashboard Authorization', type: :system do
         sign_in(parent)
 
         visit dashboard_path
+        open_as_needed_disclosures
 
         # Should see child's schedule
         expect(page).to have_text('Paracetamol')
@@ -139,6 +140,7 @@ RSpec.describe 'Dashboard Authorization', type: :system do
         sign_in(adult_patient)
 
         visit dashboard_path
+        open_as_needed_disclosures
 
         # Should see their own schedule (paracetamol)
         expect(page).to have_text('Paracetamol')
@@ -148,5 +150,9 @@ RSpec.describe 'Dashboard Authorization', type: :system do
         expect(page).to have_no_text('Ibuprofen')
       end
     end
+  end
+
+  def open_as_needed_disclosures
+    page.all('details[data-testid="dashboard-as-needed-person"] summary').to_a.each(&:click)
   end
 end

--- a/spec/fixtures/person_medications.yml
+++ b/spec/fixtures/person_medications.yml
@@ -6,6 +6,7 @@ john_vitamin_d:
   dose_unit: IU
   position: 0
   notes: Take with breakfast
+  administration_kind: routine
   max_daily_doses: 1
 
 jane_vitamin_d:
@@ -14,6 +15,7 @@ jane_vitamin_d:
   dose_amount: 1000
   dose_unit: IU
   position: 0
+  administration_kind: routine
   max_daily_doses: 2
   min_hours_between_doses: 12
 
@@ -23,5 +25,6 @@ bob_vitamin_c:
   dose_amount: 500
   dose_unit: mg
   position: 0
+  administration_kind: as_needed
   max_daily_doses: 3
   min_hours_between_doses: 4

--- a/spec/models/person_medication_spec.rb
+++ b/spec/models/person_medication_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe PersonMedication do
     end
   end
 
+  describe '#administration_kind' do
+    it 'distinguishes routine medication from as-needed medication' do
+      routine = build(:person_medication, administration_kind: :routine)
+      as_needed = build(:person_medication, administration_kind: :as_needed)
+
+      expect(routine).to be_routine
+      expect(as_needed).to be_as_needed
+    end
+  end
+
   describe 'dose validations' do
     it 'does not assign a mismatched default dosage option for an explicit custom dose' do
       medication = create(:medication, dosage_amount: nil, dosage_unit: nil)

--- a/spec/requests/api/v1/resources_spec.rb
+++ b/spec/requests/api/v1/resources_spec.rb
@@ -74,4 +74,18 @@ RSpec.describe 'API v1 resources' do
     )
     expect(schedule).not_to have_key('dosage_id')
   end
+
+  it 'serializes person medication administration kind' do
+    login_data = api_login(user)
+
+    get api_v1_person_medications_path,
+        headers: api_auth_headers(login_data.fetch('access_token')),
+        as: :json
+
+    person_medication = response.parsed_body.fetch('data').find do |row|
+      row.fetch('id') == person_medications(:john_vitamin_d).id
+    end
+
+    expect(person_medication).to include('administration_kind' => 'routine')
+  end
 end

--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Medication Timing Restrictions' do
-  fixtures :accounts, :people, :locations, :medications, :users, :dosages, :schedules, :carer_relationships
+  fixtures :accounts, :people, :locations, :medications, :users, :dosages, :schedules, :carer_relationships,
+           :location_memberships
 
   # Use carer account (doesn't require 2FA)
   let(:carer_account) { accounts(:carer) }

--- a/spec/requests/person_medications_edit_spec.rb
+++ b/spec/requests/person_medications_edit_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe 'Person medication edit and update' do
         expect(person_medication.max_daily_doses).to eq(5)
       end
 
+      it 'updates the administration kind' do
+        patch person_person_medication_path(person, person_medication),
+              params: { person_medication: { administration_kind: 'routine' } }
+
+        expect(response).to redirect_to(person_path(person))
+        expect(person_medication.reload.administration_kind).to eq('routine')
+      end
+
       it 'updates via Turbo Stream' do
         patch person_person_medication_path(person, person_medication),
               params: { person_medication: { notes: 'Turbo update' } },

--- a/spec/requests/person_medications_policy_scope_spec.rb
+++ b/spec/requests/person_medications_policy_scope_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'PersonMedicationsController medication options' do
-  fixtures :accounts, :people, :locations, :medications, :users, :carer_relationships
+  fixtures :accounts, :people, :locations, :location_memberships, :medications, :users, :carer_relationships
 
   let(:adult_patient_user) { users(:adult_patient) }
   let(:adult_patient_person) { people(:adult_patient_person) }
@@ -101,6 +101,24 @@ RSpec.describe 'PersonMedicationsController medication options' do
         end.not_to change(PersonMedication, :count)
 
         expect(response).to redirect_to(root_path)
+      end
+
+      it 'permits routine administration kind when creating medication' do
+        expect do
+          post person_person_medications_path(adult_patient_person),
+               params: {
+                 person_medication: {
+                   medication_id: medications(:vitamin_d).id,
+                   dose_amount: 1000,
+                   dose_unit: 'IU',
+                   administration_kind: 'routine',
+                   max_daily_doses: 1,
+                   min_hours_between_doses: ''
+                 }
+               }
+        end.to change(PersonMedication, :count).by(1)
+
+        expect(PersonMedication.order(:created_at).last.administration_kind).to eq('routine')
       end
     end
   end

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe FamilyDashboard::ScheduleQuery do
-  fixtures :people, :carer_relationships, :schedules, :person_medications, :medication_takes,
+  fixtures :accounts, :people, :carer_relationships, :schedules, :person_medications, :medication_takes,
            :locations, :medications, :dosages
 
   let(:jane) { people(:jane) }
@@ -57,9 +57,63 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       expect(pms).to include(person_medications(:jane_vitamin_d))
     end
 
+    it 'keeps routine direct medications due after a previous-day dose' do
+      travel_to Time.zone.parse('2026-05-05 08:00:00') do
+        routine_medication = create_routine_person_medication
+        MedicationTake.create!(
+          person_medication: routine_medication,
+          taken_at: Time.zone.parse('2026-05-04 20:00:00'),
+          dose_amount: 500,
+          dose_unit: 'mg'
+        )
+
+        rows = described_class.new([people(:john)]).call.select { |row| row[:source] == routine_medication }
+
+        expect(rows.pluck(:status)).to include(:upcoming)
+      end
+    end
+
+    it 'does not emit a reset-time row after today routine direct medication has been taken' do
+      travel_to Time.zone.parse('2026-05-05 20:00:00') do
+        routine_medication = create_routine_person_medication
+        MedicationTake.create!(
+          person_medication: routine_medication,
+          taken_at: Time.zone.parse('2026-05-05 08:00:00'),
+          dose_amount: 500,
+          dose_unit: 'mg'
+        )
+
+        rows = described_class.new([people(:john)]).call.select { |row| row[:source] == routine_medication }
+
+        expect(rows.pluck(:status)).to eq([:taken])
+      end
+    end
+
+    it 'groups PRN schedules under as-needed medications instead of routine tasks' do
+      prn_schedule = create_prn_schedule
+      query = described_class.new([people(:john)])
+
+      routine_rows = query.call.select { |row| row[:source] == prn_schedule }
+      as_needed_rows = query.as_needed_by_person.fetch(people(:john)).select { |row| row[:source] == prn_schedule }
+
+      expect(routine_rows).to be_empty
+      expect(as_needed_rows.pluck(:status)).to eq([:available])
+    end
+
+    it 'marks PRN availability as max reached when the daily limit is exhausted' do
+      prn_schedule = create_prn_schedule(max_daily_doses: 1)
+      MedicationTake.create!(schedule: prn_schedule, taken_at: Time.current, dose_amount: 1000, dose_unit: 'mg')
+      query = described_class.new([people(:john)])
+
+      query.call
+      rows = query.as_needed_by_person.fetch(people(:john)).select { |row| row[:source] == prn_schedule }
+
+      expect(rows.pluck(:status)).to eq([:max_reached])
+    end
+
     it 'returns doses sorted by scheduled_at' do
       results = query.call
-      times = results.pluck(:scheduled_at)
+      times = results.pluck(:scheduled_at).compact
       expect(times).to eq(times.sort)
     end
 
@@ -209,5 +263,32 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
         expect(upcoming).to be_empty
       end
     end
+  end
+
+  def create_routine_person_medication
+    PersonMedication.create!(
+      person: people(:john),
+      medication: medications(:vitamin_c),
+      dose_amount: 500,
+      dose_unit: 'mg',
+      max_daily_doses: 1,
+      min_hours_between_doses: nil,
+      administration_kind: :routine
+    )
+  end
+
+  def create_prn_schedule(max_daily_doses: 4, min_hours_between_doses: 4)
+    Schedule.create!(
+      person: people(:john),
+      medication: medications(:paracetamol),
+      dose_amount: 1000,
+      dose_unit: 'mg',
+      start_date: Time.zone.today,
+      end_date: 1.year.from_now.to_date,
+      frequency: 'As needed',
+      schedule_type: :prn,
+      max_daily_doses: max_daily_doses,
+      min_hours_between_doses: min_hours_between_doses
+    )
   end
 end


### PR DESCRIPTION
## Summary
- add routine/as-needed classification for direct person medications, including migration, params, serializer, and form controls
- split dashboard medication rows into per-person routine cards and collapsed as-needed disclosures
- make routine direct medications calendar-day tasks while keeping PRN medications as availability-only items

## Verification
- task rubocop
- task test
- browser smoke check at http://localhost:56402/dashboard