### PR TITLE
fix: tighten dashboard schedule layout

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -12,7 +12,7 @@ module Components
       end
 
       def view_template
-        div(class: 'container mx-auto max-w-6xl px-4 py-8', data: { testid: 'dashboard' }) do
+        div(class: 'container mx-auto max-w-6xl px-4 py-6', data: { testid: 'dashboard' }) do
           render_header
           render_stats_section
 
@@ -46,7 +46,7 @@ module Components
       end
 
       def render_header
-        div(class: 'flex flex-col md:flex-row md:items-end justify-between gap-6 mb-12') do
+        div(class: 'flex flex-col md:flex-row md:items-end justify-between gap-6 mb-8') do
           div do
             m3_text(variant: :label_large, class: 'uppercase tracking-[0.2em] mb-1 block font-black opacity-40') do
               Time.current.strftime('%A, %b %d')
@@ -85,29 +85,33 @@ module Components
       end
 
       def render_stats_section
-        div(class: 'grid grid-cols-2 lg:grid-cols-4 auto-rows-fr gap-4 mb-12') do
+        div(class: 'grid grid-cols-2 lg:grid-cols-4 auto-rows-fr gap-3 mb-8') do
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.people'),
             value: people.size,
             icon_type: 'users',
-            href: people_path
+            href: people_path,
+            layout: :compact
           )
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.active_schedules'),
             value: active_schedules.size,
             icon_type: 'active_schedules',
-            href: schedules_path
+            href: schedules_path,
+            layout: :compact
           )
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.compliance'),
             value: "#{compliance_percentage}%",
             icon_type: 'compliance',
-            href: reports_path
+            href: reports_path,
+            layout: :compact
           )
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.next_dose'),
             value: next_dose_value,
-            icon_type: 'clock'
+            icon_type: 'clock',
+            layout: :compact
           )
         end
       end

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -86,7 +86,7 @@ module Components
           end
           div(class: 'flex shrink-0 items-center gap-2 sm:justify-end') do
             render_action(row)
-            render_status_badge(row)
+            render_status_badge(row) unless row[:status] == :upcoming
           end
         end
       end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -186,6 +186,23 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(rendered.text).to include('1 routine task left today')
       expect(rendered.text).not_to include('Routine tasks done today')
     end
+
+    it 'does not duplicate the default upcoming state as a badge' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter))
+      routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
+
+      expect(routine_task.text).not_to include('Upcoming')
+    end
+  end
+
+  describe 'dashboard density' do
+    it 'renders top metric cards with the compact layout' do
+      rendered = render_inline(dashboard_view)
+      html = rendered.to_html
+
+      expect(html).to include('min-h-[7rem]')
+      expect(html).not_to include('min-h-[9.5rem]')
+    end
   end
 
   context 'when there are no active schedules or person medications' do


### PR DESCRIPTION
## Summary
- remove the redundant Upcoming badge from default dashboard routine rows
- use compact dashboard metric cards and reduce top-section spacing
- add component coverage for the cleaned-up state and compact card layout

## Verification
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb
- task rubocop
- task test
- browser check at http://localhost:56691/dashboard