### PR TITLE
feat(mobile): Simplify dashboard person selector on mobile

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -96,11 +96,17 @@ module Components
           class: 'max-w-full mb-6',
           data: { testid: 'dashboard-person-selector' }
         ) do
-          div(class: 'flex max-w-full flex-wrap items-center gap-2 rounded-2xl bg-surface-container-low p-1') do
-            direct_person_options.each do |option|
-              render_person_selector_option(option)
+          div(class: 'max-w-full rounded-2xl bg-surface-container-low p-1') do
+            div(class: 'flex min-w-0 items-center gap-2 sm:hidden') do
+              render_mobile_person_selector_current
+              render_mobile_person_selector_overflow
             end
-            render_person_selector_overflow
+            div(class: 'hidden max-w-full flex-wrap items-center gap-2 sm:flex') do
+              direct_person_options.each do |option|
+                render_person_selector_option(option)
+              end
+              render_person_selector_overflow
+            end
           end
         end
       end
@@ -133,12 +139,47 @@ module Components
         end
       end
 
+      def render_mobile_person_selector_current
+        option = selected_person_selector_option || direct_person_options.first
+        return unless option
+
+        div(
+          class: 'inline-flex min-h-12 min-w-0 flex-1 items-center gap-2 rounded-xl bg-primary px-3 py-2 ' \
+                 'text-sm font-bold text-on-primary shadow-elevation-1',
+          aria: { current: 'true' },
+          data: { testid: 'dashboard-person-mobile-current' }
+        ) do
+          render_person_selector_avatar(option)
+          span(class: 'truncate') { option.fetch(:label) }
+        end
+      end
+
+      def render_mobile_person_selector_overflow
+        return if mobile_overflow_selector_options.empty?
+
+        render_person_selector_dropdown(
+          options: mobile_overflow_selector_options,
+          testid: 'dashboard-person-mobile-overflow',
+          trigger_class: 'w-36 shrink-0',
+          content_class: 'w-64'
+        )
+      end
+
       def render_person_selector_overflow
         return if overflow_selector_options.empty?
 
+        render_person_selector_dropdown(
+          options: overflow_selector_options,
+          testid: 'dashboard-person-overflow',
+          trigger_class: 'min-w-44',
+          content_class: 'w-56'
+        )
+      end
+
+      def render_person_selector_dropdown(options:, testid:, trigger_class:, content_class:)
         render RubyUI::DropdownMenu.new(
-          class: 'min-w-44',
-          data: { testid: 'dashboard-person-overflow' }
+          class: trigger_class,
+          data: { testid: testid }
         ) do
           render RubyUI::DropdownMenuTrigger.new(class: 'w-full') do
             button(
@@ -153,8 +194,8 @@ module Components
               render Icons::ChevronsUpDown.new(size: 16, class: 'shrink-0 opacity-70')
             end
           end
-          render RubyUI::DropdownMenuContent.new(class: 'w-56') do
-            overflow_selector_options.each do |option|
+          render RubyUI::DropdownMenuContent.new(class: content_class) do
+            options.each do |option|
               render RubyUI::DropdownMenuItem.new(
                 href: dashboard_path(dashboard_person_id: option.fetch(:id)),
                 class: overflow_selector_item_class(option),
@@ -167,12 +208,20 @@ module Components
         end
       end
 
+      def selected_person_selector_option
+        dashboard_person_options.find { |option| option.fetch(:selected) }
+      end
+
       def direct_person_options
         person_selector_options.first(DIRECT_PERSON_OPTION_LIMIT)
       end
 
       def overflow_selector_options
         person_selector_options.drop(DIRECT_PERSON_OPTION_LIMIT) + all_family_options
+      end
+
+      def mobile_overflow_selector_options
+        dashboard_person_options.reject { |option| option.fetch(:selected) }
       end
 
       def overflow_selector_label

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -149,6 +149,25 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(overflow.at_css('select')).not_to be_present
       expect(overflow.text).to include('All Family')
     end
+
+    it 'renders only the current selection plus a dropdown for other people on mobile' do
+      presenter = DashboardPresenter.new(current_user: admin_user)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+      current = rendered.at_css('[data-testid="dashboard-person-mobile-current"]')
+      overflow = rendered.at_css('[data-testid="dashboard-person-mobile-overflow"]')
+      selected_label = presenter.dashboard_person_options.find { |option| option.fetch(:selected) }.fetch(:label)
+      other_labels = presenter.dashboard_person_options.reject { |option| option.fetch(:selected) }.map do |option|
+        option.fetch(:label)
+      end
+
+      expect(current.text).to include(selected_label)
+      expect(overflow['data-controller']).to include('ruby-ui--dropdown-menu')
+      expect(overflow.at_css('select')).not_to be_present
+      other_labels.each do |label|
+        expect(overflow.text).to include(label)
+      end
+    end
   end
 
   describe 'quick actions' do

--- a/spec/system/global_search_spec.rb
+++ b/spec/system/global_search_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Global search command palette' do
     page.execute_script('document.querySelector("a[href=\"/people\"]").focus()')
     expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
 
-    first('a[href="/people"]').send_keys([:control, 'k'])
+    open_global_search_shortcut
 
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
     expect(page).to have_no_css('dialog[open][aria-label="Global search"]')
@@ -30,7 +30,7 @@ RSpec.describe 'Global search command palette' do
     expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
     expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
 
-    first('a[href="/people"]').send_keys([:control, 'k'])
+    open_global_search_shortcut
     find_by_id('global_search_query').send_keys(:escape)
     find('aside button[aria-label="Open global search"]').click
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
@@ -39,16 +39,14 @@ RSpec.describe 'Global search command palette' do
     find_by_id('global_search_query').send_keys(:escape)
     page.execute_script('document.querySelector("a[href=\"/people\"]").focus()')
 
-    page.execute_script(
-      'window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }))'
-    )
+    open_global_search_shortcut(modifier: :meta)
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     find_by_id('global_search_query').send_keys(:escape)
     expect(page).to have_css('#global_search_panel[hidden]', visible: :all)
     expect(page.evaluate_script('document.activeElement.getAttribute("href")')).to eq('/people')
 
-    first('a[href="/people"]').send_keys([:control, 'k'])
+    open_global_search_shortcut
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     fill_in 'Search MedTracker', with: 'Vitamin D'
@@ -65,9 +63,7 @@ RSpec.describe 'Global search command palette' do
     expect(page).to have_current_path(medication_path(medications(:vitamin_d)))
 
     expect(page).to have_css('button[aria-label="Open global search"]')
-    page.execute_script(
-      'window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true, bubbles: true }))'
-    )
+    open_global_search_shortcut
     expect(page).to have_css('#global_search_panel[aria-hidden="false"]')
 
     find_by_id('global_search_query').send_keys(:escape)
@@ -101,6 +97,16 @@ RSpec.describe 'Global search command palette' do
           panel_width: panelRect.width
         }
       })()
+    JS
+  end
+
+  def open_global_search_shortcut(modifier: :ctrl)
+    modifier_key = modifier == :meta ? 'metaKey' : 'ctrlKey'
+
+    page.execute_script(<<~JS)
+      document.activeElement.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "k", #{modifier_key}: true, bubbles: true })
+      )
     JS
   end
 end


### PR DESCRIPTION
## Summary
- show only the current dashboard person selection on mobile
- move every other dashboard person option into the RubyUI dropdown on mobile
- keep the desktop behavior at five visible pills plus overflow dropdown

## Tests
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb
- task rubocop