### PR TITLE
feat: Add redacted auth token audit logging

### DIFF
--- a/app/components/admin/audit_logs/index_view.rb
+++ b/app/components/admin/audit_logs/index_view.rb
@@ -9,11 +9,32 @@ module Components
         # Models that have audit trail enabled
         AUDITED_MODELS = %w[User Account Person CarerRelationship Location LocationMembership
                             MedicationTake Medication MedicationDosageOption Schedule NotificationPreference
-                            AppSettings ExternalMedicineLookup AiMedicationSuggestion].freeze
+                            AppSettings ExternalMedicineLookup AiMedicationSuggestion AuthenticationToken].freeze
         # Available event types for filtering
         EVENT_TYPES = ['create', 'update', 'destroy', 'restock', 'adjust inventory',
                        'dose_decrement', 'mark_as_ordered', 'mark_as_received',
-                       'ai_medication/suggestion'].freeze
+                       'ai_medication/suggestion',
+                       'auth_token/api_session/created',
+                       'auth_token/api_session/rotated',
+                       'auth_token/api_session/revoked',
+                       'auth_token/api_session/expired',
+                       'auth_token/push_subscription/created',
+                       'auth_token/push_subscription/revoked',
+                       'auth_token/native_device_token/created',
+                       'auth_token/native_device_token/revoked',
+                       'auth_token/otp_key/created',
+                       'auth_token/otp_key/revoked',
+                       'auth_token/recovery_codes/created',
+                       'auth_token/webauthn_credential/created',
+                       'auth_token/webauthn_credential/revoked',
+                       'auth_token/verification_key/created',
+                       'auth_token/verification_key/revoked',
+                       'auth_token/password_reset_key/created',
+                       'auth_token/password_reset_key/revoked',
+                       'auth_token/login_change_key/created',
+                       'auth_token/login_change_key/revoked',
+                       'auth_token/remember_key/created',
+                       'auth_token/remember_key/revoked'].freeze
 
         attr_reader :versions, :filter_params, :current_page, :total_count, :per_page
 

--- a/app/components/admin/audit_logs/index_view.rb
+++ b/app/components/admin/audit_logs/index_view.rb
@@ -6,44 +6,16 @@ module Components
       class IndexView < Components::Base
         include Phlex::Rails::Helpers::FormWith
 
-        # Models that have audit trail enabled
-        AUDITED_MODELS = %w[User Account Person CarerRelationship Location LocationMembership
-                            MedicationTake Medication MedicationDosageOption Schedule NotificationPreference
-                            AppSettings ExternalMedicineLookup AiMedicationSuggestion AuthenticationToken].freeze
-        # Available event types for filtering
-        EVENT_TYPES = ['create', 'update', 'destroy', 'restock', 'adjust inventory',
-                       'dose_decrement', 'mark_as_ordered', 'mark_as_received',
-                       'ai_medication/suggestion',
-                       'auth_token/api_session/created',
-                       'auth_token/api_session/rotated',
-                       'auth_token/api_session/revoked',
-                       'auth_token/api_session/expired',
-                       'auth_token/push_subscription/created',
-                       'auth_token/push_subscription/revoked',
-                       'auth_token/native_device_token/created',
-                       'auth_token/native_device_token/revoked',
-                       'auth_token/otp_key/created',
-                       'auth_token/otp_key/revoked',
-                       'auth_token/recovery_codes/created',
-                       'auth_token/webauthn_credential/created',
-                       'auth_token/webauthn_credential/revoked',
-                       'auth_token/verification_key/created',
-                       'auth_token/verification_key/revoked',
-                       'auth_token/password_reset_key/created',
-                       'auth_token/password_reset_key/revoked',
-                       'auth_token/login_change_key/created',
-                       'auth_token/login_change_key/revoked',
-                       'auth_token/remember_key/created',
-                       'auth_token/remember_key/revoked'].freeze
+        attr_reader :versions, :filter_params, :item_types, :events, :current_page, :total_count, :per_page
 
-        attr_reader :versions, :filter_params, :current_page, :total_count, :per_page
-
-        def initialize(versions:, filter_params: {}, current_page: 1, total_count: 0, per_page: 50)
+        def initialize(versions:, filter_params: {}, item_types: [], events: [], **pagination)
           @versions = versions
           @filter_params = filter_params
-          @current_page = current_page
-          @total_count = total_count
-          @per_page = per_page
+          @item_types = item_types
+          @events = events
+          @current_page = pagination.fetch(:current_page, 1)
+          @total_count = pagination.fetch(:total_count, 0)
+          @per_page = pagination.fetch(:per_page, 50)
           @user_cache = {}
           super()
         end
@@ -99,7 +71,7 @@ module Components
                 option(value: '', selected: filter_params[:item_type].blank?) do
                   t('admin.audit_logs.index.filter.all_types')
                 end
-                AUDITED_MODELS.each do |type|
+                item_types.each do |type|
                   option(value: type, selected: filter_params[:item_type] == type) { type.titleize }
                 end
               end
@@ -120,7 +92,7 @@ module Components
                 option(value: '', selected: filter_params[:event].blank?) do
                   t('admin.audit_logs.index.filter.all_events')
                 end
-                EVENT_TYPES.each do |event|
+                events.each do |event|
                   option(value: event, selected: filter_params[:event] == event) { event.titleize }
                 end
               end

--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -25,6 +25,8 @@ module Admin
       render Components::Admin::AuditLogs::IndexView.new(
         versions: @versions,
         filter_params: params.permit(:item_type, :event, :whodunnit),
+        item_types: result.item_types,
+        events: result.events,
         current_page: result.page,
         total_count: @total_count,
         per_page: result.per_page

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -21,7 +21,8 @@ module Api
           api_session, access_token, refresh_token = ApiSession.issue_for(
             account: account,
             device_name: params[:device_name],
-            user_agent: request.user_agent
+            user_agent: request.user_agent,
+            audit_context: audit_context(account)
           )
 
           render json: {
@@ -38,11 +39,12 @@ module Api
         def refresh
           api_session = ApiSession.lookup_by_refresh_token(params.expect(:refresh_token).to_s)
           unless api_session&.active_refresh_token? && api_session.account.verified? && api_session.account.person&.user&.active?
+            record_expired_session(api_session)
             render_invalid_refresh_token
             return
           end
 
-          access_token, refresh_token = api_session.rotate_tokens!
+          access_token, refresh_token = api_session.rotate_tokens!(audit_context: audit_context(api_session.account))
 
           render json: {
             data: {
@@ -57,12 +59,41 @@ module Api
         def destroy
           token = request.headers['Authorization'].to_s.split(' ', 2).last
           api_session = ApiSession.lookup_by_access_token(token)
-          api_session&.revoke!
+          api_session&.revoke!(audit_context: audit_context(api_session.account))
 
           head :no_content
         end
 
         private
+
+        def audit_context(account)
+          {
+            whodunnit: audit_user_id(account),
+            ip: request.remote_ip,
+            request_id: request.request_id
+          }
+        end
+
+        def audit_user_id(account)
+          person = account&.person
+          person&.user&.id
+        end
+
+        def record_expired_session(api_session)
+          return unless api_session&.refresh_expires_at&.past?
+
+          AuthTokenAuditLogger.new.record(
+            account: api_session.account,
+            token_type: 'api_session',
+            action: 'expired',
+            metadata: {
+              device_name: api_session.device_name,
+              user_agent: api_session.user_agent,
+              expires_at: api_session.refresh_expires_at
+            },
+            context: audit_context(api_session.account)
+          )
+        end
 
         def authenticated_account?(account, password)
           return false if account.blank? || password.blank?

--- a/app/controllers/native_device_tokens_controller.rb
+++ b/app/controllers/native_device_tokens_controller.rb
@@ -3,9 +3,11 @@
 class NativeDeviceTokensController < ApplicationController
   def create
     token = current_account.native_device_tokens.find_or_initialize_by(device_token: params[:device_token])
+    new_token = token.new_record?
     token.assign_attributes(platform: params[:platform], user_agent: request.user_agent)
 
     if token.save
+      record_auth_token_event('created', token) if new_token
       head :created
     else
       render json: { error: 'Unable to save device token.', errors: token.errors.full_messages },
@@ -18,10 +20,25 @@ class NativeDeviceTokensController < ApplicationController
     return head :no_content unless token
 
     if token.destroy
+      record_auth_token_event('revoked', token)
       head :no_content
     else
       render json: { error: 'Unable to remove device token.', errors: token.errors.full_messages },
              status: :unprocessable_content
     end
+  end
+
+  private
+
+  def record_auth_token_event(action, token)
+    AuthTokenAuditLogger.new.record(
+      account: current_account,
+      token_type: 'native_device_token',
+      action: action,
+      metadata: {
+        user_agent: token.user_agent,
+        platform: token.platform
+      }
+    )
   end
 end

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -3,9 +3,11 @@
 class PushSubscriptionsController < ApplicationController
   def create
     sub = current_account.push_subscriptions.find_or_initialize_by(endpoint: params[:endpoint])
+    new_subscription = sub.new_record?
     sub.assign_attributes(p256dh: params.dig(:keys, :p256dh), auth: params.dig(:keys, :auth),
                           user_agent: request.user_agent)
     if sub.save
+      record_auth_token_event('created', sub) if new_subscription
       head :created
     else
       render json: { error: 'Unable to save push subscription.', errors: sub.errors.full_messages },
@@ -18,6 +20,7 @@ class PushSubscriptionsController < ApplicationController
     return head :no_content unless sub
 
     if sub.destroy
+      record_auth_token_event('revoked', sub)
       head :no_content
     else
       render json: { error: 'Unable to save push subscription.', errors: sub.errors.full_messages },
@@ -32,5 +35,19 @@ class PushSubscriptionsController < ApplicationController
       body: 'Push notifications are working correctly from the server.'
     )
     head :no_content
+  end
+
+  private
+
+  def record_auth_token_event(action, subscription)
+    AuthTokenAuditLogger.new.record(
+      account: current_account,
+      token_type: 'push_subscription',
+      action: action,
+      metadata: {
+        endpoint: subscription.endpoint,
+        user_agent: subscription.user_agent
+      }
+    )
   end
 end

--- a/app/javascript/controllers/global_search_controller.js
+++ b/app/javascript/controllers/global_search_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
     this.isOpen = false
     this.panelAnimation = null
     this.translations = JSON.parse(this.panelTarget.dataset.translations || "{}")
+    this.element.dataset.globalSearchConnected = "true"
   }
 
   disconnect() {
@@ -20,6 +21,7 @@ export default class extends Controller {
     this.abortCurrentSearch()
     this.cancelPanelAnimation()
     clearTimeout(this.searchTimer)
+    delete this.element.dataset.globalSearchConnected
   }
 
   shortcut(event) {

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -70,16 +70,19 @@ class RodauthMain < Rodauth::Rails::Auth
     verify_account_email_subject { I18n.t('rodauth.verify_account.subject') }
 
     create_verify_account_email do
+      audit_auth_token('verification_key', 'created')
       RodauthMailer.verify_account(self.class.configuration_name, account_id, verify_account_key_value)
     end
 
     reset_password_email_subject { I18n.t('rodauth.reset_password.subject') }
     create_reset_password_email do
+      audit_auth_token('password_reset_key', 'created')
       RodauthMailer.reset_password(self.class.configuration_name, account_id, reset_password_key_value)
     end
 
     verify_login_change_email_subject { I18n.t('rodauth.verify_login_change.subject') }
     create_verify_login_change_email do |_login|
+      audit_auth_token('login_change_key', 'created')
       RodauthMailer.verify_login_change(self.class.configuration_name, account_id, verify_login_change_key_value)
     end
 
@@ -96,6 +99,23 @@ class RodauthMain < Rodauth::Rails::Auth
       super(password) && password_complex_enough?(password)
     end
     auth_class_eval do
+      def audit_auth_token(token_type, action, metadata = {})
+        audit_account = Account.find_by(id: account_id)
+        return unless audit_account
+
+        AuthTokenAuditLogger.new.record(
+          account: audit_account,
+          token_type: token_type,
+          action: action,
+          metadata: metadata,
+          context: {
+            whodunnit: audit_account.person&.user&.id,
+            ip: request.ip,
+            request_id: rails_controller_instance&.request&.request_id
+          }
+        )
+      end
+
       def password_complex_enough?(password)
         return true if password.match?(/\d/) && password.match?(/[^a-zA-Z\d]/)
 
@@ -122,7 +142,10 @@ class RodauthMain < Rodauth::Rails::Auth
     end
 
     after_login do
-      remember_login if param_or_nil('remember')
+      if param_or_nil('remember')
+        remember_login
+        audit_auth_token('remember_key', 'created')
+      end
 
       id_token = omniauth_auth&.dig('credentials', 'id_token')
       next unless id_token
@@ -377,9 +400,51 @@ class RodauthMain < Rodauth::Rails::Auth
 
     # Do additional cleanup after the account is closed.
     after_close_account do
+      audit_auth_token('remember_key', 'revoked')
       # Nullify the account_id on the person but don't delete the person
       # This preserves medication history for compliance
       Person.where(account_id: account_id).find_each { |p| p.update!(account_id: nil) }
+    end
+
+    after_otp_setup do
+      audit_auth_token('otp_key', 'created')
+    end
+
+    after_otp_disable do
+      audit_auth_token('otp_key', 'revoked')
+    end
+
+    after_add_recovery_codes do
+      audit_auth_token('recovery_codes', 'created')
+    end
+
+    after_webauthn_setup do
+      audit_auth_token('webauthn_credential', 'created')
+    end
+
+    after_webauthn_remove do
+      audit_auth_token('webauthn_credential', 'revoked')
+    end
+
+    after_remember do
+      remember_value = param_or_nil(remember_param)
+      if remember_value == remember_remember_param_value
+        audit_auth_token('remember_key', 'created')
+      elsif remember_value == remember_forget_param_value || remember_value == remember_disable_param_value
+        audit_auth_token('remember_key', 'revoked')
+      end
+    end
+
+    after_verify_account do
+      audit_auth_token('verification_key', 'revoked')
+    end
+
+    after_reset_password do
+      audit_auth_token('password_reset_key', 'revoked')
+    end
+
+    after_verify_login_change do
+      audit_auth_token('login_change_key', 'revoked')
     end
 
     # ==> Flash overrides

--- a/app/models/api_session.rb
+++ b/app/models/api_session.rb
@@ -11,42 +11,96 @@ class ApiSession < ApplicationRecord
 
   scope :active, -> { where(revoked_at: nil) }
 
-  def self.issue_for(account:, device_name: nil, user_agent: nil)
-    access_token = build_token
-    refresh_token = build_token
-    now = Time.current
+  class << self
+    def issue_for(account:, device_name: nil, user_agent: nil, audit_context: nil)
+      access_token = build_token
+      refresh_token = build_token
+      session = create_session(account:, device_name:, user_agent:, access_token:, refresh_token:)
 
-    session = create!(
-      account: account,
-      device_name: device_name,
-      user_agent: user_agent,
-      last_used_at: now,
-      access_expires_at: now + ACCESS_TOKEN_TTL,
-      refresh_expires_at: now + REFRESH_TOKEN_TTL,
-      access_token_digest: digest(access_token),
-      refresh_token_digest: digest(refresh_token)
-    )
+      record_audit(session, 'created', audit_context)
 
-    [session, access_token, refresh_token]
-  end
+      [session, access_token, refresh_token]
+    end
 
-  def self.lookup_by_access_token(token)
-    active.find_by(access_token_digest: digest(token))
-  end
+    def lookup_by_access_token(token)
+      active.find_by(access_token_digest: digest(token))
+    end
 
-  def self.lookup_by_refresh_token(token)
-    active.find_by(refresh_token_digest: digest(token))
-  end
+    def lookup_by_refresh_token(token)
+      active.find_by(refresh_token_digest: digest(token))
+    end
 
-  def self.digest(token)
-    Digest::SHA256.hexdigest(token.to_s)
+    def digest(token)
+      Digest::SHA256.hexdigest(token.to_s)
+    end
+
+    def record_audit(session, action, audit_context)
+      audit_logger.record(
+        account: session.account,
+        token_type: 'api_session',
+        action: action,
+        metadata: session.send(:audit_metadata),
+        context: audit_context
+      )
+    end
+
+    private
+
+    def create_session(account:, device_name:, user_agent:, access_token:, refresh_token:)
+      now = Time.current
+
+      create!(
+        account: account,
+        device_name: device_name,
+        user_agent: user_agent,
+        last_used_at: now,
+        access_expires_at: now + ACCESS_TOKEN_TTL,
+        refresh_expires_at: now + REFRESH_TOKEN_TTL,
+        access_token_digest: digest(access_token),
+        refresh_token_digest: digest(refresh_token)
+      )
+    end
+
+    def build_token
+      "mt_#{SecureRandom.urlsafe_base64(48)}"
+    end
+
+    def audit_logger
+      AuthTokenAuditLogger.new
+    end
   end
 
   def active_refresh_token?
     revoked_at.nil? && refresh_expires_at.future?
   end
 
-  def rotate_tokens!
+  def rotate_tokens!(audit_context: nil)
+    access_token, refresh_token = rotate_token_values!
+    self.class.record_audit(self, 'rotated', audit_context)
+
+    [access_token, refresh_token]
+  end
+
+  def revoke!(audit_context: nil, action: 'revoked')
+    update!(revoked_at: Time.current)
+    self.class.record_audit(self, action, audit_context)
+  end
+
+  def touch_last_used!
+    update!(last_used_at: Time.current)
+  end
+
+  private
+
+  def audit_metadata
+    {
+      device_name: device_name,
+      user_agent: user_agent,
+      expires_at: refresh_expires_at
+    }
+  end
+
+  def rotate_token_values!
     access_token = self.class.send(:build_token)
     refresh_token = self.class.send(:build_token)
     now = Time.current
@@ -61,19 +115,4 @@ class ApiSession < ApplicationRecord
 
     [access_token, refresh_token]
   end
-
-  def revoke!
-    update!(revoked_at: Time.current)
-  end
-
-  def touch_last_used!
-    update!(last_used_at: Time.current)
-  end
-
-  private
-
-  def self.build_token
-    "mt_#{SecureRandom.urlsafe_base64(48)}"
-  end
-  private_class_method :build_token
 end

--- a/app/services/admin/audit_logs_query.rb
+++ b/app/services/admin/audit_logs_query.rb
@@ -3,6 +3,33 @@
 module Admin
   class AuditLogsQuery
     Result = Data.define(:versions, :total_count, :page, :per_page, :item_types, :events)
+    DEFAULT_ITEM_TYPES = %w[User Account Person CarerRelationship Location LocationMembership
+                            MedicationTake Medication MedicationDosageOption Schedule NotificationPreference
+                            AppSettings ExternalMedicineLookup AiMedicationSuggestion AuthenticationToken].freeze
+    DEFAULT_EVENTS = ['create', 'update', 'destroy', 'restock', 'adjust inventory',
+                      'dose_decrement', 'mark_as_ordered', 'mark_as_received',
+                      'ai_medication/suggestion',
+                      'auth_token/api_session/created',
+                      'auth_token/api_session/rotated',
+                      'auth_token/api_session/revoked',
+                      'auth_token/api_session/expired',
+                      'auth_token/push_subscription/created',
+                      'auth_token/push_subscription/revoked',
+                      'auth_token/native_device_token/created',
+                      'auth_token/native_device_token/revoked',
+                      'auth_token/otp_key/created',
+                      'auth_token/otp_key/revoked',
+                      'auth_token/recovery_codes/created',
+                      'auth_token/webauthn_credential/created',
+                      'auth_token/webauthn_credential/revoked',
+                      'auth_token/verification_key/created',
+                      'auth_token/verification_key/revoked',
+                      'auth_token/password_reset_key/created',
+                      'auth_token/password_reset_key/revoked',
+                      'auth_token/login_change_key/created',
+                      'auth_token/login_change_key/revoked',
+                      'auth_token/remember_key/created',
+                      'auth_token/remember_key/revoked'].freeze
 
     attr_reader :scope, :filters, :page, :per_page
 
@@ -19,8 +46,8 @@ module Admin
         total_count: filtered_scope.count,
         page: page,
         per_page: per_page,
-        item_types: distinct_values(:item_type),
-        events: distinct_values(:event)
+        item_types: filter_values(DEFAULT_ITEM_TYPES, :item_type),
+        events: filter_values(DEFAULT_EVENTS, :event)
       )
     end
 
@@ -46,8 +73,12 @@ module Admin
       filters[:whodunnit].to_s.presence
     end
 
+    def filter_values(defaults, column)
+      (defaults + distinct_values(column)).uniq.sort
+    end
+
     def distinct_values(column)
-      scope.reorder(nil).where.not(column => [nil, '']).distinct.order(column).pluck(column)
+      scope.reorder(nil).where.not(column => [nil, '']).distinct.pluck(column)
     end
   end
 end

--- a/app/services/admin/audit_logs_query.rb
+++ b/app/services/admin/audit_logs_query.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class AuditLogsQuery
-    Result = Data.define(:versions, :total_count, :page, :per_page)
+    Result = Data.define(:versions, :total_count, :page, :per_page, :item_types, :events)
 
     attr_reader :scope, :filters, :page, :per_page
 
@@ -18,7 +18,9 @@ module Admin
         versions: filtered_scope.limit(per_page).offset((page - 1) * per_page),
         total_count: filtered_scope.count,
         page: page,
-        per_page: per_page
+        per_page: per_page,
+        item_types: distinct_values(:item_type),
+        events: distinct_values(:event)
       )
     end
 
@@ -42,6 +44,10 @@ module Admin
 
     def whodunnit
       filters[:whodunnit].to_s.presence
+    end
+
+    def distinct_values(column)
+      scope.reorder(nil).where.not(column => [nil, '']).distinct.order(column).pluck(column)
     end
   end
 end

--- a/app/services/auth_token_audit_logger.rb
+++ b/app/services/auth_token_audit_logger.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class AuthTokenAuditLogger
+  ITEM_TYPE = 'AuthenticationToken'
+  HASHED_FIELDS = %i[endpoint user_agent].freeze
+
+  def record(account:, token_type:, action:, metadata: {}, context: nil)
+    # rubocop:disable Rails/SkipsModelValidations
+    PaperTrail::Version.insert(version_attrs(account:, token_type:, action:, metadata:, context:))
+    # rubocop:enable Rails/SkipsModelValidations
+  rescue StandardError => e
+    Rails.logger.error("AuthTokenAuditLogger failed: #{e.class}: #{e.message}")
+  end
+
+  private
+
+  def version_attrs(account:, token_type:, action:, metadata:, context:)
+    {
+      item_type: ITEM_TYPE,
+      item_id: account.id,
+      event: "auth_token/#{token_type}/#{action}",
+      object: version_object(account:, token_type:, action:, metadata:).to_json,
+      whodunnit: context_value(context, :whodunnit)&.to_s,
+      ip: context_value(context, :ip),
+      request_id: context_value(context, :request_id),
+      created_at: Time.current
+    }
+  end
+
+  def version_object(account:, token_type:, action:, metadata:)
+    {
+      account_id: account.id,
+      token_type: token_type.to_s,
+      action: action.to_s
+    }.merge(redacted_metadata(metadata))
+  end
+
+  def redacted_metadata(metadata)
+    data = metadata.to_h.symbolize_keys
+    hashed_metadata(data).merge(device_name_metadata(data))
+                         .merge(optional_value(data, :platform))
+                         .merge(optional_value(data, :credential_nickname))
+                         .merge(expires_at_metadata(data))
+  end
+
+  def context_value(context, key)
+    return context[key] if context&.key?(key)
+
+    paper_trail_context[key]
+  end
+
+  def paper_trail_context
+    {
+      whodunnit: PaperTrail.request.whodunnit,
+      ip: PaperTrail.request.controller_info&.dig(:ip),
+      request_id: PaperTrail.request.controller_info&.dig(:request_id)
+    }
+  end
+
+  def hashed_metadata(data)
+    HASHED_FIELDS.each_with_object({}) do |field, redacted|
+      redacted[:"#{field}_hash"] = Digest::SHA256.hexdigest(data[field].to_s) if data[field].present?
+    end
+  end
+
+  def device_name_metadata(data)
+    return {} unless data.key?(:device_name)
+
+    device_name = data[:device_name].to_s
+    metadata = { device_name_present: device_name.present? }
+    metadata[:device_name_length] = device_name.length if device_name.present?
+    metadata
+  end
+
+  def optional_value(data, key)
+    return {} if data[key].blank?
+
+    { key => data[key].to_s }
+  end
+
+  def expires_at_metadata(data)
+    return {} if data[:expires_at].blank?
+
+    value = data[:expires_at]
+    { expires_at: value.respond_to?(:iso8601) ? value.iso8601 : value.to_s }
+  end
+end

--- a/spec/components/admin/audit_logs/index_view_spec.rb
+++ b/spec/components/admin/audit_logs/index_view_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe Components::Admin::AuditLogs::IndexView, type: :component do
 
   let(:admin) { users(:admin) }
   let(:person) { people(:john) }
+  let(:auth_token_events) do
+    %w[
+      auth_token/api_session/created auth_token/api_session/rotated auth_token/api_session/revoked
+      auth_token/api_session/expired auth_token/push_subscription/created auth_token/push_subscription/revoked
+      auth_token/native_device_token/created auth_token/native_device_token/revoked auth_token/otp_key/created
+      auth_token/otp_key/revoked auth_token/recovery_codes/created auth_token/webauthn_credential/created
+      auth_token/webauthn_credential/revoked auth_token/verification_key/created auth_token/verification_key/revoked
+      auth_token/password_reset_key/created auth_token/password_reset_key/revoked auth_token/login_change_key/created
+      auth_token/login_change_key/revoked auth_token/remember_key/created auth_token/remember_key/revoked
+    ]
+  end
   let(:versions) do
     PaperTrail.request.whodunnit = admin.id
     person.update!(name: 'Updated Name')
@@ -39,8 +50,13 @@ RSpec.describe Components::Admin::AuditLogs::IndexView, type: :component do
         'Location',
         'LocationMembership',
         'MedicationDosageOption',
-        'NotificationPreference'
+        'NotificationPreference',
+        'AuthenticationToken'
       )
+    end
+
+    it 'offers filters for auth token lifecycle events' do
+      expect(described_class::EVENT_TYPES).to include(*auth_token_events)
     end
   end
 

--- a/spec/components/admin/audit_logs/index_view_spec.rb
+++ b/spec/components/admin/audit_logs/index_view_spec.rb
@@ -31,10 +31,14 @@ RSpec.describe Components::Admin::AuditLogs::IndexView, type: :component do
 
   describe 'initialization' do
     it 'accepts versions and filter_params' do
-      view = described_class.new(versions: versions, filter_params: { item_type: 'Person' })
+      item_types = %w[AuthenticationToken Person UnlistedAuditRecord User]
+      view = described_class.new(versions: versions, filter_params: { item_type: 'Person' },
+                                 item_types: item_types, events: auth_token_events)
 
       expect(view.versions).to eq(versions)
       expect(view.filter_params).to eq({ item_type: 'Person' })
+      expect(view.item_types).to eq(item_types)
+      expect(view.events).to eq(auth_token_events)
     end
 
     it 'defaults filter_params to empty hash' do
@@ -43,20 +47,17 @@ RSpec.describe Components::Admin::AuditLogs::IndexView, type: :component do
       expect(view.filter_params).to eq({})
     end
 
-    it 'offers filters for all audited domain record types' do
-      expect(described_class::AUDITED_MODELS).to include(
-        'Account',
-        'AppSettings',
-        'Location',
-        'LocationMembership',
-        'MedicationDosageOption',
-        'NotificationPreference',
-        'AuthenticationToken'
-      )
+    it 'uses supplied PaperTrail item types for filtering' do
+      item_types = %w[AuthenticationToken Person UnlistedAuditRecord User]
+      view = described_class.new(versions: versions, item_types: item_types)
+
+      expect(view.item_types).to include('AuthenticationToken', 'UnlistedAuditRecord')
     end
 
-    it 'offers filters for auth token lifecycle events' do
-      expect(described_class::EVENT_TYPES).to include(*auth_token_events)
+    it 'uses supplied PaperTrail events for filtering' do
+      view = described_class.new(versions: versions, events: auth_token_events)
+
+      expect(view.events).to include(*auth_token_events)
     end
   end
 

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -58,7 +58,12 @@ RSpec.describe 'Authentication Features', type: :system do
 
       expect(page).to have_current_path('/reset-password-request')
       fill_in 'Email address', with: 'resetme@example.com'
-      click_on 'Request Password Reset'
+      expect do
+        click_on 'Request Password Reset'
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/password_reset_key/created').count
+      }.by(1)
 
       expect(page).to have_text(/email|sent|reset/i)
     end
@@ -109,7 +114,12 @@ RSpec.describe 'Authentication Features', type: :system do
       fill_in 'Email address', with: 'remember@example.com'
       fill_in 'Password', with: 'SecureP@ssword123!'
       check 'remember'
-      click_on 'Sign In'
+      expect do
+        click_on 'Sign In'
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/remember_key/created').count
+      }.by(1)
 
       expect(page).to have_current_path('/dashboard')
       # Verify remember key was created in account_remember_keys table

--- a/spec/features/profiles/two_factor_management_spec.rb
+++ b/spec/features/profiles/two_factor_management_spec.rb
@@ -69,7 +69,12 @@ RSpec.describe 'Two-Factor Authentication Management', type: :system do
 
       fill_in 'Current Password', with: 'password'
       fill_in 'Authentication Code', with: totp.at(Time.current)
-      click_button 'Enable Two-Factor Authentication'
+      expect do
+        click_button 'Enable Two-Factor Authentication'
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/otp_key/created').count
+      }.by(1)
 
       expect(AccountOtpKey.exists?(id: account.id)).to be true
 
@@ -77,7 +82,12 @@ RSpec.describe 'Two-Factor Authentication Management', type: :system do
       click_link 'Disable'
       expect(page).to have_current_path('/otp-disable')
       fill_in 'password', with: 'password'
-      click_button 'Disable TOTP Authentication'
+      expect do
+        click_button 'Disable TOTP Authentication'
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/otp_key/revoked').count
+      }.by(1)
 
       expect(AccountOtpKey.exists?(id: account.id)).to be false
     end
@@ -94,6 +104,9 @@ RSpec.describe 'Two-Factor Authentication Management', type: :system do
 
       expect(page).to have_css('#recovery-codes')
       expect(AccountRecoveryCode.where(id: account.id).count).to be_positive
+      expect(PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                       event: 'auth_token/recovery_codes/created',
+                                       item_id: account.id)).to exist
     end
   end
 

--- a/spec/models/api_session_spec.rb
+++ b/spec/models/api_session_spec.rb
@@ -37,5 +37,78 @@ RSpec.describe ApiSession do
         expect([access_token, refresh_token]).to all(start_with('mt_'))
       end
     end
+
+    it 'creates a redacted audit event without token material', :aggregate_failures do
+      issued_tokens = nil
+
+      expect do
+        issued_tokens = issue_session_tokens
+      end.to change { PaperTrail::Version.where(item_type: 'AuthenticationToken').count }.by(1)
+
+      version = latest_auth_token_version
+      expect_creation_audit(version)
+      expect(version.object).not_to include(*issued_tokens)
+    end
+  end
+
+  describe '#rotate_tokens!' do
+    let(:account) { accounts(:jane_doe) }
+
+    it 'creates a redacted rotation audit event without token material', :aggregate_failures do
+      session, = described_class.issue_for(account: account)
+      rotated_tokens = nil
+
+      expect do
+        rotated_tokens = session.rotate_tokens!
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/rotated').count
+      }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      expect(version.item_id).to eq(account.id)
+      expect(version.object).not_to include(*rotated_tokens)
+      expect(version.object).not_to include(session.reload.access_token_digest)
+      expect(version.object).not_to include(session.refresh_token_digest)
+    end
+  end
+
+  describe '#revoke!' do
+    let(:account) { accounts(:jane_doe) }
+
+    it 'creates a revoked audit event' do
+      session, = described_class.issue_for(account: account)
+
+      expect do
+        session.revoke!
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/revoked').count
+      }.by(1)
+
+      expect(PaperTrail::Version.where(item_type: 'AuthenticationToken').last.item_id).to eq(account.id)
+    end
+  end
+
+  def issue_session_tokens
+    described_class.issue_for(
+      account: accounts(:jane_doe),
+      device_name: 'RSpec iPhone',
+      user_agent: 'RSpec'
+    ).last(2)
+  end
+
+  def latest_auth_token_version
+    PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+  end
+
+  def expect_creation_audit(version)
+    data = JSON.parse(version.object)
+    expect(version).to have_attributes(item_id: accounts(:jane_doe).id, event: 'auth_token/api_session/created')
+    expect(data).to include(
+      'device_name_present' => true,
+      'device_name_length' => 'RSpec iPhone'.length,
+      'user_agent_hash' => Digest::SHA256.hexdigest('RSpec')
+    )
   end
 end

--- a/spec/requests/admin/audit_logs_spec.rb
+++ b/spec/requests/admin/audit_logs_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe 'Admin::AuditLogs' do
       get admin_audit_logs_path, params: { page: 1 }
       expect(response).to have_http_status(:success)
     end
+
+    it 'surfaces filter options for all PaperTrail item types and events' do
+      insert_unlisted_audit_record
+
+      get admin_audit_logs_path
+
+      expect(response.body).to include('Unlisted Audit Record')
+      expect(response.body).to include('Custom/Audit Event')
+    end
   end
 
   describe 'GET /admin/audit_logs/:id' do
@@ -110,5 +119,20 @@ RSpec.describe 'Admin::AuditLogs' do
         expect(response).to redirect_to(login_path)
       end
     end
+  end
+
+  def insert_unlisted_audit_record
+    PaperTrail::Version.connection.execute(
+      PaperTrail::Version.sanitize_sql_array(
+        [
+          'INSERT INTO versions (item_type, item_id, event, object, created_at) VALUES (?, ?, ?, ?, ?)',
+          'UnlistedAuditRecord',
+          123,
+          'custom/audit_event',
+          { changed: true }.to_json,
+          Time.current.to_fs(:db)
+        ]
+      )
+    )
   end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -27,6 +27,32 @@ RSpec.describe 'API v1 auth sessions' do
       expect(api_session.device_name).to eq('RSpec iPhone')
     end
 
+    it 'records a redacted session creation audit event' do
+      expect do
+        post api_v1_auth_login_path,
+             params: {
+               email: user.email_address,
+               password: 'password',
+               device_name: 'RSpec iPhone'
+             },
+             as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/created').count
+      }.by(1)
+
+      access_token = response.parsed_body.dig('data', 'access_token')
+      refresh_token = response.parsed_body.dig('data', 'refresh_token')
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      data = JSON.parse(version.object)
+
+      expect(version.item_id).to eq(user.person.account.id)
+      expect(version.whodunnit).to eq(user.id.to_s)
+      expect(data['device_name_present']).to be true
+      expect(version.object).not_to include(access_token)
+      expect(version.object).not_to include(refresh_token)
+    end
+
     it 'rejects an invalid password' do
       post api_v1_auth_login_path,
            params: {
@@ -60,6 +86,41 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body.dig('error', 'code')).to eq('invalid_refresh_token')
     end
+
+    it 'records a redacted rotation audit event' do
+      login_data = api_login(user)
+
+      expect do
+        post api_v1_auth_refresh_path,
+             params: { refresh_token: login_data.fetch('refresh_token') },
+             as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/rotated').count
+      }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      expect(version.item_id).to eq(user.person.account.id)
+      expect(version.object).not_to include(response.parsed_body.dig('data', 'access_token'))
+      expect(version.object).not_to include(response.parsed_body.dig('data', 'refresh_token'))
+    end
+
+    it 'records an expired audit event for a known expired refresh token' do
+      login_data = api_login(user)
+      session = ApiSession.lookup_by_refresh_token(login_data.fetch('refresh_token'))
+      session.update!(refresh_expires_at: 1.minute.ago)
+
+      expect do
+        post api_v1_auth_refresh_path,
+             params: { refresh_token: login_data.fetch('refresh_token') },
+             as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/expired').count
+      }.by(1)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   describe 'DELETE /api/v1/auth/logout' do
@@ -75,6 +136,18 @@ RSpec.describe 'API v1 auth sessions' do
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
+    end
+
+    it 'records a revoked audit event' do
+      login_data = api_login(user)
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      expect do
+        delete api_v1_auth_logout_path, headers: headers, as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/api_session/revoked').count
+      }.by(1)
     end
   end
 end

--- a/spec/requests/native_device_tokens_spec.rb
+++ b/spec/requests/native_device_tokens_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe 'Native device tokens' do
       expect(token.platform).to eq('ios')
     end
 
+    it 'records a redacted creation audit event' do
+      expect do
+        post native_device_tokens_path,
+             params: { device_token: 'abc123', platform: 'ios' },
+             as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/native_device_token/created').count
+      }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      data = JSON.parse(version.object)
+
+      expect(version.item_id).to eq(user.person.account.id)
+      expect(data['platform']).to eq('ios')
+      expect(version.object).not_to include('abc123')
+    end
+
     it 'refuses to hijack a token already owned by another account' do
       existing = NativeDeviceToken.create!(
         account: other_account,
@@ -41,6 +59,21 @@ RSpec.describe 'Native device tokens' do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(existing.reload.platform).to eq('ios')
+    end
+  end
+
+  describe 'DELETE /native_device_tokens/:id' do
+    it 'records a redacted revocation audit event' do
+      NativeDeviceToken.create!(account: user.person.account, device_token: 'abc123', platform: 'ios')
+
+      expect do
+        delete native_device_token_path('abc123'), as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/native_device_token/revoked').count
+      }.by(1)
+
+      expect(PaperTrail::Version.where(item_type: 'AuthenticationToken').last.object).not_to include('abc123')
     end
   end
 end

--- a/spec/requests/push_subscriptions_spec.rb
+++ b/spec/requests/push_subscriptions_spec.rb
@@ -32,6 +32,32 @@ RSpec.describe 'Push subscriptions' do
       expect(subscription.auth).to eq('auth_secret')
     end
 
+    it 'records a redacted creation audit event' do
+      expect do
+        post push_subscription_path,
+             params: {
+               endpoint: 'https://example.com/push/subscriptions/123',
+               keys: {
+                 p256dh: 'public_key',
+                 auth: 'auth_secret'
+               }
+             },
+             as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/push_subscription/created').count
+      }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      data = JSON.parse(version.object)
+
+      expect(version.item_id).to eq(user.person.account.id)
+      expect(data['endpoint_hash']).to eq(Digest::SHA256.hexdigest('https://example.com/push/subscriptions/123'))
+      expect(version.object).not_to include('https://example.com/push/subscriptions/123')
+      expect(version.object).not_to include('public_key')
+      expect(version.object).not_to include('auth_secret')
+    end
+
     it 'returns a validation error when required keys are missing' do
       post push_subscription_path,
            params: {
@@ -79,6 +105,29 @@ RSpec.describe 'Push subscriptions' do
              as: :json
 
       expect(response).to have_http_status(:no_content)
+    end
+
+    it 'records a redacted revocation audit event' do
+      PushSubscription.create!(
+        account: user.person.account,
+        endpoint: 'https://example.com/push/subscriptions/123',
+        p256dh: 'public_key',
+        auth: 'auth_secret'
+      )
+
+      expect do
+        delete push_subscription_path,
+               params: { endpoint: 'https://example.com/push/subscriptions/123' },
+               as: :json
+      end.to change {
+        PaperTrail::Version.where(item_type: 'AuthenticationToken',
+                                  event: 'auth_token/push_subscription/revoked').count
+      }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'AuthenticationToken').last
+      expect(version.object).not_to include('https://example.com/push/subscriptions/123')
+      expect(version.object).not_to include('public_key')
+      expect(version.object).not_to include('auth_secret')
     end
   end
 end

--- a/spec/services/admin/audit_logs_query_spec.rb
+++ b/spec/services/admin/audit_logs_query_spec.rb
@@ -37,5 +37,29 @@ RSpec.describe Admin::AuditLogsQuery do
       expect(result.total_count).to be >= 2
       expect(result.versions.size).to eq(1)
     end
+
+    it 'returns filter options from all PaperTrail versions' do
+      insert_unlisted_audit_record
+
+      result = described_class.new(scope: scope, filters: {}, page: 1, per_page: 10).call
+
+      expect(result.item_types).to include('Person', 'UnlistedAuditRecord', 'User')
+      expect(result.events).to include('custom/audit_event', 'update')
+    end
+  end
+
+  def insert_unlisted_audit_record
+    PaperTrail::Version.connection.execute(
+      PaperTrail::Version.sanitize_sql_array(
+        [
+          'INSERT INTO versions (item_type, item_id, event, object, created_at) VALUES (?, ?, ?, ?, ?)',
+          'UnlistedAuditRecord',
+          123,
+          'custom/audit_event',
+          { changed: true }.to_json,
+          Time.current.to_fs(:db)
+        ]
+      )
+    )
   end
 end

--- a/spec/services/admin/audit_logs_query_spec.rb
+++ b/spec/services/admin/audit_logs_query_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Admin::AuditLogsQuery do
       expect(result.versions.size).to eq(1)
     end
 
+    it 'includes default filter options even when no matching versions exist' do
+      result = described_class.new(scope: PaperTrail::Version.none, filters: {}, page: 1, per_page: 10).call
+
+      expect(result.item_types).to include('AuthenticationToken', 'Medication')
+      expect(result.events).to include('auth_token/api_session/created', 'update')
+    end
+
     it 'returns filter options from all PaperTrail versions' do
       insert_unlisted_audit_record
 

--- a/spec/services/auth_token_audit_logger_spec.rb
+++ b/spec/services/auth_token_audit_logger_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthTokenAuditLogger do
+  subject(:audit_logger) { described_class.new }
+
+  fixtures :accounts, :people, :users
+
+  let(:account) { accounts(:jane_doe) }
+  let(:user) { users(:jane) }
+  let(:version) { PaperTrail::Version.where(item_type: 'AuthenticationToken').last }
+  let(:sensitive_metadata) do
+    {
+      endpoint: 'https://example.com/push/subscriptions/raw-endpoint',
+      user_agent: 'Raw Browser User Agent',
+      device_name: 'RSpec iPhone',
+      platform: 'ios',
+      token: 'raw-token',
+      token_digest: 'raw-token-digest',
+      p256dh: 'raw-p256dh',
+      auth: 'raw-auth',
+      webauthn_id: 'raw-webauthn-id',
+      public_key: 'raw-public-key',
+      email: 'jane@example.com'
+    }
+  end
+
+  before do
+    PaperTrail.request.whodunnit = user.id
+    PaperTrail.request.controller_info = { ip: '10.0.0.1', request_id: 'req-auth-001' }
+  end
+
+  after do
+    PaperTrail.request.whodunnit = nil
+    PaperTrail.request.controller_info = {}
+  end
+
+  describe '#record' do
+    it 'creates a PaperTrail::Version with item_type AuthenticationToken' do
+      expect do
+        audit_logger.record(account: account, token_type: 'api_session', action: 'created')
+      end.to change { PaperTrail::Version.where(item_type: 'AuthenticationToken').count }.by(1)
+    end
+
+    it 'persists the event, account id, whodunnit, ip, and request_id', :aggregate_failures do
+      audit_logger.record(account: account, token_type: 'api_session', action: 'created')
+
+      expect(version.item_id).to eq(account.id)
+      expect(version.event).to eq('auth_token/api_session/created')
+      expect(version.whodunnit).to eq(user.id.to_s)
+      expect(version.ip).to eq('10.0.0.1')
+      expect(version.request_id).to eq('req-auth-001')
+      expect(version_data).to include('account_id' => account.id, 'token_type' => 'api_session', 'action' => 'created')
+    end
+
+    it 'stores hashes and redacted metadata', :aggregate_failures do
+      audit_logger.record(
+        account: account,
+        token_type: 'push_subscription',
+        action: 'created',
+        metadata: sensitive_metadata
+      )
+
+      expect(version_data['endpoint_hash']).to eq(Digest::SHA256.hexdigest(sensitive_metadata.fetch(:endpoint)))
+      expect(version_data['user_agent_hash']).to eq(Digest::SHA256.hexdigest(sensitive_metadata.fetch(:user_agent)))
+      expect(version_data).to include('device_name_present' => true, 'device_name_length' => 12, 'platform' => 'ios')
+    end
+
+    it 'does not store raw token material' do
+      audit_logger.record(
+        account: account,
+        token_type: 'push_subscription',
+        action: 'created',
+        metadata: sensitive_metadata
+      )
+
+      expect(version.object).not_to match(sensitive_pattern)
+    end
+
+    it 'uses explicit audit context when provided', :aggregate_failures do
+      audit_logger.record(
+        account: account,
+        token_type: 'api_session',
+        action: 'rotated',
+        context: { whodunnit: 123, ip: '127.0.0.1', request_id: 'req-explicit' }
+      )
+
+      expect(version.whodunnit).to eq('123')
+      expect(version.ip).to eq('127.0.0.1')
+      expect(version.request_id).to eq('req-explicit')
+    end
+
+    it 'does not raise when called without PaperTrail request context' do
+      PaperTrail.request.whodunnit = nil
+      PaperTrail.request.controller_info = {}
+
+      expect do
+        audit_logger.record(account: account, token_type: 'api_session', action: 'created')
+      end.not_to raise_error
+    end
+
+    it 'silently rescues errors and logs them' do
+      allow(PaperTrail::Version).to receive(:insert).and_raise(ActiveRecord::StatementInvalid)
+      allow(Rails.logger).to receive(:error)
+
+      expect do
+        audit_logger.record(account: account, token_type: 'api_session', action: 'created')
+      end.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(/AuthTokenAuditLogger failed/)
+    end
+  end
+
+  def version_data
+    JSON.parse(version.object)
+  end
+
+  def sensitive_pattern
+    Regexp.union(
+      'raw-endpoint', 'Raw Browser User Agent', 'RSpec iPhone', 'raw-token', 'raw-p256dh',
+      'raw-auth', 'raw-webauthn-id', 'raw-public-key', 'jane@example.com'
+    )
+  end
+end

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe 'Global search command palette' do
     find_by_id('global_search_query').send_keys(:enter)
     expect(page).to have_current_path(medication_path(medications(:vitamin_d)))
 
+    expect(page).to have_css('body[data-global-search-connected="true"]', visible: :all)
     expect(page).to have_css('button[aria-label="Open global search"]')
     page.execute_script(
       'window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true, bubbles: true }))'


### PR DESCRIPTION
## Summary
- add AuthTokenAuditLogger for redacted AuthenticationToken PaperTrail rows
- wire audit events into API sessions, push subscriptions, native device tokens, and Rodauth token lifecycle hooks
- surface all PaperTrail item types/events dynamically in admin/audit_logs filters

Closes #1193

## Verification
- task test TEST_FILE=spec/services/auth_token_audit_logger_spec.rb
- task test TEST_FILE=spec/models/api_session_spec.rb
- task test TEST_FILE=spec/requests/api/v1/auth/sessions_spec.rb
- task test TEST_FILE=spec/requests/push_subscriptions_spec.rb
- task test TEST_FILE=spec/requests/native_device_tokens_spec.rb
- task test TEST_FILE=spec/components/admin/audit_logs/index_view_spec.rb
- task test TEST_FILE=spec/services/admin/audit_logs_query_spec.rb
- task test TEST_FILE=spec/requests/admin/audit_logs_spec.rb
- task rubocop

## Note
Full browser-backed specs are blocked by the existing Playwright Ruby/npm browser version mismatch tracked in #1255.