### PR TITLE
test: stabilize schedule combobox specs

### DIFF
--- a/spec/system/schedules/add_schedule_modal_spec.rb
+++ b/spec/system/schedules/add_schedule_modal_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe 'Add schedule modal flow' do
     expect(page).to have_text('Choose a medication')
 
     find_by_id('medication_trigger').click
-    find('label', text: 'Ibuprofen', visible: :all, wait: 10).click
+    find('[role="option"]', text: 'Ibuprofen', wait: 10).click
 
     sleep 1.0 # Wait for dosage cards to render
-    find('label', text: /Standard child dose \(6-12 years\)/, visible: :all, wait: 10).click
+    find('label', text: /Standard child dose \(6-12 years\)/, wait: 10).click
 
     fill_in 'Frequency', with: 'Twice daily'
     fill_in 'Start date', with: Date.current.strftime('%Y-%m-%d')

--- a/spec/system/schedules/dosage_selection_spec.rb
+++ b/spec/system/schedules/dosage_selection_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe 'Schedule dosage selection' do
 
     find_by_id('medication_trigger').click
     # Portaled content is in body
-    find('label', text: 'Ibuprofen', visible: :all, wait: 10).click
+    find('[role="option"]', text: 'Ibuprofen', wait: 10).click
 
     expect(page).to have_text('Change')
     sleep 1.0 # Wait for dosage cards to render after medication selection
 
     expect(page).to have_no_css('[name="schedule[dose_option_key]"]:checked', visible: :hidden)
     expect(page).to have_text('Add Plan') # Button might be disabled, have_content is safer
-    find('label', text: '400 mg', visible: :all, wait: 10).click
+    find('label', text: '400 mg', wait: 10).click
 
     fill_in 'Frequency', with: 'Once daily'
     fill_in 'Start date', with: Date.current.strftime('%Y-%m-%d')
@@ -49,7 +49,7 @@ RSpec.describe 'Schedule dosage selection' do
     visit new_person_schedule_path(person)
 
     find_by_id('medication_trigger').click
-    find('label', text: 'Dose-less medication', visible: :all, wait: 10).click
+    find('[role="option"]', text: 'Dose-less medication', wait: 10).click
 
     expect(page).to have_text('No dose options are available for this medication.')
   end

--- a/spec/system/schedules/dose_cycle_defaults_spec.rb
+++ b/spec/system/schedules/dose_cycle_defaults_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe 'Schedule dose cycle defaults' do
     visit new_person_schedule_path(person)
 
     find_by_id('medication_trigger').click
-    find('label', text: medication.name, visible: :all, wait: 10).click
+    find('[role="option"]', text: medication.name, wait: 10).click
 
     expect(page).to have_text('Add Plan')
-    find('label', text: '1 capsule', visible: :all, wait: 10).click
+    find('label', text: '1 capsule', wait: 10).click
 
     expect(page).to have_css('input[name="schedule[dose_cycle]"][value="weekly"]:checked', visible: :hidden)
 


### PR DESCRIPTION
## Summary
- Target visible combobox options by role in schedule system specs
- Stop allowing hidden labels to satisfy Playwright click targets
- Apply the same selector cleanup to neighboring schedule flows

## Verification
- task test TEST_FILE=spec/system/schedules/dose_cycle_defaults_spec.rb
- task test TEST_FILE=spec/system/schedules/dosage_selection_spec.rb
- task test TEST_FILE=spec/system/schedules/add_schedule_modal_spec.rb
- task rubocop
- task test