### PR TITLE
test: 🧪 Add missing test for nil archive path in NhsDmdImport

### DIFF
--- a/spec/models/nhs_dmd_import_spec.rb
+++ b/spec/models/nhs_dmd_import_spec.rb
@@ -3,6 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe NhsDmdImport do
+  describe '#persist_archive!' do
+    let(:import) { described_class.new(uploaded_filename: 'nhsbsa_dmd_release.zip') }
+
+    it 'raises ArgumentError when uploaded file is nil' do
+      expect { import.persist_archive!(nil) }.to raise_error(ArgumentError, 'Import archive is missing.')
+    end
+
+    it 'raises ArgumentError when uploaded file is an empty string' do
+      expect { import.persist_archive!('') }.to raise_error(ArgumentError, 'Import archive is missing.')
+    end
+  end
+
   describe '#complete!' do
     it 'includes unchanged records in the fallback processed total' do
       import = described_class.create!(uploaded_filename: 'nhsbsa_dmd_release.zip')


### PR DESCRIPTION
🎯 **What:** Added tests for edge cases in `NhsDmdImport#persist_archive!` where the uploaded file is `nil` or an empty string.
📊 **Coverage:** Added specs testing that calling `persist_archive!` with `nil` or an empty string successfully raises the expected `ArgumentError`.
✨ **Result:** Improved unit test coverage and safety for the `NhsDmdImport` model.

---
*PR created automatically by Jules for task [2116597227419912161](https://jules.google.com/task/2116597227419912161) started by @damacus*