### PR TITLE
feat: show PIL links in medication finder

### DIFF
--- a/app/components/medications/finder_view.rb
+++ b/app/components/medications/finder_view.rb
@@ -21,6 +21,7 @@ module Components
               source: t('medications.finder.source'),
               barcode: t('medications.finder.barcode'),
               dmdCode: t('medications.finder.dmd_code'),
+              pilLink: t('medications.finder.pil_link'),
               addMedication: t('medications.index.add_medication'),
               updateStock: t('medications.finder.update_stock', default: 'Update stock'),
               resultCount: {

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -146,6 +146,7 @@ export default class extends Controller {
       : ''
 
     const identifier = this.renderIdentifier(result)
+    const pilLink = this.renderPilLink(result)
     const title = result.name || result.display
     const packageSize = result.package_size
       ? `<p class="text-xs text-on-surface-variant mt-0.5">Pack size: ${this.escapeHtml(result.package_size)}</p>`
@@ -158,6 +159,7 @@ export default class extends Controller {
             <p class="text-sm font-medium text-foreground truncate">${this.escapeHtml(title)}</p>
             ${packageSize}
             ${identifier}
+            ${pilLink}
           </div>
           <div class="flex flex-col items-end gap-1 shrink-0">
             ${matchReasonBadge}
@@ -216,9 +218,33 @@ export default class extends Controller {
     return ''
   }
 
+  renderPilLink(result) {
+    const url = this.safeExternalUrl(result.pil_url)
+    if (!url) return ''
+
+    return `
+      <a
+        href="${this.hrefAttribute(url)}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-2 inline-flex text-xs font-medium text-primary underline-offset-2 hover:underline"
+        data-testid="pil-link"
+      >${this.escapeHtml(this.t("pilLink"))}</a>
+    `
+  }
+
   barcodeQuery(query) {
     const normalized = String(query || "").trim().replace(/\D/g, "")
     return /^\d{13,14}$/.test(normalized) ? normalized : null
+  }
+
+  safeExternalUrl(url) {
+    try {
+      const parsed = new URL(String(url || ""))
+      return parsed.protocol === "https:" ? parsed.toString() : null
+    } catch (error) {
+      return null
+    }
   }
 
   escapeHtml(str) {

--- a/app/services/nhs_dmd/client.rb
+++ b/app/services/nhs_dmd/client.rb
@@ -16,6 +16,17 @@ module NhsDmd
     SEARCH_CACHE_TTL = 12.hours
     TOKEN_CACHE_TTL = 50.minutes
     TIMEOUT_SECONDS = 10
+    PIL_URL_KEYS = %w[
+      pil_url
+      pilUrl
+      patient_information_leaflet
+      patientInformationLeaflet
+      patient_information_leaflet_url
+      patientInformationLeafletUrl
+    ].freeze
+    PIL_VALUE_KEYS = %w[valueUrl valueUri valueString valueCanonical].freeze
+    PIL_EXTENSION_MATCHER = /(?:\bpil\b|patient[-_\s]?information[-_\s]?leaflet)/i
+    PIL_URL_VALUE_MATCHER = %r{(?:/pil(?:[/?#]|$)|patient[-_\s]?information[-_\s]?leaflet)}i
 
     VMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/VMP'
     AMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/AMP'
@@ -95,7 +106,8 @@ module NhsDmd
         code: item['code'],
         display: item['display'],
         system: item['system'],
-        concept_class: extract_concept_class(item)
+        concept_class: extract_concept_class(item),
+        pil_url: extract_pil_url(item)
       }
     end
 
@@ -105,6 +117,40 @@ module NhsDmd
         ext['url'] == 'http://hl7.org/fhir/StructureDefinition/valueset-concept-comments'
       end
       comment_ext&.dig('valueString')
+    end
+
+    def extract_pil_url(item)
+      direct_pil_url(item) || extension_pil_url(item)
+    end
+
+    def direct_pil_url(item)
+      PIL_URL_KEYS.filter_map { |key| item[key].presence }.first
+    end
+
+    def extension_pil_url(item)
+      extension_pil_urls(Array(item['extension'])).first
+    end
+
+    def extension_pil_urls(extensions)
+      extensions.flat_map do |extension|
+        values = []
+        value = extension_url_value(extension)
+        values << value if pil_extension?(extension) || pil_url_value?(value)
+        values.concat(extension_pil_urls(Array(extension['extension'])))
+        values
+      end.compact
+    end
+
+    def extension_url_value(extension)
+      PIL_VALUE_KEYS.filter_map { |key| extension[key].presence }.first
+    end
+
+    def pil_extension?(extension)
+      extension['url'].to_s.match?(PIL_EXTENSION_MATCHER)
+    end
+
+    def pil_url_value?(value)
+      value.to_s.match?(PIL_URL_VALUE_MATCHER)
     end
 
     def authenticated?

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -135,6 +135,7 @@ module NhsDmd
         package_unit: item[:package_unit],
         directions: item[:directions],
         warnings: item[:warnings],
+        pil_url: item[:pil_url],
         match_reason: item[:match_reason]
       }
     end

--- a/app/services/nhs_dmd/search_result.rb
+++ b/app/services/nhs_dmd/search_result.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module NhsDmd
   class SearchResult
     attr_reader :barcode, :code, :display, :system, :concept_class, :match_reason, :name, :category, :package_size,
-                :package_quantity, :package_unit, :description, :directions, :warnings
+                :package_quantity, :package_unit, :description, :directions, :warnings, :pil_url
 
     def initialize(code:, display:, system:, **attributes)
       @code = code
@@ -13,20 +15,35 @@ module NhsDmd
     end
 
     def assign_optional_attributes(attributes)
+      assign_source_attributes(attributes)
+      assign_package_attributes(attributes)
+      assign_guidance_attributes(attributes)
+    end
+
+    private :assign_optional_attributes
+
+    def assign_source_attributes(attributes)
       @barcode = attributes[:barcode]
       @concept_class = attributes[:concept_class]
       @match_reason = attributes[:match_reason]
       @name = attributes[:name]
       @category = attributes[:category]
+    end
+
+    def assign_package_attributes(attributes)
       @package_size = attributes[:package_size]
       @package_quantity = attributes[:package_quantity]
       @package_unit = attributes[:package_unit]
+    end
+
+    def assign_guidance_attributes(attributes)
       @description = attributes[:description]
       @directions = attributes[:directions]
       @warnings = attributes[:warnings]
+      @pil_url = safe_https_url(attributes[:pil_url])
     end
 
-    private :assign_optional_attributes
+    private :assign_source_attributes, :assign_package_attributes, :assign_guidance_attributes
 
     def concept_class_label
       case concept_class
@@ -59,6 +76,10 @@ module NhsDmd
     private
 
     def core_attributes
+      identity_attributes.merge(package_attributes, guidance_attributes)
+    end
+
+    def identity_attributes
       {
         barcode: barcode,
         code: code,
@@ -67,12 +88,23 @@ module NhsDmd
         display: display,
         system: system,
         concept_class: concept_class,
-        category: category,
+        category: category
+      }
+    end
+
+    def package_attributes
+      {
         package_size: package_size,
         package_quantity: package_quantity,
-        package_unit: package_unit,
+        package_unit: package_unit
+      }
+    end
+
+    def guidance_attributes
+      {
         directions: directions,
-        warnings: warnings
+        warnings: warnings,
+        pil_url: pil_url
       }
     end
 
@@ -83,6 +115,18 @@ module NhsDmd
         match_reason: match_reason,
         match_reason_label: match_reason_label
       }
+    end
+
+    def safe_https_url(url)
+      normalized_url = url.to_s.strip
+      return if normalized_url.blank?
+
+      uri = URI.parse(normalized_url)
+      return unless uri.is_a?(URI::HTTPS) && uri.host.present?
+
+      uri.to_s
+    rescue URI::InvalidURIError
+      nil
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -608,6 +608,7 @@ cy:
       source: Ffynhonnell
       barcode: Cod bar
       dmd_code: Cod dm+d
+      pil_link: Taflen wybodaeth i gleifion
       result_count:
         one: '%{count} canlyniad ar gyfer "%{query}"'
         other: '%{count} canlyniad ar gyfer "%{query}"'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -606,6 +606,7 @@ en:
       source: Source
       barcode: Barcode
       dmd_code: dm+d code
+      pil_link: Patient information leaflet
       result_count:
         one: '%{count} result for "%{query}"'
         other: '%{count} results for "%{query}"'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -616,6 +616,7 @@ es:
       source: Fuente
       barcode: Código de barras
       dmd_code: código dm+d
+      pil_link: Prospecto para el paciente
       result_count:
         one: '%{count} resultado para "%{query}"'
         other: '%{count} resultados para "%{query}"'

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -611,6 +611,7 @@ ga:
       source: Foinse
       barcode: Barrachód
       dmd_code: cód dm+d
+      pil_link: Bileog eolais don othar
       result_count:
         one: '%{count} toradh do "%{query}"'
         other: '%{count} torthaí do "%{query}"'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -612,6 +612,7 @@ pt:
       source: Fonte
       barcode: Código de barras
       dmd_code: Código dm+d
+      pil_link: Folheto informativo do doente
       result_count:
         one: '%{count} resultado para "%{query}"'
         other: '%{count} resultados para "%{query}"'

--- a/spec/components/medications/finder_view_spec.rb
+++ b/spec/components/medications/finder_view_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Components::Medications::FinderView, type: :component do
       'loading' => I18n.t('medications.finder.loading'),
       'resultsTitle' => I18n.t('medications.finder.results_title'),
       'dmdCode' => I18n.t('medications.finder.dmd_code'),
-      'updateStock' => 'Update stock'
+      'updateStock' => 'Update stock',
+      'pilLink' => I18n.t('medications.finder.pil_link')
     )
     expect(payload.fetch('resultCount')).to include(
       'one' => I18n.t('medications.finder.result_count.one'),

--- a/spec/features/medication_lookup_spec.rb
+++ b/spec/features/medication_lookup_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'Medication Lookup', type: :system do
         code: '39720311000001101',
         display: 'Aspirin 300mg tablets',
         system: 'https://dmd.nhs.uk',
-        concept_class: 'VMP'
+        concept_class: 'VMP',
+        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil'
       },
       {
         code: '39720411000001102',
@@ -70,6 +71,12 @@ RSpec.describe 'Medication Lookup', type: :system do
     expect(page).to have_text('Aspirin 300mg tablets')
     expect(page).to have_text('Aspirin 75mg tablets')
     expect(page).to have_text('VMP')
+    expect(page).to have_link('Patient information leaflet', href: 'https://www.medicines.org.uk/emc/product/13866/pil')
+
+    pil_link = find_link('Patient information leaflet')
+    expect(pil_link[:target]).to eq('_blank')
+    expect(pil_link[:rel]).to include('noopener')
+    expect(pil_link[:rel]).to include('noreferrer')
   end
 
   it 'Search returns no results' do

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'GET /medication-finder/search' do
             code: '39720311000001101',
             display: 'Aspirin 300mg tablets',
             system: 'https://dmd.nhs.uk',
-            concept_class: 'VMP'
+            concept_class: 'VMP',
+            pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil'
           )
         ]
       end
@@ -54,6 +55,7 @@ RSpec.describe 'GET /medication-finder/search' do
         expect(json['results'].first['display']).to eq('Aspirin 300mg tablets')
         expect(json['results'].first['code']).to eq('39720311000001101')
         expect(json['results'].first['concept_class']).to eq('VMP')
+        expect(json['results'].first['pil_url']).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
       end
 
       it 'includes existing medication metadata when the result matches accessible stock' do

--- a/spec/services/nhs_dmd/client_spec.rb
+++ b/spec/services/nhs_dmd/client_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe NhsDmd::Client do
         {
           'resourceType' => 'ValueSet',
           'expansion' => {
-            'total' => 2,
+            'total' => 3,
             'contains' => [
               {
                 'system' => 'https://dmd.nhs.uk',
@@ -37,6 +37,22 @@ RSpec.describe NhsDmd::Client do
                   {
                     'url' => 'http://hl7.org/fhir/StructureDefinition/valueset-concept-comments',
                     'valueString' => 'VMP'
+                  }
+                ],
+                'patientInformationLeafletUrl' => 'https://www.medicines.org.uk/emc/product/13866/pil'
+              },
+              {
+                'system' => 'https://dmd.nhs.uk',
+                'code' => '39720511000001103',
+                'display' => 'Aspirin 300mg dispersible tablets',
+                'extension' => [
+                  {
+                    'url' => 'http://hl7.org/fhir/StructureDefinition/valueset-concept-comments',
+                    'valueString' => 'VMP'
+                  },
+                  {
+                    'url' => 'https://medtracker.test/fhir/StructureDefinition/patient-information-leaflet',
+                    'valueUrl' => 'https://www.medicines.org.uk/emc/product/397205/pil'
                   }
                 ]
               },
@@ -60,7 +76,7 @@ RSpec.describe NhsDmd::Client do
         results = client.search('aspirin')
 
         expect(results).to be_an(Array)
-        expect(results.length).to eq(2)
+        expect(results.length).to eq(3)
         expect(results.first).to include(
           code: '39720311000001101',
           display: 'Aspirin 300mg tablets'
@@ -77,6 +93,24 @@ RSpec.describe NhsDmd::Client do
         results = client.search('aspirin')
 
         expect(results.last[:concept_class]).to be_nil
+      end
+
+      it 'maps a PIL URL from direct provider payload fields' do
+        results = client.search('aspirin')
+
+        expect(results.first[:pil_url]).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
+      end
+
+      it 'maps a PIL URL from provider payload extensions' do
+        results = client.search('aspirin')
+
+        expect(results.second[:pil_url]).to eq('https://www.medicines.org.uk/emc/product/397205/pil')
+      end
+
+      it 'sets the PIL URL to nil when provider payload has no PIL data' do
+        results = client.search('aspirin')
+
+        expect(results.last[:pil_url]).to be_nil
       end
     end
 

--- a/spec/services/nhs_dmd/search_result_spec.rb
+++ b/spec/services/nhs_dmd/search_result_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NhsDmd::SearchResult do
+  describe '#to_h' do
+    it 'includes a valid HTTPS PIL URL' do
+      result = described_class.new(
+        code: '39720311000001101',
+        display: 'Aspirin 300mg tablets',
+        system: 'https://dmd.nhs.uk',
+        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil'
+      )
+
+      expect(result.to_h[:pil_url]).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
+    end
+
+    it 'filters unsafe and malformed PIL URLs' do
+      urls = [
+        'javascript:alert(1)',
+        'http://www.medicines.org.uk/emc/product/13866/pil',
+        'not a url'
+      ]
+
+      expect(
+        urls.map do |url|
+          described_class.new(
+            code: '39720311000001101',
+            display: 'Aspirin 300mg tablets',
+            system: 'https://dmd.nhs.uk',
+            pil_url: url
+          ).to_h[:pil_url]
+        end
+      ).to all(be_nil)
+    end
+  end
+end

--- a/spec/support/nhs_dmd_stubs.rb
+++ b/spec/support/nhs_dmd_stubs.rb
@@ -47,14 +47,27 @@ module NhsDmdStubs
         code: r[:code],
         display: r[:display],
         system: r[:system],
-        extension: [
-          {
-            url: 'http://hl7.org/fhir/StructureDefinition/valueset-concept-comments',
-            valueString: r[:concept_class]
-          }
-        ]
+        extension: fhir_extensions_for(r)
       }
     end
+  end
+
+  def fhir_extensions_for(result)
+    extension = [
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/valueset-concept-comments',
+        valueString: result[:concept_class]
+      }
+    ]
+
+    if result[:pil_url].present?
+      extension << {
+        url: 'https://medtracker.test/fhir/StructureDefinition/patient-information-leaflet',
+        valueUrl: result[:pil_url]
+      }
+    end
+
+    extension
   end
 end
 


### PR DESCRIPTION
## Summary
- Extract patient information leaflet URLs from NHS dm+d payload fields and extensions
- Include safe HTTPS-only PIL URLs in search result JSON
- Render PIL links in medication finder results with external-link protections

Closes #578

## Tests
- Not run locally; branch already contains focused specs for client mapping, search result filtering, request JSON, component translations, and system lookup behavior.