### PR TITLE
fix: Remove dashboard compliance card

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -35,7 +35,7 @@ module Components
 
       delegate :people, :active_schedules, :upcoming_schedules,
                :current_user, :doses, :next_dose_time, :routine_tasks_due?,
-               :routine_tasks_by_person, :as_needed_by_person, :compliance_percentage, to: :presenter
+               :routine_tasks_by_person, :as_needed_by_person, to: :presenter
 
       def next_dose_value
         time = next_dose_time
@@ -85,7 +85,7 @@ module Components
       end
 
       def render_stats_section
-        div(class: 'grid grid-cols-2 lg:grid-cols-4 auto-rows-fr gap-3 mb-8') do
+        div(class: 'grid grid-cols-1 sm:grid-cols-3 auto-rows-fr gap-3 mb-8') do
           render Components::Shared::MetricCard.new(
             title: t('dashboard.stats.people'),
             value: people.size,
@@ -98,13 +98,6 @@ module Components
             value: active_schedules.size,
             icon_type: 'active_schedules',
             href: schedules_path,
-            layout: :compact
-          )
-          render Components::Shared::MetricCard.new(
-            title: t('dashboard.stats.compliance'),
-            value: "#{compliance_percentage}%",
-            icon_type: 'compliance',
-            href: reports_path,
             layout: :compact
           )
           render Components::Shared::MetricCard.new(

--- a/app/components/shared/metric_card.rb
+++ b/app/components/shared/metric_card.rb
@@ -147,7 +147,6 @@ module Components
         when 'inventory', 'pill' then render Icons::Inventory.new(size: size)
         when 'active_schedules' then render Icons::ActiveSchedules.new(size: size)
         when 'check' then render Icons::CheckCircle.new(size: size)
-        when 'compliance' then render Icons::Compliance.new(size: size)
         when 'clock' then render Icons::Clock.new(size: size)
         else render Icons::Activity.new(size: size)
         end
@@ -169,7 +168,7 @@ module Components
         case icon_type
         when 'users' then 'text-primary'
         when 'pill', 'active_schedules' then 'text-on-success-container'
-        when 'check', 'compliance' then 'text-on-secondary-container'
+        when 'check' then 'text-on-secondary-container'
         when 'clock' then 'text-on-warning-container'
         else 'text-foreground'
         end

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -38,13 +38,6 @@ class DashboardPresenter
     upcoming.filter_map { |d| d[:scheduled_at] }.min
   end
 
-  def compliance_percentage
-    expected, actual = compliance_counts
-    return 100 if expected.zero?
-
-    [(actual.to_f / expected * 100).round, 100].min
-  end
-
   def smart_insights
     @smart_insights ||= SmartInsights::IndexQuery.new(
       people: people,
@@ -58,19 +51,6 @@ class DashboardPresenter
   end
 
   private
-
-  def compliance_counts
-    daily_data = Reports::IndexQuery.new(
-      people: people,
-      start_date: Time.zone.today - 6.days,
-      end_date: Time.zone.today
-    ).call.daily_data
-
-    [
-      daily_data.sum { |day| day[:expected] },
-      daily_data.sum { |day| day[:actual] }
-    ]
-  end
 
   def load_people
     return Person.none if current_user.nil?

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1391,7 +1391,6 @@ cy:
     stats:
       people: Pobl
       active_schedules: Presgripsiynau Gweithredol
-      compliance: Cydymffurfiaeth
       next_dose: Dos nesaf
       due_today: Heddiw
       no_upcoming_doses: Dim un heddiw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1537,7 +1537,6 @@ en:
     stats:
       people: People
       active_schedules: Active Schedules
-      compliance: Compliance
       next_dose: Next Dose
       due_today: Today
       no_upcoming_doses: None today

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1369,7 +1369,6 @@ es:
       people: Personas
       active_schedules: Prescripciones Activas
       no_upcoming_doses: Ninguna hoy
-      compliance: Adherencia
       next_dose: Próxima dosis
       due_today: Hoy
     person_schedule:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1478,7 +1478,6 @@ ga:
     stats:
       people: Daoine
       active_schedules: Oideas Leigheasanna Gníomhacha
-      compliance: Comhlíonadh
       next_dose: An Chéad Dháileog Eile
       due_today: Inniu
       no_upcoming_doses: Níl ceann ar bith inniu

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1568,7 +1568,6 @@ pt:
     stats:
       people: Pessoas
       active_schedules: Prescrições Ativas
-      compliance: Conformidade
       next_dose: Próxima dose
       due_today: Hoje
       no_upcoming_doses: Nenhuma hoje

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -20,19 +20,6 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     ].join
   end
 
-  let(:compliance_icon_path) do
-    [
-      'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 ',
-      '90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 ',
-      '800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 ',
-      '840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 ',
-      '56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 ',
-      '56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 ',
-      '0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 ',
-      '118-57 57-120-119q-18 11-38.5 16.5T480-320Z'
-    ].join
-  end
-
   let(:admin_user) { users(:admin) }
   let(:presenter) { DashboardPresenter.new(current_user: admin_user) }
 
@@ -97,10 +84,14 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(rendered.css("a[href='/schedules']")).to be_present
     end
 
-    it 'links Compliance stat card to reports page' do
+    it 'renders the dashboard summary row with operational metric cards' do
       rendered = render_inline(dashboard_view)
 
-      expect(rendered.css("a[href='/reports']")).to be_present
+      labels = rendered.css('p').map { |label| label.text.strip }
+
+      expect(labels).to include('People', 'Active Schedules', 'Next Dose')
+      expect(rendered.css("a[href='/people']")).to be_present
+      expect(rendered.css("a[href='/schedules']")).to be_present
     end
 
     it 'renders the active schedules icon on the active schedules stat card' do
@@ -108,13 +99,6 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       card = rendered.at_css("a[href='/schedules']")
 
       expect(card.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
-    end
-
-    it 'renders the compliance icon on the compliance stat card' do
-      rendered = render_inline(dashboard_view)
-      card = rendered.at_css("a[href='/reports']")
-
-      expect(card.at_css("path[d='#{compliance_icon_path}']")).to be_present
     end
   end
 
@@ -262,6 +246,8 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(dashboard_view)
       html = rendered.to_html
 
+      expect(html.scan('min-h-[7rem]').size).to eq(3)
+      expect(html).to include('sm:grid-cols-3')
       expect(html).to include('min-h-[7rem]')
       expect(html).not_to include('min-h-[9.5rem]')
     end
@@ -287,7 +273,6 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       people: [person],
       active_schedules: [],
       current_user: admin_user,
-      compliance_percentage: 85,
       next_dose_time: nil,
       smart_insights: insight_result || learning_insight_result,
       can_view_reports?: can_view_reports,

--- a/spec/components/shared/metric_card_spec.rb
+++ b/spec/components/shared/metric_card_spec.rb
@@ -13,19 +13,6 @@ RSpec.describe Components::Shared::MetricCard, type: :component do
     ].join
   end
 
-  let(:compliance_icon_path) do
-    [
-      'M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v200h-80v-145l-240-90-240 ',
-      '90v189q0 121 68 220t172 132q26-8 49.5-20.5T576-214l56 56q-33 27-71.5 47T480-80Zm331.5-11.5Q800-103 ',
-      '800-120t11.5-28.5Q823-160 840-160t28.5 11.5Q880-137 880-120t-11.5 28.5Q857-80 ',
-      '840-80t-28.5-11.5ZM800-240v-240h80v240h-80ZM480-480Zm56.5 ',
-      '56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 ',
-      '56.5Q447-400 480-400t56.5-23.5ZM480-320q-66 ',
-      '0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 22-5.5 42.5T618-398l119 ',
-      '118-57 57-120-119q-18 11-38.5 16.5T480-320Z'
-    ].join
-  end
-
   it 'renders a block link wrapper when href is provided' do
     rendered = render_inline(
       described_class.new(title: 'People', value: 5, icon_type: 'users', href: '/people')
@@ -102,14 +89,5 @@ RSpec.describe Components::Shared::MetricCard, type: :component do
 
     expect(rendered.at_css('svg')['viewbox']).to eq('0 -960 960 960')
     expect(rendered.at_css("path[d='#{active_schedules_icon_path}']")).to be_present
-  end
-
-  it 'renders the compliance icon path' do
-    rendered = render_inline(
-      described_class.new(title: 'Compliance', value: '85%', icon_type: 'compliance')
-    )
-
-    expect(rendered.at_css('svg')['viewbox']).to eq('0 -960 960 960')
-    expect(rendered.at_css("path[d='#{compliance_icon_path}']")).to be_present
   end
 end

--- a/spec/system/mobile_navigation_spec.rb
+++ b/spec/system/mobile_navigation_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Mobile Navigation' do
   let(:mobile_metric_label_overflow_script) do
     <<~JS
       (() => {
-        const expectedLabels = ['People', 'Compliance', 'Next Dose']
+        const expectedLabels = ['People', 'Active Schedules', 'Next Dose']
         const labels = Array.from(document.querySelectorAll('#main-content p'))
 
         return expectedLabels.map((text) => {


### PR DESCRIPTION
Closes #1249

Summary:
- Removed the dashboard Compliance metric card so the summary row shows People, Active Schedules, and Next Dose.
- Collapsed the dashboard summary grid to three responsive columns.
- Removed dashboard-only compliance presenter logic, metric-card compliance branch, translations, and obsolete tests while leaving report compliance calculations intact.

Verification:
- task rubocop: passed
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb: passed
- task test TEST_FILE=spec/components/shared/metric_card_spec.rb: passed before rebase
- task test TEST_FILE=spec/system/mobile_navigation_spec.rb: passed
- task test: ran full suite after implementation; failed on two unrelated system examples, both passed when rerun in isolation.