### PR TITLE
refactor: Refactor two factor auth spec fake

### DIFF
--- a/spec/components/views/rodauth/two_factor_auth_spec.rb
+++ b/spec/components/views/rodauth/two_factor_auth_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Views::Rodauth::TwoFactorAuth, type: :component do
-  # rubocop:disable RSpec/VerifiedDoubles
   it 'renders the two-factor auth selection screen' do
-    rodauth = double('Rodauth', two_factor_auth_links: [[10, '/otp-auth', 'Authenticator app']])
+    rodauth = Struct.new(:two_factor_auth_links).new([[10, '/otp-auth', 'Authenticator app']])
 
     allow(controller).to receive(:rodauth).and_return(rodauth)
 
@@ -15,5 +14,4 @@ RSpec.describe Views::Rodauth::TwoFactorAuth, type: :component do
     expect(rendered.text).to include('Authenticator app')
     expect(rendered.to_html).to include('min-h-screen')
   end
-  # rubocop:enable RSpec/VerifiedDoubles
 end


### PR DESCRIPTION
## What changed

- Replaced the unverified Rodauth double in `spec/components/views/rodauth/two_factor_auth_spec.rb` with a concrete `Struct` fake.
- Removed the now-unneeded `RSpec/VerifiedDoubles` RuboCop suppression from that spec.

## Why this improves maintainability/readability

The spec now expresses the tiny interface the component needs directly, without an inline lint disable around a generic test double.

## How behavior was preserved

The fake returns the same `two_factor_auth_links` payload as before, and the existing render assertions continue to cover the visible output and layout class.

## Verification commands run

- `task rubocop` after removing the suppression, to confirm the red signal: one `RSpec/VerifiedDoubles` offense.
- `task test TEST_FILE=spec/components/views/rodauth/two_factor_auth_spec.rb`
- `task rubocop`
- `task test`