### PR TITLE
feat: add profile avatars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,8 @@ USER root
 RUN npx playwright install --with-deps chromium \
   && chmod -R 755 /ms-playwright
 
+RUN bash -c 'for browser in chromium chromium_headless_shell; do expected="/ms-playwright/${browser}-1208"; if [ ! -e "$expected" ]; then installed="$(find /ms-playwright -maxdepth 1 -type d -name "${browser}-*" | sort | tail -n 1)"; ln -s "$(basename "$installed")" "$expected"; fi; done'
+
 USER ruby
 
 COPY --chown=ruby:ruby . .

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -131,12 +131,15 @@ module Components
       end
 
       def render_person_selector_avatar(option)
+        person = option.fetch(:person)
+        return render Components::Shared::PersonAvatar.new(person: person, size: :sm) if person
+
         span(
-          class: 'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-container-high ' \
-                 'text-xs font-black text-on-surface'
-        ) do
-          option.fetch(:initials)
-        end
+          class: 'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-shape-full ' \
+                 'bg-secondary-container text-xs font-black text-on-secondary-container',
+          data: { testid: 'person-avatar' },
+          aria: { label: option.fetch(:label) }
+        ) { option.fetch(:initials) }
       end
 
       def render_mobile_person_selector_current

--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -36,9 +36,7 @@ module Components
       end
 
       def render_person_avatar
-        div(class: 'w-12 h-12 rounded-full flex items-center justify-center bg-surface-container text-foreground') do
-          render Icons::User.new(size: 24)
-        end
+        render Components::Shared::PersonAvatar.new(person: person, size: :lg)
       end
 
       def render_schedules_grid

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -28,9 +28,12 @@ module Components
 
       def render_header
         div(class: 'flex items-start justify-between gap-4 pb-4') do
-          div(class: 'min-w-0') do
-            m3_heading(variant: :title_large, level: 3, class: 'font-black tracking-tight') { person.name }
-            m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') { routine_summary }
+          div(class: 'flex min-w-0 items-center gap-3') do
+            render Components::Shared::PersonAvatar.new(person: person, size: :md)
+            div(class: 'min-w-0') do
+              m3_heading(variant: :title_large, level: 3, class: 'font-black tracking-tight') { person.name }
+              m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') { routine_summary }
+            end
           end
           m3_badge(variant: remaining_routine_count.positive? ? :filled : :tonal,
                    class: 'shrink-0 px-3 py-1 text-[10px] font-black uppercase tracking-wider') do

--- a/app/components/dashboard/schedule_card.rb
+++ b/app/components/dashboard/schedule_card.rb
@@ -47,12 +47,7 @@ module Components
       end
 
       def render_person_avatar
-        div(
-          class: 'w-8 h-8 rounded-full bg-secondary-container flex items-center justify-center ' \
-                 'text-on-secondary-container shadow-inner'
-        ) do
-          span(class: 'text-xs font-black') { person.name.first.upcase }
-        end
+        render Components::Shared::PersonAvatar.new(person: person, size: :sm)
       end
 
       def render_medication_info

--- a/app/components/dashboard/schedule_row.rb
+++ b/app/components/dashboard/schedule_row.rb
@@ -40,11 +40,7 @@ module Components
       end
 
       def render_person_avatar
-        Avatar(size: :sm) do
-          AvatarFallback do
-            render Icons::User.new(size: 14, aria_hidden: 'true', class: 'text-on-secondary-container')
-          end
-        end
+        render Components::Shared::PersonAvatar.new(person: person, size: :xs)
       end
 
       def render_medication_cell

--- a/app/components/layouts/current_user_context.rb
+++ b/app/components/layouts/current_user_context.rb
@@ -23,12 +23,6 @@ module Components
       def current_user_name
         current_user&.name
       end
-
-      def current_user_initials
-        return 'U' if current_user_name.blank?
-
-        current_user_name.split.map(&:first).join.upcase
-      end
     end
   end
 end

--- a/app/components/layouts/profile_menu.rb
+++ b/app/components/layouts/profile_menu.rb
@@ -10,7 +10,12 @@ module Components
       def view_template
         render RubyUI::DropdownMenu.new do
           render RubyUI::DropdownMenuTrigger.new(class: 'w-full') do
-            m3_button(variant: :outlined) { current_user_name || t('layouts.profile_menu.account') }
+            m3_button(variant: :outlined, class: 'gap-2') do
+              if current_user&.person
+                render Components::Shared::PersonAvatar.new(person: current_user.person, size: :xs)
+              end
+              span { current_user_name || t('layouts.profile_menu.account') }
+            end
           end
           render RubyUI::DropdownMenuContent.new do
             render(RubyUI::DropdownMenuLabel.new { t('layouts.profile_menu.my_account') })

--- a/app/components/layouts/sidebar.rb
+++ b/app/components/layouts/sidebar.rb
@@ -108,12 +108,7 @@ module Components
                   class: 'flex items-center gap-3 rounded-full p-2 ' \
                          'transition-all no-underline group relative state-layer ' \
                          'bg-surface-container-high text-on-surface' do
-            div(
-              class: 'w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary ' \
-                     'font-bold text-xs overflow-hidden flex-shrink-0 z-10'
-            ) do
-              current_user_initials
-            end
+            render Components::Shared::PersonAvatar.new(person: current_user.person, size: :sm, class: 'z-10')
             div(class: 'hidden md:block overflow-hidden z-10') do
               p(class: 'text-xs font-bold truncate text-foreground') do
                 current_user_name || t('layouts.sidebar.user_fallback')

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -149,12 +149,7 @@ module Components
               location.members.each do |member|
                 div(class: 'flex items-center justify-between group') do
                   div(class: 'flex items-center gap-3') do
-                    div(
-                      class: 'w-8 h-8 rounded-full bg-primary/10 flex items-center ' \
-                             'justify-center text-on-surface-variant'
-                    ) do
-                      render Icons::User.new(size: 16)
-                    end
+                    render Components::Shared::PersonAvatar.new(person: member, size: :sm)
                     m3_text(size: '2', weight: 'semibold', class: 'text-foreground') { member.name }
                   end
 

--- a/app/components/medication_workflow/person_selection.rb
+++ b/app/components/medication_workflow/person_selection.rb
@@ -47,10 +47,7 @@ module Components
                      'hover:border-primary hover:bg-primary/5 active:bg-primary/10 ' \
                      'transition-all cursor-pointer no-underline'
             ) do
-              div(class: 'w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center ' \
-                         'text-primary font-bold text-sm flex-none') do
-                plain person.name.first.upcase
-              end
+              render Components::Shared::PersonAvatar.new(person: person, size: :md)
               div do
                 div(class: 'font-semibold text-sm text-foreground') { person.name }
                 div(class: 'text-on-surface-variant text-xs mt-0.5') { person.person_type.humanize }
@@ -74,6 +71,7 @@ module Components
 
                 people.each do |person|
                   render RubyUI::ComboboxItem.new do
+                    render Components::Shared::PersonAvatar.new(person: person, size: :sm)
                     render RubyUI::ComboboxRadio.new(
                       name: 'person_id',
                       id: "person_#{person.id}",

--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -43,12 +43,7 @@ module Components
       end
 
       def render_person_icon
-        div(
-          class: 'w-10 h-10 rounded-xl flex items-center justify-center ' \
-                 'bg-secondary-container text-on-secondary-container'
-        ) do
-          render Icons::User.new(size: 20)
-        end
+        render Components::Shared::PersonAvatar.new(person: person, size: :md)
       end
 
       def render_card_content

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -46,12 +46,7 @@ module Components
                  'border-outline-variant/30'
         ) do
           div(class: 'flex items-center gap-6') do
-            div(
-              class: 'w-24 h-24 rounded-[2rem] bg-primary/10 flex items-center justify-center text-primary ' \
-                     'font-black text-3xl shadow-inner'
-            ) do
-              person.name.split.map(&:first).join.upcase
-            end
+            render Components::Shared::PersonAvatar.new(person: person, size: :xl)
             div(class: 'space-y-1') do
               div(class: 'flex items-center gap-3') do
                 m3_heading(variant: :display_small, level: 1, class: 'font-black tracking-tight') { person.name }

--- a/app/components/shared/person_avatar.rb
+++ b/app/components/shared/person_avatar.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'digest/md5'
+
+module Components
+  module Shared
+    class PersonAvatar < Components::Base
+      SIZES = {
+        xs: { class: 'h-6 w-6 text-[0.625rem]', pixels: 24 },
+        sm: { class: 'h-8 w-8 text-xs', pixels: 32 },
+        md: { class: 'h-10 w-10 text-sm', pixels: 40 },
+        lg: { class: 'h-14 w-14 text-lg', pixels: 56 },
+        xl: { class: 'h-24 w-24 text-3xl', pixels: 96 }
+      }.freeze
+
+      attr_reader :person, :size, :gravatar, :attrs
+
+      def self.initials_for(person)
+        person.name.to_s.split.filter_map { |part| part[0] }.join.upcase.presence || '?'
+      end
+
+      def initialize(person:, size: :md, gravatar: true, **attrs)
+        @person = person
+        @size = size.to_sym
+        @gravatar = gravatar
+        @attrs = merged_attrs(attrs)
+        super()
+      end
+
+      def view_template
+        span(**attrs) do
+          render_fallback
+          render_image if avatar_url.present?
+        end
+      end
+
+      private
+
+      def merged_attrs(user_attrs)
+        base_attrs = default_attrs
+        base_attrs[:class] = [base_attrs[:class], user_attrs[:class]].compact.join(' ')
+        base_attrs[:class] = RubyUI::Base::TAILWIND_MERGER.merge(base_attrs[:class])
+        base_attrs[:data] = base_attrs.fetch(:data, {}).merge(user_attrs.fetch(:data, {}))
+        base_attrs[:aria] = base_attrs.fetch(:aria, {}).merge(user_attrs.fetch(:aria, {}))
+        base_attrs.merge(user_attrs.except(:class, :data, :aria))
+      end
+
+      def default_attrs
+        {
+          class: [
+            'relative inline-flex shrink-0 overflow-hidden rounded-shape-full bg-secondary-container',
+            'text-on-secondary-container shadow-inner ring-1 ring-outline-variant/40',
+            size_config.fetch(:class)
+          ].join(' '),
+          data: { testid: 'person-avatar' },
+          aria: { label: person.name }
+        }
+      end
+
+      def render_fallback
+        span(class: 'flex h-full w-full items-center justify-center font-black tracking-normal') do
+          plain self.class.initials_for(person)
+        end
+      end
+
+      def render_image
+        img(
+          src: avatar_url,
+          alt: person.name,
+          loading: 'lazy',
+          class: 'absolute inset-0 h-full w-full object-cover',
+          data: {
+            controller: 'avatar-image',
+            action: 'error->avatar-image#error'
+          }
+        )
+      end
+
+      def avatar_url
+        @avatar_url ||= uploaded_avatar_url || gravatar_url
+      end
+
+      def uploaded_avatar_url
+        return unless person.avatar.attached?
+
+        view_context.url_for(person.avatar)
+      end
+
+      def gravatar_url
+        return unless gravatar
+        return unless gravatar_enabled?
+        return if avatar_email.blank?
+
+        digest = Digest::MD5.hexdigest(avatar_email.downcase)
+        "https://www.gravatar.com/avatar/#{digest}?d=404&s=#{size_config.fetch(:pixels)}"
+      end
+
+      def gravatar_enabled?
+        person.user&.gravatar_enabled?
+      end
+
+      def avatar_email
+        person.email.presence || person.user&.email_address.presence || person.account&.email
+      end
+
+      def size_config
+        SIZES.fetch(size) { SIZES.fetch(:md) }
+      end
+    end
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -20,57 +20,31 @@ class ProfilesController < ApplicationController
     @person = current_user.person
     @account = current_account
 
-    if person_params.present?
-      if @person.update(person_params)
-        respond_to do |format|
-          format.html { redirect_to profile_path, notice: t('profiles.updated') }
-          format.turbo_stream do
-            flash.now[:notice] = t('profiles.updated')
-            render turbo_stream: [
-              turbo_stream.update('modal', ''),
-              turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice])),
-              turbo_stream.replace('main-content', Views::Profiles::Show.new(person: @person.reload, account: @account, user: current_user))
-            ]
-          end
-        end
-      else
-        respond_to do |format|
-          format.html { redirect_to profile_path, alert: t('profiles.profile_update_failed', errors: @person.errors.full_messages.join(', ')) }
-          format.turbo_stream do
-            flash.now[:alert] = t('profiles.profile_update_failed', errors: @person.errors.full_messages.join(', '))
-            render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
-          end
-        end
-      end
-    elsif account_params.present?
-      if @account.update(account_params)
-        respond_to do |format|
-          format.html { redirect_to profile_path, notice: t('profiles.email_updated') }
-          format.turbo_stream do
-            flash.now[:notice] = t('profiles.email_updated')
-            render turbo_stream: [
-              turbo_stream.update('modal', ''),
-              turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice])),
-              turbo_stream.replace('main-content', Views::Profiles::Show.new(person: @person, account: @account.reload, user: current_user))
-            ]
-          end
-        end
-      else
-        respond_to do |format|
-          format.html { redirect_to profile_path, alert: t('profiles.email_update_failed', errors: @account.errors.full_messages.join(', ')) }
-          format.turbo_stream do
-            flash.now[:alert] = t('profiles.email_update_failed', errors: @account.errors.full_messages.join(', '))
-            render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
-          end
-        end
-      end
-    else
-      respond_to do |format|
-        format.html { redirect_to profile_path, alert: t('profiles.no_changes') }
-        format.turbo_stream do
-          flash.now[:alert] = t('profiles.no_changes')
-          render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
-        end
+    attributes = person_params
+    return update_person_profile(attributes) if attributes.present?
+
+    attributes = user_params
+    return update_user_profile(attributes) if attributes.present?
+
+    attributes = account_params
+    return update_account_profile(attributes) if attributes.present?
+
+    respond_no_changes
+  end
+
+  def avatar
+    current_user.person.avatar.purge
+    @person = current_user.person
+    @account = current_account
+
+    respond_to do |format|
+      format.html { redirect_to profile_path, notice: t('.removed') }
+      format.turbo_stream do
+        flash.now[:notice] = t('.removed')
+        render turbo_stream: [
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice])),
+          turbo_stream.replace('main-content', Views::Profiles::Show.new(person: @person, account: @account, user: current_user))
+        ]
       end
     end
   end
@@ -101,11 +75,98 @@ class ProfilesController < ApplicationController
 
   private
 
+  def update_person_profile(attributes)
+    if @person.update(attributes)
+      respond_profile_updated(person: @person.reload, account: @account, close_modal: true)
+    else
+      respond_profile_failed(@person)
+    end
+  end
+
+  def update_user_profile(attributes)
+    if current_user.update(attributes)
+      respond_profile_updated(person: @person, account: @account)
+    else
+      respond_profile_failed(current_user)
+    end
+  end
+
+  def update_account_profile(attributes)
+    if @account.update(attributes)
+      respond_email_updated
+    else
+      respond_email_failed
+    end
+  end
+
+  def respond_profile_updated(person:, account:, close_modal: false)
+    respond_to do |format|
+      format.html { redirect_to profile_path, notice: t('profiles.updated') }
+      format.turbo_stream do
+        flash.now[:notice] = t('profiles.updated')
+        streams = [turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))]
+        streams.unshift(turbo_stream.update('modal', '')) if close_modal
+        streams << turbo_stream.replace('main-content', Views::Profiles::Show.new(person: person, account: account, user: current_user))
+        render turbo_stream: streams
+      end
+    end
+  end
+
+  def respond_profile_failed(record)
+    message = t('profiles.profile_update_failed', errors: record.errors.full_messages.join(', '))
+    respond_to do |format|
+      format.html { redirect_to profile_path, alert: message }
+      format.turbo_stream do
+        flash.now[:alert] = message
+        render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
+      end
+    end
+  end
+
+  def respond_email_updated
+    respond_to do |format|
+      format.html { redirect_to profile_path, notice: t('profiles.email_updated') }
+      format.turbo_stream do
+        flash.now[:notice] = t('profiles.email_updated')
+        render turbo_stream: [
+          turbo_stream.update('modal', ''),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice])),
+          turbo_stream.replace('main-content', Views::Profiles::Show.new(person: @person, account: @account.reload, user: current_user))
+        ]
+      end
+    end
+  end
+
+  def respond_email_failed
+    message = t('profiles.email_update_failed', errors: @account.errors.full_messages.join(', '))
+    respond_to do |format|
+      format.html { redirect_to profile_path, alert: message }
+      format.turbo_stream do
+        flash.now[:alert] = message
+        render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
+      end
+    end
+  end
+
+  def respond_no_changes
+    respond_to do |format|
+      format.html { redirect_to profile_path, alert: t('profiles.no_changes') }
+      format.turbo_stream do
+        flash.now[:alert] = t('profiles.no_changes')
+        render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert]))
+      end
+    end
+  end
+
   def person_params
-    params.expect(person: [:date_of_birth]) if params[:person]
+    params.expect(person: %i[date_of_birth avatar]) if params[:person]
   end
 
   def account_params
     params.expect(account: [:email]) if params[:account]
+  end
+
+  def user_params
+    params.expect(user: [:gravatar_enabled]) if params[:user]
   end
 end

--- a/app/javascript/controllers/avatar_image_controller.js
+++ b/app/javascript/controllers/avatar_image_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    error() {
+        this.element.classList.add("hidden");
+    }
+}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -11,6 +11,7 @@ class Person < ApplicationRecord
   has_paper_trail
 
   belongs_to :account, optional: true
+  has_one_attached :avatar
   has_one :user, inverse_of: :person, dependent: :destroy
   has_many :schedules, dependent: :destroy
   has_many :medications, through: :schedules
@@ -56,6 +57,8 @@ class Person < ApplicationRecord
                     uniqueness: { allow_blank: true }
   validate :carer_required_when_lacking_capacity
   validate :must_have_at_least_one_location
+  validate :avatar_must_be_supported_image
+  validate :avatar_must_be_smaller_than_five_megabytes
 
   scope :without_carers, -> { where.missing(:carer_relationships) }
 
@@ -139,5 +142,19 @@ class Person < ApplicationRecord
     return if locations.any? || location_memberships.any?
 
     errors.add(:base, 'A person must belong to at least one location')
+  end
+
+  def avatar_must_be_supported_image
+    return unless avatar.attached?
+    return if avatar.blob.content_type.in?(%w[image/png image/jpeg image/webp])
+
+    errors.add(:avatar, 'must be a PNG, JPEG, or WebP image')
+  end
+
+  def avatar_must_be_smaller_than_five_megabytes
+    return unless avatar.attached?
+    return if avatar.blob.byte_size <= 5.megabytes
+
+    errors.add(:avatar, 'must be smaller than 5 MB')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,15 @@ class User < ApplicationRecord
 
   WIZARD_VARIANTS = %w[fullpage modal slideover].freeze
 
-  store_accessor :preferences, :wizard_variant
+  store_accessor :preferences, :wizard_variant, :gravatar_enabled
 
   def wizard_variant
     v = super
     WIZARD_VARIANTS.include?(v) ? v : 'fullpage'
+  end
+
+  def gravatar_enabled?
+    !!ActiveModel::Type::Boolean.new.cast(gravatar_enabled)
   end
 
   belongs_to :person, inverse_of: :user

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -28,9 +28,12 @@ module Views
 
       def render_header
         div(class: header_classes, data: { testid: 'profile-hero' }) do
-          div(class: 'relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between') do
-            render_header_copy
-            div(class: 'grid gap-3 sm:grid-cols-2 lg:w-[24rem]') do
+          div(class: 'flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between') do
+            div(class: 'flex flex-col gap-5 sm:flex-row sm:items-center') do
+              render Components::Shared::PersonAvatar.new(person: person, size: :xl)
+              render_header_copy
+            end
+            div(class: 'grid gap-3 sm:grid-cols-2 lg:w-[25rem]') do
               render_header_stat(t('profiles.show.stats.profile_name'), person.name)
               render_header_stat(t('profiles.show.stats.sign_in_email'), account.email)
             end
@@ -39,7 +42,8 @@ module Views
       end
 
       def header_classes
-        'relative mb-8 overflow-hidden border border-border/70 bg-card px-6 py-8 shadow-elevation-2 sm:px-8'
+        'mb-8 overflow-hidden rounded-shape-xl border border-outline-variant/70 bg-surface-container-low ' \
+          'px-6 py-8 shadow-elevation-2 sm:px-8'
       end
 
       def render_header_copy
@@ -66,6 +70,7 @@ module Views
       def render_left_column
         div(class: 'space-y-6') do
           render ThemePickerCard.new
+          render_avatar_card
           render_personal_info_card
           render TwoFactorCard.new(account: account)
         end
@@ -95,9 +100,84 @@ module Views
       end
 
       def render_header_stat(label, value)
-        div(class: 'rounded-shape-xl border border-border/70 bg-popover px-4 py-4 shadow-elevation-1') do
+        div(class: 'rounded-shape-xl border border-outline-variant/70 bg-surface-container px-4 py-4 shadow-elevation-1') do
           p(class: 'text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-on-surface-variant') { label }
           p(class: 'mt-2 truncate text-sm font-semibold text-foreground sm:text-base') { value.presence || t('profiles.show.not_set') }
+        end
+      end
+
+      def render_avatar_card
+        m3_card(
+          class: 'overflow-hidden border border-border/70 shadow-elevation-2',
+          data: { testid: 'profile-avatar-card' }
+        ) do
+          m3_card_header do
+            m3_card_title { t('profiles.avatar.title') }
+            m3_card_description { t('profiles.avatar.description') }
+          end
+          m3_card_content(class: 'space-y-6') do
+            render_avatar_identity
+            render_avatar_upload_form
+            render_gravatar_form
+          end
+        end
+      end
+
+      def render_avatar_identity
+        div(class: 'flex flex-col gap-5 sm:flex-row sm:items-center') do
+          render Components::Shared::PersonAvatar.new(person: person, size: :xl)
+          div(class: 'space-y-1') do
+            m3_text(variant: :title_medium, class: 'font-bold') { person.name }
+            m3_text(variant: :body_medium, class: 'text-on-surface-variant') { t('profiles.avatar.supported_formats') }
+          end
+        end
+      end
+
+      def render_avatar_upload_form
+        div(class: 'rounded-shape-xl border border-outline-variant/70 bg-surface-container p-4') do
+          form_with(url: profile_path, method: :patch, multipart: true, class: 'space-y-4') do
+            label(class: 'block text-sm font-bold text-foreground', for: 'person_avatar') do
+              t('profiles.avatar.upload_label')
+            end
+            input(
+              id: 'person_avatar',
+              type: 'file',
+              name: 'person[avatar]',
+              accept: 'image/png,image/jpeg,image/webp',
+              class: 'block w-full rounded-shape-md border border-outline-variant bg-surface px-3 py-2 text-sm text-on-surface'
+            )
+            m3_button(type: :submit, variant: :filled, size: :sm) { t('profiles.avatar.upload') }
+          end
+          render_avatar_remove_form if person.avatar.attached?
+        end
+      end
+
+      def render_avatar_remove_form
+        form_with(url: profile_avatar_path, method: :delete) do
+          m3_button(type: :submit, variant: :outlined, size: :sm) { t('profiles.avatar.remove') }
+        end
+      end
+
+      def render_gravatar_form
+        div(class: 'rounded-shape-xl border border-outline-variant/70 bg-surface-container p-4') do
+          form_with(url: profile_path, method: :patch, class: 'flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between') do
+            div(class: 'flex items-start gap-3') do
+              input(type: 'hidden', name: 'user[gravatar_enabled]', value: '0')
+              input(
+                id: 'user_gravatar_enabled',
+                type: 'checkbox',
+                name: 'user[gravatar_enabled]',
+                value: '1',
+                checked: user.gravatar_enabled?,
+                class: 'mt-1 h-4 w-4 rounded border-outline text-primary focus:ring-primary'
+              )
+              label(class: 'space-y-1', for: 'user_gravatar_enabled') do
+                span(class: 'block text-sm font-bold text-foreground') { t('profiles.avatar.gravatar_label') }
+                span(class: 'block text-sm text-on-surface-variant') { t('profiles.avatar.gravatar_description') }
+              end
+            end
+            m3_button(type: :submit, variant: :tonal, size: :sm) { t('profiles.avatar.save_gravatar') }
+          end
         end
       end
     end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1145,6 +1145,17 @@ cy:
       personal_information:
         title: Gwybodaeth Bersonol
         description: Eich gwybodaeth broffil sylfaenol
+    avatar:
+      title: Llun proffil
+      description: Uwchlwythwch avatar ar gyfer y mannau lle mae eich enw'n ymddangos.
+      supported_formats: PNG, JPEG, neu WebP hyd at 5 MB.
+      upload_label: Uwchlwytho avatar personol
+      upload: Uwchlwytho avatar
+      remove: Tynnu avatar
+      removed: Tynnwyd y llun proffil.
+      gravatar_label: Defnyddio Gravatar
+      gravatar_description: Dangos eich Gravatar pan nad oes avatar personol wedi'i uwchlwytho.
+      save_gravatar: Cadw dewis Gravatar
     account_security:
       title: Diogelwch Cyfrif
       description: Rheoli eich manylion mewngofnodi a'ch gosodiadau diogelwch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1250,6 +1250,17 @@ en:
       personal_information:
         title: Personal Information
         description: Your basic profile information
+    avatar:
+      title: Profile photo
+      description: Upload an avatar for places where your name appears.
+      supported_formats: PNG, JPEG, or WebP up to 5 MB.
+      upload_label: Upload a custom avatar
+      upload: Upload avatar
+      remove: Remove avatar
+      removed: Profile photo removed.
+      gravatar_label: Use Gravatar
+      gravatar_description: Show your Gravatar when no custom avatar is uploaded.
+      save_gravatar: Save Gravatar choice
     account_security:
       title: Account Security
       description: Manage your login credentials and security settings

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1139,6 +1139,17 @@ es:
       personal_information:
         title: Información personal
         description: Tu información básica de perfil
+    avatar:
+      title: Foto de perfil
+      description: Sube un avatar para los lugares donde aparece tu nombre.
+      supported_formats: PNG, JPEG o WebP hasta 5 MB.
+      upload_label: Subir un avatar personalizado
+      upload: Subir avatar
+      remove: Eliminar avatar
+      removed: Foto de perfil eliminada.
+      gravatar_label: Usar Gravatar
+      gravatar_description: Muestra tu Gravatar cuando no haya un avatar personalizado subido.
+      save_gravatar: Guardar elección de Gravatar
     account_security:
       title: Seguridad de la cuenta
       description: Gestiona tus credenciales de acceso y ajustes de seguridad

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1122,6 +1122,17 @@ ga:
       personal_information:
         title: Faisnéis Phearsanta
         description: Eolas bunúsach do phróifíle
+    avatar:
+      title: Grianghraf próifíle
+      description: Uaslódáil avatar do na háiteanna ina dtaispeántar d'ainm.
+      supported_formats: PNG, JPEG, nó WebP suas le 5 MB.
+      upload_label: Uaslódáil avatar saincheaptha
+      upload: Uaslódáil avatar
+      remove: Bain avatar
+      removed: Baineadh an grianghraf próifíle.
+      gravatar_label: Úsáid Gravatar
+      gravatar_description: Taispeáin do Gravatar nuair nach bhfuil avatar saincheaptha uaslódáilte.
+      save_gravatar: Sábháil rogha Gravatar
     account_security:
       title: Slándáil Chuntais
       description: Bainistigh do dhintiúir logála isteach agus do shocruithe slándála

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1242,6 +1242,17 @@ pt:
       personal_information:
         title: Informação Pessoal
         description: As informações básicas do seu perfil
+    avatar:
+      title: Foto de perfil
+      description: Carregue um avatar para os locais onde o seu nome aparece.
+      supported_formats: PNG, JPEG ou WebP até 5 MB.
+      upload_label: Carregar um avatar personalizado
+      upload: Carregar avatar
+      remove: Remover avatar
+      removed: Foto de perfil removida.
+      gravatar_label: Usar Gravatar
+      gravatar_description: Mostrar o seu Gravatar quando não existir um avatar personalizado carregado.
+      save_gravatar: Guardar escolha de Gravatar
     account_security:
       title: Segurança da Conta
       description: Gira as suas credenciais de início de sessão e definições de segurança

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   resource :profile, only: %i[show update] do
     patch :experiments, on: :member
   end
+  delete 'profile/avatar', to: 'profiles#avatar', as: :profile_avatar
 
   # Reports
   resources :reports, only: %i[index]

--- a/db/migrate/20260512160000_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260512160000_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class CreateActiveStorageTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type
+      t.text :metadata
+      t.string :service_name, null: false
+      t.bigint :byte_size, null: false
+      t.string :checksum
+      t.datetime :created_at, null: false
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false
+      t.references :blob, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[record_type record_id name blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_12_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -131,6 +131,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_11_120000) do
     t.string "subscription_plan", default: "free", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "api_sessions", force: :cascade do |t|
@@ -462,6 +490,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_11_120000) do
   add_foreign_key "account_verification_keys", "accounts"
   add_foreign_key "account_webauthn_keys", "accounts", on_delete: :cascade
   add_foreign_key "account_webauthn_user_ids", "accounts", on_delete: :cascade
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "api_sessions", "accounts"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
 
       expect(selected.text).to include('Parent Person')
       expect(selected.text).to include('PP')
+      expect(selected.at_css('[data-testid="person-avatar"]')).to be_present
     end
 
     it 'wraps selector controls instead of requiring horizontal scrolling' do

--- a/spec/components/dashboard/schedule_row_spec.rb
+++ b/spec/components/dashboard/schedule_row_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe Components::Dashboard::ScheduleRow, type: :component do
     expect(rendered.text).to include(MedicationStockQuantityFormatter.format(schedule.medication.current_supply))
   end
 
-  it 'renders the person avatar with an SVG icon instead of emoji' do
+  it 'renders the shared person avatar with initials instead of emoji' do
     rendered = render_inline(row)
 
     expect(rendered.text).not_to include('👤')
-    expect(rendered.css('svg.lucide-user')).to be_present
+    expect(rendered.at_css('[data-testid="person-avatar"]')).to be_present
+    expect(rendered.text).to include('JD')
   end
 end

--- a/spec/components/layouts/current_user_context_spec.rb
+++ b/spec/components/layouts/current_user_context_spec.rb
@@ -54,20 +54,6 @@ RSpec.describe Components::Layouts::CurrentUserContext do
     end
   end
 
-  describe '#current_user_initials' do
-    it 'returns initials from the user name' do
-      expect(component.send(:current_user_initials)).to eq('AD')
-    end
-
-    context 'when the user has no name' do
-      let(:current_user) { build_user(name: nil, administrator: false) }
-
-      it 'falls back to U' do
-        expect(component.send(:current_user_initials)).to eq('U')
-      end
-    end
-  end
-
   def build_user(name:, administrator:)
     Class.new do
       attr_reader :name

--- a/spec/components/layouts/sidebar_spec.rb
+++ b/spec/components/layouts/sidebar_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Components::Layouts::Sidebar, type: :component do
       expect(inventory_link['class']).to include('bg-secondary-container')
       expect(inventory_link['class']).to include('text-on-secondary-container')
     end
+
+    it 'renders the shared person avatar in the profile navigation item' do
+      rendered = render_sidebar(user: admin_user)
+      profile_link = rendered.at_css(%(a[href="#{Rails.application.routes.url_helpers.profile_path}"]))
+
+      expect(profile_link.at_css('[data-testid="person-avatar"]')).to be_present
+    end
   end
 
   context 'when user is not an administrator' do

--- a/spec/components/locations/show_view_spec.rb
+++ b/spec/components/locations/show_view_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Components::Locations::ShowView, type: :component do
     expect(supply_badge['class']).to include('shrink-0')
   end
 
+  it 'renders location members with the shared person avatar' do
+    person = create(:person, name: 'Location Member')
+    create(:location_membership, location: location, person: person)
+
+    rendered = render_location
+
+    expect(rendered.text).to include('Location Member')
+    expect(rendered.at_css('[data-testid="person-avatar"]')).to be_present
+  end
+
   def render_location
     vc = view_context
     policy_stub = Struct.new(:update?).new(false)

--- a/spec/components/people/show_view_spec.rb
+++ b/spec/components/people/show_view_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Components::People::ShowView, type: :component do
     rendered = render_view
     expect(rendered.text).to include(person.name)
     expect(rendered.text).to include('Adult')
+    expect(rendered.at_css('[data-testid="person-avatar"]')).to be_present
   end
 
   it 'renders the Profile Overview card' do

--- a/spec/components/shared/person_avatar_spec.rb
+++ b/spec/components/shared/person_avatar_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'digest/md5'
+
+RSpec.describe Components::Shared::PersonAvatar, type: :component do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  let(:person) { people(:damacus) }
+
+  it 'renders initials when no uploaded avatar or enabled Gravatar is present' do
+    rendered = render_inline(described_class.new(person: person))
+
+    expect(rendered.text).to include('DU')
+    expect(rendered.css('img')).to be_empty
+  end
+
+  it 'does not request Gravatar until the linked user opts in' do
+    rendered = render_inline(described_class.new(person: person))
+
+    expect(rendered.to_html).not_to include('gravatar.com/avatar')
+  end
+
+  it 'renders a Gravatar image when the linked user opts in' do
+    person.user.update!(gravatar_enabled: '1')
+    digest = Digest::MD5.hexdigest(person.email.downcase)
+
+    rendered = render_inline(described_class.new(person: person))
+
+    expect(rendered.at_css("img[src*='gravatar.com/avatar/#{digest}']")).to be_present
+    expect(rendered.text).to include('DU')
+  end
+
+  it 'prefers uploaded avatars over Gravatar' do
+    person.user.update!(gravatar_enabled: '1')
+    person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+
+    rendered = render_inline(described_class.new(person: person))
+
+    expect(rendered.at_css("img[alt='Damacus User']")).to be_present
+    expect(rendered.to_html).not_to include('gravatar.com/avatar')
+  end
+end

--- a/spec/components/views/profiles/show_spec.rb
+++ b/spec/components/views/profiles/show_spec.rb
@@ -22,4 +22,17 @@ RSpec.describe Views::Profiles::Show, type: :component do
 
     expect(banned_classes.none? { |class_name| html.include?(class_name) }).to be(true)
   end
+
+  it 'renders an M3 identity header with the person avatar and profile metadata' do
+    component = described_class.new(person: person, account: account, user: user)
+    allow(component).to receive(:render_left_column) { component.send(:render_avatar_card) }
+    allow(component).to receive(:render_right_column)
+
+    rendered = render_inline(component)
+
+    expect(rendered.at_css('[data-testid="profile-hero"] [data-testid="person-avatar"]')).to be_present
+    expect(rendered.at_css('[data-testid="profile-avatar-card"]')).to be_present
+    expect(rendered.text).to include('Profile photo')
+    expect(rendered.text).to include('Use Gravatar')
+  end
 end

--- a/spec/models/person_avatar_spec.rb
+++ b/spec/models/person_avatar_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Person do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  let(:person) { people(:damacus) }
+
+  describe 'avatar attachment' do
+    it 'accepts supported image uploads' do
+      person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+
+      expect(person).to be_valid
+    end
+
+    it 'rejects non-image uploads' do
+      person.avatar.attach(io: StringIO.new('not an image'), filename: 'avatar.txt', content_type: 'text/plain')
+
+      expect(person).not_to be_valid
+      expect(person.errors[:avatar]).to include('must be a PNG, JPEG, or WebP image')
+    end
+
+    it 'rejects avatars larger than five megabytes' do
+      person.avatar.attach(
+        io: StringIO.new('x' * 6.megabytes),
+        filename: 'avatar.png',
+        content_type: 'image/png'
+      )
+
+      expect(person).not_to be_valid
+      expect(person.errors[:avatar]).to include('must be smaller than 5 MB')
+    end
+  end
+end

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  fixtures :accounts, :people, :users
+
+  describe '#gravatar_enabled?' do
+    it 'defaults to false' do
+      expect(users(:damacus).gravatar_enabled?).to be(false)
+    end
+
+    it 'normalizes truthy preference values' do
+      user = users(:damacus)
+
+      user.gravatar_enabled = '1'
+
+      expect(user.gravatar_enabled?).to be(true)
+    end
+  end
+end

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Profiles' do
-  fixtures :accounts, :people, :users
+  fixtures :accounts, :people, :users, :locations, :location_memberships
 
   let(:user) { users(:damacus) }
   let(:account) { user.person.account }
@@ -75,6 +75,72 @@ RSpec.describe 'Profiles' do
   end
 
   describe 'PATCH /profile' do
+    it 'uploads the signed-in person avatar' do
+      file = Tempfile.new(['avatar', '.png'])
+      file.write('avatar')
+      file.rewind
+
+      patch profile_path,
+            params: { person: { avatar: Rack::Test::UploadedFile.new(file.path, 'image/png') } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(user.person.reload.avatar).to be_attached, flash[:alert]
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it 'rejects invalid avatar uploads without attaching them' do
+      file = Tempfile.new(['avatar', '.txt'])
+      file.write('not an image')
+      file.rewind
+
+      patch profile_path,
+            params: { person: { avatar: Rack::Test::UploadedFile.new(file.path, 'text/plain') } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(flash[:alert]).to include('must be a PNG, JPEG, or WebP image')
+      expect(user.person.reload.avatar).not_to be_attached
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it 'keeps the existing avatar when an invalid replacement is uploaded' do
+      user.person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+      original_blob = user.person.avatar.blob
+      file = Tempfile.new(['avatar', '.txt'])
+      file.write('not an image')
+      file.rewind
+
+      patch profile_path,
+            params: { person: { avatar: Rack::Test::UploadedFile.new(file.path, 'text/plain') } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(flash[:alert]).to include('must be a PNG, JPEG, or WebP image')
+      expect(user.person.reload.avatar).to be_attached
+      expect(user.person.avatar.blob).to eq(original_blob)
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    it 'updates the Gravatar opt-in preference' do
+      patch profile_path, params: { user: { gravatar_enabled: '1' } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(user.reload.gravatar_enabled?).to be(true)
+    end
+
+    it 'disables the Gravatar opt-in preference' do
+      user.update!(gravatar_enabled: '1')
+
+      patch profile_path, params: { user: { gravatar_enabled: '0' } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(user.reload.gravatar_enabled?).to be(false)
+    end
+
     it 'returns turbo_stream and updates flash when no changes are submitted' do
       patch profile_path, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
@@ -82,6 +148,28 @@ RSpec.describe 'Profiles' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include('target="flash"')
       expect(response.body).to include(I18n.t('profiles.no_changes'))
+    end
+  end
+
+  describe 'DELETE /profile/avatar' do
+    it 'removes the signed-in person avatar' do
+      user.person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+
+      delete profile_avatar_path
+
+      expect(response).to redirect_to(profile_path)
+      expect(user.person.reload.avatar).not_to be_attached
+    end
+
+    it 'returns turbo_stream and refreshes the profile page shell' do
+      user.person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+
+      delete profile_avatar_path, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include('target="main-content"')
+      expect(response.body).to include(I18n.t('profiles.avatar.removed'))
     end
   end
 end


### PR DESCRIPTION
## Summary
- add person-backed avatars with Active Storage upload, removal, and validation
- add opt-in Gravatar support through user preferences with initials fallback
- refresh the profile page with an M3 identity header and shared avatar surfaces across dashboard, people, locations, and navigation
- add a Playwright browser revision compatibility link for the test image

## Verification
- task rubocop
- task test TEST_FILE=spec/components/shared/person_avatar_spec.rb
- task test TEST_FILE=spec/models/person_avatar_spec.rb
- task test TEST_FILE=spec/models/user_preferences_spec.rb
- task test TEST_FILE=spec/requests/profiles_show_spec.rb
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb
- task test TEST_FILE=spec/requests/dashboard_home_spec.rb
- task test TEST_FILE=spec/system/profile_editing_spec.rb spec/system/profile_experiments_spec.rb spec/system/two_factor_soft_enforcement_spec.rb

Note: full test runs exposed intermittent Docker test-stack/db-test DNS and deadlock failures after long browser runs; affected slices pass when rerun cleanly.