### PR TITLE
refactor: 🧹 Remove unused active_access_token? and inline logic

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -29,7 +29,7 @@ module Api
         token = bearer_token
         @current_api_session = ApiSession.lookup_by_access_token(token)
 
-        unless @current_api_session&.active_access_token?
+        unless @current_api_session && @current_api_session.revoked_at.nil? && @current_api_session.access_expires_at&.future?
           render_unauthorized('Authentication required')
           return
         end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -26,20 +26,19 @@ module Api
       end
 
       def authenticate_api_request!
-        token = bearer_token
-        @current_api_session = ApiSession.lookup_by_access_token(token)
-
-        unless @current_api_session && @current_api_session.revoked_at.nil? && @current_api_session.access_expires_at&.future?
-          render_unauthorized('Authentication required')
-          return
-        end
-
-        if current_account.blank? || !current_account.verified? || current_user.blank? || !current_user.active?
-          render_unauthorized('Authentication required')
-          return
-        end
+        @current_api_session = ApiSession.lookup_by_access_token(bearer_token)
+        return render_unauthorized('Authentication required') unless valid_session?
+        return render_unauthorized('Authentication required') unless valid_account_and_user?
 
         @current_api_session.touch_last_used!
+      end
+
+      def valid_session?
+        @current_api_session.present? && @current_api_session.revoked_at.nil? && @current_api_session.access_expires_at&.future?
+      end
+
+      def valid_account_and_user?
+        current_account.present? && current_account.verified? && current_user.present? && current_user.active?
       end
 
       def bearer_token

--- a/app/models/api_session.rb
+++ b/app/models/api_session.rb
@@ -42,9 +42,6 @@ class ApiSession < ApplicationRecord
     Digest::SHA256.hexdigest(token.to_s)
   end
 
-  def active_access_token?
-    revoked_at.nil? && access_expires_at.future?
-  end
 
   def active_refresh_token?
     revoked_at.nil? && refresh_expires_at.future?

--- a/app/models/api_session.rb
+++ b/app/models/api_session.rb
@@ -42,7 +42,6 @@ class ApiSession < ApplicationRecord
     Digest::SHA256.hexdigest(token.to_s)
   end
 
-
   def active_refresh_token?
     revoked_at.nil? && refresh_expires_at.future?
   end


### PR DESCRIPTION
🎯 **What:** Removed the `active_access_token?` method from `ApiSession` and safely inlined its logic into the caller (`Api::V1::BaseController`). 
💡 **Why:** To improve code maintainability by eliminating redundant indirection. The method was flagged as unused in documentation but was actually called directly. We translated the logic completely securely, taking care to preserve the revocation status check and including safe navigation for future expiration (`&.future?`).
✅ **Verification:** Verified with isolated unit tests and static syntax checks via `ruby -c`.
✨ **Result:** A slightly cleaner `ApiSession` model while successfully preserving strict token validation within `BaseController`.

---
*PR created automatically by Jules for task [16816564882590002228](https://jules.google.com/task/16816564882590002228) started by @damacus*