### PR TITLE
fix: allow daily scheduled doses after reset

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -85,16 +85,13 @@ class Schedule < ApplicationRecord
   end
 
   def effective_min_hours_between_doses(date = Time.zone.today)
+    return nil if schedule_type_daily? && Array(config_value(effective_config_for(date), 'times')).compact_blank.one?
+
     numeric_config_value(effective_config_for(date), 'min_hours_between_doses', 'min_hours', 'minimum_hours') ||
       min_hours_between_doses
   end
 
-  def active?
-    today = Time.zone.today
-    return false if start_date.nil? || end_date.nil?
-
-    today.between?(start_date, end_date)
-  end
+  def active? = start_date.present? && end_date.present? && Time.zone.today.between?(start_date, end_date)
 
   def cycle_period
     DoseCycle.new(dose_cycle).period

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
     end
 
+    it 'keeps a once-daily scheduled medication due after a late previous-day dose' do
+      travel_to Time.zone.parse('2026-05-12 10:20:00') do
+        schedule = create_daily_scheduled_medication
+        MedicationTake.create!(
+          schedule: schedule,
+          taken_at: Time.zone.parse('2026-05-11 20:00:00'),
+          dose_amount: 1,
+          dose_unit: 'tablet'
+        )
+
+        rows = described_class.new([people(:john)]).call.select { |row| row[:source] == schedule }
+
+        expect(rows.pluck(:status)).to eq([:upcoming])
+      end
+    end
+
     it 'groups PRN schedules under as-needed medications instead of routine tasks' do
       prn_schedule = create_prn_schedule
       query = described_class.new([people(:john)])
@@ -289,6 +305,25 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       schedule_type: :prn,
       max_daily_doses: max_daily_doses,
       min_hours_between_doses: min_hours_between_doses
+    )
+  end
+
+  def create_daily_scheduled_medication
+    medication = medications(:vitamin_c).tap { |candidate| candidate.update!(current_supply: 30) }
+
+    create(
+      :schedule,
+      person: people(:john),
+      medication: medication,
+      dosage: nil,
+      dose_amount: 1,
+      dose_unit: 'tablet',
+      frequency: 'Once daily',
+      schedule_type: :daily,
+      schedule_config: { 'times' => ['08:00'] },
+      max_daily_doses: 1,
+      min_hours_between_doses: 24,
+      dose_cycle: :daily
     )
   end
 end


### PR DESCRIPTION
## Summary
- Treat once-daily scheduled medications as daily-cycle limited instead of rolling 24-hour cooldown limited
- Add regression coverage for a previous-night dose still allowing the next morning scheduled dose

## Verification
- task rubocop
- task test