### PR TITLE
fix: improve smart insights CTA

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -237,9 +237,10 @@ module Components
 
         m3_link(
           href: reports_path(anchor: 'insights'),
-          variant: :text,
-          class: "mt-8 p-0 h-auto font-black uppercase tracking-widest #{dashboard_insight_link_classes} " \
-                 'border-b-2 rounded-none hover:bg-transparent transition-all'
+          variant: :tonal,
+          class: 'mt-8 inline-flex max-w-full items-center justify-center rounded-shape-full px-5 py-2.5 ' \
+                 'min-h-[44px] h-auto text-center text-sm font-bold uppercase tracking-wide leading-snug ' \
+                 "#{dashboard_insight_link_classes} shadow-elevation-1 transition-all"
         ) do
           t('dashboard.insights.view_report')
         end
@@ -294,9 +295,9 @@ module Components
 
       def dashboard_insight_link_classes
         if presenter.smart_insights.primary_insight.present?
-          'text-current border-current/30 hover:border-current'
+          'bg-surface-container-low text-on-surface border border-outline-variant/70 hover:bg-surface-container-high'
         else
-          'text-primary border-primary/30 hover:border-primary'
+          'bg-primary text-on-primary hover:bg-primary/90'
         end
       end
 

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -175,15 +175,19 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(rendered.css("a[href='/reports#insights']")).to be_present
     end
 
-    it 'renders the reports insights link with visible link affordance' do
+    it 'renders the reports insights link with visible link affordance', :aggregate_failures do
       presenter = person_task_presenter(insight_result: detected_insight_result, can_view_reports: true)
 
       rendered = render_inline(described_class.new(presenter: presenter))
       link = rendered.at_css("a[href='/reports#insights']")
 
       expect(link.text).to include('View Full Report')
-      expect(link['class']).to include('border-b-2')
-      expect(link['class']).to include('hover:border-current')
+      expect(link['class']).to include('bg-surface-container-low')
+      expect(link['class']).to include('text-on-surface')
+      expect(link['class']).to include('px-5')
+      expect(link['class']).to include('min-h-[44px]')
+      expect(link['class']).to include('max-w-full')
+      expect(link['class']).not_to include('p-0')
     end
 
     it 'omits the reports link when the user cannot view reports' do

--- a/spec/components/views/profiles/version_info_spec.rb
+++ b/spec/components/views/profiles/version_info_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Views::Profiles::VersionInfo, type: :component do
     expect(html).to include('/Users/damacus/.codex/worktrees/a270/med-tracker')
     expect(html).to include('Commit')
     expect(html).to include('bb956afc')
-    expect(html).not_to include('v0.3.51')
+    expect(html).not_to include("v#{MedTracker::VERSION}")
   end
 
   it 'renders app version and release notes outside development' do
@@ -29,9 +29,9 @@ RSpec.describe Views::Profiles::VersionInfo, type: :component do
     html = rendered.to_html
 
     expect(html).to include('App Version')
-    expect(html).to include('v0.3.51')
+    expect(html).to include("v#{MedTracker::VERSION}")
     expect(html).to include('Release Notes')
-    expect(html).to include('https://github.com/damacus/med-tracker/releases/tag/v0.3.51')
+    expect(html).to include("https://github.com/damacus/med-tracker/releases/tag/v#{MedTracker::VERSION}")
     expect(html).not_to match(/Worktree|Commit/)
   end
 


### PR DESCRIPTION
## Summary
- restyle the Smart Insights "View Full Report" link as a contained tokenized action so the full label fits and contrasts with the insight card background
- add a component regression spec for CTA contrast, padding, full-width constraints, and tap target size
- update the profile version info spec to use MedTracker::VERSION instead of a stale release literal so current-main tests stay green

## Verification
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb
- task test TEST_FILE=spec/components/views/profiles/version_info_spec.rb
- task rubocop
- task test