### PR TITLE
feat: redesign mobile medicine dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -1,0 +1,147 @@
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.dashboard-dose-card {
+  border-width: 1px !important;
+  box-shadow: 0 14px 34px -26px rgb(15 23 42 / 45%) !important;
+}
+
+.dashboard-dose-card--green {
+  border-color: rgb(167 243 208) !important;
+  background: linear-gradient(135deg, rgb(236 253 245 / 92%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-card--blue {
+  border-color: rgb(191 219 254) !important;
+  background: linear-gradient(135deg, rgb(239 246 255 / 95%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-card--violet {
+  border-color: rgb(221 214 254) !important;
+  background: linear-gradient(135deg, rgb(245 243 255 / 95%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-card--amber {
+  border-color: rgb(254 215 170) !important;
+  background: linear-gradient(135deg, rgb(255 247 237 / 95%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-card--rose {
+  border-color: rgb(254 205 211) !important;
+  background: linear-gradient(135deg, rgb(255 241 242 / 95%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-card--teal {
+  border-color: rgb(153 246 228) !important;
+  background: linear-gradient(135deg, rgb(240 253 250 / 95%), rgb(255 255 255 / 96%)) !important;
+}
+
+.dashboard-dose-icon {
+  box-shadow: 0 0 0 8px rgb(255 255 255 / 68%);
+}
+
+.dashboard-dose-icon--green {
+  color: rgb(4 120 87);
+  background: rgb(209 250 229);
+}
+
+.dashboard-dose-icon--blue {
+  color: rgb(29 78 216);
+  background: rgb(219 234 254);
+}
+
+.dashboard-dose-icon--violet {
+  color: rgb(109 40 217);
+  background: rgb(237 233 254);
+}
+
+.dashboard-dose-icon--amber {
+  color: rgb(194 65 12);
+  background: rgb(255 237 213);
+}
+
+.dashboard-dose-icon--rose {
+  color: rgb(225 29 72);
+  background: rgb(255 228 230);
+}
+
+.dashboard-dose-icon--teal {
+  color: rgb(15 118 110);
+  background: rgb(204 251 241);
+}
+
+.dashboard-dose-status {
+  background: rgb(239 246 255) !important;
+  color: rgb(30 64 175) !important;
+}
+
+.dashboard-dose-status--green {
+  background: rgb(209 250 229) !important;
+  color: rgb(4 120 87) !important;
+}
+
+.dashboard-dose-status--violet {
+  background: rgb(237 233 254) !important;
+  color: rgb(109 40 217) !important;
+}
+
+.dashboard-dose-status--amber {
+  background: rgb(255 237 213) !important;
+  color: rgb(194 65 12) !important;
+}
+
+.dashboard-dose-status--rose {
+  background: rgb(255 228 230) !important;
+  color: rgb(225 29 72) !important;
+}
+
+.dashboard-dose-status--teal {
+  background: rgb(204 251 241) !important;
+  color: rgb(15 118 110) !important;
+}
+
+.dashboard-dose-action {
+  color: white !important;
+  border: 0 !important;
+}
+
+.dashboard-dose-action--blue {
+  background: rgb(37 99 235) !important;
+  box-shadow: 0 14px 28px -16px rgb(37 99 235 / 70%) !important;
+}
+
+.dashboard-dose-action--violet {
+  background: rgb(124 58 237) !important;
+  box-shadow: 0 14px 28px -16px rgb(124 58 237 / 70%) !important;
+}
+
+.dashboard-dose-action--amber {
+  background: rgb(249 115 22) !important;
+  box-shadow: 0 14px 28px -16px rgb(249 115 22 / 70%) !important;
+}
+
+.dashboard-dose-action--teal {
+  background: rgb(13 148 136) !important;
+  box-shadow: 0 14px 28px -16px rgb(13 148 136 / 70%) !important;
+}
+
+.mobile-fab-stack {
+  right: calc(1rem + env(safe-area-inset-right)) !important;
+  bottom: calc(7rem + env(safe-area-inset-bottom)) !important;
+}
+
+.mobile-bottom-nav {
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100% !important;
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  padding-bottom: calc(0.5rem + env(safe-area-inset-bottom)) !important;
+}

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -4,49 +4,33 @@ module Components
   module Dashboard
     # Dashboard index view component that renders the main dashboard page
     class IndexView < Components::Base
-      attr_reader :presenter
+      FILTERS = %w[all needs_action upcoming taken].freeze
 
-      def initialize(presenter:)
+      attr_reader :presenter, :filter
+
+      def initialize(presenter:, filter: 'all')
         @presenter = presenter
+        @filter = FILTERS.include?(filter.to_s) ? filter.to_s : 'all'
         super()
       end
 
       def view_template
-        div(class: 'container mx-auto max-w-6xl px-4 py-8', data: { testid: 'dashboard' }) do
+        div(class: 'container mx-auto max-w-3xl px-4 pb-24 pt-4 md:py-8', data: { testid: 'dashboard' }) do
           render_header
-          render_stats_section
-
-          div(class: 'grid grid-cols-1 lg:grid-cols-3 gap-8 items-start') do
-            div(class: 'lg:col-span-2') do
-              render_timeline_section
-            end
-            div(class: 'space-y-8') do
-              render_supply_levels
-            end
-            div(class: 'lg:col-span-2') do
-              render_health_insights
-            end
-          end
+          render_mobile_title
+          render_daily_summary
+          render_filter_strip
+          render_timeline_section
           render_version_footer
         end
       end
 
       private
 
-      delegate :people, :active_schedules, :upcoming_schedules,
-               :current_user, :doses, :next_dose_time, :routine_tasks_due?,
-               :routine_tasks_by_person, :as_needed_by_person, :compliance_percentage, to: :presenter
-
-      def next_dose_value
-        time = next_dose_time
-        return time.strftime('%H:%M') if time
-        return t('dashboard.stats.due_today') if routine_tasks_due?
-
-        t('dashboard.stats.no_upcoming_doses')
-      end
+      delegate :current_user, :doses, :next_dose_time, :as_needed_by_person, to: :presenter
 
       def render_header
-        div(class: 'flex flex-col md:flex-row md:items-end justify-between gap-6 mb-12') do
+        div(class: 'mb-8 hidden flex-col justify-between gap-6 md:flex md:flex-row md:items-end') do
           div do
             m3_text(variant: :label_large, class: 'uppercase tracking-[0.2em] mb-1 block font-black opacity-40') do
               Time.current.strftime('%A, %b %d')
@@ -84,157 +68,244 @@ module Components
         end
       end
 
-      def render_stats_section
-        div(class: 'grid grid-cols-2 lg:grid-cols-4 auto-rows-fr gap-4 mb-12') do
-          render Components::Shared::MetricCard.new(
-            title: t('dashboard.stats.people'),
-            value: people.size,
-            icon_type: 'users',
-            href: people_path
-          )
-          render Components::Shared::MetricCard.new(
-            title: t('dashboard.stats.active_schedules'),
-            value: active_schedules.size,
-            icon_type: 'active_schedules',
-            href: schedules_path
-          )
-          render Components::Shared::MetricCard.new(
-            title: t('dashboard.stats.compliance'),
-            value: "#{compliance_percentage}%",
-            icon_type: 'compliance',
-            href: reports_path
-          )
-          render Components::Shared::MetricCard.new(
-            title: t('dashboard.stats.next_dose'),
-            value: next_dose_value,
-            icon_type: 'clock'
-          )
+      def render_mobile_title
+        div(class: 'mb-4 flex items-end justify-between gap-4 md:hidden') do
+          div(class: 'min-w-0') do
+            m3_heading(
+              variant: :headline_medium,
+              level: 1,
+              class: 'text-3xl font-black leading-tight tracking-tight text-foreground'
+            ) do
+              t('dashboard.todays_medicines')
+            end
+            m3_text(variant: :body_medium, class: 'mt-2 font-medium text-on-surface-variant') do
+              Time.current.strftime('%A, %d %B')
+            end
+          end
+          div(
+            class: 'flex h-11 w-11 shrink-0 items-center justify-center rounded-shape-xl border ' \
+                   'border-primary/20 bg-primary-container/40 text-primary shadow-elevation-1'
+          ) do
+            render Icons::Calendar.new(size: 20)
+          end
         end
       end
 
+      def render_daily_summary
+        m3_card(
+          variant: :filled,
+          class: 'mb-4 overflow-hidden rounded-shape-xl border border-primary/15 bg-gradient-to-br ' \
+                 'from-emerald-50 via-white to-sky-50 shadow-elevation-2 ' \
+                 'dark:from-emerald-950/30 dark:via-surface-container-low dark:to-sky-950/20',
+          data: { testid: 'dashboard-daily-summary' }
+        ) do
+          div(class: 'p-5') do
+            div(class: 'flex items-start justify-between gap-5') do
+              div(class: 'min-w-0 flex-1') do
+                m3_text(variant: :title_medium, class: 'font-black tracking-tight text-foreground') do
+                  t('dashboard.summary.today_progress', completed: completed_dose_count, total: total_dose_count)
+                end
+                m3_text(variant: :body_small, class: 'mt-1 text-on-surface-variant') do
+                  summary_support_text
+                end
+              end
+
+              div(class: 'shrink-0 text-right') do
+                div(class: 'text-2xl font-black leading-none text-primary') { "#{completion_percentage}%" }
+                m3_text(variant: :label_small, class: 'text-on-surface-variant') { t('dashboard.summary.completed') }
+              end
+            end
+
+            div(class: 'mt-4 flex gap-1.5', aria: { hidden: 'true' }) do
+              progress_segments.times do |index|
+                div(class: progress_segment_class(index))
+              end
+            end
+
+            div(class: 'mt-4 flex flex-wrap items-center gap-2') do
+              div(
+                class: 'inline-flex items-center gap-2 rounded-shape-full bg-white/80 px-3 py-2 ' \
+                       'text-primary shadow-elevation-1 dark:bg-surface-container'
+              ) do
+                render Icons::Clock.new(size: 17)
+                m3_text(variant: :label_large, class: 'font-black') do
+                  t('dashboard.summary.next_due', time: next_due_value)
+                end
+              end
+              div(
+                class: 'inline-flex items-center gap-2 rounded-shape-full bg-teal-100/80 px-3 py-2 ' \
+                       'text-teal-700 dark:bg-teal-900/30 dark:text-teal-200'
+              ) do
+                render Icons::CheckCircle.new(size: 17)
+                m3_text(variant: :label_large, class: 'font-black') do
+                  t('dashboard.summary.remaining', count: remaining_dose_count)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def render_filter_strip
+        nav(
+          class: 'no-scrollbar mb-5 overflow-x-auto pb-1',
+          aria: { label: t('dashboard.filters.label') },
+          data: { testid: 'dashboard-filter-strip' }
+        ) do
+          div(class: 'flex min-w-max gap-2') do
+            filter_options.each do |option|
+              a(
+                href: dashboard_path(filter: option[:value]),
+                class: filter_chip_class(option[:value]),
+                aria: { current: option[:value] == filter ? 'page' : nil }
+              ) do
+                render option[:icon].new(size: 17, class: 'shrink-0')
+                span { option[:label] }
+                span(class: filter_count_class(option[:value])) { option[:count].to_s }
+              end
+            end
+          end
+        end
+      end
+
+      def filter_options
+        [
+          {
+            value: 'all',
+            label: t('dashboard.filters.all'),
+            count: medicine_rows.size,
+            icon: Icons::Home
+          },
+          {
+            value: 'needs_action',
+            label: t('dashboard.filters.needs_action'),
+            count: medicine_rows.count { |dose| action_needed?(dose) },
+            icon: Icons::CheckCircle
+          },
+          {
+            value: 'upcoming',
+            label: t('dashboard.filters.upcoming'),
+            count: medicine_rows.count { |dose| upcoming_or_blocked?(dose) },
+            icon: Icons::Clock
+          },
+          {
+            value: 'taken',
+            label: t('dashboard.filters.taken'),
+            count: medicine_rows.count { |dose| dose[:status] == :taken },
+            icon: Icons::Check
+          }
+        ]
+      end
+
       def render_timeline_section
-        div(class: 'space-y-6') do
-          div(class: 'flex items-center justify-between mb-2 px-1') do
-            m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
-              t('dashboard.todays_schedule')
+        div(class: 'space-y-4') do
+          div(class: 'flex items-center justify-between px-1') do
+            m3_heading(variant: :title_large, level: 2, class: 'font-black tracking-tight') do
+              t('dashboard.todays_medicines')
+            end
+            m3_text(variant: :label_large, class: 'font-black text-on-surface-variant') do
+              t('dashboard.filtered_count', count: filtered_doses.size)
             end
           end
 
-          task_people = people_with_dashboard_items
-          if task_people.any?
-            div(class: 'space-y-4') do
-              task_people.each do |person|
-                render Components::Dashboard::PersonTaskCard.new(
-                  person: person,
-                  routine_tasks: routine_tasks_by_person.fetch(person, []),
-                  as_needed_items: as_needed_by_person.fetch(person, []),
-                  current_user: current_user
-                )
+          if filtered_doses.any?
+            div(class: 'space-y-3', data: { testid: 'dashboard-medicine-list' }) do
+              filtered_doses.each do |dose|
+                render Components::Dashboard::TimelineItem.new(dose: dose, current_user: current_user)
               end
             end
           else
             m3_card(variant: :filled,
-                    class: 'p-16 text-center rounded-[2.5rem] border-dashed border-2 ' \
-                           'border-outline-variant/50 bg-surface-container-low') do
-              m3_text(variant: :body_large, class: 'text-on-surface-variant font-medium italic') do
-                t('dashboard.empty_state')
+                    class: 'rounded-shape-xl border-2 border-dashed border-outline-variant/50 ' \
+                           'bg-surface-container-low p-8 text-center',
+                    data: { testid: 'dashboard-medicine-list' }) do
+              m3_text(variant: :body_large, class: 'text-on-surface-variant font-medium') do
+                t(filtered_empty_key)
               end
             end
           end
         end
       end
 
-      def people_with_dashboard_items
-        people.select do |person|
-          routine_tasks_by_person.fetch(person, []).any? || as_needed_by_person.fetch(person, []).any?
+      def filtered_empty_key
+        filter == 'all' ? 'dashboard.empty_state' : 'dashboard.empty_filtered_state'
+      end
+
+      def filtered_doses
+        @filtered_doses ||= begin
+          predicate = filtered_dose_predicate
+          predicate ? medicine_rows.select { |dose| send(predicate, dose) } : medicine_rows
         end
       end
 
-      def render_health_insights
-        div(class: 'space-y-4 pt-4') do
-          m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
-            t('dashboard.insights.title')
-          end
-          m3_card(
-            variant: :filled,
-            class: 'bg-primary rounded-[2.5rem] p-10 text-on-primary relative overflow-hidden border-none ' \
-                   'transition-all duration-300 hover:shadow-xl hover:shadow-primary/30 ' \
-                   'group cursor-default'
-          ) do
-            div(class: 'absolute -right-12 -top-12 w-48 h-48 bg-white/10 rounded-full blur-3xl ' \
-                       'group-hover:bg-white/20 transition-all')
-            div(class: 'relative z-10') do
-              div(class: 'w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center mb-6 ' \
-                         'group-hover:scale-110 transition-transform shadow-inner') do
-                render Icons::AlertCircle.new(size: 24)
-              end
-              m3_heading(variant: :headline_small, level: 3, class: 'font-black mb-2 tracking-tight') do
-                t('dashboard.insights.pattern_detected')
-              end
-              m3_text(variant: :body_large, class: 'text-on-primary/90 leading-relaxed mb-8 font-medium') do
-                t('dashboard.insights.message')
-              end
-              m3_button(
-                variant: :text,
-                class: 'p-0 h-auto font-black uppercase tracking-widest text-on-primary ' \
-                       'border-b-2 border-on-primary/30 ' \
-                       'rounded-none hover:border-on-primary hover:bg-transparent transition-all'
-              ) do
-                t('dashboard.insights.view_report')
-              end
-            end
-          end
+      def medicine_rows
+        @medicine_rows ||= (doses + as_needed_rows).sort_by do |dose|
+          [dose[:scheduled_at] || Time.current.end_of_day, dose[:source].id]
         end
       end
 
-      def render_supply_levels
-        div(class: 'space-y-6') do
-          m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
-            t('dashboard.inventory.title')
-          end
-          m3_card(
-            variant: :elevated,
-            class: 'bg-surface-container-low p-8 rounded-[2.5rem] border-none shadow-elevation-1 transition-all ' \
-                   'duration-300 hover:shadow-elevation-2 cursor-default'
-          ) do
-            div(class: 'space-y-8') do
-              active_schedules.take(3).each do |p|
-                render_supply_item(p.medication)
-              end
-              m3_link(
-                href: medications_path,
-                variant: :tonal,
-                size: :lg,
-                class: 'w-full py-6 rounded-xl font-black uppercase tracking-widest transition-all'
-              ) do
-                t('dashboard.inventory.order_refills')
-              end
-            end
-          end
+      def as_needed_rows
+        as_needed_by_person.values.flatten
+      end
+
+      def filtered_dose_predicate
+        {
+          'needs_action' => :action_needed?,
+          'upcoming' => :upcoming_or_blocked?,
+          'taken' => :taken?
+        }[filter]
+      end
+
+      def action_needed?(dose)
+        %i[upcoming available].include?(dose[:status])
+      end
+
+      def upcoming_or_blocked?(dose)
+        %i[upcoming cooldown max_reached out_of_stock].include?(dose[:status])
+      end
+
+      def taken?(dose)
+        dose[:status] == :taken
+      end
+
+      def filter_chip_class(value)
+        base = 'inline-flex h-12 items-center gap-2 rounded-shape-full border px-4 text-sm font-black ' \
+               'transition-all whitespace-nowrap'
+        if value == filter
+          "#{base} border-primary bg-primary text-on-primary shadow-elevation-2"
+        else
+          "#{base} border-outline-variant bg-surface-container-low text-on-surface-variant shadow-elevation-1 " \
+            'hover:border-primary/60 hover:text-primary'
         end
       end
 
-      def render_supply_item(medication)
-        current = ::Medications::SupplyStatusPresenter.new(medication: medication).inventory_units_label
-        percentage = medication.supply_percentage
-
-        div(class: 'space-y-3') do
-          div(class: 'flex justify-between items-center') do
-            m3_text(variant: :label_large, class: 'font-black text-foreground uppercase tracking-tight') do
-              medication.name
-            end
-            m3_text(variant: :label_medium, class: 'text-on-surface-variant font-black') do
-              t('dashboard.inventory.left', count: current)
-            end
-          end
-          div(class: 'h-3 w-full bg-surface-container rounded-full overflow-hidden shadow-inner') do
-            div(
-              class: "h-full #{medication.low_stock? ? 'bg-error' : 'bg-primary'} " \
-                     'rounded-full transition-all duration-1000',
-              style: "width: #{percentage}%"
-            )
-          end
+      def filter_count_class(value)
+        if value == filter
+          'ml-1 rounded-shape-full bg-white/20 px-2 py-0.5 text-xs text-on-primary'
+        else
+          'ml-1 rounded-shape-full bg-surface-container-high px-2 py-0.5 text-xs text-on-surface-variant'
         end
+      end
+
+      def progress_segments
+        total_dose_count.clamp(1, 8)
+      end
+
+      def progress_segment_class(index)
+        base = 'h-2 flex-1 rounded-shape-full transition-colors'
+        return "#{base} bg-primary shadow-sm shadow-primary/30" if index < completed_progress_segments
+
+        "#{base} bg-white/70 dark:bg-surface-container-high"
+      end
+
+      def completed_progress_segments
+        return 0 if total_dose_count.zero?
+
+        ((completed_dose_count.to_f / total_dose_count) * progress_segments).round
+      end
+
+      def remaining_dose_count
+        [total_dose_count - completed_dose_count, 0].max
       end
 
       def greeting_key
@@ -251,8 +322,33 @@ module Components
         view_context.policy(Person.new).new?
       end
 
+      def completed_dose_count
+        @completed_dose_count ||= doses.count { |dose| dose[:status] == :taken }
+      end
+
+      def total_dose_count
+        @total_dose_count ||= doses.size
+      end
+
+      def completion_percentage
+        return 0 if total_dose_count.zero?
+
+        ((completed_dose_count.to_f / total_dose_count) * 100).round.clamp(0, 100)
+      end
+
+      def next_due_value
+        time = next_dose_time
+        time ? time.strftime('%l:%M %p').strip : t('dashboard.summary.no_next_due')
+      end
+
+      def summary_support_text
+        return t('dashboard.summary.all_done') if total_dose_count.positive? && completed_dose_count == total_dose_count
+
+        t('dashboard.summary.keep_it_up')
+      end
+
       def render_version_footer
-        div(class: 'mt-16 pt-6 border-t border-outline-variant/30 text-center') do
+        div(class: 'mt-10 border-t border-outline-variant/30 pt-6 text-center') do
           span(class: 'text-[10px] text-on-surface-variant/50 font-mono font-bold uppercase tracking-widest') do
             "v#{app_version}"
           end

--- a/app/components/dashboard/timeline_item.rb
+++ b/app/components/dashboard/timeline_item.rb
@@ -3,6 +3,8 @@
 module Components
   module Dashboard
     class TimelineItem < Components::Base
+      ACCENT_PALETTES = %w[blue violet teal amber].freeze
+
       attr_reader :dose, :current_user
 
       def initialize(dose:, current_user: nil)
@@ -15,37 +17,57 @@ module Components
         card_id = "timeline_#{dose[:source].class.name.underscore}_#{dose[:source].id}"
         render M3::Card.new(
           variant: :elevated,
-          class: "border-none border-l-4 #{status_border_class} transition-all duration-300 " \
-                 'hover:scale-[1.01] hover:shadow-elevation-2 bg-surface-container-low',
+          class: "overflow-hidden rounded-shape-xl border #{card_chrome_class} bg-card shadow-elevation-2",
           id: card_id,
-          data: { id: "dose_#{dose_id}" }
+          data: {
+            id: "dose_#{dose_id}",
+            testid: "dashboard-medicine-card-#{dose_id}",
+            status: dose[:status],
+            palette: palette_name
+          }
         ) do
-          div(class: 'flex items-center justify-between p-5') do
-            div(class: 'flex items-center gap-5') do
-              m3_text(variant: :label_large, class: 'text-on-surface-variant w-14 hidden md:block font-black') do
-                if dose[:scheduled_at]
-                  dose[:scheduled_at].strftime('%H:%M')
-                else
-                  '--:--'
-                end
-              end
-              div do
-                m3_heading(variant: :title_medium, level: 3, class: 'font-bold tracking-tight') do
-                  dose[:source].medication.name
-                end
-                m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') { subtitle_text }
-              end
-            end
+          div(class: 'p-4') do
+            div(class: 'flex items-start gap-4') do
+              render_icon_well
 
-            div(class: 'flex items-center gap-3') do
-              render_action_button if dose[:status] == :upcoming
-              status_badge
+              div(class: 'min-w-0 flex-1') do
+                div(class: 'flex items-start justify-between gap-3') do
+                  m3_heading(
+                    variant: :title_medium,
+                    level: 3,
+                    class: 'min-w-0 font-black leading-tight tracking-tight'
+                  ) do
+                    dose[:source].medication.name
+                  end
+                  status_badge
+                end
+
+                m3_text(
+                  variant: :body_medium,
+                  class: 'mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-on-surface-variant'
+                ) do
+                  plain metadata_text
+                end
+
+                div(class: 'mt-4 flex justify-end') do
+                  render_action_button if actionable_status?
+                end
+              end
             end
           end
         end
       end
 
       private
+
+      def render_icon_well
+        div(
+          class: "flex h-16 w-16 shrink-0 items-center justify-center rounded-shape-xl #{icon_well_class}",
+          data: { testid: 'dashboard-medicine-icon', palette: palette_name }
+        ) do
+          render status_icon
+        end
+      end
 
       def own_dose?
         return true if current_user.nil?
@@ -57,34 +79,43 @@ module Components
         own_dose? ? t('person_medications.card.take') : t('person_medications.card.give')
       end
 
-      def status_border_class
-        case dose[:status]
-        when :taken then 'border-l-success'
-        when :upcoming then 'border-l-primary'
-        when :cooldown then 'border-l-warning'
-        when :out_of_stock then 'border-l-error'
-        else 'border-l-border'
-        end
+      def card_chrome_class
+        "dashboard-dose-card dashboard-dose-card--#{palette_name}"
+      end
+
+      def icon_well_class
+        "dashboard-dose-icon dashboard-dose-icon--#{palette_name}"
+      end
+
+      def action_button_class
+        'min-w-32 rounded-shape-full px-6 font-black text-base shadow-elevation-2 ' \
+          "dashboard-dose-action dashboard-dose-action--#{palette_name}"
+      end
+
+      def palette_name
+        return 'green' if dose[:status] == :taken
+        return 'amber' if %i[cooldown max_reached].include?(dose[:status])
+        return 'rose' if dose[:status] == :out_of_stock
+        return 'teal' unless own_dose?
+
+        ACCENT_PALETTES[dose[:source].id.to_i % ACCENT_PALETTES.size]
       end
 
       def dose_id
         "#{dose[:source].class.name.downcase}_#{dose[:source].id}"
       end
 
-      def subtitle_text
-        person_name = dose[:person].name
+      def metadata_text
+        [dose[:person].name, dose_time_text, location_name].compact_blank.join(' · ')
+      end
 
-        if dose[:status] == :taken && dose[:taken_at]
-          time = dose[:taken_at].strftime('%l:%M %p').strip
-          location_name = dose[:taken_from_location_name]
-          if location_name.present?
-            "#{t('dashboard.dose_taken_at', person: person_name, time: time)} • #{location_name}"
-          else
-            t('dashboard.dose_taken_at', person: person_name, time: time)
-          end
-        else
-          person_name
-        end
+      def dose_time_text
+        time = dose[:taken_at] || dose[:scheduled_at]
+        time&.strftime('%l:%M %p')&.strip
+      end
+
+      def location_name
+        dose[:taken_from_location_name].presence || dose[:source].medication.location&.name
       end
 
       def render_action_button
@@ -97,47 +128,64 @@ module Components
           amount: amount,
           button: {
             label: take_label,
-            variant: :outlined,
+            variant: :filled,
             size: :md,
             icon: Icons::Pill,
+            class: action_button_class,
             testid: "take-dose-#{dose_id}",
-            form_class: nil
+            form_class: 'w-full sm:w-auto'
           }
         )
+      end
+
+      def actionable_status?
+        %i[upcoming available].include?(dose[:status])
       end
 
       def status_icon
         case dose[:status]
         when :taken
-          render Icons::CheckCircle.new(size: 24, class: 'text-on-success-container')
-        when :upcoming
-          render Icons::Pill.new(size: 24, class: 'text-on-primary-container')
-        when :cooldown
-          render Icons::AlertCircle.new(size: 24, class: 'text-on-warning-container')
+          Icons::CheckCircle.new(size: 34)
+        when :cooldown, :max_reached
+          Icons::Clock.new(size: 34)
         when :out_of_stock
-          render Icons::XCircle.new(size: 24, class: 'text-on-error-container')
+          Icons::XCircle.new(size: 34)
         else
-          render Icons::AlertCircle.new(size: 24, class: 'text-on-error-container')
+          Icons::Pill.new(size: 34)
         end
       end
 
       def status_badge
-        variant_map = {
-          taken: :tonal,
-          upcoming: :filled,
-          cooldown: :outlined,
-          out_of_stock: :destructive
-        }
-        m3_variant = variant_map[dose[:status]] || :destructive
+        m3_badge(
+          variant: :tonal,
+          class: "shrink-0 px-3 py-1 text-xs font-black dashboard-dose-status #{status_badge_class}"
+        ) do
+          status_label
+        end
+      end
 
-        label = if dose[:status] == :cooldown && dose[:source].respond_to?(:countdown_display)
-                  "#{t('dashboard.statuses.cooldown')} (#{dose[:source].countdown_display})"
-                else
-                  t("dashboard.statuses.#{dose[:status]}")
-                end
+      def status_badge_class
+        "dashboard-dose-status--#{palette_name}"
+      end
 
-        m3_badge(variant: m3_variant, class: 'px-3 py-1 text-[10px] font-black uppercase tracking-wider') do
-          label
+      def status_label
+        case dose[:status]
+        when :available
+          t('dashboard.statuses.available_now')
+        when :max_reached
+          t('dashboard.statuses.max_reached')
+        when :cooldown
+          cooldown_label
+        else
+          t("dashboard.statuses.#{dose[:status]}")
+        end
+      end
+
+      def cooldown_label
+        if dose[:source].respond_to?(:countdown_display)
+          "#{t('dashboard.statuses.cooldown')} (#{dose[:source].countdown_display})"
+        else
+          t('dashboard.statuses.cooldown')
         end
       end
     end

--- a/app/components/layouts/floating_action_menu.rb
+++ b/app/components/layouts/floating_action_menu.rb
@@ -26,9 +26,7 @@ module Components
           )
 
           div(
-            class: 'fixed bottom-[calc(1.5rem+env(safe-area-inset-bottom))] ' \
-                   'right-[calc(1rem+env(safe-area-inset-right))] ' \
-                   'z-50 flex flex-col items-end gap-3'
+            class: 'mobile-fab-stack fixed z-50 flex flex-col items-end gap-3'
           ) do
             div(
               id: 'floating-action-menu-items',
@@ -82,8 +80,6 @@ module Components
         request_path = view_context.request.path
 
         [
-          root_path,
-          dashboard_path,
           people_path,
           medications_path,
           locations_path,

--- a/app/components/layouts/mobile_rail.rb
+++ b/app/components/layouts/mobile_rail.rb
@@ -10,53 +10,53 @@ module Components
       def view_template
         return unless authenticated?
 
-        aside(
-          class: 'fixed left-0 top-16 bottom-0 z-40 flex w-16 flex-col items-center border-r ' \
-                 'border-outline-variant/50 bg-surface-container-low py-4 md:hidden',
+        nav(
+          class: 'mobile-bottom-nav fixed bottom-[calc(1.5rem+env(safe-area-inset-bottom))] left-0 right-0 z-40 ' \
+                 'mx-auto w-[90%] rounded-shape-xl border border-outline-variant/60 ' \
+                 'bg-surface-container-lowest/95 px-2 py-2 shadow-elevation-3 backdrop-blur md:hidden',
           aria: { label: t('layouts.mobile_rail.primary_navigation') },
-          data: { testid: 'mobile-rail' }
+          data: { testid: 'mobile-bottom-nav' }
         ) do
-          nav(
-            class: 'flex w-full flex-1 flex-col items-center gap-2 px-2',
-            aria: { label: t('layouts.mobile_rail.primary_navigation') }
-          ) do
-            primary_navigation_items.each do |item|
-              render_nav_item(item)
-            end
-          end
-
-          div(
-            class: 'mt-auto flex w-full items-center justify-center px-2 ' \
-                   'pb-[max(1rem,env(safe-area-inset-bottom))] pt-4'
-          ) do
-            render_nav_item(profile_navigation_item)
+          div(class: 'flex justify-between gap-1') do
+            bottom_navigation_items.each { |item| render_nav_item(item) }
           end
         end
       end
 
       private
 
+      def bottom_navigation_items
+        [
+          primary_navigation_items[0],
+          primary_navigation_items[1],
+          primary_navigation_items[5],
+          profile_navigation_item
+        ]
+      end
+
       def render_nav_item(item)
         is_active = active_navigation_path?(item[:path])
 
         link_to(
           item[:path],
-          class: 'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-2xl p-1 no-underline',
+          class: 'flex min-h-[56px] min-w-[80px] flex-col items-center justify-center gap-1 rounded-shape-lg ' \
+                 'px-2 py-1 text-xs font-bold no-underline transition-all',
           aria: {
             label: item[:label],
             current: is_active ? 'page' : nil
           }
         ) do
           div(
-            class: 'flex h-12 w-12 items-center justify-center rounded-2xl transition-all state-layer ' \
+            class: 'flex h-8 min-w-12 items-center justify-center rounded-shape-full px-4 transition-all state-layer ' \
                    "#{if is_active
-                        'bg-secondary-container text-on-secondary-container shadow-sm'
+                        'bg-primary-container text-primary shadow-sm'
                       else
                         'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface'
                       end}"
           ) do
-            render item[:icon].new(size: 24)
+            render item[:icon].new(size: 22)
           end
+          span(class: is_active ? 'text-primary' : 'text-on-surface-variant') { item[:label] }
         end
       end
     end

--- a/app/components/layouts/navigation.rb
+++ b/app/components/layouts/navigation.rb
@@ -55,15 +55,15 @@ module Components
 
       def render_auth_actions
         if authenticated?
-          button(
-            type: 'button',
+          link_to(
+            profile_path(anchor: 'notifications-card'),
             class: 'flex h-11 w-11 items-center justify-center rounded-full text-on-surface-variant ' \
                    'hover:bg-surface-container-high focus-visible:outline-none focus-visible:ring-2 ' \
                    'focus-visible:ring-primary',
-            aria: { label: t('global_search.open'), expanded: 'false', controls: 'global_search_panel' },
-            data: { action: 'global-search#open', global_search_target: 'trigger' }
+            aria: { label: t('layouts.navigation.notifications') }
           ) do
-            render Icons::Search.new(size: 22)
+            render Icons::Bell.new(size: 22)
+            span(class: 'sr-only') { t('layouts.navigation.notifications') }
           end
         end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,6 +8,6 @@ class DashboardController < ApplicationController
       current_user: current_user
     )
 
-    render Components::Dashboard::IndexView.new(presenter: presenter)
+    render Components::Dashboard::IndexView.new(presenter: presenter, filter: params[:filter])
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
     <%= javascript_include_tag "appearance_boot", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "hamburgers", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "dashboard", "data-turbo-track": "reload" %>
     <% if current_user %>
       <%= javascript_importmap_tags %>
     <% else %>
@@ -38,7 +39,7 @@
     <body class="bg-background text-foreground transition-colors duration-300"<% if current_user %> data-controller="global-search"<% end %>>
     <% hide_signed_out_chrome = !current_user && request.path == "/login" %>
     <% main_classes = ["transition-all duration-500"] %>
-    <% main_classes << "ml-16 pb-28 md:ml-64 md:pb-0" if current_user %>
+    <% main_classes << "pb-28 md:ml-64 md:pb-0" if current_user %>
     <%= render Components::Layouts::Sidebar.new(current_user: current_user) %>
     <%= render Components::Layouts::Navigation.new(current_user: current_user) unless hide_signed_out_chrome %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1083,6 +1083,7 @@ cy:
       skip_to_content: "Neidio i'r cynnwys"
       brand: "MedTracker"
       login: "Mewngofnodi"
+      notifications: "Hysbysiadau"
     desktop_nav:
       medications: "Meddyginiaethau"
       people: "Pobl"
@@ -1222,6 +1223,26 @@ cy:
     greeting_evening: "Noswaith dda, %{name}"
     subtitle: "Amserlen meddyginiaeth eich teulu am heddiw."
     todays_schedule: "Amserlen Heddiw"
+    todays_medicines: "Meddyginiaethau heddiw"
+    summary:
+      today_progress: "Heddiw: %{completed} o %{total} wedi'u cwblhau"
+      next_due: "Nesaf erbyn %{time}"
+      no_next_due: "dim heddiw"
+      keep_it_up: "Daliwch ati."
+      all_done: "Popeth wedi'i wneud am heddiw."
+      completed: "Wedi cwblhau"
+      remaining:
+        one: "1 ar ôl"
+        other: "%{count} ar ôl"
+    filters:
+      label: "Hidlyddion meddyginiaeth y dangosfwrdd"
+      all: "Pawb"
+      needs_action: "Angen gweithredu"
+      upcoming: "Ar ddod"
+      taken: "Wedi cymryd"
+    filtered_count:
+      one: "1 dos"
+      other: "%{count} dos"
     as_needed:
       title: "Yn ôl yr angen"
     overdue_alert: "Hwyr: %{medication} ar gyfer %{person} (wedi'i drefnu am %{time})"
@@ -1248,6 +1269,7 @@ cy:
       left_today:
         one: "1 dasg reolaidd ar ôl heddiw"
         other: "%{count} tasg reolaidd ar ôl heddiw"
+    empty_filtered_state: "Dim meddyginiaethau yn cyfateb i'r hidlydd hwn."
     stats:
       people: "Pobl"
       active_schedules: "Presgripsiynau Gweithredol"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1187,6 +1187,7 @@ en:
       skip_to_content: "Skip to content"
       brand: "MedTracker"
       login: "Login"
+      notifications: "Notifications"
     desktop_nav:
       medications: "Medications"
       people: "People"
@@ -1376,6 +1377,26 @@ en:
     greeting_evening: "Good evening, %{name}"
     subtitle: "Your family's medication schedule for today."
     todays_schedule: "Today's Schedule"
+    todays_medicines: "Today’s medicines"
+    summary:
+      today_progress: "Today: %{completed} of %{total} complete"
+      next_due: "Next due %{time}"
+      no_next_due: "none today"
+      keep_it_up: "Keep it up."
+      all_done: "All done for today."
+      completed: "Completed"
+      remaining:
+        one: "1 left"
+        other: "%{count} left"
+    filters:
+      label: "Dashboard medicine filters"
+      all: "All"
+      needs_action: "Needs action"
+      upcoming: "Upcoming"
+      taken: "Taken"
+    filtered_count:
+      one: "1 dose"
+      other: "%{count} doses"
     as_needed:
       title: "As needed"
     overdue_alert: "Overdue: %{medication} for %{person} (scheduled at %{time})"
@@ -1392,6 +1413,7 @@ en:
       left_today:
         one: "1 routine task left today"
         other: "%{count} routine tasks left today"
+    empty_filtered_state: "No medicines match this filter."
     insights:
       title: "Smart Insights"
       pattern_detected: "Pattern detected"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1053,6 +1053,7 @@ es:
       skip_to_content: "Saltar al contenido"
       brand: "MedTracker"
       login: "Iniciar sesión"
+      notifications: "Notificaciones"
     desktop_nav:
       medications: "Medicamentos"
       people: "Personas"
@@ -1194,6 +1195,26 @@ es:
     as_needed:
       title: "Tomar según sea necesario"
     todays_schedule: "Horario de Hoy"
+    todays_medicines: "Medicamentos de hoy"
+    summary:
+      today_progress: "Hoy: %{completed} de %{total} completados"
+      next_due: "Próxima a las %{time}"
+      no_next_due: "ninguna hoy"
+      keep_it_up: "Sigue así."
+      all_done: "Todo listo por hoy."
+      completed: "Completado"
+      remaining:
+        one: "1 restante"
+        other: "%{count} restantes"
+    filters:
+      label: "Filtros de medicamentos del panel"
+      all: "Todos"
+      needs_action: "Necesita acción"
+      upcoming: "Próximos"
+      taken: "Tomados"
+    filtered_count:
+      one: "1 dosis"
+      other: "%{count} dosis"
     medication_schedule: "Horario de Medicamentos"
     no_active_schedules: "No se encontraron prescripciones activas"
     add_schedules_hint: "Agregue prescripciones para verlas aquí"
@@ -1209,6 +1230,7 @@ es:
       left_today:
         one: "1 tarea rutinaria pendiente hoy"
         other: "%{count} tareas rutinarias pendientes hoy"
+    empty_filtered_state: "Ningún medicamento coincide con este filtro."
     insights:
       title: "Información inteligente"
       pattern_detected: "Patrón detectado"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -987,6 +987,7 @@ ga:
       skip_to_content: "Léim go dtí an t-ábhar"
       brand: "MedTracker"
       login: "Logáil isteach"
+      notifications: "Fógraí"
     desktop_nav:
       medications: "Leigheasanna"
       people: "Daoine"
@@ -1159,6 +1160,26 @@ ga:
     greeting_evening: "Oíche mhaith, %{name}"
     subtitle: "Sceideal leigheasanna do theaghlaigh inniu."
     todays_schedule: "Sceideal an Lae Innuit"
+    todays_medicines: "Leigheasanna an lae inniu"
+    summary:
+      today_progress: "Inniu: %{completed} as %{total} críochnaithe"
+      next_due: "An chéad cheann eile %{time}"
+      no_next_due: "níl ceann ar bith inniu"
+      keep_it_up: "Lean ort."
+      all_done: "Gach rud déanta don lá inniu."
+      completed: "Críochnaithe"
+      remaining:
+        one: "1 fágtha"
+        other: "%{count} fágtha"
+    filters:
+      label: "Scagairí leigheasanna an deais"
+      all: "Uile"
+      needs_action: "Gníomh de dhíth"
+      upcoming: "Ag teacht"
+      taken: "Tógtha"
+    filtered_count:
+      one: "1 dáileog"
+      other: "%{count} dáileog"
     medication_schedule: "Sceideal Leigheasanna"
     as_needed:
       title: "Glac de réir mar is gá"
@@ -1176,6 +1197,7 @@ ga:
       left_today:
         one: "1 tasc rialta fágtha inniu"
         other: "%{count} tasc rialta fágtha inniu"
+    empty_filtered_state: "Níl aon leigheas ag teacht leis an scagaire seo."
     insights:
       title: "Léarchéal Cliste"
       pattern_detected: "Patrún aimsithe"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1106,6 +1106,7 @@ pt:
       skip_to_content: "Saltar para o conteúdo"
       brand: "MedTracker"
       login: "Iniciar sessão"
+      notifications: "Notificações"
     desktop_nav:
       medications: "Medicamentos"
       people: "Pessoas"
@@ -1328,6 +1329,26 @@ pt:
     greeting_evening: "Boa noite, %{name}"
     subtitle: "O horário de medicamentos da sua família para hoje."
     todays_schedule: "Horário de Hoje"
+    todays_medicines: "Medicamentos de hoje"
+    summary:
+      today_progress: "Hoje: %{completed} de %{total} concluídos"
+      next_due: "Próxima às %{time}"
+      no_next_due: "nenhuma hoje"
+      keep_it_up: "Continue assim."
+      all_done: "Tudo concluído por hoje."
+      completed: "Concluído"
+      remaining:
+        one: "1 restante"
+        other: "%{count} restantes"
+    filters:
+      label: "Filtros de medicamentos do painel"
+      all: "Todos"
+      needs_action: "Precisa de ação"
+      upcoming: "Próximos"
+      taken: "Tomados"
+    filtered_count:
+      one: "1 dose"
+      other: "%{count} doses"
     as_needed:
       title: "Tomar conforme necessário"
     overdue_alert: "Atrasado: %{medication} para %{person} (agendado às %{time})"
@@ -1345,6 +1366,7 @@ pt:
       left_today:
         one: "1 tarefa de rotina pendente hoje"
         other: "%{count} tarefas de rotina pendentes hoje"
+    empty_filtered_state: "Nenhum medicamento corresponde a este filtro."
     insights:
       title: "Informações inteligentes"
       pattern_detected: "Padrão detetado"

--- a/docs/plans/2026-05-10-mobile-dashboard-redesign.md
+++ b/docs/plans/2026-05-10-mobile-dashboard-redesign.md
@@ -1,0 +1,58 @@
+# Mobile Dashboard Redesign
+
+## Goal
+
+The mobile dashboard should behave like a daily medicine command surface, not an analytics page. The first useful read should answer three questions:
+
+- What medicines are due today?
+- What needs action now?
+- Which button do I tap: Take or Give?
+
+## Visual Direction
+
+Use a clinically polished app feel with clear colour semantics:
+
+- Teal and green remain the brand and successful-completion colours.
+- Blue, purple, amber, teal, and rose are used as medicine/status accents so the list is scannable.
+- Surfaces stay light, spacious, and softly layered, but cards should have deliberate coloured borders, icon wells, and action buttons.
+- Medicine cards are the dominant content. Summary information and filters support the list instead of competing with it.
+
+## Required Mobile Structure
+
+1. Top app bar with menu, MedTracker brand, and notifications only.
+2. Page title/date area for today's medicines.
+3. Compact progress strip showing completed doses, next due time, and a small progress indicator.
+4. Filter chips for All, Needs action, Upcoming, and Taken.
+5. Colour-coded medicine cards with large icon wells, compact metadata, status chips, and a Take/Give action only when needed.
+6. Quiet bottom navigation.
+
+## Filter Behaviour
+
+Filters are important because families often need to switch between the full day and the immediate work queue.
+
+- All: every dose for today.
+- Needs action: doses that still expose a Take/Give action.
+- Upcoming: scheduled future work.
+- Taken: completed doses.
+
+Filters should be URL-addressable so they survive refresh and can be tested without JavaScript.
+
+## Medicine Card Rules
+
+Each card must show:
+
+- Medicine name.
+- Person name, time, and location in compact metadata.
+- Status chip.
+- Take/Give button only when the dose can still be recorded.
+
+The status colour should be obvious before reading the text:
+
+- Taken: green.
+- Needs action / primary upcoming: blue or purple.
+- Child/care-giver action accents may use amber or teal when useful.
+- Blocked states use warning or error colours without showing a primary action.
+
+## Implementation Notes
+
+Implement one stronger default first: a filtered, colour-coded schedule stack inspired by the reference images. Keep a profile experiment option available as a future follow-up if we decide to compare multiple dashboard structures such as time-rail, family-grouped, or dense action-stack layouts.

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -10,29 +10,6 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     described_class.new(presenter: presenter)
   end
 
-  let(:active_schedules_icon_path) do
-    [
-      'M200-640h560v-80H200v80Zm0 0v-80 80Zm0 560q-33 0-56.5-23.5T120-160v-560q0-33 ',
-      '23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v227q-19-9-39-15t-41-9v-43H200v400h252q7 ',
-      '22 16.5 42T491-80H200Zm378.5-18.5Q520-157 520-240t58.5-141.5Q637-440 ',
-      '720-440t141.5 58.5Q920-323 920-240T861.5-98.5Q803-40 ',
-      '720-40T578.5-98.5ZM787-145l28-28-75-75v-112h-40v128l87 87Z'
-    ].join
-  end
-
-  let(:compliance_icon_path) do
-    [
-      'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 ',
-      '90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 ',
-      '800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 ',
-      '840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 ',
-      '56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 ',
-      '56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 ',
-      '0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 ',
-      '118-57 57-120-119q-18 11-38.5 16.5T480-320Z'
-    ].join
-  end
-
   let(:admin_user) { users(:admin) }
   let(:presenter) { DashboardPresenter.new(current_user: admin_user) }
 
@@ -59,62 +36,46 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
-  it 'renders the schedule heading' do
+  it 'renders the medicine list heading' do
     rendered = render_inline(dashboard_view)
-    expect(rendered.text).to include("Today's Schedule")
+    expect(rendered.text).to include('Today’s medicines')
   end
 
-  describe 'stats display' do
-    it 'renders people count' do
-      rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include(presenter.people.count.to_s)
-    end
-
-    it 'renders active schedules count' do
-      rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include(presenter.active_schedules.count.to_s)
-    end
-
-    it 'renders parent-scoped people count including self' do
-      parent_presenter = DashboardPresenter.new(current_user: users(:parent))
-      parent_view = described_class.new(presenter: parent_presenter)
-      expected_count = users(:parent).person.patients.where(person_type: :minor).count + 1
-
-      rendered = render_inline(parent_view)
-
-      expect(rendered.text).to include(expected_count.to_s)
-    end
-
-    it 'links People stat card to people page' do
+  describe 'daily summary' do
+    it 'renders one compact daily summary with progress and next dose copy' do
       rendered = render_inline(dashboard_view)
 
-      expect(rendered.css("a[href='/people']")).to be_present
+      summary = rendered.at_css('[data-testid="dashboard-daily-summary"]')
+
+      expect(summary).to be_present
+      expect(rendered.css('[data-testid="dashboard-daily-summary"]').size).to eq(1)
+      expect(summary.text).to include('Today:')
+      expect(summary.text).to include('complete')
+      expect(summary.text).to include('Next due')
     end
 
-    it 'links Active Schedules stat card to schedules page' do
+    it 'renders the daily summary above the medicine list' do
       rendered = render_inline(dashboard_view)
+      summary = rendered.at_css('[data-testid="dashboard-daily-summary"]')
+      medicine_list = rendered.at_css('[data-testid="dashboard-medicine-list"]')
 
-      expect(rendered.css("a[href='/schedules']")).to be_present
+      expect(rendered.to_html.index(summary.to_html)).to be < rendered.to_html.index(medicine_list.to_html)
     end
 
-    it 'links Compliance stat card to reports page' do
+    it 'does not render the old multi-card analytics grid' do
       rendered = render_inline(dashboard_view)
 
-      expect(rendered.css("a[href='/reports']")).to be_present
+      expect(rendered.text).not_to include('Active Schedules')
+      expect(rendered.text).not_to include('Compliance')
+      expect(rendered.text).not_to include('People')
+      expect(rendered.css('[data-testid="dashboard-stat-grid"]')).to be_empty
     end
 
-    it 'renders the active schedules icon on the active schedules stat card' do
+    it 'does not render inventory or insight panels above the medicine list' do
       rendered = render_inline(dashboard_view)
-      card = rendered.at_css("a[href='/schedules']")
 
-      expect(card.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
-    end
-
-    it 'renders the compliance icon on the compliance stat card' do
-      rendered = render_inline(dashboard_view)
-      card = rendered.at_css("a[href='/reports']")
-
-      expect(card.at_css("path[d='#{compliance_icon_path}']")).to be_present
+      expect(rendered.text).not_to include('Smart Insights')
+      expect(rendered.text).not_to include('Stock Inventory')
     end
   end
 
@@ -130,61 +91,72 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
-  describe 'high-fidelity sections' do
-    it 'renders Smart Insights' do
+  describe 'medicine card stack' do
+    it 'renders dashboard filters with counts' do
       rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include('Smart Insights')
+      filter_strip = rendered.at_css('[data-testid="dashboard-filter-strip"]')
+
+      expect(filter_strip).to be_present
+      expect(filter_strip.text).to include('All', 'Needs action', 'Upcoming', 'Taken')
+      expect(filter_strip.at_css('[aria-current="page"]').text).to include('All')
     end
 
-    it 'renders Stock Inventory' do
-      rendered = render_inline(dashboard_view)
-      expect(rendered.text).to include('Stock Inventory')
+    it 'filters the medicine stack to action-needed doses' do
+      filtered_view = described_class.new(presenter: presenter, filter: 'needs_action')
+      rendered = render_inline(filtered_view)
+      cards = rendered.css('[data-testid^="dashboard-medicine-card-"]')
+      medicine_rows = presenter.doses + presenter.as_needed_by_person.values.flatten
+      action_needed_count = medicine_rows.count { |dose| %i[upcoming available].include?(dose[:status]) }
+      active_filter = rendered.at_css('[data-testid="dashboard-filter-strip"] [aria-current="page"]')
+
+      expect(cards.size).to eq(action_needed_count)
+      expect(active_filter.text).to include('Needs action')
     end
 
-    it 'does not render a duplicate Next Dose card in the right rail' do
+    it 'renders medicine cards with compact metadata' do
       rendered = render_inline(dashboard_view)
+      cards = rendered.css('[data-testid^="dashboard-medicine-card-"]')
 
-      expect(rendered.at_css('[data-testid="dashboard-right-rail-next-dose"]')).not_to be_present
+      expect(cards).not_to be_empty
+      expect(cards.first.text).to match(/.+ · .+ · Home/)
     end
 
-    it 'does not render a duplicate Medication Schedule section in the right rail' do
-      rendered = render_inline(dashboard_view)
-
-      expect(rendered.css('h2').map(&:text)).not_to include('Medication Schedule')
-    end
-
-    it 'renders the mobile content flow with inventory before insights' do
+    it 'renders the mobile flow as summary before medicines' do
       rendered = render_inline(dashboard_view)
       html = rendered.to_html
 
-      expect(html.index('Stock Inventory')).to be < html.index('Smart Insights')
+      expect(html.index('dashboard-daily-summary')).to be < html.index('dashboard-medicine-list')
     end
   end
 
-  describe 'person task cards' do
-    it 'renders a routine task card with a collapsed as-needed disclosure' do
+  describe 'as-needed medicine rows' do
+    it 'renders routine and as-needed medicines as redesigned cards' do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
-      details = rendered.at_css('details[data-testid="dashboard-as-needed-person"]')
 
       expect(rendered.text).to include('Vitamin D')
-      expect(details).to be_present
-      expect(details['open']).to be_nil
+      expect(rendered.text).to include('Paracetamol')
+      expect(rendered.css('[data-testid^="dashboard-medicine-card-"]').size).to eq(2)
+      expect(rendered.at_css('[data-status="available"]')).to be_present
     end
 
-    it 'renders as-needed availability inside the disclosure' do
+    it 'renders as-needed availability as an actionable card' do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
-      details = rendered.at_css('details[data-testid="dashboard-as-needed-person"]')
+      available_card = rendered.at_css('[data-status="available"]')
 
-      expect(details.text).to include('As needed')
-      expect(details.text).to include('Paracetamol')
-      expect(details.text).to include('Available now')
+      expect(available_card.text).to include('Paracetamol')
+      expect(available_card.text).to include('Available now')
+      expect(available_card.text).to include('Give')
     end
 
-    it 'counts blocked routine rows as remaining tasks' do
+    it 'renders blocked routine rows without an action button' do
       rendered = render_inline(described_class.new(presenter: person_task_presenter(routine_status: :out_of_stock)))
+      blocked_card = rendered.css('[data-testid^="dashboard-medicine-card-"]').find do |card|
+        card.text.include?('Vitamin D')
+      end
 
-      expect(rendered.text).to include('1 routine task left today')
-      expect(rendered.text).not_to include('Routine tasks done today')
+      expect(blocked_card.text).to include('Vitamin D')
+      expect(blocked_card.text).to include('Out of Stock')
+      expect(blocked_card.text).not_to include('Give')
     end
   end
 
@@ -205,13 +177,9 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     person = people(:john)
     instance_double(
       DashboardPresenter,
-      people: [person],
-      active_schedules: [],
       current_user: admin_user,
-      compliance_percentage: 85,
+      doses: [routine_dashboard_row(person, status: routine_status)],
       next_dose_time: nil,
-      routine_tasks_due?: true,
-      routine_tasks_by_person: { person => [routine_dashboard_row(person, status: routine_status)] },
       as_needed_by_person: { person => [as_needed_dashboard_row(person)] }
     )
   end

--- a/spec/components/dashboard/timeline_item_spec.rb
+++ b/spec/components/dashboard/timeline_item_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
     rendered = render_inline(component)
 
     expect(rendered.to_html).to include('Taken')
-    expect(rendered.to_html).to include('Taken at')
+    expect(rendered.text).to include("Jane Doe · #{Time.current.strftime('%l:%M %p').strip} · Home")
   end
 
   it 'shows only the person name for upcoming doses' do
@@ -49,6 +49,23 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
 
     expect(rendered.to_html).to include('Jane Doe')
     expect(rendered.to_html).not_to include('Jane Doe • Taken at')
+  end
+
+  it 'renders compact person, time, and location metadata' do
+    component = described_class.new(dose: dose)
+    rendered = render_inline(component)
+
+    expect(rendered.text).to include("Jane Doe · #{Time.current.strftime('%l:%M %p').strip} · Home")
+  end
+
+  it 'renders a coloured medicine icon well for visual scanning' do
+    rendered = render_inline(described_class.new(dose: dose))
+
+    icon_well = rendered.at_css('[data-testid="dashboard-medicine-icon"]')
+
+    expect(icon_well).to be_present
+    expect(icon_well['data-palette']).to be_present
+    expect(rendered.at_css('[data-status="upcoming"]')).to be_present
   end
 
   describe 'cooldown badge' do

--- a/spec/components/layouts/floating_action_menu_spec.rb
+++ b/spec/components/layouts/floating_action_menu_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Components::Layouts::FloatingActionMenu, type: :component do
   end
 
   it 'renders quick actions on allowed pages' do
-    rendered = render_menu(user: carer_user, path: Rails.application.routes.url_helpers.root_path)
+    rendered = render_menu(user: carer_user, path: Rails.application.routes.url_helpers.medications_path)
 
     expect(rendered.css('button[aria-label="Open quick actions"]')).to be_present
     expect(rendered.text).to include('Add Medication', 'Add Person')
@@ -41,8 +41,6 @@ RSpec.describe Components::Layouts::FloatingActionMenu, type: :component do
 
   it 'renders on each allowed index page' do
     allowed_paths = [
-      Rails.application.routes.url_helpers.root_path,
-      Rails.application.routes.url_helpers.dashboard_path,
       Rails.application.routes.url_helpers.people_path,
       Rails.application.routes.url_helpers.medications_path,
       Rails.application.routes.url_helpers.locations_path,
@@ -64,6 +62,8 @@ RSpec.describe Components::Layouts::FloatingActionMenu, type: :component do
 
   it 'hides the menu on forms, workflow, profile, and admin pages' do
     hidden_paths = [
+      Rails.application.routes.url_helpers.root_path,
+      Rails.application.routes.url_helpers.dashboard_path,
       Rails.application.routes.url_helpers.profile_path,
       Rails.application.routes.url_helpers.admin_root_path,
       Rails.application.routes.url_helpers.new_person_path,
@@ -79,8 +79,8 @@ RSpec.describe Components::Layouts::FloatingActionMenu, type: :component do
   end
 
   it 'renders policy-permitted quick actions only' do
-    carer_rendered = render_menu(user: carer_user, path: Rails.application.routes.url_helpers.root_path)
-    admin_rendered = render_menu(user: admin_user, path: Rails.application.routes.url_helpers.root_path)
+    carer_rendered = render_menu(user: carer_user, path: Rails.application.routes.url_helpers.medications_path)
+    admin_rendered = render_menu(user: admin_user, path: Rails.application.routes.url_helpers.medications_path)
 
     expect(carer_rendered.text).to include('Add Medication', 'Add Person')
     expect(carer_rendered.text).not_to include('Add Location')

--- a/spec/components/layouts/mobile_rail_spec.rb
+++ b/spec/components/layouts/mobile_rail_spec.rb
@@ -16,13 +16,16 @@ RSpec.describe Components::Layouts::MobileRail, type: :component do
     Nokogiri::HTML::DocumentFragment.parse(html)
   end
 
-  it 'renders icon-only navigation with aria labels and no logout action' do
+  it 'renders a quiet bottom navigation with aria labels and no logout action' do
     rendered = render_rail(user: admin_user)
 
-    expect(rendered.css('aside[data-testid="mobile-rail"]')).to be_present
-    expect(rendered.css('a[aria-label="Dashboard"]')).to be_present
-    expect(rendered.css('a[aria-label="Inventory"]')).to be_present
-    expect(rendered.css('a[aria-label="Profile"]')).to be_present
+    expect(rendered.css('nav[data-testid="mobile-bottom-nav"]')).to be_present
+    expect(rendered.css('a[aria-label]').pluck('aria-label')).to contain_exactly(
+      'Dashboard',
+      'Inventory',
+      'Reports',
+      'Profile'
+    )
     expect(rendered.css('button[aria-label="Sign Out"]')).to be_empty
   end
 

--- a/spec/components/layouts/navigation_spec.rb
+++ b/spec/components/layouts/navigation_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Components::Layouts::Navigation, type: :component do
+  fixtures :accounts, :people, :users
+
   describe 'i18n translations' do
     it 'renders navigation with default locale translations' do
       component = described_class.new(current_user: nil)
@@ -22,6 +24,20 @@ RSpec.describe Components::Layouts::Navigation, type: :component do
       rendered = render_inline(component)
 
       expect(rendered.to_html).to include('nav__brand-link text-foreground')
+    end
+  end
+
+  describe 'authenticated mobile actions' do
+    it 'renders notification bell instead of the search trigger' do
+      rendered = render_inline(described_class.new(current_user: users(:admin)))
+
+      notifications_link = rendered.at_css("a[aria-label='Notifications']")
+
+      expect(rendered.css('button[data-action="global-search#open"]')).to be_empty
+      expect(rendered.css('.nav__right svg.lucide-search')).to be_empty
+      expect(notifications_link).to be_present
+      expect(notifications_link['href']).to eq('/profile#notifications-card')
+      expect(notifications_link.at_css('svg.lucide-bell')).to be_present
     end
   end
 end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'Dashboard' do
       visit dashboard_path
 
       expect(page).to have_text('Good morning')
-      expect(page).to have_text("Today's Schedule")
+      expect(page).to have_text('Today’s medicines')
       expect(page).to have_text('Ibuprofen')
       expect(page).to have_text('Jane Doe')
       expect(page).to have_text('Child Patient')
 
-      button = first('[data-testid^="take-dose-"]')
+      button = first('[data-testid^="take-dose-"]', text: I18n.t('person_medications.card.take'))
 
       expect do
         button.click

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -64,18 +64,21 @@ RSpec.describe 'Global search command palette' do
     expect(page).to have_current_path(medication_path(medications(:vitamin_d)))
 
     expect(page).to have_css('button[aria-label="Open global search"]')
-    find('button[aria-label="Open global search"]').send_keys([:control, 'k'])
+    find('body').send_keys([:control, 'k'])
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     find_by_id('global_search_query').send_keys(:escape)
     expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
   end
 
-  scenario 'opens from the mobile trigger' do
+  scenario 'opens from the mobile keyboard shortcut without a top-bar trigger' do
     page.current_window.resize_to(375, 667)
     visit root_path
 
-    find('button[aria-label="Open global search"]').click
+    expect(page).to have_css('button[aria-label="Open menu"]')
+    expect(page).to have_no_css('header button[aria-label="Open global search"]')
+
+    find('body').send_keys([:control, 'k'])
 
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
     expect(page.evaluate_script('document.activeElement.id')).to eq('global_search_query')

--- a/spec/system/mobile_navigation_spec.rb
+++ b/spec/system/mobile_navigation_spec.rb
@@ -21,35 +21,15 @@ RSpec.describe 'Mobile Navigation' do
             bounds.height > 0
         }
 
-        const rail = document.querySelector('[data-testid="mobile-rail"]')
-        const sidebar = Array.from(document.querySelectorAll('aside')).find((element) => element !== rail)
+        const bottomNav = document.querySelector('[data-testid="mobile-bottom-nav"]')
+        const sidebar = document.querySelector('aside')
 
         return {
-          rail: visible(rail),
+          bottom_nav: visible(bottomNav),
           sidebar: visible(sidebar),
           header: visible(document.querySelector('header')),
           fab: visible(document.querySelector('[data-testid="floating-action-menu-toggle"]'))
         }
-      })()
-    JS
-  end
-  let(:mobile_metric_label_overflow_script) do
-    <<~JS
-      (() => {
-        const expectedLabels = ['People', 'Compliance', 'Next Dose']
-        const labels = Array.from(document.querySelectorAll('#main-content p'))
-
-        return expectedLabels.map((text) => {
-          const label = labels.find((element) => element.textContent.trim() === text)
-
-          return {
-            text,
-            found: Boolean(label),
-            clientWidth: label ? label.clientWidth : 0,
-            scrollWidth: label ? label.scrollWidth : 0,
-            overflows: !label || label.scrollWidth > label.clientWidth + 1
-          }
-        })
       })()
     JS
   end
@@ -63,12 +43,12 @@ RSpec.describe 'Mobile Navigation' do
     visit root_path
 
     expect(page).to have_css('button[aria-label="Open menu"]')
-    expect(page).to have_css('aside[data-testid="mobile-rail"]')
+    expect(page).to have_css('nav[data-testid="mobile-bottom-nav"]')
     expect(page).to have_css(%(a[aria-label="Dashboard"][aria-current="page"]))
     expect(page).to have_css(%(a[aria-label="Inventory"][href="#{medications_path}"]))
-    expect(page).to have_css(%(a[aria-label="Locations"][href="#{locations_path}"]))
     expect(page).to have_css(%(a[aria-label="Reports"][href="#{reports_path}"]))
     expect(page).to have_css(%(a[aria-label="Profile"][href="#{profile_path}"]))
+    expect(page).to have_no_css(%(a[aria-label="Locations"][href="#{locations_path}"]))
     expect(page).to have_no_css('nav.mobile-nav')
   end
 
@@ -84,29 +64,44 @@ RSpec.describe 'Mobile Navigation' do
     visit root_path
 
     expect(navigation_visibility).to include(
-      'rail' => true,
+      'bottom_nav' => true,
       'sidebar' => false,
       'header' => true,
-      'fab' => true
+      'fab' => false
     )
 
     page.current_window.resize_to(768, 844)
 
     expect(navigation_visibility).to include(
-      'rail' => false,
+      'bottom_nav' => false,
       'sidebar' => true,
       'header' => false,
       'fab' => false
     )
   end
 
-  scenario 'keeps core mobile dashboard metric labels readable beside the rail' do
+  scenario 'keeps the medicine-first dashboard readable above the bottom navigation' do
     page.current_window.resize_to(390, 844)
     visit dashboard_path
 
-    overflowing_labels = mobile_metric_label_overflow.select { |label| label['overflows'] }
+    expect(page).to have_css('[data-testid="dashboard-daily-summary"]')
+    expect(page).to have_css('[data-testid="dashboard-medicine-list"]')
+    expect(page).to have_text('Today:')
+    expect(page).to have_text('Today’s medicines')
+    expect(page).to have_no_text('Compliance')
+    expect(page).to have_no_text('Next Dose')
+    expect(page).to have_no_css('button[aria-label="Open quick actions"]')
 
-    expect(overflowing_labels).to be_empty
+    main_left = page.evaluate_script('document.querySelector("main").getBoundingClientRect().left')
+    expect(main_left).to eq(0)
+
+    nav_top = page.evaluate_script(
+      'document.querySelector("[data-testid=\"mobile-bottom-nav\"]").getBoundingClientRect().top'
+    )
+    summary_bottom = page.evaluate_script(
+      'document.querySelector("[data-testid=\"dashboard-daily-summary\"]").getBoundingClientRect().bottom'
+    )
+    expect(summary_bottom).to be < nav_top
   end
 
   scenario 'opens a left-side drawer with navigation and accessible sizing' do
@@ -170,7 +165,7 @@ RSpec.describe 'Mobile Navigation' do
 
   scenario 'opens and closes the floating action menu and launches the medication workflow' do
     page.current_window.resize_to(375, 667)
-    visit root_path
+    visit medications_path
 
     expect(page).to have_css('button[aria-label="Open quick actions"]')
 
@@ -196,9 +191,5 @@ RSpec.describe 'Mobile Navigation' do
 
   def navigation_visibility
     page.evaluate_script(navigation_visibility_script)
-  end
-
-  def mobile_metric_label_overflow
-    page.evaluate_script(mobile_metric_label_overflow_script)
   end
 end


### PR DESCRIPTION
## Summary
- Replaces the mobile dashboard analytics grid with a compact daily summary, filters, and a medicine-first card stack.
- Redesigns medicine cards with palette/icon treatment, compact metadata, and action-only Take/Give buttons.
- Removes mobile dashboard search chrome, quiets bottom navigation, and preserves routine/as-needed medicine rows in the new stack.
- Adds a concrete mobile dashboard redesign brief for follow-up variants and design direction.

## Verification
- task rubocop
- task test (2221 examples, 0 failures, 2 pending)