### PR TITLE
feat: add invitation cancellation

### DIFF
--- a/app/components/admin/invitations/index_view.rb
+++ b/app/components/admin/invitations/index_view.rb
@@ -11,11 +11,13 @@ module Components
         def initialize(
           invitation: Invitation.new,
           invitations: Invitation.order(created_at: :desc),
-          resendable_invitation_ids: []
+          resendable_invitation_ids: [],
+          cancellable_invitation_ids: []
         )
           @invitation = invitation
           @invitations = invitations
           @resendable_invitation_ids = resendable_invitation_ids
+          @cancellable_invitation_ids = cancellable_invitation_ids
         end
 
         def view_template
@@ -132,11 +134,27 @@ module Components
               p(class: 'text-xs text-on-surface-variant') { invitation_metadata(invitation) }
             end
 
-            next unless resendable_invitation?(invitation)
+            render_invitation_actions(invitation)
+          end
+        end
 
-            form_with(url: resend_admin_invitation_path(invitation), method: :post, class: 'shrink-0') do
-              m3_button(type: :submit, variant: :outlined, size: :sm, class: 'rounded-xl') do
-                t('admin.invitations.index.resend')
+        def render_invitation_actions(invitation)
+          return unless resendable_invitation?(invitation) || cancellable_invitation?(invitation)
+
+          div(class: 'flex items-center gap-2 shrink-0') do
+            if resendable_invitation?(invitation)
+              form_with(url: resend_admin_invitation_path(invitation), method: :post, class: 'shrink-0') do
+                m3_button(type: :submit, variant: :outlined, size: :sm, class: 'rounded-xl') do
+                  t('admin.invitations.index.resend')
+                end
+              end
+            end
+
+            if cancellable_invitation?(invitation)
+              form_with(url: admin_invitation_path(invitation), method: :delete, class: 'shrink-0') do
+                m3_button(type: :submit, variant: :outlined, size: :sm, class: 'rounded-xl') do
+                  t('admin.invitations.index.cancel')
+                end
               end
             end
           end
@@ -144,6 +162,10 @@ module Components
 
         def resendable_invitation?(invitation)
           @resendable_invitation_ids.include?(invitation.id)
+        end
+
+        def cancellable_invitation?(invitation)
+          @cancellable_invitation_ids.include?(invitation.id)
         end
 
         def invitation_status_label(invitation)

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -50,6 +50,18 @@ module Admin
       end
     end
 
+    def destroy
+      @invitation = Invitation.find(params.expect(:id))
+      authorize @invitation, :destroy?
+
+      if @invitation.cancellable?
+        @invitation.destroy!
+        redirect_with_invitation_notice(t('admin.invitations.cancelled'))
+      else
+        redirect_with_invitation_alert(t('admin.invitations.cannot_cancel_accepted'))
+      end
+    end
+
     private
 
     def invitation_params
@@ -68,7 +80,8 @@ module Admin
       Components::Admin::Invitations::IndexView.new(
         invitation: invitation,
         invitations: result.invitations,
-        resendable_invitation_ids: result.resendable_invitation_ids
+        resendable_invitation_ids: result.resendable_invitation_ids,
+        cancellable_invitation_ids: result.cancellable_invitation_ids
       )
     end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -44,6 +44,10 @@ class Invitation < ApplicationRecord
     !self.class.pending.where.not(id: id).exists?(email: email)
   end
 
+  def cancellable?
+    !accepted?
+  end
+
   def resend!
     raise ActiveRecord::RecordInvalid, self unless resendable?
 

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -12,4 +12,8 @@ class InvitationPolicy < ApplicationPolicy
   def resend?
     admin?
   end
+
+  def destroy?
+    admin?
+  end
 end

--- a/app/services/admin/invitations_index_query.rb
+++ b/app/services/admin/invitations_index_query.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class InvitationsIndexQuery
-    Result = Data.define(:invitations, :resendable_invitation_ids)
+    Result = Data.define(:invitations, :resendable_invitation_ids, :cancellable_invitation_ids)
 
     attr_reader :scope
 
@@ -15,7 +15,8 @@ module Admin
 
       Result.new(
         invitations: current_invitations,
-        resendable_invitation_ids: resendable_invitation_ids(current_invitations)
+        resendable_invitation_ids: resendable_invitation_ids(current_invitations),
+        cancellable_invitation_ids: cancellable_invitation_ids(current_invitations)
       )
     end
 
@@ -30,6 +31,12 @@ module Admin
         pending_count = pending_counts_by_email[invitation.email].to_i
         next invitation.id if invitation.pending? && pending_count == 1
         next invitation.id if invitation.expired? && pending_count.zero?
+      end
+    end
+
+    def cancellable_invitation_ids(current_invitations)
+      current_invitations.filter_map do |invitation|
+        invitation.id if invitation.cancellable?
       end
     end
   end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -278,7 +278,9 @@ cy:
     invitations:
       created: Anfonwyd y gwahoddiad
       resent: Ailanfonwyd y gwahoddiad
+      cancelled: Gwahoddiad wedi'i ganslo
       cannot_resend_accepted: Ni ellir ailanfon gwahoddiadau sydd wedi'u derbyn
+      cannot_cancel_accepted: Ni ellir canslo gwahoddiadau sydd wedi'u derbyn
       resend_failed: Ni ellid ailanfon y gwahoddiad hwn. Mae'n bosibl bod gwahoddiad
         sy'n aros am yr e-bost hwn eisoes yn bodoli.
       index:
@@ -286,6 +288,7 @@ cy:
         subtitle: Gwahoddwch ddefnyddwyr newydd i ymuno â MedTracker.
         recent: Gwahoddiadau diweddar
         resend: Ail-anfon
+        cancel: Canslo
         form:
           email: E-bost
           role: Rôl

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,9 @@ en:
     invitations:
       created: Invitation sent
       resent: Invitation resent
+      cancelled: Invitation cancelled
       cannot_resend_accepted: Accepted invitations cannot be resent
+      cannot_cancel_accepted: Accepted invitations cannot be cancelled
       resend_failed: This invitation could not be resent. A pending invitation for
         this email may already exist.
       index:
@@ -100,6 +102,7 @@ en:
         subtitle: Invite new users to join MedTracker.
         recent: Recent invitations
         resend: Resend
+        cancel: Cancel
         form:
           email: Email
           role: Role

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -283,7 +283,9 @@ es:
     invitations:
       created: Invitación enviada
       resent: Invitación reenviada
+      cancelled: Invitación cancelada
       cannot_resend_accepted: Las invitaciones aceptadas no se pueden reenviar
+      cannot_cancel_accepted: Las invitaciones aceptadas no se pueden cancelar
       resend_failed: No se pudo reenviar esta invitación. Es posible que ya exista
         una invitación pendiente para este correo electrónico.
       index:
@@ -291,6 +293,7 @@ es:
         subtitle: Invita a nuevos usuarios a unirse a MedTracker.
         recent: Invitaciones recientes
         resend: Reenviar
+        cancel: Cancelar
         form:
           email: Correo electrónico
           role: Rol

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -92,7 +92,9 @@ ga:
     invitations:
       created: Cuireadh seolta
       resent: Cuireadh athsheolta
+      cancelled: Cuireadh cealaithe
       cannot_resend_accepted: Ní féidir cuirí a nglactar leo a athsheoladh
+      cannot_cancel_accepted: Ní féidir cuirí a nglactar leo a chealú
       resend_failed: Níorbh fhéidir an cuireadh seo a athsheoladh. Seans go bhfuil
         cuireadh ar feitheamh don ríomhphost seo ann cheana féin.
       index:
@@ -100,6 +102,7 @@ ga:
         subtitle: Tabhair cuireadh d'úsáideoirí nua páirt a ghlacadh i MedTracker.
         recent: Cuirí le déanaí
         resend: Athsheol
+        cancel: Cealaigh
         form:
           email: Ríomhphost
           role: Ról

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -283,7 +283,9 @@ pt:
     invitations:
       created: Convite enviado
       resent: Convite reenviado
+      cancelled: Convite cancelado
       cannot_resend_accepted: Convites aceitos não podem ser reenviados
+      cannot_cancel_accepted: Convites aceitos não podem ser cancelados
       resend_failed: Este convite não pôde ser reenviado. Já pode existir um convite
         pendente para este e-mail.
       index:
@@ -291,6 +293,7 @@ pt:
         subtitle: Convide novos utilizadores para aderirem ao MedTracker.
         recent: Convites recentes
         resend: Reenviar
+        cancel: Cancelar
         form:
           email: Email
           role: Função

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
         post :verify
       end
     end
-    resources :invitations, only: %i[index create] do
+    resources :invitations, only: %i[index create destroy] do
       member do
         post :resend
       end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -139,4 +139,21 @@ RSpec.describe Invitation do
       expect(invitation).not_to be_resendable
     end
   end
+
+  describe '#cancellable?' do
+    it 'returns true for pending invitations' do
+      invitation = build(:invitation)
+      expect(invitation).to be_cancellable
+    end
+
+    it 'returns true for expired invitations' do
+      invitation = build(:invitation, :expired)
+      expect(invitation).to be_cancellable
+    end
+
+    it 'returns false for accepted invitations' do
+      invitation = build(:invitation, :accepted)
+      expect(invitation).not_to be_cancellable
+    end
+  end
 end

--- a/spec/policies/invitation_policy_spec.rb
+++ b/spec/policies/invitation_policy_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe InvitationPolicy do
     it 'permits resend' do
       expect(policy.resend?).to be true
     end
+
+    it 'permits destroy' do
+      expect(policy.destroy?).to be true
+    end
   end
 
   context 'when user is a doctor' do
@@ -41,6 +45,10 @@ RSpec.describe InvitationPolicy do
 
     it 'forbids resend' do
       expect(policy.resend?).to be false
+    end
+
+    it 'forbids destroy' do
+      expect(policy.destroy?).to be false
     end
   end
 
@@ -60,6 +68,10 @@ RSpec.describe InvitationPolicy do
     it 'forbids resend' do
       expect(policy.resend?).to be false
     end
+
+    it 'forbids destroy' do
+      expect(policy.destroy?).to be false
+    end
   end
 
   context 'when user is a carer' do
@@ -77,6 +89,10 @@ RSpec.describe InvitationPolicy do
 
     it 'forbids resend' do
       expect(policy.resend?).to be false
+    end
+
+    it 'forbids destroy' do
+      expect(policy.destroy?).to be false
     end
   end
 
@@ -96,6 +112,10 @@ RSpec.describe InvitationPolicy do
     it 'forbids resend' do
       expect(policy.resend?).to be false
     end
+
+    it 'forbids destroy' do
+      expect(policy.destroy?).to be false
+    end
   end
 
   context 'when user is a minor' do
@@ -113,6 +133,10 @@ RSpec.describe InvitationPolicy do
 
     it 'forbids resend' do
       expect(policy.resend?).to be false
+    end
+
+    it 'forbids destroy' do
+      expect(policy.destroy?).to be false
     end
   end
 end

--- a/spec/requests/admin/invitations_spec.rb
+++ b/spec/requests/admin/invitations_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin::Invitations' do
+  fixtures :accounts, :people, :users
+
+  let(:admin) { users(:admin) }
+  let(:regular_user) { users(:jane) }
+
+  describe 'DELETE /admin/invitations/:id' do
+    context 'when authenticated as administrator' do
+      before { sign_in(admin) }
+
+      it 'destroys a pending invitation and redirects with a notice' do
+        invitation = create(:invitation)
+
+        delete admin_invitation_path(invitation)
+
+        expect(response).to redirect_to(admin_invitations_path)
+        expect(flash[:notice]).to eq('Invitation cancelled')
+        expect(Invitation.exists?(invitation.id)).to be false
+      end
+
+      it 'destroys an expired invitation and redirects with a notice' do
+        invitation = create(:invitation, :expired)
+
+        delete admin_invitation_path(invitation)
+
+        expect(response).to redirect_to(admin_invitations_path)
+        expect(flash[:notice]).to eq('Invitation cancelled')
+        expect(Invitation.exists?(invitation.id)).to be false
+      end
+
+      it 'refuses to destroy an accepted invitation and redirects with an alert' do
+        invitation = create(:invitation, :accepted)
+
+        delete admin_invitation_path(invitation)
+
+        expect(response).to redirect_to(admin_invitations_path)
+        expect(flash[:alert]).to eq('Accepted invitations cannot be cancelled')
+        expect(Invitation.exists?(invitation.id)).to be true
+      end
+
+      it 'returns turbo_stream for pending invitation destroy' do
+        invitation = create(:invitation)
+
+        delete admin_invitation_path(invitation), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include('target="flash"')
+        expect(Invitation.exists?(invitation.id)).to be false
+      end
+    end
+
+    context 'when authenticated as non-administrator' do
+      before { sign_in(regular_user) }
+
+      it 'denies access' do
+        invitation = create(:invitation)
+
+        delete admin_invitation_path(invitation)
+
+        expect(response).to redirect_to(root_path)
+        expect(Invitation.exists?(invitation.id)).to be true
+      end
+    end
+  end
+end

--- a/spec/services/admin/invitations_index_query_spec.rb
+++ b/spec/services/admin/invitations_index_query_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::InvitationsIndexQuery do
   describe '#call' do
-    it 'returns invitations newest first with the resendable ids' do
+    it 'returns invitations newest first with the resendable and cancellable ids' do
       newest_pending = create(:invitation, email: 'solo.pending@example.com', created_at: 1.hour.from_now)
       expired_duplicate = create(:invitation, :expired, email: 'duplicate@example.com')
       pending_duplicate = create(:invitation, email: 'duplicate@example.com')
@@ -16,6 +16,10 @@ RSpec.describe Admin::InvitationsIndexQuery do
       expect(result.invitations.first).to eq(newest_pending)
       expect(result.resendable_invitation_ids).to include(newest_pending.id, pending_duplicate.id, expired_singleton.id)
       expect(result.resendable_invitation_ids).not_to include(expired_duplicate.id, accepted.id)
+      expect(result.cancellable_invitation_ids).to include(
+        newest_pending.id, expired_duplicate.id, pending_duplicate.id, expired_singleton.id
+      )
+      expect(result.cancellable_invitation_ids).not_to include(accepted.id)
     end
   end
 end


### PR DESCRIPTION
Allows administrators to cancel pending and expired invitations from the admin invitations page.