### PR TITLE
test: 🧪 Add tests for NhsDmdImport#start! method

### DIFF
--- a/spec/models/nhs_dmd_import_spec.rb
+++ b/spec/models/nhs_dmd_import_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NhsDmdImport do
       import = described_class.create!(uploaded_filename: 'release.zip')
 
       freeze_time do
-        expect { import.start! }.to change { import.reload.started_at }.from(nil).to(Time.current)
+        expect { import.start! }.to(change { import.reload.started_at }.from(nil).to(Time.current))
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe NhsDmdImport do
       existing_time = 1.day.ago.round
       import = described_class.create!(uploaded_filename: 'release.zip', started_at: existing_time)
 
-      expect { import.start! }.not_to change { import.reload.started_at }
+      expect { import.start! }.not_to(change { import.reload.started_at })
     end
   end
 

--- a/spec/models/nhs_dmd_import_spec.rb
+++ b/spec/models/nhs_dmd_import_spec.rb
@@ -3,6 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe NhsDmdImport do
+  describe '#start!' do
+    it 'sets started_at to current time when blank' do
+      import = described_class.create!(uploaded_filename: 'release.zip')
+
+      freeze_time do
+        expect { import.start! }.to change { import.reload.started_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'does not update started_at when already present' do
+      existing_time = 1.day.ago.round
+      import = described_class.create!(uploaded_filename: 'release.zip', started_at: existing_time)
+
+      expect { import.start! }.not_to change { import.reload.started_at }
+    end
+  end
+
   describe '#complete!' do
     it 'includes unchanged records in the fallback processed total' do
       import = described_class.create!(uploaded_filename: 'nhsbsa_dmd_release.zip')


### PR DESCRIPTION
🎯 **What:** The `start!` method in `NhsDmdImport` model was missing test coverage. This PR adds tests to ensure the timestamp `started_at` gets populated when currently blank, and remains unchanged if it already exists.
📊 **Coverage:** Added coverage for both branches of the conditional logic `if started_at.blank?` within `NhsDmdImport#start!`.
✨ **Result:** Improved test reliability ensuring the core timing extraction logic functions as expected without unintentional regressions.

---
*PR created automatically by Jules for task [6760838957990114457](https://jules.google.com/task/6760838957990114457) started by @damacus*