### PR TITLE
feat: improve audit log details

### DIFF
--- a/app/components/admin/audit_logs/show_view.rb
+++ b/app/components/admin/audit_logs/show_view.rb
@@ -18,7 +18,10 @@ module Components
         end
 
         def view_template
-          div(data: { testid: 'admin-audit-log-detail' }, class: 'space-y-8') do
+          div(
+            data: { testid: 'admin-audit-log-detail' },
+            class: 'container mx-auto max-w-6xl space-y-6 px-4 py-8 pb-24 md:pb-8'
+          ) do
             render_header
             render_version_details
             render_changes_section
@@ -29,28 +32,43 @@ module Components
         private
 
         def render_header
-          header(class: 'flex items-center justify-between') do
-            div(class: 'space-y-2') do
+          header(class: 'flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between') do
+            div(class: 'space-y-1') do
               m3_heading(level: 1) { t('admin.audit_logs.show.title') }
-              m3_text(weight: 'muted') { "#{version.item_type} ##{version.item_id} - #{version.event.titleize}" }
+              m3_text(weight: 'muted') { event_heading }
             end
-            Link(href: '/admin/audit_logs', variant: :outlined) { t('admin.audit_logs.show.back') }
+            Link(href: '/admin/audit_logs', variant: :outlined, class: 'shrink-0 self-start') do
+              t('admin.audit_logs.show.back')
+            end
           end
         end
 
+        def event_heading
+          [version.item_type.titleize, record_identifier, version.event.titleize].compact.join(' - ')
+        end
+
+        def record_identifier
+          "##{version.item_id}" unless version.item_id.to_i.zero?
+        end
+
         def render_version_details
-          Card do
-            CardHeader do
+          Card(variant: :outlined, class: 'rounded-xl border border-outline bg-surface shadow-sm') do
+            CardHeader(class: 'space-y-2 p-6 pb-4') do
               m3_heading(level: 2, size: '4', class: 'font-semibold leading-none tracking-tight') do
                 t('admin.audit_logs.show.event_information')
               end
+              m3_text(size: '2', weight: 'muted') { t('admin.audit_logs.show.event_information_description') }
             end
-            CardContent do
-              dl(class: 'grid grid-cols-1 gap-4 sm:grid-cols-2') do
+            CardContent(class: 'space-y-6 p-6 pt-0') do
+              render_event_summary if event_summary_items.any?
+              dl(class: 'grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2 lg:grid-cols-3') do
                 render_detail_item(t('admin.audit_logs.show.timestamp'),
                                    version.created_at.strftime('%Y-%m-%d %H:%M:%S %Z'))
                 render_detail_item(t('admin.audit_logs.show.record_type'), version.item_type.titleize)
-                render_detail_item(t('admin.audit_logs.show.record_id'), version.item_id.to_s)
+                render_detail_item(
+                  t('admin.audit_logs.show.record_id'),
+                  record_identifier || t('admin.audit_logs.show.na')
+                )
                 render_detail_item(t('admin.audit_logs.show.event_type'), version.event.titleize)
                 render_detail_item(t('admin.audit_logs.show.user'), user_name)
                 render_detail_item(t('admin.audit_logs.show.ip_address'), version.ip || t('admin.audit_logs.show.na'))
@@ -59,10 +77,21 @@ module Components
           end
         end
 
+        def render_event_summary
+          section(class: 'rounded-lg border border-outline-variant bg-surface-container-low p-4') do
+            h3(class: 'text-sm font-semibold text-foreground') { t('admin.audit_logs.show.event_summary') }
+            dl(class: 'mt-4 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2') do
+              event_summary_items.each do |label, value|
+                render_detail_item(label, value)
+              end
+            end
+          end
+        end
+
         def render_detail_item(label, value)
           div do
-            dt(class: 'text-sm font-medium text-on-surface-variant') { label }
-            dd(class: 'mt-1 text-sm text-foreground') { value }
+            dt(class: 'text-xs font-medium uppercase text-on-surface-variant') { label }
+            dd(class: 'mt-1 break-words text-sm text-foreground') { value }
           end
         end
 
@@ -76,15 +105,15 @@ module Components
         def render_changes_section
           return if version.object.blank?
 
-          Card do
-            CardHeader do
+          Card(variant: :outlined, class: 'rounded-xl border border-outline bg-surface shadow-sm') do
+            CardHeader(class: 'space-y-2 p-6 pb-4') do
               m3_heading(level: 2, size: '4', class: 'font-semibold leading-none tracking-tight') do
-                t('admin.audit_logs.show.previous_state')
+                object_section_title
               end
-              CardDescription { t('admin.audit_logs.show.previous_state_description') }
+              CardDescription { object_section_description }
             end
-            CardContent do
-              pre(class: 'bg-secondary-container p-4 rounded-lg overflow-x-auto text-xs font-mono') do
+            CardContent(class: 'p-6 pt-0') do
+              pre(class: raw_payload_classes) do
                 code { format_object(version.object) }
               end
             end
@@ -97,19 +126,61 @@ module Components
           new_state = compute_new_state
           return if new_state.blank?
 
-          Card do
-            CardHeader do
+          Card(variant: :outlined, class: 'rounded-xl border border-outline bg-surface shadow-sm') do
+            CardHeader(class: 'space-y-2 p-6 pb-4') do
               m3_heading(level: 2, size: '4', class: 'font-semibold leading-none tracking-tight') do
                 t('admin.audit_logs.show.new_state')
               end
               CardDescription { description_for_new_state }
             end
-            CardContent do
-              pre(class: 'bg-secondary-container p-4 rounded-lg overflow-x-auto text-xs font-mono') do
+            CardContent(class: 'p-6 pt-0') do
+              pre(class: raw_payload_classes) do
                 code { format_new_state(new_state) }
               end
             end
           end
+        end
+
+        def object_section_title
+          external_lookup? ? t('admin.audit_logs.show.audit_payload') : t('admin.audit_logs.show.previous_state')
+        end
+
+        def raw_payload_classes
+          'max-h-[28rem] overflow-auto rounded-lg bg-surface-container p-4 text-xs font-mono leading-relaxed ' \
+            'text-foreground'
+        end
+
+        def object_section_description
+          if external_lookup?
+            t('admin.audit_logs.show.audit_payload_description')
+          else
+            t('admin.audit_logs.show.previous_state_description')
+          end
+        end
+
+        def event_summary_items
+          return [] unless external_lookup_data
+
+          {
+            I18n.t('admin.audit_logs.show.lookup') => external_lookup_data['query'],
+            I18n.t('admin.audit_logs.show.result') => external_lookup_data['result_status']&.titleize,
+            I18n.t('admin.audit_logs.show.matches') => external_lookup_data['result_count']&.to_s,
+            I18n.t('admin.audit_logs.show.matched_guidance') => external_lookup_data['matched_title'],
+            I18n.t('admin.audit_logs.show.matched_url') => external_lookup_data['matched_url']
+          }.filter_map { |label, value| [label, value] if value.present? }
+        end
+
+        def external_lookup?
+          version.item_type == ExternalLookup::AuditLogger::ITEM_TYPE
+        end
+
+        def external_lookup_data
+          return nil unless external_lookup? && version.object.present?
+
+          data = JSON.parse(version.object)
+          data if data.is_a?(Hash)
+        rescue JSON::ParserError
+          nil
         end
 
         def description_for_new_state

--- a/app/services/external_lookup/audit_logger.rb
+++ b/app/services/external_lookup/audit_logger.rb
@@ -4,12 +4,12 @@ module ExternalLookup
   class AuditLogger
     ITEM_TYPE = 'ExternalMedicineLookup'
 
-    def record(source:, event:, query:, result_status:, result_count: 0)
+    def record(source:, event:, query:, result_status:, **details)
       # rubocop:disable Rails/SkipsModelValidations
       # PaperTrail::Version is a gem storage table — there are no meaningful validations to run.
       # We use insert to bypass PaperTrail's before_create callbacks, which would attempt to
       # resolve the item type string into a matching ActiveRecord class.
-      PaperTrail::Version.insert(version_attrs(source:, event:, query:, result_status:, result_count:))
+      PaperTrail::Version.insert(version_attrs(source:, event:, query:, result_status:, **details))
       # rubocop:enable Rails/SkipsModelValidations
     rescue StandardError => e
       Rails.logger.error("ExternalLookup::AuditLogger failed: #{e.class}: #{e.message}")
@@ -17,19 +17,26 @@ module ExternalLookup
 
     private
 
-    def version_attrs(source:, event:, query:, result_status:, result_count:)
+    def version_attrs(source:, event:, query:, result_status:, **details)
       {
         item_type: ITEM_TYPE,
         item_id: 0,
         event: "#{source}/#{event}",
-        object: { query_hash: Digest::SHA256.hexdigest(query.to_s.strip.downcase),
-                  result_status: result_status,
-                  result_count: result_count }.to_json,
+        object: object_attrs(query:, result_status:, **details).to_json,
         whodunnit: PaperTrail.request.whodunnit,
         ip: PaperTrail.request.controller_info&.dig(:ip),
         request_id: PaperTrail.request.controller_info&.dig(:request_id),
         created_at: Time.current
       }
+    end
+
+    def object_attrs(query:, result_status:, **details)
+      {
+        query: query.to_s,
+        query_hash: Digest::SHA256.hexdigest(query.to_s.strip.downcase),
+        result_status: result_status,
+        result_count: details.fetch(:result_count, 0)
+      }.merge(details.fetch(:metadata, {}))
     end
   end
 end

--- a/app/services/nhs_website_content/medicine_guidance_lookup.rb
+++ b/app/services/nhs_website_content/medicine_guidance_lookup.rb
@@ -55,13 +55,13 @@ module NhsWebsiteContent
 
     def fetch_guidance_with_audit(name, page)
       result = build_result(@client.get_medicine(slug: slug_from(page['url']), modules: true))
-      audit(name, 'success', 1)
+      audit(name, 'success', 1, 'matched_title' => result.title, 'matched_url' => result.webpage)
       result
     end
 
-    def audit(name, status, count = 0)
+    def audit(name, status, count = 0, metadata = {})
       @audit_logger.record(source: 'nhs_website_content', event: 'medicine_guidance_lookup',
-                           query: name, result_status: status, result_count: count)
+                           query: name, result_status: status, result_count: count, metadata: metadata)
     end
 
     def audit_and_nil(name, status)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -419,12 +419,21 @@ cy:
         title: Manylion Log Archwilio
         back: "← Yn ôl i Logiau Archwilio"
         event_information: Gwybodaeth Digwyddiad
+        event_information_description: Y ffeithiau allweddol a gofnodwyd ar gyfer y digwyddiad archwilio hwn
+        event_summary: Crynodeb o'r digwyddiad
         timestamp: Amser
         record_type: Math o Gofnod
         record_id: ID Cofnod
         event_type: Math o Ddigwyddiad
         user: Defnyddiwr
         ip_address: Cyfeiriad IP
+        lookup: Chwiliad
+        result: Canlyniad
+        matches: Cyfatebiadau
+        matched_guidance: Canllaw cyfatebol
+        matched_url: URL cyfatebol
+        audit_payload: Llwyth archwilio
+        audit_payload_description: Y manylion chwilio strwythuredig a gofnodwyd ar gyfer y digwyddiad hwn
         na: Amh
         system: System
         previous_state: Cyflwr Blaenorol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,12 +249,21 @@ en:
         title: Audit Log Details
         back: "← Back to Audit Logs"
         event_information: Event Information
+        event_information_description: The key facts recorded for this audit event
+        event_summary: Event Summary
         timestamp: Timestamp
         record_type: Record Type
         record_id: Record ID
         event_type: Event Type
         user: User
         ip_address: IP Address
+        lookup: Lookup
+        result: Result
+        matches: Matches
+        matched_guidance: Matched guidance
+        matched_url: Matched URL
+        audit_payload: Audit Payload
+        audit_payload_description: The structured lookup details recorded for this event
         na: N/A
         system: System
         previous_state: Previous State

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -425,12 +425,21 @@ es:
         title: Detalles del Registro de Auditoría
         back: "← Volver a Registros de Auditoría"
         event_information: Información del Evento
+        event_information_description: Los datos clave registrados para este evento de auditoría
+        event_summary: Resumen del evento
         timestamp: Marca de Tiempo
         record_type: Tipo de Registro
         record_id: ID de Registro
         event_type: Tipo de Evento
         user: Usuario
         ip_address: Dirección IP
+        lookup: Búsqueda
+        result: Resultado
+        matches: Coincidencias
+        matched_guidance: Guía coincidente
+        matched_url: URL coincidente
+        audit_payload: Datos de auditoría
+        audit_payload_description: Los detalles estructurados de búsqueda registrados para este evento
         na: N/D
         system: Sistema
         previous_state: Estado Anterior

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -233,12 +233,21 @@ ga:
         title: Sonraí Logála Fíoraithe
         back: "← Ar ais go Logáil Fíoraithe"
         event_information: Faisnéis Imeachta
+        event_information_description: Na príomhfhíricí a taifeadadh don imeacht iniúchta seo
+        event_summary: Achoimre imeachta
         timestamp: Stamp Ama
         record_type: Cineál Taifid
         record_id: ID Taifid
         event_type: Cineál Imeachta
         user: Úsáideoir
         ip_address: Seoladh IP
+        lookup: Cuardach
+        result: Toradh
+        matches: Meaitseálacha
+        matched_guidance: Treoir mheaitseáilte
+        matched_url: URL meaitseáilte
+        audit_payload: Ualach iniúchta
+        audit_payload_description: Na sonraí cuardaigh struchtúrtha a taifeadadh don imeacht seo
         na: N/A
         system: Córas
         previous_state: Stáid Roimhe Seo

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -424,12 +424,21 @@ pt:
         title: Detalhes do Registo de Auditoria
         back: "← Voltar aos Registos de Auditoria"
         event_information: Informação do Evento
+        event_information_description: Os principais factos registados para este evento de auditoria
+        event_summary: Resumo do evento
         timestamp: Data/Hora
         record_type: Tipo de Registo
         record_id: ID do Registo
         event_type: Tipo de Evento
         user: Utilizador
         ip_address: Endereço IP
+        lookup: Pesquisa
+        result: Resultado
+        matches: Correspondências
+        matched_guidance: Orientação correspondente
+        matched_url: URL correspondente
+        audit_payload: Dados de auditoria
+        audit_payload_description: Os detalhes estruturados da pesquisa registados para este evento
         na: N/D
         system: Sistema
         previous_state: Estado Anterior

--- a/spec/components/admin/audit_logs/show_view_spec.rb
+++ b/spec/components/admin/audit_logs/show_view_spec.rb
@@ -135,5 +135,32 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
         expect(view.send(:format_new_state, 123)).to eq('123')
       end
     end
+
+    describe '#event_summary_items' do
+      let(:version) do
+        PaperTrail::Version.new(
+          item_type: 'ExternalMedicineLookup',
+          item_id: 0,
+          event: 'nhs_website_content/medicine_guidance_lookup',
+          object: {
+            query: 'Panadol 500mg tablets',
+            result_status: 'success',
+            result_count: 1,
+            matched_title: 'Paracetamol for adults',
+            matched_url: 'https://www.nhs.uk/medicines/paracetamol-for-adults/'
+          }.to_json
+        )
+      end
+
+      it 'promotes external lookup context into readable summary items' do
+        expect(view.send(:event_summary_items)).to include(
+          ['Lookup', 'Panadol 500mg tablets'],
+          %w[Result Success],
+          %w[Matches 1],
+          ['Matched guidance', 'Paracetamol for adults'],
+          ['Matched URL', 'https://www.nhs.uk/medicines/paracetamol-for-adults/']
+        )
+      end
+    end
   end
 end

--- a/spec/services/external_lookup/audit_logger_spec.rb
+++ b/spec/services/external_lookup/audit_logger_spec.rb
@@ -35,15 +35,30 @@ RSpec.describe ExternalLookup::AuditLogger do
       expect(version.request_id).to eq('req-abc-123')
     end
 
-    it 'stores a SHA256 hash of the query and metadata in object JSON' do
+    it 'stores the readable query, SHA256 query hash, and metadata in object JSON' do
       audit_logger.record(source: 'nhs_dmd', event: 'search', query: 'Aspirin 300mg',
                           result_status: 'success', result_count: 3)
       version = PaperTrail::Version.where(item_type: 'ExternalMedicineLookup').last
       data = JSON.parse(version.object)
+      expect(data['query']).to eq('Aspirin 300mg')
       expect(data['query_hash']).to eq(Digest::SHA256.hexdigest('aspirin 300mg'))
       expect(data['result_status']).to eq('success')
       expect(data['result_count']).to eq(3)
-      expect(version.object).not_to include('Aspirin')
+    end
+
+    it 'stores additional lookup details when provided' do
+      audit_logger.record(source: 'nhs_website_content', event: 'medicine_guidance_lookup',
+                          query: 'Panadol 500mg tablets', result_status: 'success',
+                          result_count: 1,
+                          metadata: {
+                            'matched_title' => 'Paracetamol for adults',
+                            'matched_url' => 'https://www.nhs.uk/medicines/paracetamol-for-adults/'
+                          })
+      version = PaperTrail::Version.where(item_type: 'ExternalMedicineLookup').last
+      data = JSON.parse(version.object)
+
+      expect(data['matched_title']).to eq('Paracetamol for adults')
+      expect(data['matched_url']).to eq('https://www.nhs.uk/medicines/paracetamol-for-adults/')
     end
 
     it 'normalises the query before hashing (lowercase, stripped)' do

--- a/spec/services/nhs_website_content/medicine_guidance_lookup_spec.rb
+++ b/spec/services/nhs_website_content/medicine_guidance_lookup_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe NhsWebsiteContent::MedicineGuidanceLookup do
     )
   end
 
+  it 'records the requested medication and matched NHS guidance page in the audit log' do
+    lookup.call('Panadol 500mg tablets')
+
+    expect(audit_logger).to have_received(:record).with(
+      source: 'nhs_website_content',
+      event: 'medicine_guidance_lookup',
+      query: 'Panadol 500mg tablets',
+      result_status: 'success',
+      result_count: 1,
+      metadata: {
+        'matched_title' => 'Paracetamol for adults',
+        'matched_url' => 'https://www.nhs.uk/medicines/paracetamol-for-adults/'
+      }
+    )
+  end
+
   it 'returns nil when the client is unavailable' do
     allow(client).to receive(:configured?).and_return(false)
 


### PR DESCRIPTION
## Summary
- store readable external lookup queries alongside hashed lookup identifiers
- include matched NHS guidance title and URL in medicine guidance audit entries
- redesign audit log details with a prominent event summary and quieter bounded payload sections
- add translated labels and focused coverage for the new audit context

## Verification
- task rubocop
- task test TEST_FILE=spec/services/external_lookup/audit_logger_spec.rb
- task test TEST_FILE=spec/services/nhs_website_content/medicine_guidance_lookup_spec.rb
- task test TEST_FILE=spec/components/admin/audit_logs/show_view_spec.rb
- task test initially hit unrelated Docker/test DB orchestration failures; clean rerun reported 645 examples, 0 failures, 2 pending, but the task wrapper still exited non-zero