### PR TITLE
feat: add material medication icons

### DIFF
--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -125,7 +125,7 @@ module Components
             label: t('dashboard.person_schedule.take_now'),
             variant: :text,
             size: :sm,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             class: 'text-primary hover:underline font-medium p-0 h-auto',
             testid: "take-medication-#{schedule.id}",
             form_class: 'inline-block'

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -102,7 +102,7 @@ module Components
             label: take_label,
             variant: row[:status] == :available ? :outlined : :filled,
             size: :md,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             testid: "take-dose-#{dose_id(row[:source])}",
             form_class: nil
           }

--- a/app/components/dashboard/schedule_card.rb
+++ b/app/components/dashboard/schedule_card.rb
@@ -116,7 +116,7 @@ module Components
             label: t('dashboard.person_schedule.take_now'),
             variant: :tonal,
             size: :md,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             class: 'inline-flex rounded-xl font-bold shadow-sm',
             testid: "take-medication-#{schedule.id}",
             form_class: 'inline-block'

--- a/app/components/dashboard/schedule_row.rb
+++ b/app/components/dashboard/schedule_row.rb
@@ -86,7 +86,7 @@ module Components
             label: t('dashboard.person_schedule.take_now'),
             variant: :success_outline,
             size: :sm,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             class: 'inline-block',
             testid: "take-medication-#{schedule.id}",
             form_class: 'inline-block'

--- a/app/components/dashboard/timeline_item.rb
+++ b/app/components/dashboard/timeline_item.rb
@@ -99,7 +99,7 @@ module Components
             label: take_label,
             variant: :outlined,
             size: :md,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             testid: "take-dose-#{dose_id}",
             form_class: nil
           }

--- a/app/components/icons/hand_package.rb
+++ b/app/components/icons/hand_package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class HandPackage < MaterialSymbolBase
+      def view_template
+        svg(**attrs) do |s|
+          s.path(d: 'M600-800H360v280h240v-280Zm200 0H680v280h120v-280ZM575-440H320v240h222q21 0 40.5-7t35.5-21l166-137q-8-8-18-12t-21-6q-17-3-33 1t-30 15l-108 87H400v-80h146l44-36q5-3 7.5-8t2.5-11q0-10-7.5-17.5T575-440Zm-335 0h-80v280h80v-280Zm40 0v-360q0-33 23.5-56.5T360-880h440q33 0 56.5 23.5T880-800v280q0 33-23.5 56.5T800-440H280ZM240-80h-80q-33 0-56.5-23.5T80-160v-280q0-33 23.5-56.5T160-520h415q85 0 164 29t127 98l27 41-223 186q-27 23-60 34.5T542-120H309q-11 18-29 29t-40 11Z')
+        end
+      end
+    end
+  end
+end

--- a/app/components/icons/inventory.rb
+++ b/app/components/icons/inventory.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class Inventory < MaterialSymbolBase
+      def view_template
+        svg(**attrs) do |s|
+          s.path(d: 'M620-163 450-333l56-56 114 114 226-226 56 56-282 282Zm220-397h-80v-200h-80v120H280v-120h-80v560h240v80H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h167q11-35 43-57.5t70-22.5q40 0 71.5 22.5T594-840h166q33 0 56.5 23.5T840-760v200ZM480-760q17 0 28.5-11.5T520-800q0-17-11.5-28.5T480-840q-17 0-28.5 11.5T440-800q0 17 11.5 28.5T480-760Z')
+        end
+      end
+    end
+  end
+end

--- a/app/components/icons/material_symbol_base.rb
+++ b/app/components/icons/material_symbol_base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class MaterialSymbolBase < Base
+      private
+
+      def default_attrs
+        {
+          xmlns: 'http://www.w3.org/2000/svg',
+          width: size.to_s,
+          height: size.to_s,
+          viewBox: '0 -960 960 960',
+          fill: 'currentColor',
+          class: "material-symbol material-symbol-#{self.class.name.demodulize.underscore.dasherize}"
+        }
+      end
+    end
+  end
+end

--- a/app/components/icons/medication.rb
+++ b/app/components/icons/medication.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Components
+  module Icons
+    class Medication < MaterialSymbolBase
+      def view_template
+        svg(**attrs) do |s|
+          s.path(d: 'M420-260h120v-100h100v-120H540v-100H420v100H320v120h100v100ZM280-120q-33 0-56.5-23.5T200-200v-440q0-33 23.5-56.5T280-720h400q33 0 56.5 23.5T760-640v440q0 33-23.5 56.5T680-120H280Zm0-80h400v-440H280v440Zm-40-560v-80h480v80H240Zm40 120v440-440Z')
+        end
+      end
+    end
+  end
+end

--- a/app/components/layouts/navigation_items.rb
+++ b/app/components/layouts/navigation_items.rb
@@ -8,7 +8,7 @@ module Components
       def primary_navigation_items
         [
           navigation_item(t('layouts.sidebar.dashboard'), root_path, Icons::Home),
-          navigation_item(t('layouts.sidebar.inventory'), medications_path, Icons::Pill),
+          navigation_item(t('layouts.sidebar.inventory'), medications_path, Icons::Inventory),
           navigation_item(t('layouts.sidebar.locations'), locations_path, Icons::Home),
           navigation_item(t('layouts.sidebar.people'), people_path, Icons::Users),
           navigation_item(t('layouts.sidebar.finder'), medication_finder_path, Icons::Search),

--- a/app/components/medications/administration_modal.rb
+++ b/app/components/medications/administration_modal.rb
@@ -67,7 +67,7 @@ module Components
                 label: t('medications.show.log_administration'),
                 variant: :filled,
                 size: :lg,
-                icon: Icons::Pill,
+                icon: Icons::HandPackage,
                 class: 'w-full rounded-full lg:w-auto',
                 testid: "log-administration-#{option.class.name.underscore}-#{option.id}",
                 form_class: 'w-full lg:w-auto'

--- a/app/components/medications/index_view.rb
+++ b/app/components/medications/index_view.rb
@@ -48,7 +48,7 @@ module Components
               class: 'w-20 h-20 rounded-shape-xl bg-primary/10 flex items-center justify-center ' \
                      'text-primary shadow-inner'
             ) do
-              render Icons::Pill.new(size: 32)
+              render Icons::Inventory.new(size: 32)
             end
             div(class: 'space-y-1') do
               m3_text(size: '2', weight: 'bold',

--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -22,15 +22,14 @@ module Components
                  'group overflow-hidden'
         ) do
           CardHeader(class: 'pb-4 pt-8 px-8') do
-            div(class: 'flex justify-between items-start mb-4') do
+            div(class: 'flex items-start gap-3 min-w-0') do
               render_medication_icon
-              render_status_badge
-            end
-            div(class: 'space-y-2') do
-              m3_heading(level: 2, size: '5', class: 'font-bold tracking-tight break-words leading-tight') do
-                medication.display_name
+              div(class: 'min-w-0 space-y-2') do
+                m3_heading(level: 2, size: '5', class: 'font-bold tracking-tight break-words leading-tight') do
+                  medication.display_name
+                end
+                Badge(variant: :outlined, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
               end
-              Badge(variant: :outlined, class: 'w-fit rounded-full text-[10px]') { medication.location.name }
             end
           end
 
@@ -58,17 +57,11 @@ module Components
         @presenter ||= ::Medications::SupplyStatusPresenter.new(medication: medication)
       end
 
-      def render_status_badge
-        Badge(variant: presenter.status_variant, class: 'shrink-0 whitespace-nowrap justify-center') do
-          presenter.status_label
-        end
-      end
-
       def render_supply_bar
         div(class: 'space-y-2') do
           div(
             class: 'flex justify-between items-center text-[10px] font-black uppercase ' \
-                   'tracking-widest text-on-surface-variant'
+                   "tracking-widest #{presenter.list_inventory_text_class}"
           ) do
             span { t('medications.index.inventory_level') }
             span { presenter.inventory_units_label }
@@ -81,13 +74,7 @@ module Components
       end
 
       def render_medication_icon
-        div(
-          class: 'w-12 h-12 rounded-shape-xl bg-card flex items-center ' \
-                 'justify-center text-on-surface-variant ' \
-                 'group-hover:text-primary group-hover:bg-primary/5 transition-all'
-        ) do
-          render Icons::Pill.new(size: 24)
-        end
+        render Icons::Medication.new(size: 24, class: 'mt-1 shrink-0 text-on-surface-variant group-hover:text-primary')
       end
 
       def render_actions

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -51,7 +51,7 @@ module Components
                      'text-primary shadow-inner flex-shrink-0',
               data: { testid: 'medication-hero-icon' }
             ) do
-              render Icons::Pill.new(size: 32)
+              render Icons::Inventory.new(size: 32)
             end
             div(class: 'space-y-1 min-w-0') do
               m3_text(variant: :label_medium, class: 'uppercase tracking-[0.2em] opacity-40 block mb-1 font-black') do

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -230,7 +230,7 @@ module Components
             label: take_label,
             variant: :filled,
             size: :lg,
-            icon: Icons::Pill,
+            icon: Icons::HandPackage,
             class: 'w-full rounded-xl py-6 font-bold shadow-lg shadow-primary/20 hover:shadow-xl ' \
                    'hover:shadow-primary/30',
             testid: "take-person-medication-#{person_medication.id}",

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -58,7 +58,7 @@ module Components
               label: presenter.take_label,
               variant: :filled,
               size: :lg,
-              icon: Icons::Pill,
+              icon: Icons::HandPackage,
               class: 'w-full rounded-xl py-6 font-bold shadow-lg shadow-primary/20 hover:shadow-xl ' \
                      'hover:shadow-primary/30 transition-all',
               testid: "take-schedule-#{schedule.id}",

--- a/app/components/shared/metric_card.rb
+++ b/app/components/shared/metric_card.rb
@@ -144,7 +144,7 @@ module Components
       def render_icon(size:)
         case icon_type
         when 'users' then render Icons::Users.new(size: size)
-        when 'pill' then render Icons::Pill.new(size: size)
+        when 'inventory', 'pill' then render Icons::Inventory.new(size: size)
         when 'active_schedules' then render Icons::ActiveSchedules.new(size: size)
         when 'check' then render Icons::CheckCircle.new(size: size)
         when 'compliance' then render Icons::Compliance.new(size: size)
@@ -158,7 +158,7 @@ module Components
 
         case icon_type
         when 'users' then 'bg-primary/10'
-        when 'pill', 'active_schedules' then 'bg-success-container/50'
+        when 'inventory', 'pill', 'active_schedules' then 'bg-success-container/50'
         else 'bg-secondary-container'
         end
       end

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -45,7 +45,11 @@ module Medications
     end
 
     def list_supply_bar_class
-      supply_level.low_stock? ? 'bg-destructive' : 'bg-primary'
+      list_stock_alert? ? 'bg-destructive' : 'bg-primary'
+    end
+
+    def list_inventory_text_class
+      list_stock_alert? ? 'text-destructive' : 'text-primary'
     end
 
     def remaining_units_label
@@ -97,6 +101,81 @@ module Medications
 
     def volume_stock?
       MedicationStockConsumption.volume_unit?(medication.dosage_unit)
+    end
+
+    def list_stock_alert?
+      return false unless supply_level.tracked?
+      return scheduled_stock_alert? if scheduled_inventory?
+      return as_needed_stock_alert? if as_needed_inventory?
+
+      supply_level.low_stock?
+    end
+
+    def scheduled_stock_alert?
+      medication.days_until_out_of_stock.present? && medication.days_until_out_of_stock < 5
+    end
+
+    def as_needed_stock_alert?
+      as_needed_doses_left < 10
+    end
+
+    def as_needed_doses_left
+      BigDecimal(supply_level.current.to_s) / as_needed_dose_quantity
+    end
+
+    def as_needed_dose_quantity
+      quantities = as_needed_sources.map { |source| dose_quantity_for(source) }.select(&:positive?)
+
+      quantities.max || BigDecimal('1')
+    end
+
+    def dose_quantity_for(source)
+      MedicationStockConsumption.quantity_for(
+        dose_amount: dose_amount_for(source),
+        dose_unit: dose_unit_for(source)
+      )
+    end
+
+    def dose_amount_for(source)
+      return source.effective_dose_amount if source.respond_to?(:effective_dose_amount)
+
+      source.default_dose_amount
+    end
+
+    def dose_unit_for(source)
+      return source.effective_dose_unit if source.respond_to?(:effective_dose_unit)
+
+      source.dose_unit
+    end
+
+    def scheduled_inventory?
+      scheduled_sources.any?
+    end
+
+    def as_needed_inventory?
+      as_needed_sources.any?
+    end
+
+    def scheduled_sources
+      @scheduled_sources ||= medication.schedules.select do |schedule|
+        schedule.active? && !as_needed_schedule?(schedule)
+      end
+    end
+
+    def as_needed_sources
+      @as_needed_sources ||= medication.person_medications.select(&:as_needed?) + as_needed_schedules
+    end
+
+    def as_needed_schedules
+      medication.schedules.select do |schedule|
+        schedule.active? && as_needed_schedule?(schedule)
+      end
+    end
+
+    def as_needed_schedule?(schedule)
+      schedule.schedule_type_prn? ||
+        schedule.schedule_config.to_h['as_needed'] == true ||
+        schedule.frequency.to_s.casecmp('as needed').zero?
     end
 
     def low_stock_forecast

--- a/spec/components/dashboard/schedule_card_spec.rb
+++ b/spec/components/dashboard/schedule_card_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe Components::Dashboard::ScheduleCard, type: :component do
       expect(rendered.text).to include(MedicationStockQuantityFormatter.format(schedule.medication.current_supply))
     end
 
-    it 'renders the take action with a pill icon' do
+    it 'renders the take action with a hand package icon' do
       rendered = render_inline(described_class.new(person: person, schedule: schedule))
+      selector = "button[data-testid='take-medication-#{schedule.id}'] svg.material-symbol-hand-package"
 
-      expect(rendered.css("button[data-testid='take-medication-#{schedule.id}'] svg.lucide-pill")).to be_present
+      expect(rendered.css(selector)).to be_present
     end
   end
 

--- a/spec/components/dashboard/stat_card_spec.rb
+++ b/spec/components/dashboard/stat_card_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Components::Dashboard::StatCard, type: :component do
       expect(rendered.css('svg')).to be_present
     end
 
-    it 'renders a pill icon when icon_type is pill' do
-      rendered = render_inline(described_class.new(title: 'Medications', value: 3, icon_type: 'pill'))
+    it 'renders an inventory icon when icon_type is inventory' do
+      rendered = render_inline(described_class.new(title: 'Medications', value: 3, icon_type: 'inventory'))
 
-      expect(rendered.css('svg')).to be_present
+      expect(rendered.css('svg.material-symbol-inventory')).to be_present
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe Components::Dashboard::StatCard, type: :component do
     end
 
     it 'renders the title' do
-      rendered = render_inline(described_class.new(title: 'Active Schedules', value: 10, icon_type: 'pill'))
+      rendered = render_inline(described_class.new(title: 'Active Schedules', value: 10, icon_type: 'inventory'))
 
       expect(rendered.text).to include('Active Schedules')
     end

--- a/spec/components/dashboard/timeline_item_spec.rb
+++ b/spec/components/dashboard/timeline_item_spec.rb
@@ -125,10 +125,11 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
       expect(rendered.css('button[type="submit"]')).not_to be_empty
     end
 
-    it 'renders the action button with a pill icon' do
+    it 'renders the action button with a hand package icon' do
       rendered = render_inline(described_class.new(dose: dose))
+      selector = "button[data-testid='take-dose-schedule_#{source.id}'] svg.material-symbol-hand-package"
 
-      expect(rendered.css("button[data-testid='take-dose-schedule_#{source.id}'] svg.lucide-pill")).to be_present
+      expect(rendered.css(selector)).to be_present
     end
   end
 end

--- a/spec/components/icons/hand_package_spec.rb
+++ b/spec/components/icons/hand_package_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Icons::HandPackage, type: :component do
+  let(:icon_path) do
+    [
+      'M600-800H360v280h240v-280Zm200 0H680v280h120v-280Z',
+      'M575-440H320v240h222q21 0 40.5-7t35.5-21l166-137q-8-8-18-12t-21-6',
+      'q-17-3-33 1t-30 15l-108 87H400v-80h146l44-36q5-3 7.5-8t2.5-11',
+      'q0-10-7.5-17.5T575-440Zm-335 0h-80v280h80v-280Z',
+      'm40 0v-360q0-33 23.5-56.5T360-880h440q33 0 56.5 23.5T880-800v280',
+      'q0 33-23.5 56.5T800-440H280ZM240-80h-80q-33 0-56.5-23.5T80-160v-280',
+      'q0-33 23.5-56.5T160-520h415q85 0 164 29t127 98l27 41-223 186',
+      'q-27 23-60 34.5T542-120H309q-11 18-29 29t-40 11Z'
+    ].join
+  end
+
+  it 'renders as a currentColor Material Symbols SVG' do
+    rendered = render_inline(described_class.new(size: 20, class: 'mr-2', aria_hidden: 'true'))
+    svg = rendered.at_css('svg')
+
+    expect(svg['viewbox']).to eq('0 -960 960 960')
+    expect(svg['fill']).to eq('currentColor')
+    expect(svg['stroke']).to be_nil
+    expect(svg['class'].split).to include('material-symbol', 'material-symbol-hand-package', 'mr-2')
+  end
+
+  it 'preserves caller attributes' do
+    rendered = render_inline(described_class.new(size: 20, class: 'mr-2', aria_hidden: 'true'))
+    svg = rendered.at_css('svg')
+
+    expect(svg['aria-hidden']).to eq('true')
+    expect(svg['width']).to eq('20')
+  end
+
+  it 'renders the Material Symbols hand_package path' do
+    rendered = render_inline(described_class.new)
+
+    expect(rendered.css("path[d='#{icon_path}']").count).to eq(1)
+  end
+end

--- a/spec/components/icons/inventory_spec.rb
+++ b/spec/components/icons/inventory_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Icons::Inventory, type: :component do
+  let(:icon_path) do
+    [
+      'M620-163 450-333l56-56 114 114 226-226 56 56-282 282Z',
+      'm220-397h-80v-200h-80v120H280v-120h-80v560h240v80H200',
+      'q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h167',
+      'q11-35 43-57.5t70-22.5q40 0 71.5 22.5T594-840h166',
+      'q33 0 56.5 23.5T840-760v200ZM480-760q17 0 28.5-11.5T520-800',
+      'q0-17-11.5-28.5T480-840q-17 0-28.5 11.5T440-800',
+      'q0 17 11.5 28.5T480-760Z'
+    ].join
+  end
+
+  it 'renders as a currentColor Material Symbols SVG' do
+    rendered = render_inline(described_class.new(size: 24, class: 'text-primary'))
+    svg = rendered.at_css('svg')
+
+    expect(svg['viewbox']).to eq('0 -960 960 960')
+    expect(svg['fill']).to eq('currentColor')
+    expect(svg['stroke']).to be_nil
+    expect(svg['class'].split).to include('material-symbol', 'material-symbol-inventory', 'text-primary')
+  end
+
+  it 'preserves caller attributes' do
+    rendered = render_inline(described_class.new(size: 24, class: 'text-primary'))
+    svg = rendered.at_css('svg')
+
+    expect(svg['width']).to eq('24')
+  end
+
+  it 'renders the Material Symbols inventory path' do
+    rendered = render_inline(described_class.new)
+
+    expect(rendered.css("path[d='#{icon_path}']").count).to eq(1)
+  end
+end

--- a/spec/components/icons/medication_spec.rb
+++ b/spec/components/icons/medication_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Icons::Medication, type: :component do
+  let(:icon_path) do
+    [
+      'M420-260h120v-100h100v-120H540v-100H420v100H320v120h100v100Z',
+      'M280-120q-33 0-56.5-23.5T200-200v-440q0-33 23.5-56.5T280-720h400',
+      'q33 0 56.5 23.5T760-640v440q0 33-23.5 56.5T680-120H280Z',
+      'm0-80h400v-440H280v440Zm-40-560v-80h480v80H240Zm40 120v440-440Z'
+    ].join
+  end
+
+  it 'renders as a currentColor Material Symbols SVG' do
+    rendered = render_inline(described_class.new(size: 24, class: 'text-primary'))
+    svg = rendered.at_css('svg')
+
+    expect(svg['viewbox']).to eq('0 -960 960 960')
+    expect(svg['fill']).to eq('currentColor')
+    expect(svg['stroke']).to be_nil
+    expect(svg['class'].split).to include('material-symbol', 'material-symbol-medication', 'text-primary')
+  end
+
+  it 'renders the Material Symbols medication path' do
+    rendered = render_inline(described_class.new)
+
+    expect(rendered.css("path[d='#{icon_path}']").count).to eq(1)
+  end
+end

--- a/spec/components/layouts/mobile_rail_spec.rb
+++ b/spec/components/layouts/mobile_rail_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Components::Layouts::MobileRail, type: :component do
     expect(rendered.css('button[aria-label="Sign Out"]')).to be_empty
   end
 
+  it 'renders the inventory item with the inventory icon' do
+    rendered = render_rail(user: admin_user)
+
+    expect(rendered.at_css('a[aria-label="Inventory"] svg.material-symbol-inventory')).to be_present
+  end
+
   it 'marks the active rail item with aria-current' do
     rendered = render_rail(user: admin_user, path: Rails.application.routes.url_helpers.medications_path)
     inventory_link = rendered.at_css(%(a[aria-label="Inventory"]))

--- a/spec/components/medications/administration_modal_spec.rb
+++ b/spec/components/medications/administration_modal_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Components::Medications::AdministrationModal, type: :component do
   let(:schedule) { schedules(:jane_ibuprofen) }
   let(:current_user) { users(:admin) }
 
-  it 'renders each administration action with a pill icon' do
+  it 'renders each administration action with a hand package icon' do
     rendered = render_inline(
       described_class.new(
         medication: medication,
@@ -19,7 +19,7 @@ RSpec.describe Components::Medications::AdministrationModal, type: :component do
       )
     )
 
-    selector = "button[data-testid='log-administration-schedule-#{schedule.id}'] svg.lucide-pill"
+    selector = "button[data-testid='log-administration-schedule-#{schedule.id}'] svg.material-symbol-hand-package"
 
     expect(rendered.css(selector)).to be_present
   end

--- a/spec/components/medications/list_item_component_spec.rb
+++ b/spec/components/medications/list_item_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Components::Medications::ListItemComponent, type: :component do
-  fixtures :medications
+  fixtures :locations, :medications
 
   it 'renders the view link with a top-level frame target' do
     medication = medications(:paracetamol)
@@ -31,5 +31,31 @@ RSpec.describe Components::Medications::ListItemComponent, type: :component do
 
     expect(rendered.at_css('h2').text).to include('Movicol Paediatric Plain')
     expect(rendered.at_css('h2').text).not_to include('Norgine Pharmaceuticals')
+  end
+
+  it 'renders each medicine with the medication icon' do
+    medication = medications(:paracetamol)
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.at_css("div#medication_#{medication.id} svg.material-symbol-medication")).to be_present
+  end
+
+  it 'renders the medication icon inline with the medicine name' do
+    medication = medications(:paracetamol)
+
+    rendered = render_inline(described_class.new(medication: medication))
+    header_group = rendered.at_css("div#medication_#{medication.id} div.flex.items-start.gap-3")
+
+    expect(header_group.at_css('svg.material-symbol-medication')).to be_present
+    expect(header_group.text).to include(medication.display_name)
+  end
+
+  it 'does not render the duplicate stock badge' do
+    medication = medications(:paracetamol)
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).not_to include('In Stock')
   end
 end

--- a/spec/components/medications/take_action_spec.rb
+++ b/spec/components/medications/take_action_spec.rb
@@ -47,16 +47,16 @@ RSpec.describe Components::Medications::TakeAction, type: :component do
   end
 
   it 'renders decorative SVG icons on enabled and confirmation buttons' do
-    rendered = render_take_action(button: { icon: Components::Icons::Pill })
+    rendered = render_take_action(button: { icon: Components::Icons::HandPackage })
 
-    icons = rendered.css('button svg.lucide-pill')
+    icons = rendered.css('button svg.material-symbol-hand-package')
     expect(icons.count).to eq(2)
     expect(icons.all? { |icon| icon['aria-hidden'] == 'true' }).to be(true)
   end
 
   it 'renders a decorative SVG icon on disabled buttons' do
     rendered = render_take_action(
-      button: { icon: Components::Icons::Pill },
+      button: { icon: Components::Icons::HandPackage },
       state: { disabled: true, label: 'Out of Stock', icon: Components::Icons::AlertCircle }
     )
 

--- a/spec/presenters/medications/supply_status_presenter_spec.rb
+++ b/spec/presenters/medications/supply_status_presenter_spec.rb
@@ -102,6 +102,60 @@ RSpec.describe Medications::SupplyStatusPresenter do
 
       expect(presenter.list_supply_bar_class).to eq('bg-primary')
     end
+
+    it 'returns destructive class when scheduled medication has less than five days left' do
+      medication = create(:medication, current_supply: 4, reorder_threshold: 0)
+      create(:schedule, medication: medication, dose_amount: 500, dose_unit: 'mg', max_daily_doses: 1,
+                        frequency: 'Once daily')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_supply_bar_class).to eq('bg-destructive')
+    end
+
+    it 'returns primary class when scheduled medication has five days left' do
+      medication = create(:medication, current_supply: 5, reorder_threshold: 10)
+      create(:schedule, medication: medication, dose_amount: 500, dose_unit: 'mg', max_daily_doses: 1,
+                        frequency: 'Once daily')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_supply_bar_class).to eq('bg-primary')
+    end
+
+    it 'returns destructive class when as-needed medication has less than ten doses left' do
+      medication = create(:medication, current_supply: 18, reorder_threshold: 0)
+      create(:person_medication, :as_needed, medication: medication, dose_amount: 2, dose_unit: 'tablet')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_supply_bar_class).to eq('bg-destructive')
+    end
+
+    it 'returns primary class when as-needed medication has ten doses left' do
+      medication = create(:medication, current_supply: 20, reorder_threshold: 10)
+      create(:person_medication, :as_needed, medication: medication, dose_amount: 2, dose_unit: 'tablet')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_supply_bar_class).to eq('bg-primary')
+    end
+  end
+
+  describe '#list_inventory_text_class' do
+    it 'returns destructive class for red inventory levels' do
+      medication = create(:medication, current_supply: 4, reorder_threshold: 0)
+      create(:schedule, medication: medication, dose_amount: 500, dose_unit: 'mg', max_daily_doses: 1,
+                        frequency: 'Once daily')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_inventory_text_class).to eq('text-destructive')
+    end
+
+    it 'returns primary class for blue inventory levels' do
+      medication = create(:medication, current_supply: 5, reorder_threshold: 10)
+      create(:schedule, medication: medication, dose_amount: 500, dose_unit: 'mg', max_daily_doses: 1,
+                        frequency: 'Once daily')
+      presenter = described_class.new(medication:)
+
+      expect(presenter.list_inventory_text_class).to eq('text-primary')
+    end
   end
 
   describe '#remaining_units_label' do


### PR DESCRIPTION
## Summary
- add local Material Symbols icon components for give, inventory, and medication surfaces
- replace give/action and inventory-specific pill icons with the new components
- update medication cards to show the medication icon inline with the name, remove the duplicate In Stock badge, and color inventory levels by remaining scheduled/as-needed supply

## Verification
- task rubocop
- task test