### PR TITLE
feat: rebuild smart insights

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -157,34 +157,149 @@ module Components
           end
           m3_card(
             variant: :filled,
-            class: 'bg-primary rounded-[2.5rem] p-10 text-on-primary relative overflow-hidden border-none ' \
-                   'transition-all duration-300 hover:shadow-xl hover:shadow-primary/30 ' \
-                   'group cursor-default'
+            class: 'rounded-[2.5rem] p-10 relative overflow-hidden border-none transition-all duration-300 ' \
+                   "#{dashboard_insight_card_classes}"
           ) do
-            div(class: 'absolute -right-12 -top-12 w-48 h-48 bg-white/10 rounded-full blur-3xl ' \
-                       'group-hover:bg-white/20 transition-all')
             div(class: 'relative z-10') do
-              div(class: 'w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center mb-6 ' \
-                         'group-hover:scale-110 transition-transform shadow-inner') do
-                render Icons::AlertCircle.new(size: 24)
-              end
-              m3_heading(variant: :headline_small, level: 3, class: 'font-black mb-2 tracking-tight') do
-                t('dashboard.insights.pattern_detected')
-              end
-              m3_text(variant: :body_large, class: 'text-on-primary/90 leading-relaxed mb-8 font-medium') do
-                t('dashboard.insights.message')
-              end
-              m3_button(
-                variant: :text,
-                class: 'p-0 h-auto font-black uppercase tracking-widest text-on-primary ' \
-                       'border-b-2 border-on-primary/30 ' \
-                       'rounded-none hover:border-on-primary hover:bg-transparent transition-all'
-              ) do
-                t('dashboard.insights.view_report')
-              end
+              render_dashboard_insight_content
             end
           end
         end
+      end
+
+      def render_dashboard_insight_content
+        insight = presenter.smart_insights.primary_insight
+
+        if presenter.smart_insights.learning_state?
+          render_dashboard_insight_state(
+            icon: Icons::Activity,
+            content: {
+              title: t('smart_insights.learning.title'),
+              summary: t('smart_insights.learning.summary'),
+              detail: t('smart_insights.learning.detail')
+            }
+          )
+        elsif insight
+          render_dashboard_primary_insight(insight)
+        else
+          render_dashboard_insight_state(
+            icon: Icons::CheckCircle,
+            content: {
+              title: t('smart_insights.no_action.title'),
+              summary: t('smart_insights.no_action.summary'),
+              detail: t('smart_insights.no_action.detail')
+            }
+          )
+        end
+      end
+
+      def render_dashboard_primary_insight(insight)
+        render_dashboard_insight_state(
+          icon: dashboard_insight_icon(insight),
+          content: {
+            title: insight.title,
+            summary: insight.summary,
+            detail: insight.detail,
+            metric_label: insight.metric_label,
+            metric_value: insight.metric_value
+          }
+        )
+      end
+
+      def render_dashboard_insight_state(icon:, content:)
+        div(class: dashboard_insight_icon_tile_classes) do
+          render icon.new(size: 24)
+        end
+        m3_heading(variant: :headline_small, level: 3, class: 'font-black mb-2 tracking-tight') do
+          content.fetch(:title)
+        end
+        m3_text(variant: :body_large, class: dashboard_insight_body_text_classes) { content.fetch(:summary) }
+        m3_text(variant: :body_medium, class: dashboard_insight_detail_text_classes) { content.fetch(:detail) }
+        render_dashboard_insight_metric(content)
+        render_dashboard_insight_link
+      end
+
+      def render_dashboard_insight_metric(content)
+        return if content[:metric_label].blank? || content[:metric_value].blank?
+
+        div(class: dashboard_insight_metric_tile_classes) do
+          span(class: 'text-xs font-bold uppercase tracking-widest') { content.fetch(:metric_label) }
+          span(class: 'text-sm font-black') { content.fetch(:metric_value) }
+        end
+      end
+
+      def render_dashboard_insight_link
+        return unless presenter.can_view_reports?
+
+        m3_link(
+          href: reports_path(anchor: 'insights'),
+          variant: :text,
+          class: "mt-8 p-0 h-auto font-black uppercase tracking-widest #{dashboard_insight_link_classes} " \
+                 'border-b-2 rounded-none hover:bg-transparent transition-all'
+        ) do
+          t('dashboard.insights.view_report')
+        end
+      end
+
+      def dashboard_insight_card_classes
+        insight = presenter.smart_insights.primary_insight
+        if insight.blank?
+          return 'bg-surface-container-low text-on-surface border border-outline-variant/70 shadow-elevation-1'
+        end
+
+        {
+          urgent: 'bg-error-container text-on-error-container shadow-elevation-2',
+          warning: 'bg-tertiary-container text-on-tertiary-container shadow-elevation-2',
+          positive: 'bg-primary text-on-primary shadow-elevation-2',
+          info: 'bg-secondary-container text-on-secondary-container shadow-elevation-1'
+        }.fetch(insight.severity, 'bg-secondary-container text-on-secondary-container shadow-elevation-1')
+      end
+
+      def dashboard_insight_icon_classes
+        presenter.smart_insights.primary_insight.present? ? 'bg-white/20' : 'bg-primary/10 text-primary'
+      end
+
+      def dashboard_insight_icon_tile_classes
+        "w-12 h-12 rounded-2xl #{dashboard_insight_icon_classes} " \
+          'flex items-center justify-center mb-6 shadow-inner'
+      end
+
+      def dashboard_insight_body_classes
+        presenter.smart_insights.primary_insight.present? ? 'text-current/90' : 'text-on-surface'
+      end
+
+      def dashboard_insight_body_text_classes
+        "#{dashboard_insight_body_classes} leading-relaxed font-medium"
+      end
+
+      def dashboard_insight_detail_classes
+        presenter.smart_insights.primary_insight.present? ? 'text-current/80' : 'text-on-surface-variant'
+      end
+
+      def dashboard_insight_detail_text_classes
+        "#{dashboard_insight_detail_classes} leading-relaxed mt-3"
+      end
+
+      def dashboard_insight_metric_classes
+        presenter.smart_insights.primary_insight.present? ? 'bg-white/20' : 'bg-primary/10 text-primary'
+      end
+
+      def dashboard_insight_metric_tile_classes
+        "mt-6 inline-flex items-center gap-2 rounded-full px-3 py-1.5 #{dashboard_insight_metric_classes}"
+      end
+
+      def dashboard_insight_link_classes
+        if presenter.smart_insights.primary_insight.present?
+          'text-current border-current/30 hover:border-current'
+        else
+          'text-primary border-primary/30 hover:border-primary'
+        end
+      end
+
+      def dashboard_insight_icon(insight)
+        return Icons::AlertCircle if %i[urgent warning].include?(insight.severity)
+
+        Icons::CheckCircle
       end
 
       def render_supply_levels

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,12 +12,13 @@ class ReportsController < ApplicationController
     # We use PersonPolicy::Scope to fetch people the user is authorized to see
     @people = policy_scope(Person)
     report_data = Reports::IndexQuery.new(people: @people, start_date: @start_date, end_date: @end_date).call
+    smart_insights = SmartInsights::IndexQuery.new(people: @people, start_date: @start_date, end_date: @end_date).call
     @daily_data = report_data.daily_data
     @inventory_alerts = report_data.inventory_alerts
 
     render Views::Reports::Index.new(
       daily_data: @daily_data,
-      inventory_alerts: @inventory_alerts,
+      smart_insights: smart_insights,
       start_date: @start_date,
       end_date: @end_date
     )

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -39,12 +39,38 @@ class DashboardPresenter
   end
 
   def compliance_percentage
-    # Placeholder for actual compliance logic
-    # For now, return a realistic-looking mock value
-    85
+    expected, actual = compliance_counts
+    return 100 if expected.zero?
+
+    [(actual.to_f / expected * 100).round, 100].min
+  end
+
+  def smart_insights
+    @smart_insights ||= SmartInsights::IndexQuery.new(
+      people: people,
+      start_date: Time.zone.today - 6.days,
+      end_date: Time.zone.today
+    ).call
+  end
+
+  def can_view_reports?
+    ReportPolicy.new(current_user, :report).index?
   end
 
   private
+
+  def compliance_counts
+    daily_data = Reports::IndexQuery.new(
+      people: people,
+      start_date: Time.zone.today - 6.days,
+      end_date: Time.zone.today
+    ).call.daily_data
+
+    [
+      daily_data.sum { |day| day[:expected] },
+      daily_data.sum { |day| day[:actual] }
+    ]
+  end
 
   def load_people
     return Person.none if current_user.nil?

--- a/app/services/smart_insights/context.rb
+++ b/app/services/smart_insights/context.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  class Context
+    delegate :daily_data, :inventory_alerts, to: :report_data
+
+    attr_reader :people, :start_date, :end_date
+
+    def initialize(people:, start_date:, end_date:)
+      @people = people
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def schedules
+      @schedules ||= Schedule.where(person_id: person_ids)
+                             .where('start_date <= ? AND end_date >= ?', end_date, start_date)
+                             .includes(:person, :medication)
+                             .to_a
+    end
+
+    def active_schedules
+      @active_schedules ||= schedules.select(&:active?)
+    end
+
+    def person_medications
+      @person_medications ||= PersonMedication.where(person_id: person_ids)
+                                              .includes(:person, :medication)
+                                              .to_a
+    end
+
+    def takes
+      @takes ||= source_scope.where(taken_at: start_date.beginning_of_day..end_date.end_of_day)
+                             .includes(:schedule, :person_medication)
+                             .to_a
+    end
+
+    def evidence_days
+      (start_date..end_date).count
+    end
+
+    def expected_events
+      daily_data.sum { |day| day[:expected] }
+    end
+
+    def logged_events
+      daily_data.sum { |day| day[:actual] } + prn_takes.count
+    end
+
+    def enough_evidence?
+      evidence_days >= IndexQuery::MINIMUM_EVIDENCE_DAYS &&
+        (expected_events + logged_events) >= IndexQuery::MINIMUM_EVENTS
+    end
+
+    def evidence_summary
+      I18n.t(
+        'smart_insights.evidence_summary',
+        count: expected_events + logged_events,
+        days: evidence_days,
+        events: expected_events + logged_events
+      )
+    end
+
+    def prn_takes
+      takes.select { |take| prn_source?(take.source) }
+    end
+
+    def prn_sources
+      schedules.select(&:schedule_type_prn?) +
+        person_medications.select(&:as_needed?)
+    end
+
+    private
+
+    def person_ids
+      @person_ids ||= if people.respond_to?(:pluck)
+                        people.pluck(:id)
+                      else
+                        Array(people).map(&:id)
+                      end
+    end
+
+    def report_data
+      @report_data ||= Reports::IndexQuery.new(people: people, start_date: start_date, end_date: end_date).call
+    end
+
+    def source_scope
+      schedule_ids = schedules.map(&:id)
+      person_medication_ids = person_medications.map(&:id)
+
+      MedicationTake.where(schedule_id: schedule_ids)
+                    .or(MedicationTake.where(person_medication_id: person_medication_ids))
+    end
+
+    def prn_source?(source)
+      return false if source.blank?
+      return source.schedule_type_prn? if source.is_a?(Schedule)
+
+      source.as_needed?
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/adherence_streak.rb
+++ b/app/services/smart_insights/detectors/adherence_streak.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class AdherenceStreak < Base
+      def call
+        streak = current_streak
+        return [] if streak < 3
+
+        [
+          insight(
+            key: :adherence_streak,
+            family: :adherence,
+            severity: :positive,
+            title: I18n.t('smart_insights.detectors.adherence_streak.title'),
+            summary: I18n.t('smart_insights.detectors.adherence_streak.summary', count: streak),
+            detail: I18n.t('smart_insights.detectors.adherence_streak.detail'),
+            metric_label: I18n.t('smart_insights.detectors.adherence_streak.metric_label'),
+            metric_value: I18n.t('smart_insights.detectors.adherence_streak.metric_value', count: streak)
+          )
+        ]
+      end
+
+      private
+
+      def current_streak
+        context.daily_data.reverse.take_while do |day|
+          day[:expected].positive? && day[:actual] >= day[:expected]
+        end.count
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/base.rb
+++ b/app/services/smart_insights/detectors/base.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class Base
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def call
+        raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+
+      private
+
+      def insight(**attributes)
+        attributes[:cta_path] = nil unless attributes.key?(:cta_path)
+        Insight.new(**attributes)
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/inventory_risk.rb
+++ b/app/services/smart_insights/detectors/inventory_risk.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class InventoryRisk < Base
+      def call
+        alert = context.inventory_alerts.first
+        return [] unless alert
+
+        [
+          insight(
+            key: :inventory_risk,
+            family: :inventory,
+            severity: alert[:low_stock] ? :urgent : :warning,
+            title: I18n.t('smart_insights.detectors.inventory_risk.title'),
+            summary: summary(alert),
+            detail: I18n.t('smart_insights.detectors.inventory_risk.detail', medication_name: alert[:medication_name]),
+            metric_label: I18n.t('smart_insights.detectors.inventory_risk.metric_label'),
+            metric_value: I18n.t('smart_insights.detectors.inventory_risk.metric_value', count: alert[:days_left])
+          )
+        ]
+      end
+
+      private
+
+      def summary(alert)
+        if alert[:days_left] <= 0
+          I18n.t('smart_insights.detectors.inventory_risk.summary_zero', medication_name: alert[:medication_name])
+        else
+          I18n.t(
+            'smart_insights.detectors.inventory_risk.summary',
+            medication_name: alert[:medication_name],
+            count: alert[:days_left]
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/missed_dose_pattern.rb
+++ b/app/services/smart_insights/detectors/missed_dose_pattern.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class MissedDosePattern < Base
+      def call
+        streak = longest_missed_streak
+        return [] if streak < 2
+
+        [
+          insight(
+            key: :missed_dose_pattern,
+            family: :adherence,
+            severity: :warning,
+            title: I18n.t('smart_insights.detectors.missed_dose_pattern.title'),
+            summary: I18n.t('smart_insights.detectors.missed_dose_pattern.summary', count: streak),
+            detail: I18n.t('smart_insights.detectors.missed_dose_pattern.detail'),
+            metric_label: I18n.t('smart_insights.detectors.missed_dose_pattern.metric_label'),
+            metric_value: I18n.t('smart_insights.detectors.missed_dose_pattern.metric_value', count: streak)
+          )
+        ]
+      end
+
+      private
+
+      def longest_missed_streak
+        context.daily_data.each_with_object([0, 0]) do |day, streaks|
+          current, longest = streaks
+          current = missed_day?(day) ? current + 1 : 0
+          streaks[0] = current
+          streaks[1] = [longest, current].max
+        end.last
+      end
+
+      def missed_day?(day)
+        day[:expected].positive? && day[:actual] < day[:expected]
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/prn_usage.rb
+++ b/app/services/smart_insights/detectors/prn_usage.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class PrnUsage < Base
+      def call
+        return [] unless prn_usage?
+
+        [
+          insight(
+            key: :prn_usage,
+            family: :as_needed,
+            severity: :info,
+            title: I18n.t('smart_insights.detectors.prn_usage.title'),
+            summary: I18n.t('smart_insights.detectors.prn_usage.summary', count: context.prn_takes.count),
+            detail: I18n.t('smart_insights.detectors.prn_usage.detail'),
+            metric_label: I18n.t('smart_insights.detectors.prn_usage.metric_label'),
+            metric_value: I18n.t('smart_insights.detectors.prn_usage.metric_value', count: context.prn_takes.count)
+          )
+        ]
+      end
+
+      private
+
+      def prn_usage?
+        context.prn_sources.any? && context.prn_takes.any?
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/schedule_hygiene.rb
+++ b/app/services/smart_insights/detectors/schedule_hygiene.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class ScheduleHygiene < Base
+      def call
+        schedule = schedules_without_times.first
+        return [] unless schedule
+
+        [schedule_hygiene_insight(schedule)]
+      end
+
+      private
+
+      def schedule_hygiene_insight(schedule)
+        insight(
+          key: :schedule_hygiene,
+          family: :schedule,
+          severity: :info,
+          title: I18n.t('smart_insights.detectors.schedule_hygiene.title'),
+          summary: I18n.t('smart_insights.detectors.schedule_hygiene.summary',
+                          medication_name: schedule.medication_name),
+          detail: I18n.t('smart_insights.detectors.schedule_hygiene.detail'),
+          metric_label: I18n.t('smart_insights.detectors.schedule_hygiene.metric_label'),
+          metric_value: I18n.t('smart_insights.detectors.schedule_hygiene.metric_value')
+        )
+      end
+
+      def schedules_without_times
+        context.active_schedules.select do |schedule|
+          schedule.schedule_type_multiple_daily? && Array(schedule.schedule_config.to_h['times']).compact_blank.empty?
+        end
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/detectors/timing_consistency.rb
+++ b/app/services/smart_insights/detectors/timing_consistency.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  module Detectors
+    class TimingConsistency < Base
+      WINDOW_MINUTES = 90
+
+      def call
+        return [] unless enough_timing_evidence?
+        return [] if on_time_ratio < 0.8
+
+        [timing_insight]
+      end
+
+      private
+
+      def timing_insight
+        insight(
+          key: :timing_consistency,
+          family: :timing,
+          severity: :positive,
+          title: I18n.t('smart_insights.detectors.timing_consistency.title'),
+          summary: I18n.t(
+            'smart_insights.detectors.timing_consistency.summary',
+            percentage: (on_time_ratio * 100).round
+          ),
+          detail: I18n.t('smart_insights.detectors.timing_consistency.detail'),
+          metric_label: I18n.t('smart_insights.detectors.timing_consistency.metric_label'),
+          metric_value: I18n.t('smart_insights.detectors.timing_consistency.metric_value', count: on_time_count)
+        )
+      end
+
+      def enough_timing_evidence?
+        expected_occurrences.size >= IndexQuery::MINIMUM_EVENTS
+      end
+
+      def on_time_ratio
+        on_time_count.to_f / expected_occurrences.size
+      end
+
+      def on_time_count
+        @on_time_count ||= begin
+          remaining_takes = takes_with_configured_times.dup
+
+          expected_occurrences.count do |occurrence|
+            matching_take = remaining_takes.find { |take| on_time?(take, occurrence) }
+            remaining_takes.delete(matching_take) if matching_take
+          end
+        end
+      end
+
+      def takes_with_configured_times
+        @takes_with_configured_times ||= context.takes.select { |take| configured_times(take.schedule).any? }
+      end
+
+      def expected_occurrences
+        @expected_occurrences ||= context.schedules.flat_map do |schedule|
+          configured_times(schedule).flat_map do |time|
+            (context.start_date..context.end_date).filter_map do |date|
+              next unless schedule.expected_doses_on(date).positive?
+
+              { schedule: schedule, expected_at: expected_time(date, time) }
+            end
+          end
+        end
+      end
+
+      def on_time?(take, occurrence)
+        take.schedule_id == occurrence[:schedule].id &&
+          (take.taken_at - occurrence[:expected_at]).abs <= WINDOW_MINUTES.minutes
+      end
+
+      def configured_times(schedule)
+        Array(schedule&.schedule_config.to_h['times']).compact_blank
+      end
+
+      def expected_time(date, time)
+        hour, minute = time.split(':').map(&:to_i)
+        date.in_time_zone.change(hour: hour, min: minute)
+      end
+    end
+  end
+end

--- a/app/services/smart_insights/index_query.rb
+++ b/app/services/smart_insights/index_query.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  class IndexQuery
+    MINIMUM_EVIDENCE_DAYS = 7
+    MINIMUM_EVENTS = 5
+
+    DETECTORS = [
+      Detectors::InventoryRisk,
+      Detectors::MissedDosePattern,
+      Detectors::AdherenceStreak,
+      Detectors::TimingConsistency,
+      Detectors::PrnUsage,
+      Detectors::ScheduleHygiene
+    ].freeze
+
+    SEVERITY_PRIORITY = {
+      urgent: 0,
+      warning: 1,
+      positive: 2,
+      info: 3
+    }.freeze
+
+    INSIGHT_PRIORITY = {
+      inventory_risk: 0,
+      missed_dose_pattern: 1,
+      adherence_streak: 2,
+      timing_consistency: 3,
+      prn_usage: 4,
+      schedule_hygiene: 5
+    }.freeze
+
+    attr_reader :people, :start_date, :end_date
+
+    def initialize(people:, start_date:, end_date:)
+      @people = people
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def call
+      return learning_result unless context.enough_evidence?
+
+      insights = detected_insights
+      Result.new(
+        primary_insight: insights.first,
+        insights: insights,
+        learning_state?: false,
+        evidence_summary: context.evidence_summary
+      )
+    end
+
+    private
+
+    def context
+      @context ||= Context.new(people: people, start_date: start_date, end_date: end_date)
+    end
+
+    def learning_result
+      Result.new(
+        primary_insight: nil,
+        insights: [],
+        learning_state?: true,
+        evidence_summary: context.evidence_summary
+      )
+    end
+
+    def detected_insights
+      DETECTORS.flat_map { |detector| detector.new(context).call }
+               .sort_by { |insight| [SEVERITY_PRIORITY.fetch(insight.severity), INSIGHT_PRIORITY.fetch(insight.key)] }
+    end
+  end
+end

--- a/app/services/smart_insights/insight.rb
+++ b/app/services/smart_insights/insight.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  Insight = Data.define(:key, :family, :severity, :title, :summary, :detail, :metric_label, :metric_value, :cta_path)
+end

--- a/app/services/smart_insights/result.rb
+++ b/app/services/smart_insights/result.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SmartInsights
+  Result = Data.define(:primary_insight, :insights, :learning_state?, :evidence_summary)
+end

--- a/app/views/reports/index.rb
+++ b/app/views/reports/index.rb
@@ -5,9 +5,9 @@ module Views
     InsightCard = Data.define(:title, :value, :description, :icon_class, :text_color, :icon_background_class)
 
     class Index < Views::Base
-      def initialize(daily_data:, inventory_alerts:, start_date:, end_date:)
+      def initialize(daily_data:, smart_insights:, start_date:, end_date:)
         @daily_data = daily_data
-        @inventory_alerts = inventory_alerts
+        @smart_insights = smart_insights
         @start_date = start_date
         @end_date = end_date
         super()
@@ -72,10 +72,10 @@ module Views
                 total_actual >= total_expected ? t('reports.index.summary.on_track') : t('reports.index.summary.missed_doses')
               )
               summary_stat(
-                t('reports.index.summary.current_health_status'),
-                t('reports.index.summary.optimal'),
-                t('reports.index.summary.vibrant')
-              ) # This could be dynamic in the future based on compliance
+                t('reports.index.summary.evidence_reviewed'),
+                @smart_insights.evidence_summary,
+                t('reports.index.summary.based_on_logs')
+              )
             end
           end
         end
@@ -132,48 +132,46 @@ module Views
       end
 
       def render_insights_grid
-        div(class: 'grid grid-cols-1 md:grid-cols-2 gap-8') do
-          render_achievement_streak
-          render_inventory_alert
+        section(id: 'insights', class: 'space-y-6 scroll-mt-24') do
+          render_insights_header
+
+          if @smart_insights.learning_state?
+            render_learning_state
+          elsif @smart_insights.insights.any?
+            render_smart_insight_cards
+          else
+            render_no_action_state
+          end
         end
       end
 
-      def render_achievement_streak
-        render_insight_card(
-          InsightCard.new(
-            title: t('reports.index.achievement_streak.title'),
-            value: t('reports.index.achievement_streak.value'),
-            description: t('reports.index.achievement_streak.description'),
-            icon_class: Icons::CheckCircle,
-            text_color: 'text-emerald-600',
-            icon_background_class: 'bg-emerald-50'
-          )
+      def render_insights_header
+        div(class: 'space-y-2') do
+          m3_heading(level: 2, size: '5', class: 'font-bold') { t('smart_insights.title') }
+          m3_text(size: '2', class: 'text-on-surface-variant') { @smart_insights.evidence_summary }
+        end
+      end
+
+      def render_learning_state
+        render_state_card(
+          title: t('smart_insights.learning.title'),
+          summary: t('smart_insights.learning.summary'),
+          detail: t('smart_insights.learning.detail')
         )
       end
 
-      def render_inventory_alert
-        alert = @inventory_alerts.first
-        return unless alert
-
-        medication_name = alert[:medication_name]
-        days_left = alert[:days_left]
-
-        description = if days_left <= 0
-                        t('reports.index.inventory_alert.description_zero', medication_name:)
-                      else
-                        t('reports.index.inventory_alert.description', medication_name:, count: days_left)
-                      end
-
-        render_insight_card(
-          InsightCard.new(
-            title: t('reports.index.inventory_alert.title'),
-            value: days_left <= 0 ? t('reports.index.inventory_alert.out_of_stock') : t('reports.index.inventory_alert.refill_pending'),
-            description: description,
-            icon_class: Icons::AlertCircle,
-            text_color: 'text-rose-600',
-            icon_background_class: 'bg-rose-50'
-          )
+      def render_no_action_state
+        render_state_card(
+          title: t('smart_insights.no_action.title'),
+          summary: t('smart_insights.no_action.summary'),
+          detail: t('smart_insights.no_action.detail')
         )
+      end
+
+      def render_smart_insight_cards
+        div(class: 'grid grid-cols-1 md:grid-cols-2 gap-8') do
+          @smart_insights.insights.each { |insight| render_smart_insight_card(insight) }
+        end
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -197,6 +195,51 @@ module Views
       end
 
       # rubocop:enable Metrics/AbcSize
+
+      def render_smart_insight_card(insight)
+        render_insight_card(
+          InsightCard.new(
+            title: insight.title,
+            value: insight.summary,
+            description: insight.detail,
+            icon_class: insight_icon(insight),
+            text_color: insight_text_color(insight),
+            icon_background_class: insight_icon_background(insight)
+          )
+        )
+      end
+
+      def render_state_card(title:, summary:, detail:)
+        m3_card(class: 'space-y-3 border border-border/70 bg-card p-8 shadow-elevation-1') do
+          m3_heading(level: 3, size: '4', class: 'font-bold') { title }
+          m3_text(size: '2', class: 'font-semibold text-on-surface') { summary }
+          m3_text(size: '2', class: 'text-on-surface-variant leading-relaxed') { detail }
+        end
+      end
+
+      def insight_icon(insight)
+        return Icons::AlertCircle if %i[urgent warning].include?(insight.severity)
+
+        Icons::CheckCircle
+      end
+
+      def insight_text_color(insight)
+        {
+          urgent: 'text-rose-600',
+          warning: 'text-amber-700',
+          positive: 'text-emerald-600',
+          info: 'text-primary'
+        }.fetch(insight.severity, 'text-primary')
+      end
+
+      def insight_icon_background(insight)
+        {
+          urgent: 'bg-rose-50',
+          warning: 'bg-amber-50',
+          positive: 'bg-emerald-50',
+          info: 'bg-primary/10'
+        }.fetch(insight.severity, 'bg-primary/10')
+      end
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1230,8 +1230,6 @@ cy:
     out_of_stock_alert: "Allan o stoc: %{medication}. Ni ellir cofnodi dosau ar gyfer %{person}."
     insights:
       title: "Mewnwelediadau Clyfar"
-      pattern_detected: "Patrwm wedi'i ganfod"
-      message: "Rydych chi wedi bod yn gyson iawn yr wythnos hon! Da iawn am aros ar y trywydd iawn gyda'ch trefn graidd."
       view_report: "Gweld yr adroddiad llawn"
     inventory:
       title: "Rhestr Stoc"
@@ -1332,20 +1330,15 @@ cy:
       summary:
         overall_compliance: "Cydymffurfiaeth Gyffredinol"
         total_doses_logged: "Cyfanswm dosau wedi'u cofnodi"
-        current_health_status: "Statws iechyd cyfredol"
+        evidence_reviewed: "Tystiolaeth wedi'i hadolygu"
         excellent: "Ardderchog"
         needs_attention: "Angen sylw"
         on_track: "Ar y trywydd iawn"
         missed_doses: "Dosau wedi'u methu"
-        optimal: "Optimaidd"
-        vibrant: "Bywiog"
+        based_on_logs: "Yn seiliedig ar ddosau wedi'u cofnodi"
       timeline_title: "Llinell Amser Cydymffurfiaeth"
       download_pdf: "Lawrlwytho PDF"
       timeline_compliance: "%{percentage}% Cydymffurfiaeth"
-      achievement_streak:
-        title: "Stryd cyflawniad"
-        value: "4 diwrnod yn ddi-dor"
-        description: "Nid ydych wedi colli hyd yn oed un dos ers bore dydd Gwener. Mae eich corff yn cynnal lefelau optimaidd."
       inventory_alert:
         title: "Rhybudd Rhestr"
         out_of_stock: "Allan o Stoc"
@@ -1355,6 +1348,75 @@ cy:
           one: "Bydd cyflenwad %{medication_name} yn dod i ben mewn %{count} diwrnod. Rydym yn argymell archebu ail-lenwi y prynhawn yma."
           other: "Bydd cyflenwad %{medication_name} yn dod i ben mewn %{count} diwrnod. Rydym yn argymell archebu ail-lenwi y prynhawn yma."
       actionable_insight: "Mewnwelediad gweithredadwy"
+  smart_insights:
+    title: "Mewnwelediadau Clyfar"
+    evidence_summary:
+      one: "%{days} diwrnod wedi'u hadolygu gyda %{events} digwyddiad meddyginiaeth"
+      other: "%{days} diwrnod wedi'u hadolygu gyda %{events} digwyddiad meddyginiaeth"
+    learning:
+      title: "Dysgu eich trefn"
+      summary: "Parhewch i gofnodi dosau fel y gall MedTracker weld patrymau go iawn."
+      detail: "Mae Smart Insights yn aros am ddigon o dystiolaeth cyn galw rhywbeth yn batrwm."
+    no_action:
+      title: "Nid oes patrwm angen sylw"
+      summary: "Nid oes dim anarferol yn sefyll allan yn y cyfnod adrodd hwn."
+      detail: "Mae eich adroddiad yn dal i ddangos hanes dosau a rhestr stoc fel y gallwch adolygu'r manylion."
+    detectors:
+      adherence_streak:
+        title: "Stryd trefn gref"
+        summary:
+          one: "Cofnodwyd pob dos disgwyliedig ddoe."
+          other: "Cofnodwyd pob dos disgwyliedig am %{count} diwrnod."
+        detail: "Mae'r cysondeb hwnnw'n rhoi rhythm cadarn i'ch trefn ofal."
+        metric_label: "Stryd gyfredol"
+        metric_value:
+          one: "1 diwrnod"
+          other: "%{count} diwrnod"
+      missed_dose_pattern:
+        title: "Patrwm dosau wedi'u methu"
+        summary:
+          one: "Methwyd dosau disgwyliedig ddoe."
+          other: "Methwyd dosau disgwyliedig am %{count} diwrnod yn olynol."
+        detail: "Adolygwch yr amserlen a'r atgoffwyr ar gyfer y cyfnod hwn."
+        metric_label: "Rhediad hiraf"
+        metric_value:
+          one: "1 diwrnod"
+          other: "%{count} diwrnod"
+      timing_consistency:
+        title: "Amseriad dosau cyson"
+        summary: "Roedd %{percentage}% o'r dosau wedi'u cofnodi yn agos at eu hamser trefnedig."
+        detail: "Mae eich amseriad wedi'i gofnodi wedi bod yn sefydlog yn y cyfnod adrodd hwn."
+        metric_label: "Cofnodion ar amser"
+        metric_value:
+          one: "1 dos"
+          other: "%{count} dos"
+      inventory_risk:
+        title: "Mae angen sylw ar gyflenwad"
+        summary_zero: "Mae %{medication_name} yn ymddangos allan o stoc."
+        summary:
+          one: "Mae gan %{medication_name} tua 1 diwrnod o gyflenwad ar ôl."
+          other: "Mae gan %{medication_name} tua %{count} diwrnod o gyflenwad ar ôl."
+        detail: "Gwiriwch gofnod stoc %{medication_name} a chynlluniwch yr ail-lenwi nesaf."
+        metric_label: "Cyflenwad ar ôl"
+        metric_value:
+          one: "1 diwrnod"
+          other: "%{count} diwrnod"
+      prn_usage:
+        title: "Defnydd yn ôl yr angen wedi'i gofnodi"
+        summary:
+          one: "Cofnodwyd 1 dos yn ôl yr angen yn y cyfnod hwn."
+          other: "Cofnodwyd %{count} dos yn ôl yr angen yn y cyfnod hwn."
+        detail: "Adolygwch y cofnodion hyn ochr yn ochr â dosau rheolaidd i gadw'r darlun llawn yn glir."
+        metric_label: "Cofnodion PRN"
+        metric_value:
+          one: "1 dos"
+          other: "%{count} dos"
+      schedule_hygiene:
+        title: "Manylyn amserlen i'w adolygu"
+        summary: "Mae %{medication_name} wedi'i osod ar gyfer sawl dos dyddiol heb amseroedd penodol."
+        detail: "Gall ychwanegu amseroedd wneud atgoffwyr, adroddiadau a mewnwelediadau amseriad yn gliriach."
+        metric_label: "Adolygu"
+        metric_value: "Amserlen"
 
   notification_settings:
     title: "Gosodiadau Hysbysiadau"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1051,20 +1051,15 @@ en:
       summary:
         overall_compliance: "Overall Compliance"
         total_doses_logged: "Total Doses Logged"
-        current_health_status: "Current Health Status"
+        evidence_reviewed: "Evidence Reviewed"
         excellent: "Excellent"
         needs_attention: "Needs attention"
         on_track: "On Track"
         missed_doses: "Missed doses"
-        optimal: "Optimal"
-        vibrant: "Vibrant"
+        based_on_logs: "Based on logged doses"
       timeline_title: "Adherence Timeline"
       download_pdf: "Download PDF"
       timeline_compliance: "%{percentage}% Compliance"
-      achievement_streak:
-        title: "Achievement Streak"
-        value: "4 Days Uninterrupted"
-        description: "You haven't missed a single dose since Friday morning. Your body is maintaining optimal levels."
       inventory_alert:
         title: "Inventory Alert"
         out_of_stock: "Out of Stock"
@@ -1074,6 +1069,75 @@ en:
           one: "Your %{medication_name} supply will be exhausted in %{count} day. We recommend ordering a refill this afternoon."
           other: "Your %{medication_name} supply will be exhausted in %{count} days. We recommend ordering a refill this afternoon."
       actionable_insight: "Actionable insight"
+  smart_insights:
+    title: "Smart Insights"
+    evidence_summary:
+      one: "%{days} days reviewed with %{events} medication event"
+      other: "%{days} days reviewed with %{events} medication events"
+    learning:
+      title: "Learning your routine"
+      summary: "Keep logging doses so MedTracker can spot real patterns."
+      detail: "Smart Insights waits for enough evidence before calling anything a pattern."
+    no_action:
+      title: "No pattern needs attention"
+      summary: "Nothing unusual stands out in this report window."
+      detail: "Your report still shows dose history and inventory so you can review the details."
+    detectors:
+      adherence_streak:
+        title: "Strong routine streak"
+        summary:
+          one: "Every expected dose was logged yesterday."
+          other: "Every expected dose was logged for %{count} days."
+        detail: "That consistency gives your care routine a solid rhythm."
+        metric_label: "Current streak"
+        metric_value:
+          one: "1 day"
+          other: "%{count} days"
+      missed_dose_pattern:
+        title: "Missed-dose pattern"
+        summary:
+          one: "Expected doses were missed yesterday."
+          other: "Expected doses were missed for %{count} days in a row."
+        detail: "Review the schedule and reminders for this window."
+        metric_label: "Longest run"
+        metric_value:
+          one: "1 day"
+          other: "%{count} days"
+      timing_consistency:
+        title: "Consistent dose timing"
+        summary: "%{percentage}% of logged doses were close to their scheduled time."
+        detail: "Your logged timing has been steady in this report window."
+        metric_label: "On-time logs"
+        metric_value:
+          one: "1 dose"
+          other: "%{count} doses"
+      inventory_risk:
+        title: "Supply needs attention"
+        summary_zero: "%{medication_name} appears to be out of stock."
+        summary:
+          one: "%{medication_name} has about 1 day of supply left."
+          other: "%{medication_name} has about %{count} days of supply left."
+        detail: "Check the stock record for %{medication_name} and plan the next refill."
+        metric_label: "Supply left"
+        metric_value:
+          one: "1 day"
+          other: "%{count} days"
+      prn_usage:
+        title: "As-needed use logged"
+        summary:
+          one: "1 as-needed dose was logged in this window."
+          other: "%{count} as-needed doses were logged in this window."
+        detail: "Review these entries alongside routine doses to keep the full picture clear."
+        metric_label: "PRN logs"
+        metric_value:
+          one: "1 dose"
+          other: "%{count} doses"
+      schedule_hygiene:
+        title: "Schedule detail to review"
+        summary: "%{medication_name} is set for multiple daily doses without specific times."
+        detail: "Adding times can make reminders, reporting, and timing insights clearer."
+        metric_label: "Review"
+        metric_value: "Schedule"
   profiles:
     updated: "Profile updated successfully."
     email_updated: "Email updated successfully."
@@ -1396,8 +1460,6 @@ en:
         other: "%{count} routine tasks left today"
     insights:
       title: "Smart Insights"
-      pattern_detected: "Pattern detected"
-      message: "You've been remarkably consistent this week! Great job staying on track with your core regimen."
       view_report: "View Full Report"
     inventory:
       title: "Stock Inventory"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1213,8 +1213,6 @@ es:
         other: "%{count} tareas rutinarias pendientes hoy"
     insights:
       title: "Información inteligente"
-      pattern_detected: "Patrón detectado"
-      message: "¡Has sido notablemente constante esta semana! Buen trabajo manteniéndote al día con tu régimen principal."
       view_report: "Ver informe completo"
     inventory:
       title: "Inventario de stock"
@@ -1385,20 +1383,15 @@ es:
       summary:
         overall_compliance: "Adherencia general"
         total_doses_logged: "Dosis registradas en total"
-        current_health_status: "Estado de salud actual"
+        evidence_reviewed: "Evidencia revisada"
         excellent: "Excelente"
         needs_attention: "Necesita atención"
         on_track: "En buen camino"
         missed_doses: "Dosis omitidas"
-        optimal: "Óptimo"
-        vibrant: "Vibrante"
+        based_on_logs: "Basado en dosis registradas"
       timeline_title: "Cronología de adherencia"
       download_pdf: "Descargar PDF"
       timeline_compliance: "%{percentage}% de adherencia"
-      achievement_streak:
-        title: "Racha de logros"
-        value: "4 días seguidos"
-        description: "No has omitido ni una sola dosis desde el viernes por la mañana. Tu cuerpo mantiene niveles óptimos."
       inventory_alert:
         title: "Alerta de inventario"
         out_of_stock: "Sin stock"
@@ -1408,3 +1401,72 @@ es:
           one: "Tu suministro de %{medication_name} se agotará en %{count} día. Recomendamos solicitar un reabastecimiento esta tarde."
           other: "Tu suministro de %{medication_name} se agotará en %{count} días. Recomendamos solicitar un reabastecimiento esta tarde."
       actionable_insight: "Información accionable"
+  smart_insights:
+    title: "Información inteligente"
+    evidence_summary:
+      one: "%{days} días revisados con %{events} evento de medicación"
+      other: "%{days} días revisados con %{events} eventos de medicación"
+    learning:
+      title: "Aprendiendo tu rutina"
+      summary: "Sigue registrando dosis para que MedTracker pueda detectar patrones reales."
+      detail: "Smart Insights espera a tener suficiente evidencia antes de llamar patrón a algo."
+    no_action:
+      title: "Ningún patrón necesita atención"
+      summary: "Nada inusual destaca en este periodo del informe."
+      detail: "Tu informe sigue mostrando el historial de dosis y el inventario para que puedas revisar los detalles."
+    detectors:
+      adherence_streak:
+        title: "Racha de rutina sólida"
+        summary:
+          one: "Todas las dosis esperadas se registraron ayer."
+          other: "Todas las dosis esperadas se registraron durante %{count} días."
+        detail: "Esa constancia da buen ritmo a tu rutina de cuidados."
+        metric_label: "Racha actual"
+        metric_value:
+          one: "1 día"
+          other: "%{count} días"
+      missed_dose_pattern:
+        title: "Patrón de dosis omitidas"
+        summary:
+          one: "Ayer se omitieron dosis esperadas."
+          other: "Se omitieron dosis esperadas durante %{count} días seguidos."
+        detail: "Revisa el horario y los recordatorios de este periodo."
+        metric_label: "Racha más larga"
+        metric_value:
+          one: "1 día"
+          other: "%{count} días"
+      timing_consistency:
+        title: "Horario de dosis constante"
+        summary: "%{percentage}% de las dosis registradas estuvieron cerca de su hora programada."
+        detail: "El horario registrado ha sido estable en este periodo del informe."
+        metric_label: "Registros puntuales"
+        metric_value:
+          one: "1 dosis"
+          other: "%{count} dosis"
+      inventory_risk:
+        title: "El suministro necesita atención"
+        summary_zero: "%{medication_name} parece estar sin stock."
+        summary:
+          one: "%{medication_name} tiene aproximadamente 1 día de suministro."
+          other: "%{medication_name} tiene aproximadamente %{count} días de suministro."
+        detail: "Revisa el registro de stock de %{medication_name} y planifica el próximo reabastecimiento."
+        metric_label: "Suministro restante"
+        metric_value:
+          one: "1 día"
+          other: "%{count} días"
+      prn_usage:
+        title: "Uso según necesidad registrado"
+        summary:
+          one: "Se registró 1 dosis según necesidad en este periodo."
+          other: "Se registraron %{count} dosis según necesidad en este periodo."
+        detail: "Revisa estas entradas junto con las dosis rutinarias para mantener el panorama completo."
+        metric_label: "Registros PRN"
+        metric_value:
+          one: "1 dosis"
+          other: "%{count} dosis"
+      schedule_hygiene:
+        title: "Detalle del horario para revisar"
+        summary: "%{medication_name} está configurado para varias dosis diarias sin horas específicas."
+        detail: "Agregar horas puede aclarar los recordatorios, informes e insights de horario."
+        metric_label: "Revisar"
+        metric_value: "Horario"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1030,20 +1030,15 @@ ga:
       summary:
         overall_compliance: "Cloí Iomlán"
         total_doses_logged: "Líon Iomlán Dáileoga Logáilte"
-        current_health_status: "Stádas Sláinte Reatha"
+        evidence_reviewed: "Fianaise Athbhreithnithe"
         excellent: "Sármhaith"
         needs_attention: "Teastaíonn aird"
         on_track: "Ar an mbóthar ceart"
         missed_doses: "Dáileoga caillte"
-        optimal: "Optamach"
-        vibrant: "Beoga"
+        based_on_logs: "Bunaithe ar dháileoga logáilte"
       timeline_title: "Amlíne Cloí"
       download_pdf: "Íoslódáil PDF"
       timeline_compliance: "%{percentage}% Cloí"
-      achievement_streak:
-        title: "Sraith Rathanna"
-        value: "4 Lae Neamhbhriste"
-        description: "Níl dáileog amháin caillte agat ó mhaidin Dé hAoine. Tá do chorp ag coinneáil leibhéil optamacha."
       inventory_alert:
         title: "Foláireamh Stoc"
         out_of_stock: "As Stoc"
@@ -1053,6 +1048,75 @@ ga:
           one: "Beidh do sholáthar %{medication_name} ídithe i gceann %{count} lá. Molaimid athlíonadh a ordú tráthnóna inniu."
           other: "Beidh do sholáthar %{medication_name} ídithe i gceann %{count} lá. Molaimid athlíonadh a ordú tráthnóna inniu."
       actionable_insight: "Léargas inbhainistithe"
+  smart_insights:
+    title: "Léargais Chliste"
+    evidence_summary:
+      one: "%{days} lá athbhreithnithe le %{events} imeacht leighis"
+      other: "%{days} lá athbhreithnithe le %{events} imeacht leighis"
+    learning:
+      title: "Ag foghlaim do ghnáthaimh"
+      summary: "Lean ort ag logáil dáileoga ionas gur féidir le MedTracker patrúin fhíora a aimsiú."
+      detail: "Fanann Smart Insights le dóthain fianaise sula nglaonn sé patrún ar rud."
+    no_action:
+      title: "Níl patrún ar bith ag teastáil aird"
+      summary: "Ní sheasann aon rud neamhghnách amach sa tréimhse tuairisce seo."
+      detail: "Taispeánann do thuairisc stair dáileog agus stoc fós ionas gur féidir leat na sonraí a athbhreithniú."
+    detectors:
+      adherence_streak:
+        title: "Sraith ghnáthaimh láidir"
+        summary:
+          one: "Logáladh gach dáileog ionchais inné."
+          other: "Logáladh gach dáileog ionchais ar feadh %{count} lá."
+        detail: "Tugann an chomhsheasmhacht sin rithim láidir do do ghnáthamh cúraim."
+        metric_label: "Sraith reatha"
+        metric_value:
+          one: "1 lá"
+          other: "%{count} lá"
+      missed_dose_pattern:
+        title: "Patrún dáileoga caillte"
+        summary:
+          one: "Cailleadh dáileoga ionchais inné."
+          other: "Cailleadh dáileoga ionchais ar feadh %{count} lá as a chéile."
+        detail: "Athbhreithnigh an sceideal agus na meabhrúcháin don tréimhse seo."
+        metric_label: "Rith is faide"
+        metric_value:
+          one: "1 lá"
+          other: "%{count} lá"
+      timing_consistency:
+        title: "Amú dáileog comhsheasmhach"
+        summary: "Bhí %{percentage}% de na dáileoga logáilte gar dá n-am sceidealaithe."
+        detail: "Bhí d'amú logáilte seasmhach sa tréimhse tuairisce seo."
+        metric_label: "Logaí in am"
+        metric_value:
+          one: "1 dáileog"
+          other: "%{count} dáileog"
+      inventory_risk:
+        title: "Teastaíonn aird ar sholáthar"
+        summary_zero: "Is cosúil go bhfuil %{medication_name} as stoc."
+        summary:
+          one: "Tá thart ar 1 lá soláthair fágtha ag %{medication_name}."
+          other: "Tá thart ar %{count} lá soláthair fágtha ag %{medication_name}."
+        detail: "Seiceáil taifead stoic %{medication_name} agus pleanáil an chéad athlíonadh eile."
+        metric_label: "Soláthar fágtha"
+        metric_value:
+          one: "1 lá"
+          other: "%{count} lá"
+      prn_usage:
+        title: "Úsáid de réir mar is gá logáilte"
+        summary:
+          one: "Logáladh 1 dáileog de réir mar is gá sa tréimhse seo."
+          other: "Logáladh %{count} dáileog de réir mar is gá sa tréimhse seo."
+        detail: "Athbhreithnigh na hiontrálacha seo in éineacht le dáileoga rialta chun an pictiúr iomlán a choinneáil soiléir."
+        metric_label: "Logaí PRN"
+        metric_value:
+          one: "1 dáileog"
+          other: "%{count} dáileog"
+      schedule_hygiene:
+        title: "Sonra sceidil le hathbhreithniú"
+        summary: "Tá %{medication_name} socraithe do roinnt dáileoga laethúla gan amanna sonracha."
+        detail: "Is féidir le hamanna a chur leis meabhrúcháin, tuairiscí agus léargais ama a dhéanamh níos soiléire."
+        metric_label: "Athbhreithniú"
+        metric_value: "Sceideal"
   forms:
     locations:
       name_placeholder: "m.sh. Baile, Scoil, Teach na Mamó"
@@ -1180,8 +1244,6 @@ ga:
         other: "%{count} tasc rialta fágtha inniu"
     insights:
       title: "Léarchéal Cliste"
-      pattern_detected: "Patrún aimsithe"
-      message: "Tá tú tar éis bheith an-chonsasta an tseachtain seo! Maith thú le fanacht ar an bhóthar le do phríomhchlár."
       view_report: "Féach ar an Tuarascáil Iomlán"
     inventory:
       title: "Stocchaint"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -968,20 +968,15 @@ pt:
       summary:
         overall_compliance: "Cumprimento geral"
         total_doses_logged: "Total de doses registadas"
-        current_health_status: "Estado de saúde atual"
+        evidence_reviewed: "Evidência revista"
         excellent: "Excelente"
         needs_attention: "Precisa de atenção"
         on_track: "No caminho certo"
         missed_doses: "Doses em falta"
-        optimal: "Ótimo"
-        vibrant: "Vibrante"
+        based_on_logs: "Com base nas doses registadas"
       timeline_title: "Linha temporal de adesão"
       download_pdf: "Descarregar PDF"
       timeline_compliance: "%{percentage}% de conformidade"
-      achievement_streak:
-        title: "Sequência de conquistas"
-        value: "4 dias sem interrupção"
-        description: "Não falhou nenhuma dose desde sexta-feira de manhã. O seu corpo está a manter níveis ideais."
       inventory_alert:
         title: "Alerta de inventário"
         out_of_stock: "Sem stock"
@@ -991,6 +986,75 @@ pt:
           one: "O seu stock de %{medication_name} esgotar-se-á dentro de %{count} dia. Recomendamos encomendar um reabastecimento esta tarde."
           other: "O seu stock de %{medication_name} esgotar-se-á dentro de %{count} dias. Recomendamos encomendar um reabastecimento esta tarde."
       actionable_insight: "Informação acionável"
+  smart_insights:
+    title: "Informações inteligentes"
+    evidence_summary:
+      one: "%{days} dias revistos com %{events} evento de medicação"
+      other: "%{days} dias revistos com %{events} eventos de medicação"
+    learning:
+      title: "A aprender a sua rotina"
+      summary: "Continue a registar doses para que o MedTracker possa detetar padrões reais."
+      detail: "O Smart Insights espera por evidência suficiente antes de chamar algo de padrão."
+    no_action:
+      title: "Nenhum padrão precisa de atenção"
+      summary: "Nada invulgar se destaca neste período do relatório."
+      detail: "O relatório continua a mostrar o histórico de doses e o inventário para rever os detalhes."
+    detectors:
+      adherence_streak:
+        title: "Sequência de rotina forte"
+        summary:
+          one: "Todas as doses esperadas foram registadas ontem."
+          other: "Todas as doses esperadas foram registadas durante %{count} dias."
+        detail: "Essa consistência dá um bom ritmo à sua rotina de cuidados."
+        metric_label: "Sequência atual"
+        metric_value:
+          one: "1 dia"
+          other: "%{count} dias"
+      missed_dose_pattern:
+        title: "Padrão de doses em falta"
+        summary:
+          one: "Doses esperadas ficaram por registar ontem."
+          other: "Doses esperadas ficaram por registar durante %{count} dias seguidos."
+        detail: "Reveja o horário e os lembretes deste período."
+        metric_label: "Maior sequência"
+        metric_value:
+          one: "1 dia"
+          other: "%{count} dias"
+      timing_consistency:
+        title: "Horário de doses consistente"
+        summary: "%{percentage}% das doses registadas ficaram perto da hora programada."
+        detail: "O horário registado foi estável neste período do relatório."
+        metric_label: "Registos pontuais"
+        metric_value:
+          one: "1 dose"
+          other: "%{count} doses"
+      inventory_risk:
+        title: "O stock precisa de atenção"
+        summary_zero: "%{medication_name} parece estar sem stock."
+        summary:
+          one: "%{medication_name} tem cerca de 1 dia de stock."
+          other: "%{medication_name} tem cerca de %{count} dias de stock."
+        detail: "Verifique o registo de stock de %{medication_name} e planeie o próximo reabastecimento."
+        metric_label: "Stock restante"
+        metric_value:
+          one: "1 dia"
+          other: "%{count} dias"
+      prn_usage:
+        title: "Uso conforme necessário registado"
+        summary:
+          one: "Foi registada 1 dose conforme necessário neste período."
+          other: "Foram registadas %{count} doses conforme necessário neste período."
+        detail: "Reveja estas entradas juntamente com as doses de rotina para manter uma visão completa."
+        metric_label: "Registos PRN"
+        metric_value:
+          one: "1 dose"
+          other: "%{count} doses"
+      schedule_hygiene:
+        title: "Detalhe do horário para rever"
+        summary: "%{medication_name} está definido para várias doses diárias sem horas específicas."
+        detail: "Adicionar horas pode tornar lembretes, relatórios e informações de horário mais claros."
+        metric_label: "Rever"
+        metric_value: "Horário"
 
   profiles:
     updated: "Perfil atualizado com sucesso."
@@ -1349,8 +1413,6 @@ pt:
         other: "%{count} tarefas de rotina pendentes hoje"
     insights:
       title: "Informações inteligentes"
-      pattern_detected: "Padrão detetado"
-      message: "Tem sido notavelmente consistente esta semana! Bom trabalho por manter o foco no seu regime principal."
       view_report: "Ver relatório completo"
     inventory:
       title: "Inventário de stock"

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -136,6 +136,64 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(rendered.text).to include('Smart Insights')
     end
 
+    it 'does not render a fake detected pattern without an evidence-backed insight' do
+      insight_result = SmartInsights::Result.new(
+        primary_insight: nil,
+        insights: [],
+        learning_state?: true,
+        evidence_summary: '1 day tracked'
+      )
+      presenter = person_task_presenter(insight_result: insight_result)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+
+      expect(rendered.text).not_to include('Pattern detected')
+      expect(rendered.text).to include('Learning your routine')
+    end
+
+    it 'renders the no-action state when enough evidence has no detected patterns' do
+      insight_result = SmartInsights::Result.new(
+        primary_insight: nil,
+        insights: [],
+        learning_state?: false,
+        evidence_summary: '7 days tracked'
+      )
+      presenter = person_task_presenter(insight_result: insight_result)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+
+      expect(rendered.text).to include('No pattern needs attention')
+      expect(rendered.text).not_to include('Learning your routine')
+      expect(rendered.text).not_to include('Strong streak')
+    end
+
+    it 'links authorized users to the reports insights section' do
+      presenter = person_task_presenter(insight_result: detected_insight_result, can_view_reports: true)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+
+      expect(rendered.css("a[href='/reports#insights']")).to be_present
+    end
+
+    it 'renders the reports insights link with visible link affordance' do
+      presenter = person_task_presenter(insight_result: detected_insight_result, can_view_reports: true)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+      link = rendered.at_css("a[href='/reports#insights']")
+
+      expect(link.text).to include('View Full Report')
+      expect(link['class']).to include('border-b-2')
+      expect(link['class']).to include('hover:border-current')
+    end
+
+    it 'omits the reports link when the user cannot view reports' do
+      presenter = person_task_presenter(insight_result: detected_insight_result, can_view_reports: false)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+
+      expect(rendered.css("a[href='/reports#insights']")).not_to be_present
+    end
+
     it 'renders Stock Inventory' do
       rendered = render_inline(dashboard_view)
       expect(rendered.text).to include('Stock Inventory')
@@ -201,7 +259,7 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     end
   end
 
-  def person_task_presenter(routine_status: :upcoming)
+  def person_task_presenter(routine_status: :upcoming, insight_result: nil, can_view_reports: true)
     person = people(:john)
     instance_double(
       DashboardPresenter,
@@ -210,9 +268,45 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       current_user: admin_user,
       compliance_percentage: 85,
       next_dose_time: nil,
+      smart_insights: insight_result || learning_insight_result,
+      can_view_reports?: can_view_reports,
       routine_tasks_due?: true,
       routine_tasks_by_person: { person => [routine_dashboard_row(person, status: routine_status)] },
       as_needed_by_person: { person => [as_needed_dashboard_row(person)] }
+    )
+  end
+
+  def learning_insight_result
+    SmartInsights::Result.new(
+      primary_insight: nil,
+      insights: [],
+      learning_state?: true,
+      evidence_summary: '1 day tracked'
+    )
+  end
+
+  def detected_insight_result
+    insight = detected_insight
+
+    SmartInsights::Result.new(
+      primary_insight: insight,
+      insights: [insight],
+      learning_state?: false,
+      evidence_summary: '7 days tracked'
+    )
+  end
+
+  def detected_insight
+    SmartInsights::Insight.new(
+      key: :adherence_streak,
+      family: :adherence,
+      severity: :positive,
+      title: 'Strong streak',
+      summary: '7 days logged',
+      detail: 'Every expected dose was logged in this report window.',
+      metric_label: 'Current streak',
+      metric_value: '7 days',
+      cta_path: '/reports#insights'
     )
   end
 

--- a/spec/presenters/dashboard_presenter_spec.rb
+++ b/spec/presenters/dashboard_presenter_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe DashboardPresenter do
-  fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules
+  fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules, :person_medications,
+           :medication_takes
 
   let(:admin_user) { users(:admin) }
   let(:carer_user) { users(:carer) }
@@ -142,5 +143,40 @@ RSpec.describe DashboardPresenter do
       presenter = described_class.new(current_user: admin_user)
       expect(presenter.doses).to be_an(Array)
     end
+  end
+
+  describe '#smart_insights' do
+    it 'bulk loads dashboard insight sources for scoped people' do
+      baseline_counts = count_insight_source_queries { described_class.new(current_user: admin_user).smart_insights }
+
+      create_list(:person, 2).each do |person|
+        medication = create(:medication, current_supply: 500, supply_at_last_restock: 500)
+        create(:schedule, person: person, medication: medication)
+      end
+
+      expanded_counts = count_insight_source_queries { described_class.new(current_user: admin_user).smart_insights }
+
+      expect(expanded_counts[:schedules]).to eq(baseline_counts[:schedules])
+      expect(expanded_counts[:person_medications]).to eq(baseline_counts[:person_medications])
+      expect(expanded_counts[:medication_takes]).to eq(baseline_counts[:medication_takes])
+    end
+  end
+
+  def count_insight_source_queries(&)
+    counts = Hash.new(0)
+
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      counts[:schedules] += 1 if sql.include?('FROM "schedules"')
+      counts[:person_medications] += 1 if sql.include?('FROM "person_medications"')
+      counts[:medication_takes] += 1 if sql.include?('FROM "medication_takes"')
+    end
+
+    ActiveRecord::Base.uncached do
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    end
+    counts
   end
 end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe 'Reports' do
         expect(response).to have_http_status(:success)
       end
 
+      it 'renders the Smart Insights anchor section' do
+        get reports_path
+
+        expect(response.body).to include('id="insights"')
+        expect(response.body).to include('Smart Insights')
+      end
+
+      it 'renders the Smart Insights anchor with a section heading' do
+        get reports_path
+
+        page = response.parsed_body
+        insights_section = page.at_css('section#insights')
+
+        expect(insights_section).to be_present
+        expect(page.css('#insights').size).to eq(1)
+        expect(insights_section.at_css('h2')&.text).to include('Smart Insights')
+      end
+
+      it 'does not render the retired static achievement copy' do
+        get reports_path
+
+        expect(response.body).not_to include('Achievement Streak')
+        expect(response.body).not_to include('4 Days Uninterrupted')
+        expect(response.body).not_to include('maintaining optimal levels')
+        expect(response.body).not_to include('Current Health Status')
+      end
+
       it 'redirects with alert when providing invalid date formats' do
         get reports_path, params: { start_date: 'invalid-date' }
         expect(response).to redirect_to(reports_path)

--- a/spec/services/smart_insights/index_query_spec.rb
+++ b/spec/services/smart_insights/index_query_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmartInsights::IndexQuery do
+  let(:person) { create(:person) }
+  let(:people) { Person.where(id: person.id) }
+  let(:start_date) { Time.zone.today - 6.days }
+  let(:end_date) { Time.zone.today }
+  let(:medication) do
+    create(:medication, name: 'Vitamin D', current_supply: 500, supply_at_last_restock: 500)
+  end
+
+  it 'returns a learning state when there is not enough evidence' do
+    create_schedule(start_date: end_date, end_date: end_date)
+
+    result = described_class.new(people: people, start_date: end_date, end_date: end_date).call
+
+    expect(result).to be_learning_state
+    expect(result.primary_insight).to be_nil
+    expect(result.insights).to be_empty
+  end
+
+  it 'ignores evidence and patterns from people outside the caller scope' do
+    other_person = create(:person)
+    other_schedule = create_schedule(person: other_person, start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: other_schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result).to be_learning_state
+    expect(result.insights).to be_empty
+  end
+
+  it 'detects an adherence streak only after the evidence threshold is met' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result).not_to be_learning_state
+    expect(result.insights.map(&:key)).to include(:adherence_streak)
+    expect(result.primary_insight.key).to eq(:adherence_streak)
+  end
+
+  it 'returns a no-action result when evidence exists but no detector finds a pattern' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    [
+      [start_date, 8],
+      [start_date + 1.day, 10],
+      [start_date + 3.days, 12],
+      [start_date + 4.days, 14],
+      [end_date, 16]
+    ].each do |date, hour|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: hour))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result).not_to be_learning_state
+    expect(result.primary_insight).to be_nil
+    expect(result.insights).to be_empty
+  end
+
+  it 'detects missed-dose patterns from expected-versus-actual schedule data' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    [start_date, start_date + 1.day, start_date + 4.days, start_date + 5.days, end_date].each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).to include(:missed_dose_pattern)
+  end
+
+  it 'detects inventory risk using schedule-aware burn rate' do
+    low_stock = create(:medication, name: 'Low Stock Med', current_supply: 2, supply_at_last_restock: 20)
+    schedule = create_schedule(medication: low_stock, start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8), decrement_stock: false)
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).to include(:inventory_risk)
+  end
+
+  it 'detects timing consistency when logged doses stay near configured times' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8, min: 30))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).to include(:timing_consistency)
+  end
+
+  it 'does not report timing consistency when scheduled occurrences are missed' do
+    schedule = create_schedule(
+      start_date: start_date,
+      end_date: end_date,
+      schedule_config: { 'times' => %w[08:00 20:00] },
+      max_daily_doses: 2
+    )
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).not_to include(:timing_consistency)
+  end
+
+  it 'does not report timing consistency below the on-time threshold' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    (start_date..(start_date + 3.days)).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+    ((start_date + 4.days)..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 13))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).not_to include(:timing_consistency)
+  end
+
+  it 'detects as-needed usage from PRN dose logs' do
+    schedule = create_schedule(
+      start_date: start_date,
+      end_date: end_date,
+      schedule_config: {},
+      schedule_type: :prn,
+      max_daily_doses: 4
+    )
+    (start_date..(start_date + 4.days)).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 12))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).to include(:prn_usage)
+  end
+
+  it 'does not treat routine person medication takes as PRN usage' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    person_medication = create(:person_medication, :routine, person: person, medication: create(:medication))
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+      create(:medication_take, :for_person_medication,
+             person_medication: person_medication,
+             taken_at: date.in_time_zone.change(hour: 12))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).not_to include(:prn_usage)
+  end
+
+  it 'does not report inventory risk at the alert threshold' do
+    threshold_stock = create(:medication, name: 'Threshold Stock Med', current_supply: 14, supply_at_last_restock: 20)
+    schedule = create_schedule(medication: threshold_stock, start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8), decrement_stock: false)
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).not_to include(:inventory_risk)
+  end
+
+  it 'detects schedule hygiene gaps when active multiple-daily schedules have no configured times' do
+    create_schedule(start_date: start_date, end_date: end_date, schedule_config: {})
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).to include(:schedule_hygiene)
+  end
+
+  it 'does not report schedule hygiene for configured multiple-daily schedules' do
+    schedule = create_schedule(start_date: start_date, end_date: end_date)
+    (start_date..end_date).each do |date|
+      create_take(schedule: schedule, taken_at: date.in_time_zone.change(hour: 8))
+    end
+
+    result = described_class.new(people: people, start_date: start_date, end_date: end_date).call
+
+    expect(result.insights.map(&:key)).not_to include(:schedule_hygiene)
+  end
+
+  def create_schedule(**attributes)
+    create(
+      :schedule,
+      {
+        person: person,
+        medication: medication,
+        schedule_type: :multiple_daily,
+        schedule_config: { 'times' => ['08:00'] },
+        max_daily_doses: 1
+      }.merge(attributes)
+    )
+  end
+
+  def create_take(schedule:, taken_at:, decrement_stock: true)
+    take = build(:medication_take, schedule: schedule, person_medication: nil, taken_at: taken_at)
+    allow(take).to receive(:decrement_medication_stock) unless decrement_stock
+    take.save!
+    take
+  end
+end

--- a/spec/views/reports/index_spec.rb
+++ b/spec/views/reports/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Views::Reports::Index do
   subject(:report_view) do
     described_class.new(
       daily_data: daily_data,
-      inventory_alerts: inventory_alerts,
+      smart_insights: smart_insights,
       start_date: 7.days.ago.to_date,
       end_date: Time.zone.today
     )
@@ -20,10 +20,25 @@ RSpec.describe Views::Reports::Index do
     ]
   end
 
-  let(:inventory_alerts) do
-    [
-      { medication_name: 'Ibuprofen', days_left: 3, doses_left: 12 }
-    ]
+  let(:smart_insights) do
+    insight = SmartInsights::Insight.new(
+      key: :inventory_risk,
+      family: :inventory,
+      severity: :urgent,
+      title: 'Supply needs attention',
+      summary: 'Ibuprofen has about 3 days of supply left.',
+      detail: 'Check the stock record for Ibuprofen and plan the next refill.',
+      metric_label: 'Supply window',
+      metric_value: '3 days',
+      cta_path: '/reports#insights'
+    )
+
+    SmartInsights::Result.new(
+      primary_insight: insight,
+      insights: [insight],
+      learning_state?: false,
+      evidence_summary: '12 medication events across 7 days'
+    )
   end
 
   before do
@@ -54,11 +69,11 @@ RSpec.describe Views::Reports::Index do
     expect(rendered).to include('Wed')
   end
 
-  it 'renders the inventory alert with interpolated data' do
+  it 'renders the smart insight with interpolated data' do
     rendered = render report_view
-    expect(rendered).to include('Inventory Alert')
+    expect(rendered).to include('Smart Insights')
     expect(rendered).to include('Ibuprofen')
-    expect(rendered).to include('exhausted in 3 days')
+    expect(rendered).to include('about 3 days of supply left')
   end
 
   it 'renders report copy from the active locale' do


### PR DESCRIPTION
## Summary
- add shared SmartInsights result/query objects with detector strategies for adherence, missed doses, timing consistency, inventory risk, PRN usage, and schedule hygiene
- replace the dashboard fake Pattern detected card with evidence-backed primary, learning, and no-action states plus a permission-aware /reports#insights CTA
- add the reports #insights section, translated Smart Insights copy, and coverage for detector, dashboard, reports, accessibility, and query guardrail behavior

## Verification
- task rubocop
- task test

Closes #1211
Closes #1212
Closes #1213
Closes #1214
Closes #1215
Closes #1216
Closes #1217
Closes #1218
Refs #1219