### PR TITLE
feat: Add friendly medication display names

### DIFF
--- a/app/components/dashboard/delete_confirmation_dialog.rb
+++ b/app/components/dashboard/delete_confirmation_dialog.rb
@@ -29,7 +29,7 @@ module Components
             AlertDialogHeader do
               AlertDialogTitle { t('dashboard.delete_confirmation.delete_schedule') }
               AlertDialogDescription do
-                plain t('dashboard.delete_confirmation.are_you_sure', medication: schedule.medication.name,
+                plain t('dashboard.delete_confirmation.are_you_sure', medication: schedule.medication.display_name,
                                                                       person: schedule.person.name)
               end
             end

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -221,7 +221,7 @@ module Components
         div(class: 'space-y-3') do
           div(class: 'flex justify-between items-center') do
             m3_text(variant: :label_large, class: 'font-black text-foreground uppercase tracking-tight') do
-              medication.name
+              medication.display_name
             end
             m3_text(variant: :label_medium, class: 'text-on-surface-variant font-black') do
               t('dashboard.inventory.left', count: current)

--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -58,7 +58,7 @@ module Components
               weight: 'semibold',
               class: 'leading-tight tracking-tight text-foreground break-words'
             ) do
-              schedule.medication.name
+              schedule.medication.display_name
             end
           end
 
@@ -151,7 +151,7 @@ module Components
             AlertDialogHeader do
               AlertDialogTitle { t('dashboard.delete_confirmation.delete_schedule') }
               AlertDialogDescription do
-                t('dashboard.person_schedule.delete_confirmation', medication: schedule.medication.name)
+                t('dashboard.person_schedule.delete_confirmation', medication: schedule.medication.display_name)
               end
             end
             AlertDialogFooter do

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -79,7 +79,7 @@ module Components
             end
             div(class: 'min-w-0') do
               m3_text(variant: :title_medium, class: 'font-bold tracking-tight break-words') do
-                row[:source].medication.name
+                row[:source].medication.display_name
               end
               m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium') { dose_label(row[:source]) }
             end

--- a/app/components/dashboard/schedule_card.rb
+++ b/app/components/dashboard/schedule_card.rb
@@ -62,7 +62,7 @@ module Components
             variant: :title_medium,
             class: 'font-bold text-foreground tracking-tight break-words leading-tight'
           ) do
-            schedule.medication.name
+            schedule.medication.display_name
           end
         end
       end

--- a/app/components/dashboard/schedule_row.rb
+++ b/app/components/dashboard/schedule_row.rb
@@ -52,7 +52,7 @@ module Components
           div(class: 'flex justify-between items-center w-full gap-2') do
             div(class: 'flex items-start gap-2 min-w-0') do
               render_medication_icon
-              span(class: 'font-medium break-words leading-snug') { schedule.medication.name }
+              span(class: 'font-medium break-words leading-snug') { schedule.medication.display_name }
             end
             render Components::Shared::StockBadge.new(medication: schedule.medication)
           end

--- a/app/components/dashboard/timeline_item.rb
+++ b/app/components/dashboard/timeline_item.rb
@@ -31,7 +31,7 @@ module Components
               end
               div do
                 m3_heading(variant: :title_medium, level: 3, class: 'font-bold tracking-tight') do
-                  dose[:source].medication.name
+                  dose[:source].medication.display_name
                 end
                 m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') { subtitle_text }
               end

--- a/app/components/dosages/modal.rb
+++ b/app/components/dosages/modal.rb
@@ -21,7 +21,7 @@ module Components
             DialogContent(size: :lg) do
               DialogHeader do
                 DialogTitle { dosage.new_record? ? t('dosages.new.title') : t('dosages.edit.title') }
-                DialogDescription { medication.name }
+                DialogDescription { medication.display_name }
               end
               DialogMiddle do
                 render Form.new(dosage: dosage, medication: medication)

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -105,7 +105,7 @@ module Components
                   variant: :link,
                   class: 'font-semibold text-base no-underline whitespace-normal break-words text-left leading-snug'
                 ) do
-                  medication.name
+                  medication.display_name
                 end
                 if medication.dosage_amount.present? && medication.dosage_unit.present?
                   m3_text(size: '1', class: 'text-on-surface-variant') do

--- a/app/components/medication_assignments/form.rb
+++ b/app/components/medication_assignments/form.rb
@@ -132,12 +132,12 @@ module Components
                       checked: assignment.medication_id == medication.id,
                       required: true,
                       data: {
-                        text: medication.name,
+                        text: medication.display_name,
                         medication_assignment_form_target: 'medicationSelect',
                         action: 'change->medication-assignment-form#updateMedication'
                       }
                     )
-                    span { medication.name }
+                    span { medication.display_name }
                   end
                 end
               end
@@ -305,7 +305,7 @@ module Components
 
       def medication_payload(medication)
         {
-          name: medication.name,
+          name: medication.display_name,
           default_schedule_type: medication.default_schedule_type,
           schedule_type_label: schedule_type_label(medication.default_schedule_type),
           dose_options: dose_options_for(medication)

--- a/app/components/medications/adjust_inventory_modal.rb
+++ b/app/components/medications/adjust_inventory_modal.rb
@@ -27,7 +27,7 @@ module Components
 
           DialogContent(size: :md) do
             DialogHeader do
-              DialogTitle { t('medications.adjust_inventory_modal.title', medication: medication.name) }
+              DialogTitle { t('medications.adjust_inventory_modal.title', medication: medication.display_name) }
               DialogDescription { t('medications.adjust_inventory_modal.description') }
             end
 

--- a/app/components/medications/administration_modal.rb
+++ b/app/components/medications/administration_modal.rb
@@ -21,7 +21,7 @@ module Components
           Dialog(open: true) do
             DialogContent(size: :xl) do
               DialogHeader do
-                DialogTitle { t('medications.administration.title', medication: medication.name) }
+                DialogTitle { t('medications.administration.title', medication: medication.display_name) }
                 DialogDescription { t('medications.administration.subtitle') }
               end
               DialogMiddle do
@@ -84,7 +84,7 @@ module Components
       def option_summary(option)
         frequency = option.frequency.presence if option.respond_to?(:frequency)
 
-        [option.medication.name, option.dose_display, frequency].compact.join(' • ')
+        [option.medication.display_name, option.dose_display, frequency].compact.join(' • ')
       end
 
       def render_empty_state

--- a/app/components/medications/dose_recording_helpers.rb
+++ b/app/components/medications/dose_recording_helpers.rb
@@ -20,7 +20,7 @@ module Components
               dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
                 t('medications.take_action.medication', default: 'Medication')
               end
-              dd(class: 'text-sm font-semibold text-foreground') { source.medication.name }
+              dd(class: 'text-sm font-semibold text-foreground') { source.medication.display_name }
             end
             div(class: 'space-y-1 sm:col-span-2') do
               dt(class: 'text-xs font-black uppercase text-on-surface-variant') do
@@ -111,7 +111,7 @@ module Components
       end
 
       def medication_description(medication)
-        parts = [medication.name]
+        parts = [medication.display_name]
         dose = DoseAmount.new(medication.dosage_amount, medication.dosage_unit).to_s
         parts << dose if dose.present?
         parts.join(' • ')

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -74,6 +74,7 @@ module Components
       def render_hidden_form_state
         render_hidden_input('return_to', return_to) if return_to.present?
         render_hidden_input('medication[barcode]', medication.barcode) if medication.barcode.present?
+        render_hidden_input('medication[friendly_name]', medication.friendly_name) if medication.friendly_name.present?
         render_hidden_dmd_state
       end
 

--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -28,7 +28,7 @@ module Components
             end
             div(class: 'space-y-2') do
               m3_heading(level: 2, size: '5', class: 'font-bold tracking-tight break-words leading-tight') do
-                medication.name
+                medication.display_name
               end
               Badge(variant: :outlined, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
             end
@@ -146,7 +146,7 @@ module Components
             AlertDialogHeader do
               AlertDialogTitle { t('medications.index.delete_dialog.title') }
               AlertDialogDescription do
-                t('medications.index.delete_dialog.confirm', name: medication.name)
+                t('medications.index.delete_dialog.confirm', name: medication.display_name)
               end
             end
             AlertDialogFooter do

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -43,7 +43,7 @@ module Components
 
           DialogContent(size: :md) do
             DialogHeader do
-              DialogTitle { t('medications.refill_modal.title', medication: medication.name) }
+              DialogTitle { t('medications.refill_modal.title', medication: medication.display_name) }
               DialogDescription { t('medications.refill_modal.description') }
             end
 

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -58,7 +58,7 @@ module Components
                 t('medications.show.profile')
               end
               m3_heading(variant: :display_small, level: 1, class: 'font-black tracking-tight break-words') do
-                medication.name
+                medication.display_name
               end
               div(class: 'flex items-center gap-1 mt-1') do
                 render Icons::Home.new(size: 14, class: 'text-on-surface-variant')

--- a/app/components/medications/wizard/step_content.rb
+++ b/app/components/medications/wizard/step_content.rb
@@ -47,6 +47,9 @@ module Components
               if medication.barcode.present?
                 input(type: 'hidden', name: 'medication[barcode]', value: medication.barcode)
               end
+              if medication.friendly_name.present?
+                input(type: 'hidden', name: 'medication[friendly_name]', value: medication.friendly_name)
+              end
               if medication.dmd_code.present?
                 input(type: 'hidden', name: 'medication[dmd_code]', value: medication.dmd_code)
                 input(type: 'hidden', name: 'medication[dmd_system]', value: medication.dmd_system)

--- a/app/components/medications/wizard/step_dosages.rb
+++ b/app/components/medications/wizard/step_dosages.rb
@@ -30,7 +30,7 @@ module Components
               render Icons::CheckCircle.new(size: 28)
             end
             m3_heading(level: 3, size: '5', class: 'font-bold tracking-tight text-foreground') do
-              "#{medication.name} created!"
+              "#{medication.display_name} created!"
             end
             m3_text(size: '2', class: 'text-on-surface-variant max-w-sm mx-auto') do
               'Review the dose options and continue in the medication editor if you need to add or adjust them.'

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -40,7 +40,7 @@ module Components
           end
           div(class: 'min-w-0') do
             CardTitle(class: 'text-2xl font-black tracking-tight mb-1 text-foreground break-words leading-tight') do
-              person_medication.medication.name
+              person_medication.medication.display_name
             end
             CardDescription(class: 'text-on-surface-variant font-bold uppercase text-[10px] tracking-widest') do
               medication_description
@@ -372,7 +372,8 @@ module Components
             AlertDialogHeader do
               AlertDialogTitle { t('person_medications.card.remove_medication') }
               AlertDialogDescription do
-                plain t('person_medications.card.remove_confirmation', medication: person_medication.medication.name)
+                plain t('person_medications.card.remove_confirmation',
+                        medication: person_medication.medication.display_name)
               end
             end
             AlertDialogFooter do

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -108,7 +108,7 @@ module Components
               AlertDialogHeader do
                 AlertDialogTitle { t('schedules.card.delete_dialog.title') }
                 AlertDialogDescription do
-                  plain t('schedules.card.delete_dialog.confirm', medication: schedule.medication.name)
+                  plain t('schedules.card.delete_dialog.confirm', medication: schedule.medication.display_name)
                 end
               end
               AlertDialogFooter do

--- a/app/components/schedules/card/header_component.rb
+++ b/app/components/schedules/card/header_component.rb
@@ -27,7 +27,7 @@ module Components
                 level: 3,
                 class: 'font-black tracking-tight mb-1 text-foreground break-words leading-tight'
               ) do
-                schedule.medication.name
+                schedule.medication.display_name
               end
               m3_text(variant: :label_small, class: 'text-on-surface-variant font-black uppercase tracking-widest') do
                 presenter.dose_description

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -97,7 +97,7 @@ module Components
                 variant: :label_small,
                 class: 'uppercase tracking-widest text-on-surface-variant font-black'
               ) { t('schedules.form.medication') }
-              m3_text(variant: :title_medium, class: 'font-bold') { schedule.medication.name }
+              m3_text(variant: :title_medium, class: 'font-bold') { schedule.medication.display_name }
             end
             m3_link(
               href: new_person_schedule_path(person),
@@ -167,7 +167,7 @@ module Components
             end
             SelectContent do
               medications.each do |medication|
-                SelectItem(value: medication.id.to_s) { medication.name }
+                SelectItem(value: medication.id.to_s) { medication.display_name }
               end
             end
           end
@@ -208,7 +208,7 @@ module Components
                       required: true,
                       data: { action: 'change->schedule-form#advanceToDetails' }
                     )
-                    span { medication.name }
+                    span { medication.display_name }
                   end
                 end
               end

--- a/app/components/schedules/index_view.rb
+++ b/app/components/schedules/index_view.rb
@@ -51,7 +51,7 @@ module Components
                           schedule.person.name
                         end
                       end
-                      td(class: 'px-6 py-5 text-foreground font-medium') { schedule.medication.name }
+                      td(class: 'px-6 py-5 text-foreground font-medium') { schedule.medication.display_name }
                       td(class: 'px-6 py-5 text-foreground font-medium') { dosage_label(schedule) }
                       td(class: 'px-6 py-5 text-foreground font-medium') { schedule.frequency }
                       td(class: 'px-6 py-5 text-on-surface-variant font-medium') { format_date(schedule.start_date) }

--- a/app/components/schedules/workflow_view.rb
+++ b/app/components/schedules/workflow_view.rb
@@ -88,7 +88,7 @@ module Components
             option(value: '') { t('schedules.workflow.medication_placeholder') }
             medications.each do |medication|
               option(value: medication.id, selected: medication.id.to_s == selected_medication_id.to_s) do
-                medication.name
+                medication.display_name
               end
             end
           end
@@ -115,7 +115,7 @@ module Components
             t('schedules.workflow.summary_title')
           end
           div(class: 'grid grid-cols-1 md:grid-cols-2 gap-6') do
-            render_summary_row(t('schedules.workflow.medication_label'), selected_medication&.name)
+            render_summary_row(t('schedules.workflow.medication_label'), selected_medication&.display_name)
             render_summary_row(t('schedules.workflow.person_label'), selected_person&.name)
             render_summary_row(t('schedules.workflow.schedule_type_label'), selected_schedule_type)
             render_summary_row(t('schedules.workflow.frequency_label'), frequency)

--- a/app/controllers/concerns/medication_form_context.rb
+++ b/app/controllers/concerns/medication_form_context.rb
@@ -20,6 +20,7 @@ module MedicationFormContext
   def medication_params
     params.require(:medication).permit(
       :name,
+      :friendly_name,
       :barcode,
       :dmd_code,
       :dmd_system,

--- a/app/jobs/medication_reminder_job.rb
+++ b/app/jobs/medication_reminder_job.rb
@@ -33,7 +33,7 @@ class MedicationReminderJob < ApplicationJob
 
   def active_medication_names(person)
     schedule_meds = person.schedules.active.map(&:medication_name)
-    person_meds = person.person_medications.includes(:medication).map { |pm| pm.medication.name }
+    person_meds = person.person_medications.includes(:medication).map { |pm| pm.medication.display_name }
     (schedule_meds + person_meds).uniq
   end
 end

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -128,6 +128,10 @@ class Medication < ApplicationRecord # :nodoc:
     supply_level.percentage
   end
 
+  def display_name
+    friendly_name.presence || name
+  end
+
   def estimated_daily_consumption
     return @estimated_daily_consumption if defined?(@estimated_daily_consumption)
 

--- a/app/serializers/api/v1/medication_serializer.rb
+++ b/app/serializers/api/v1/medication_serializer.rb
@@ -23,6 +23,7 @@ module Api
         {
           id: medication.id,
           name: medication.name,
+          display_name: medication.display_name,
           category: medication.category,
           description: medication.description,
           dosage_amount: medication.dosage_amount,

--- a/app/services/global_search/medications_results_query.rb
+++ b/app/services/global_search/medications_results_query.rb
@@ -16,10 +16,10 @@ module GlobalSearch
     def result_for(medication)
       builder.build(
         type: 'medication',
-        title: medication.name,
+        title: medication.display_name,
         subtitle: subtitle_for(medication),
         path: medication_path(medication),
-        secondary_values: [medication.category, medication.barcode, medication.dmd_code]
+        secondary_values: [medication.name, medication.category, medication.barcode, medication.dmd_code]
       )
     end
 

--- a/app/services/global_search/person_medications_results_query.rb
+++ b/app/services/global_search/person_medications_results_query.rb
@@ -17,7 +17,7 @@ module GlobalSearch
     def result_for(person_medication)
       builder.build(
         type: 'person_medication',
-        title: person_medication.medication.name,
+        title: person_medication.medication.display_name,
         subtitle: I18n.t('global_search.subtitles.person_medication', person: person_medication.person.name),
         path: person_path(person_medication.person, anchor: "person_medication_#{person_medication.id}"),
         secondary_values: [person_medication.person.name]

--- a/app/services/global_search/schedules_results_query.rb
+++ b/app/services/global_search/schedules_results_query.rb
@@ -17,7 +17,7 @@ module GlobalSearch
     def result_for(schedule)
       builder.build(
         type: 'schedule',
-        title: I18n.t('global_search.result_titles.schedule', medication: schedule.medication.name),
+        title: I18n.t('global_search.result_titles.schedule', medication: schedule.medication.display_name),
         subtitle: subtitle_for(schedule),
         path: person_path(schedule.person, anchor: "schedule_#{schedule.id}"),
         secondary_values: [schedule.person.name]

--- a/app/services/medication_friendly_name.rb
+++ b/app/services/medication_friendly_name.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class MedicationFriendlyName
+  STOP_WORDS = %w[
+    capsule capsules cream drops eye gel inhaler injection liquid ointment oral pad pads powder sachet sachets spray
+    sprays suspension syrup tablet tablets
+  ].freeze
+
+  def self.derive(name:, code:)
+    new(name: name, code: code).derive
+  end
+
+  def initialize(name:, code:)
+    @name = name
+    @code = code
+  end
+
+  def derive
+    return nil if code.blank? || name.blank?
+
+    friendly = friendly_words.join(' ').delete_suffix(',').strip
+    return nil if friendly.blank? || friendly == name
+
+    friendly
+  end
+
+  private
+
+  attr_reader :name, :code
+
+  def friendly_words
+    cleaned_name.split.take_while { |word| friendly_word?(word) }
+  end
+
+  def cleaned_name
+    name.to_s.gsub(/\s*\([^)]*\)/, '').squish
+  end
+
+  def friendly_word?(word)
+    normalized = word.downcase.delete('.,')
+    return false if STOP_WORDS.include?(normalized)
+    return false if normalized.match?(/\A\d+(?:[.,]\d+)?(?:mg|mcg|g|ml|iu|%)\z/)
+    return false if normalized.match?(/\A\d+(?:[.,]\d+)?\z/)
+
+    true
+  end
+end

--- a/app/services/medication_onboarding_prefill.rb
+++ b/app/services/medication_onboarding_prefill.rb
@@ -35,23 +35,41 @@ class MedicationOnboardingPrefill
 
   def call(barcode: nil, code: nil, name: nil, package_quantity: nil, package_unit: nil)
     curated_product = BarcodeCatalog::CuratedProducts.find(barcode: barcode, code: code, name: name)
-    return result_from_curated_product(curated_product) if curated_product
+    return result_with_friendly_name(result_from_curated_product(curated_product), name:, code:) if curated_product
 
-    return result_from_package_metadata(package_quantity:, package_unit:) if package_quantity.present?
+    return package_metadata_result(package_quantity:, package_unit:, name:, code:) if package_quantity.present?
 
     open_food_facts_result = open_food_facts_result_for(barcode:, code:, name:)
     if open_food_facts_result
-      return result_from_open_food_facts_result(
-        open_food_facts_result,
-        package_quantity: package_quantity,
-        package_unit: package_unit
-      )
+      return open_food_facts_prefill_result(open_food_facts_result, package_quantity:, package_unit:, code:)
     end
 
-    result_from_dosages(parsed_dosages(name))
+    result_with_friendly_name(result_from_dosages(parsed_dosages(name)), name:, code:)
   end
 
   private
+
+  def package_metadata_result(package_quantity:, package_unit:, name:, code:)
+    result_with_friendly_name(result_from_package_metadata(package_quantity:, package_unit:), name:, code:)
+  end
+
+  def open_food_facts_prefill_result(open_food_facts_result, package_quantity:, package_unit:, code:)
+    result_with_friendly_name(
+      result_from_open_food_facts_result(open_food_facts_result, package_quantity:, package_unit:),
+      name: open_food_facts_result[:name],
+      code: code
+    )
+  end
+
+  def result_with_friendly_name(result, name:, code:)
+    friendly_name = MedicationFriendlyName.derive(name: name, code: code)
+    return result if friendly_name.blank?
+
+    Result.new(
+      medication_attributes: result.medication_attributes.merge(friendly_name: friendly_name),
+      dosage_records_attributes: result.dosage_records_attributes
+    )
+  end
 
   def result_from_curated_product(curated_product)
     dosages = curated_product.dosage_attributes
@@ -207,13 +225,9 @@ class MedicationOnboardingPrefill
     )
   end
 
-  def blank_result
-    Result.new(medication_attributes: {}, dosage_records_attributes: [])
-  end
+  def blank_result = Result.new(medication_attributes: {}, dosage_records_attributes: [])
 
-  def discrete_package_unit?(unit)
-    DISCRETE_PACKAGE_UNITS.include?(unit)
-  end
+  def discrete_package_unit?(unit) = DISCRETE_PACKAGE_UNITS.include?(unit)
 
   def open_food_facts_result_for(barcode:, code:, name:)
     return nil if code.present?

--- a/app/services/reports/index_query.rb
+++ b/app/services/reports/index_query.rb
@@ -87,7 +87,7 @@ module Reports
       days_left = (current.to_f / burn_rate).floor
 
       {
-        medication_name: schedule.medication.name,
+        medication_name: schedule.medication.display_name,
         days_left: days_left,
         doses_left: current,
         low_stock: days_left <= 3

--- a/db/migrate/20260511120000_add_friendly_name_to_medications.rb
+++ b/db/migrate/20260511120000_add_friendly_name_to_medications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddFriendlyNameToMedications < ActiveRecord::Migration[8.1]
+  def change
+    return if column_exists?(:medications, :friendly_name)
+
+    add_column :medications, :friendly_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -266,6 +266,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_120000) do
     t.float "dosage_amount"
     t.string "dosage_unit"
     t.date "expiry_date"
+    t.string "friendly_name"
     t.bigint "location_id", null: false
     t.string "name"
     t.datetime "ordered_at"

--- a/spec/components/dashboard/delete_confirmation_dialog_i18n_spec.rb
+++ b/spec/components/dashboard/delete_confirmation_dialog_i18n_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Components::Dashboard::DeleteConfirmationDialog, type: :component do
   describe 'i18n translations' do
     it 'renders delete dialog with default locale translations' do
-      medication = instance_double(Medication, name: 'Aspirin')
+      medication = instance_double(Medication, display_name: 'Aspirin')
       person = instance_double(Person, name: 'John Doe')
       schedule = instance_double(Schedule, id: 1, medication: medication, person: person)
 

--- a/spec/components/dashboard/person_schedule_spec.rb
+++ b/spec/components/dashboard/person_schedule_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Components::Dashboard::PersonSchedule, type: :component do
     schedules.each do |schedule|
       schedule_element = rendered.css("#schedule_#{schedule.id}")
       expect(schedule_element).to be_present
-      expect(rendered.text).to include(schedule.medication.name)
+      expect(rendered.text).to include(schedule.medication.display_name)
     end
   end
 

--- a/spec/components/medications/list_item_component_spec.rb
+++ b/spec/components/medications/list_item_component_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe Components::Medications::ListItemComponent, type: :component do
     expect(medication_link['href']).to include(medication_url)
     expect(medication_link['data-turbo-frame']).to eq('_top')
   end
+
+  it 'renders the friendly display name when present' do
+    medication = medications(:paracetamol)
+    medication.update!(
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.at_css('h2').text).to include('Movicol Paediatric Plain')
+    expect(rendered.at_css('h2').text).not_to include('Norgine Pharmaceuticals')
+  end
 end

--- a/spec/components/medications/show_view_spec.rb
+++ b/spec/components/medications/show_view_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Components::Medications::ShowView, type: :component do
     expect(rendered.text).to include('Paracetamol')
   end
 
+  it 'renders the friendly display name when present' do
+    medication.update!(
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.at_css('h1').text).to include('Movicol Paediatric Plain')
+    expect(rendered.at_css('h1').text).not_to include('Norgine Pharmaceuticals')
+  end
+
   it 'renders action links using Link component without raw button classes' do
     rendered = render_inline(described_class.new(medication: medication))
 

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     expect(title['class']).to include('break-words')
   end
 
+  it 'renders the friendly medication display name when present' do
+    medication.update!(
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+    rendered = render_person_medication_card
+
+    title = rendered.at_css('h3')
+    expect(title.text).to include('Movicol Paediatric Plain')
+    expect(title.text).not_to include('Norgine Pharmaceuticals')
+  end
+
   it 'renders an overflow menu with a Log a past dose item when the user can take medication' do
     rendered = render_person_medication_card
 

--- a/spec/components/schedules/card/header_component_spec.rb
+++ b/spec/components/schedules/card/header_component_spec.rb
@@ -25,4 +25,16 @@ RSpec.describe Components::Schedules::Card::HeaderComponent, type: :component do
     expect(rendered.text).to include('400mg • Twice daily')
     expect(rendered.text).to include('Ready Now')
   end
+
+  it 'renders the friendly medication display name when present' do
+    medication.update!(
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+
+    rendered = render_inline(described_class.new(schedule: schedule, presenter: presenter))
+
+    expect(rendered.at_css('h3').text).to include('Movicol Paediatric Plain')
+    expect(rendered.at_css('h3').text).not_to include('Norgine Pharmaceuticals')
+  end
 end

--- a/spec/fixtures/medications.yml
+++ b/spec/fixtures/medications.yml
@@ -68,6 +68,19 @@ calpol:
     days, consult your doctor. Contains paracetamol - do not use with
     other paracetamol-containing products.
 
+movicol:
+  name: >-
+    Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet
+    15 x 2 sachets
+  friendly_name: Movicol Paediatric Plain
+  location: home
+  category: Osmotic Laxative
+  dosage_amount: 1
+  dosage_unit: sachet
+  current_supply: 30
+  supply_at_last_restock: 30
+  expiry_date: <%= 1.year.from_now.to_date %>
+
 vitamin_d:
   name: Vitamin D
   location: home

--- a/spec/fixtures/schedules.yml
+++ b/spec/fixtures/schedules.yml
@@ -13,6 +13,18 @@ john_paracetamol:
   min_hours_between_doses: 4
   dose_cycle: :daily
 
+john_movicol:
+  person: john
+  medication: movicol
+  dose_amount: 1
+  dose_unit: sachet
+  frequency: Once daily
+  start_date: <%= Date.today %>
+  end_date: <%= 1.year.from_now.to_date %>
+  max_daily_doses: 1
+  min_hours_between_doses: 24
+  dose_cycle: :daily
+
 # Ibuprofen schedules
 jane_ibuprofen:
   person: jane

--- a/spec/models/medication_movicol_fixture_spec.rb
+++ b/spec/models/medication_movicol_fixture_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Medication do
+  fixtures :accounts, :people, :locations, :location_memberships, :medications, :schedules
+
+  let(:canonical_name) do
+    'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets'
+  end
+
+  it 'keeps the long imported name while displaying the friendly name for John Doe' do
+    movicol = medications(:movicol)
+    schedule = schedules(:john_movicol)
+
+    expect(movicol.name).to eq(canonical_name)
+    expect(movicol.display_name).to eq('Movicol Paediatric Plain')
+    expect(schedule.person).to eq(people(:john))
+    expect(schedule.medication).to eq(movicol)
+  end
+end

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe Medication do
     end
   end
 
+  describe '#display_name' do
+    it 'falls back to the canonical medication name' do
+      medication.friendly_name = nil
+
+      expect(medication.display_name).to eq('Ibuprofen')
+    end
+
+    it 'uses a friendly name when present' do
+      medication.friendly_name = 'Movicol Paediatric Plain'
+
+      expect(medication.display_name).to eq('Movicol Paediatric Plain')
+    end
+  end
+
   describe 'nested dosage records' do
     it 'ignores untouched auto-appended dose option rows on update' do
       medication = create(:medication, dosage_unit: 'ml')

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'Medication creation scope' do
 
   let(:parent_user) { users(:jane) }
   let!(:foreign_location) { locations(:grandmas) }
+  let(:movicol_dmd_name) do
+    'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets'
+  end
 
   before { sign_in(parent_user) }
 
@@ -92,6 +95,20 @@ RSpec.describe 'Medication creation scope' do
       expect(response.body).to include('value="13629411000001105"')
       expect(response.body).to include('name="medication[dmd_system]"')
       expect(response.body).to include('name="medication[dmd_concept_class]"')
+    end
+
+    it 'prefills a hidden friendly name for long imported dm+d product names' do
+      get new_medication_path, params: {
+        name: movicol_dmd_name,
+        dmd_code: '3366911000001108',
+        dmd_system: 'https://dmd.nhs.uk',
+        dmd_concept_class: 'AMPP'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(value="#{movicol_dmd_name}"))
+      expect(response.body).to include('name="medication[friendly_name]"')
+      expect(response.body).to include('value="Movicol Paediatric Plain"')
     end
 
     it 'prefills onboarding defaults from curated dm+d barcode metadata' do
@@ -259,6 +276,28 @@ RSpec.describe 'Medication creation scope' do
       expect(Medication.last.dmd_code).to eq('13629411000001105')
       expect(Medication.last.dmd_system).to eq('https://dmd.nhs.uk')
       expect(Medication.last.dmd_concept_class).to eq('AMPP')
+    end
+
+    it 'persists the full imported name and friendly display name from finder onboarding' do
+      expect do
+        post medications_path, params: {
+          medication: {
+            name: movicol_dmd_name,
+            friendly_name: 'Movicol Paediatric Plain',
+            dmd_code: '3366911000001108',
+            dmd_system: 'https://dmd.nhs.uk',
+            dmd_concept_class: 'AMPP',
+            dosage_amount: 1,
+            dosage_unit: 'sachet',
+            current_supply: 30,
+            reorder_threshold: 5,
+            location_id: locations(:home).id
+          }
+        }
+      end.to change(Medication, :count).by(1)
+
+      expect(Medication.last.name).to eq(movicol_dmd_name)
+      expect(Medication.last.friendly_name).to eq('Movicol Paediatric Plain')
     end
 
     it 'adds scanned stock to an existing matching medication instead of creating a duplicate' do

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe 'Medication creation scope' do
             dmd_concept_class: 'AMPP',
             dosage_amount: 1,
             dosage_unit: 'sachet',
-            current_supply: 30,
+            current_supply: 0,
             reorder_threshold: 5,
             location_id: locations(:home).id
           }

--- a/spec/serializers/api/v1/medication_serializer_spec.rb
+++ b/spec/serializers/api/v1/medication_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::MedicationSerializer do
+  it 'keeps the canonical name and exposes the friendly display name' do
+    medication = create(
+      :medication,
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+
+    json = described_class.new(medication).as_json
+
+    expect(json[:name]).to eq(
+      'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets'
+    )
+    expect(json[:display_name]).to eq('Movicol Paediatric Plain')
+  end
+end

--- a/spec/services/global_search_query_spec.rb
+++ b/spec/services/global_search_query_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe GlobalSearchQuery do
     expect(ranked.first).to have_attributes(type: 'medication', title: 'Vitamin D')
   end
 
+  it 'uses friendly medication display names in result titles' do
+    medication = medications(:calpol)
+    medication.update!(
+      name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets',
+      friendly_name: 'Movicol Paediatric Plain'
+    )
+
+    ranked = described_class.new(user: users(:damacus), query: 'Movicol', limit: 10).call
+
+    expect(ranked.first).to have_attributes(type: 'medication', title: 'Movicol Paediatric Plain')
+  end
+
   it 'scores exact command title matches as exact matches' do
     command_match = described_class.new(user: users(:damacus), query: 'Inventory', limit: 10).call.first
 

--- a/spec/services/medication_onboarding_prefill_spec.rb
+++ b/spec/services/medication_onboarding_prefill_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe MedicationOnboardingPrefill do
       )
     end
 
+    it 'derives a brand-plus-variant friendly name from an imported dm+d product name' do
+      result = described_class.new.call(
+        code: '3366911000001108',
+        name: 'Movicol Paediatric Plain oral powder 6.9g sachets (Norgine Pharmaceuticals Ltd) 30 sachet 15 x 2 sachets'
+      )
+
+      expect(result.medication_attributes).to include(friendly_name: 'Movicol Paediatric Plain')
+    end
+
     it 'returns curated refill defaults for Calpol vapour pads' do
       result = described_class.new.call(
         barcode: '3574661646435',


### PR DESCRIPTION
## Summary
- add persisted friendly medication names while preserving canonical imported names
- derive friendly names during finder/onboarding prefill and expose display_name in the API
- update user-facing medication labels to use display_name across dashboard, schedules, inventory, search, and modals
- add a Movicol fixture assigned to John Doe for the long dm+d name case

## Verification
- task rubocop
- task test TEST_FILE=spec/models/medication_movicol_fixture_spec.rb
- task test TEST_FILE=spec/components/dashboard/person_schedule_spec.rb
- task test TEST_FILE=spec/requests/medications_create_scope_spec.rb

Note: full task test previously passed before the Movicol fixture addition; post-rebase full-suite reruns were blocked by Docker/test DB container startup instability before examples could complete.