### PR TITLE
test: remove unlock request double disable

### DIFF
--- a/spec/components/views/rodauth/unlock_account_request_spec.rb
+++ b/spec/components/views/rodauth/unlock_account_request_spec.rb
@@ -3,10 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Views::Rodauth::UnlockAccountRequest, type: :component do
-  # rubocop:disable RSpec/VerifiedDoubles
+  let(:rodauth_class) do
+    Struct.new(
+      :unlock_account_request_path,
+      :unlock_account_request_button,
+      :unlock_account_request_explanatory_text,
+      :unlock_account_request_additional_form_tags,
+      :login_param,
+      :login_path,
+      :reset_password_request_path,
+      keyword_init: true
+    )
+  end
+
   let(:rodauth) do
-    double(
-      'Rodauth',
+    rodauth_class.new(
       unlock_account_request_path: '/unlock-account-request',
       unlock_account_request_button: 'Request Account Unlock',
       unlock_account_request_explanatory_text: '<p>This account is currently locked out.</p>',
@@ -16,7 +27,6 @@ RSpec.describe Views::Rodauth::UnlockAccountRequest, type: :component do
       reset_password_request_path: '/reset-password-request'
     )
   end
-  # rubocop:enable RSpec/VerifiedDoubles
 
   before do
     allow(controller).to receive_messages(rodauth: rodauth, form_authenticity_token: 'token', flash: {}, params: {})


### PR DESCRIPTION
## What changed

- Replaced the unverified Rodauth double in `spec/components/views/rodauth/unlock_account_request_spec.rb` with a concrete `Struct` fake.
- Removed the now-unneeded `RSpec/VerifiedDoubles` RuboCop suppression from that spec.

## Why this improves maintainability/readability

The spec now names the exact Rodauth reader methods the component consumes, instead of hiding a generic double behind a lint suppression.

## How behavior was preserved

The fake returns the same path, button, explanatory text, login, and reset-password values as before, and the existing render assertions still cover the generated form and text.

## Verification commands run

- `task rubocop` after removing the suppression, to confirm the red signal: one `RSpec/VerifiedDoubles` offense.
- `task test TEST_FILE=spec/components/views/rodauth/unlock_account_request_spec.rb`
- `task rubocop`
- `task test`
- After rebasing on updated `origin/main`: `task test TEST_FILE=spec/components/views/rodauth/unlock_account_request_spec.rb`, `task rubocop`, and `task test`