### PR TITLE
refactor: 🧹 Fix false positive commented-out code warning in audit_logger.rb

### DIFF
--- a/app/services/external_lookup/audit_logger.rb
+++ b/app/services/external_lookup/audit_logger.rb
@@ -8,7 +8,7 @@ module ExternalLookup
       # rubocop:disable Rails/SkipsModelValidations
       # PaperTrail::Version is a gem storage table — there are no meaningful validations to run.
       # We use insert to bypass PaperTrail's before_create callbacks, which would attempt to
-      # constantize item_type and look up a matching ActiveRecord class.
+      # resolve the item type string into a matching ActiveRecord class.
       PaperTrail::Version.insert(version_attrs(source:, event:, query:, result_status:, result_count:))
       # rubocop:enable Rails/SkipsModelValidations
     rescue StandardError => e


### PR DESCRIPTION
🎯 What: Rephrased a comment containing 'constantize item_type' to 'resolve the item type string' in `app/services/external_lookup/audit_logger.rb`.
💡 Why: The phrase was being incorrectly flagged as commented-out Ruby code by a code health scanner. Rephrasing it retains the explanatory context for the PaperTrail callback bypass without triggering the false positive, thus resolving the code health issue safely.
✅ Verification: Ran `ruby -c` to verify syntax and `bundle exec rubocop` to ensure no linting offenses. No behavior changes were made.
✨ Result: Code health issue resolved without removing valuable documentation.

---
*PR created automatically by Jules for task [17727119466906226357](https://jules.google.com/task/17727119466906226357) started by @damacus*