### PR TITLE
fix: route scan restock match json

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,12 +74,9 @@ Rails.application.routes.draw do
   end
 
   # Medication management
+  post 'medications/scan_restock', to: 'medications#scan_restock', as: :scan_restock_medications
+  get 'medications/scan_restock_match', to: 'medications#scan_restock_match', as: :scan_restock_match_medications
   resources :medications do
-    collection do
-      post :scan_restock
-      get :scan_restock_match
-    end
-
     member do
       get :administration
       get :nhs_guidance

--- a/spec/requests/medications_refill_spec.rb
+++ b/spec/requests/medications_refill_spec.rb
@@ -113,6 +113,15 @@ RSpec.describe 'Medications refill' do
   end
 
   describe 'GET /medications/scan_restock_match' do
+    it 'serves the .json path used by the scan-stock modal' do
+      medication.update!(barcode: '5012345678901')
+
+      get '/medications/scan_restock_match.json', params: { q: '5012345678901' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('matched' => true)
+    end
+
     it 'returns the matching medication for a direct barcode match' do
       medication.update!(barcode: '5012345678901')
 


### PR DESCRIPTION
## Summary
- route scan-restock collection endpoints before medication member routes
- cover the exact /medications/scan_restock_match.json path used by the scan-stock modal

## Verification
- task rubocop
- task test
- task test TEST_FILE=spec/requests/medications_refill_spec.rb