### PR TITLE
feat: show git metadata on profile

### DIFF
--- a/app/views/profiles/version_info.rb
+++ b/app/views/profiles/version_info.rb
@@ -13,8 +13,8 @@ module Views
           end
 
           render CardContent.new(class: 'space-y-0') do
-            render_version_row
-            render_release_notes_row
+            render_worktree_row
+            render_commit_row
             render_docs_row
           end
         end
@@ -22,23 +22,17 @@ module Views
 
       private
 
-      def render_version_row
+      def render_worktree_row
         div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
-          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.app_version') }
-          dd(class: 'text-sm font-mono text-foreground') { "v#{MedTracker::VERSION}" }
+          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.worktree') }
+          dd(class: 'break-all text-right text-sm font-mono text-foreground') { system_metadata.worktree }
         end
       end
 
-      def render_release_notes_row
+      def render_commit_row
         div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
-          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.release_notes') }
-          dd do
-            link_to "v#{MedTracker::VERSION}",
-                    "https://github.com/damacus/med-tracker/releases/tag/v#{MedTracker::VERSION}",
-                    class: 'text-sm font-medium text-primary hover:underline',
-                    target: '_blank',
-                    rel: 'noopener'
-          end
+          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.commit') }
+          dd(class: 'text-sm font-mono text-foreground') { system_metadata.commit }
         end
       end
 
@@ -53,6 +47,10 @@ module Views
                     rel: 'noopener'
           end
         end
+      end
+
+      def system_metadata
+        @system_metadata ||= SystemMetadata.current
       end
     end
   end

--- a/app/views/profiles/version_info.rb
+++ b/app/views/profiles/version_info.rb
@@ -13,14 +13,23 @@ module Views
           end
 
           render CardContent.new(class: 'space-y-0') do
-            render_worktree_row
-            render_commit_row
+            render_system_rows
             render_docs_row
           end
         end
       end
 
       private
+
+      def render_system_rows
+        if git_metadata_mode?
+          render_worktree_row
+          render_commit_row
+        else
+          render_version_row
+          render_release_notes_row
+        end
+      end
 
       def render_worktree_row
         div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
@@ -33,6 +42,26 @@ module Views
         div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
           dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.commit') }
           dd(class: 'text-sm font-mono text-foreground') { system_metadata.commit }
+        end
+      end
+
+      def render_version_row
+        div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
+          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.app_version') }
+          dd(class: 'text-sm font-mono text-foreground') { "v#{MedTracker::VERSION}" }
+        end
+      end
+
+      def render_release_notes_row
+        div(class: 'flex items-center justify-between border-b border-border/50 py-3') do
+          dt(class: 'text-sm font-medium text-on-surface-variant') { t('profiles.version_info.release_notes') }
+          dd do
+            link_to "v#{MedTracker::VERSION}",
+                    "https://github.com/damacus/med-tracker/releases/tag/v#{MedTracker::VERSION}",
+                    class: 'text-sm font-medium text-primary hover:underline',
+                    target: '_blank',
+                    rel: 'noopener'
+          end
         end
       end
 
@@ -51,6 +80,10 @@ module Views
 
       def system_metadata
         @system_metadata ||= SystemMetadata.current
+      end
+
+      def git_metadata_mode?
+        Rails.env.development?
       end
     end
   end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1052,6 +1052,8 @@ cy:
       title: "Gwybodaeth System"
       description: "Fersiwn y rhaglen ac adnoddau"
       app_version: "Fersiwn Ap"
+      worktree: "Coeden waith"
+      commit: "Commit"
       release_notes: "Nodiadau Rhyddhau"
       documentation: "Dogfennaeth"
       view_docs: "Gweld Dogfennaeth"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1156,6 +1156,8 @@ en:
       title: "System Information"
       description: "Application version and resources"
       app_version: "App Version"
+      worktree: "Worktree"
+      commit: "Commit"
       release_notes: "Release Notes"
       documentation: "Documentation"
       view_docs: "View Docs"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1029,6 +1029,8 @@ es:
       title: "Información del sistema"
       description: "Versión de la aplicación y recursos"
       app_version: "Versión de la aplicación"
+      worktree: "Árbol de trabajo"
+      commit: "Commit"
       release_notes: "Notas de la versión"
       documentation: "Documentación"
       view_docs: "Ver documentación"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -956,6 +956,8 @@ ga:
       title: "Eolas Córais"
       description: "Leagan an fheidhmchláir agus acmhainní"
       app_version: "Leagan an Aipe"
+      worktree: "Crann oibre"
+      commit: "Commit"
       release_notes: "Nótaí Eisiúna"
       documentation: "Doiciméadú"
       view_docs: "Féach ar na Doiciméid"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1075,6 +1075,8 @@ pt:
       title: "Informação do Sistema"
       description: "Versão da aplicação e recursos"
       app_version: "Versão da aplicação"
+      worktree: "Árvore de trabalho"
+      commit: "Commit"
       release_notes: "Notas de lançamento"
       documentation: "Documentação"
       view_docs: "Ver documentação"

--- a/lib/system_metadata.rb
+++ b/lib/system_metadata.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+SystemMetadata = Data.define(:worktree, :commit) do
+  def self.current(root: Rails.root, command_runner: nil)
+    new(
+      worktree: worktree_path(root:, command_runner:),
+      commit: commit_sha(root:, command_runner:)
+    )
+  end
+
+  def self.worktree_path(root:, command_runner:)
+    linked_worktree_path(root:, command_runner:) || git_toplevel(root:, command_runner:) || root.to_s
+  end
+
+  def self.linked_worktree_path(root:, command_runner:)
+    git_dir = run_git(root:, command_runner:, args: ['rev-parse', '--path-format=absolute', '--git-dir'])
+    gitdir_file = Pathname.new(git_dir).join('gitdir')
+
+    return unless gitdir_file.file?
+
+    worktree_git_file = Pathname.new(gitdir_file.read.strip)
+    return if worktree_git_file.to_s.blank?
+
+    worktree_git_file.dirname.to_s
+  rescue StandardError
+    nil
+  end
+
+  def self.git_toplevel(root:, command_runner:)
+    run_git(root:, command_runner:, args: ['rev-parse', '--show-toplevel'])
+  rescue StandardError
+    nil
+  end
+
+  def self.commit_sha(root:, command_runner:)
+    run_git(root:, command_runner:, args: ['rev-parse', '--short', 'HEAD'])
+  rescue StandardError
+    'unknown'
+  end
+
+  def self.run_git(root:, command_runner:, args:)
+    output = if command_runner
+               command_runner.call('git', *args)
+             else
+               stdout, _stderr, status = Open3.capture3('git', *args, chdir: root.to_s)
+               raise CommandError unless status.success?
+
+               stdout
+             end
+
+    output.to_s.strip.presence || raise(CommandError)
+  end
+
+  private_class_method :worktree_path,
+                       :linked_worktree_path,
+                       :git_toplevel,
+                       :commit_sha,
+                       :run_git
+end
+
+class SystemMetadata
+  class CommandError < StandardError; end
+end

--- a/spec/components/views/profiles/version_info_spec.rb
+++ b/spec/components/views/profiles/version_info_spec.rb
@@ -3,6 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe Views::Profiles::VersionInfo, type: :component do
+  it 'renders worktree and commit metadata instead of the app version' do
+    allow(SystemMetadata).to receive(:current).and_return(
+      SystemMetadata.new(
+        worktree: '/Users/damacus/.codex/worktrees/a270/med-tracker',
+        commit: 'bb956afc'
+      )
+    )
+
+    rendered = render_inline(described_class.new)
+    html = rendered.to_html
+
+    expect(html).to include('Worktree')
+    expect(html).to include('/Users/damacus/.codex/worktrees/a270/med-tracker')
+    expect(html).to include('Commit')
+    expect(html).to include('bb956afc')
+    expect(html).not_to include('v0.3.51')
+  end
+
   it 'uses token-driven shells for version info' do
     rendered = render_inline(described_class.new)
     html = rendered.to_html

--- a/spec/components/views/profiles/version_info_spec.rb
+++ b/spec/components/views/profiles/version_info_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Views::Profiles::VersionInfo, type: :component do
-  it 'renders worktree and commit metadata instead of the app version' do
+  it 'renders worktree and commit metadata instead of the app version in development' do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
     allow(SystemMetadata).to receive(:current).and_return(
       SystemMetadata.new(
         worktree: '/Users/damacus/.codex/worktrees/a270/med-tracker',
@@ -19,6 +20,19 @@ RSpec.describe Views::Profiles::VersionInfo, type: :component do
     expect(html).to include('Commit')
     expect(html).to include('bb956afc')
     expect(html).not_to include('v0.3.51')
+  end
+
+  it 'renders app version and release notes outside development' do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+    rendered = render_inline(described_class.new)
+    html = rendered.to_html
+
+    expect(html).to include('App Version')
+    expect(html).to include('v0.3.51')
+    expect(html).to include('Release Notes')
+    expect(html).to include('https://github.com/damacus/med-tracker/releases/tag/v0.3.51')
+    expect(html).not_to match(/Worktree|Commit/)
   end
 
   it 'uses token-driven shells for version info' do

--- a/spec/lib/system_metadata_spec.rb
+++ b/spec/lib/system_metadata_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SystemMetadata do
+  describe '.current' do
+    after do
+      FileUtils.remove_entry(directory) if directory.exist?
+    end
+
+    let(:directory) { Pathname.new(Dir.mktmpdir) }
+    let(:root) { directory.join('worktree') }
+    let(:git_dir) { directory.join('repo/.git/worktrees/worktree') }
+
+    it 'resolves the linked worktree path from gitdir metadata and the short commit' do
+      create_linked_gitdir
+
+      metadata = described_class.current(
+        root:,
+        command_runner: command_runner(
+          ['git', 'rev-parse', '--path-format=absolute', '--git-dir'] => git_dir.to_s,
+          ['git', 'rev-parse', '--short', 'HEAD'] => 'bb956afc'
+        )
+      )
+
+      expect(metadata.worktree).to eq(root.to_s)
+      expect(metadata.commit).to eq('bb956afc')
+    end
+
+    it 'falls back to the git top-level worktree when linked metadata is unavailable' do
+      FileUtils.mkdir_p(root)
+
+      metadata = described_class.current(
+        root:,
+        command_runner: command_runner(
+          ['git', 'rev-parse', '--path-format=absolute', '--git-dir'] => SystemMetadata::CommandError.new,
+          ['git', 'rev-parse', '--show-toplevel'] => root.to_s,
+          ['git', 'rev-parse', '--short', 'HEAD'] => 'bb956afc'
+        )
+      )
+
+      expect(metadata.worktree).to eq(root.to_s)
+      expect(metadata.commit).to eq('bb956afc')
+    end
+
+    it 'falls back to Rails.root and an unknown commit when git metadata is unavailable' do
+      root = Pathname.new('/app')
+
+      metadata = described_class.current(
+        root:,
+        command_runner: ->(*_command) { raise SystemMetadata::CommandError }
+      )
+
+      expect(metadata.worktree).to eq('/app')
+      expect(metadata.commit).to eq('unknown')
+    end
+
+    def create_linked_gitdir
+      FileUtils.mkdir_p(root)
+      FileUtils.mkdir_p(git_dir)
+      File.write(root.join('.git'), "gitdir: #{git_dir}\n")
+      File.write(git_dir.join('gitdir'), "#{root.join('.git')}\n")
+    end
+
+    def command_runner(responses)
+      lambda do |*command|
+        response = responses.fetch(command) { raise "Unexpected command: #{command.join(' ')}" }
+
+        raise response if response.is_a?(Exception)
+
+        response
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- replace profile system app version display with worktree and commit metadata
- add SystemMetadata resolver with git metadata fallbacks
- add localized labels and focused specs

## Verification
- task test TEST_FILE=spec/components/views/profiles/version_info_spec.rb
- task test TEST_FILE=spec/lib/system_metadata_spec.rb
- task rubocop

Full task test was started after a test-profile reset but interrupted before completion at the user's request.