### PR TITLE
fix: Round form controls to match RubyUI styling

### DIFF
--- a/app/components/admin/invitations/index_view.rb
+++ b/app/components/admin/invitations/index_view.rb
@@ -75,7 +75,7 @@ module Components
               id: 'invitation_email',
               value: @invitation.email,
               required: true,
-              class: 'rounded-md border-border bg-card py-4 px-4 focus:ring-2 ' \
+              class: 'rounded-shape-sm border-border bg-card py-4 px-4 focus:ring-2 ' \
                      'focus:ring-primary/10 focus:border-primary transition-all'
             )
           end

--- a/app/components/admin/nhs_dmd_imports/form_view.rb
+++ b/app/components/admin/nhs_dmd_imports/form_view.rb
@@ -47,7 +47,8 @@ module Components
                   name: 'nhs_dmd_import[release_zip]',
                   accept: '.zip,application/zip',
                   required: true,
-                  class: 'block w-full rounded-md border border-outline-variant bg-surface-container-lowest px-4 py-4'
+                  class: 'block w-full rounded-shape-sm border border-outline-variant ' \
+                         'bg-surface-container-lowest px-4 py-4'
                 )
                 m3_text(variant: :body_medium, class: 'text-on-surface-variant') do
                   t('admin.nhs_dmd_imports.form.help')

--- a/app/components/admin/users/form_view.rb
+++ b/app/components/admin/users/form_view.rb
@@ -112,7 +112,7 @@ module Components
               id: 'user_person_attributes_name',
               value: user.person&.name,
               required: true,
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      "#{person_field_error_class(:name)}",
               **person_field_error_attributes(:name, input_id: 'user_person_attributes_name')
             )
@@ -136,7 +136,7 @@ module Components
               value: user.person&.date_of_birth&.to_fs(:db),
               required: true,
               placeholder: 'YYYY-MM-DD',
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
               data: {
                 controller: 'ruby-ui--calendar-input'
               },
@@ -145,7 +145,7 @@ module Components
             render RubyUI::Calendar.new(
               input_id: '#user_person_attributes_date_of_birth',
               date_format: 'yyyy-MM-dd',
-              class: 'rounded-md border shadow-elevation-2 bg-surface-container-high'
+              class: 'rounded-shape-sm border shadow-elevation-2 bg-surface-container-high'
             )
             render_person_field_error(:date_of_birth, input_id: 'user_person_attributes_date_of_birth')
           end
@@ -197,7 +197,7 @@ module Components
               value: user.email_address,
               required: true,
               placeholder: 'email@example.com',
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      "#{field_error_class(user, :email_address)}",
               **field_error_attributes(user, :email_address, input_id: 'user_email_address')
             )
@@ -227,7 +227,7 @@ module Components
               id: 'user_password',
               required: user.new_record?,
               placeholder: '••••••••',
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      "#{field_error_class(user, :password)}",
               **field_error_attributes(user, :password, input_id: 'user_password')
             )
@@ -249,7 +249,7 @@ module Components
               name: 'user[password_confirmation]',
               id: 'user_password_confirmation',
               placeholder: '••••••••',
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
               required: user.new_record?
             )
           end
@@ -268,7 +268,7 @@ module Components
               render RubyUI::ComboboxTrigger.new(
                 id: 'role_trigger',
                 placeholder: user.role.presence&.titleize || t('admin.users.form.select_role'),
-                class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+                class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
               )
 
               render RubyUI::ComboboxPopover.new do

--- a/app/components/admin/users/search_form.rb
+++ b/app/components/admin/users/search_form.rb
@@ -42,7 +42,7 @@ module Components
                 id: 'search',
                 value: search_params[:search],
                 placeholder: t('admin.users.search.search_placeholder'),
-                class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+                class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
                 data: { action: 'input->filter-form#submit' }
               )
             end
@@ -57,7 +57,7 @@ module Components
                 render RubyUI::ComboboxTrigger.new(
                   id: 'role_trigger',
                   placeholder: search_params[:role].presence&.titleize || t('admin.users.search.all_roles'),
-                  class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+                  class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
                 )
 
                 render RubyUI::ComboboxPopover.new do
@@ -104,7 +104,7 @@ module Components
                 render RubyUI::ComboboxTrigger.new(
                   id: 'status_trigger',
                   placeholder: search_params[:status].presence&.humanize || t('admin.users.search.all'),
-                  class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+                  class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
                 )
 
                 render RubyUI::ComboboxPopover.new do

--- a/app/components/dosages/form.rb
+++ b/app/components/dosages/form.rb
@@ -156,7 +156,7 @@ module Components
             select(
               name: 'dosage[default_dose_cycle]',
               id: 'dosage_default_dose_cycle',
-              class: 'flex h-9 w-full rounded-md border border-outline bg-transparent px-3 py-1 text-sm shadow-sm'
+              class: 'flex h-9 w-full rounded-shape-sm border border-outline bg-transparent px-3 py-1 text-sm shadow-sm'
             ) do
               option(value: '') { '— none —' }
               Dosage::DOSE_CYCLE_OPTIONS.each do |label, value|

--- a/app/components/form_helpers.rb
+++ b/app/components/form_helpers.rb
@@ -9,7 +9,7 @@ module Components
     # Standard styling for native select elements to match RubyUI components
     # Use this when RubyUI::Select is not compatible with Capybara tests
     def select_classes
-      'block h-9 w-full rounded-md border border-outline ' \
+      'block h-9 w-full rounded-shape-sm border border-outline ' \
         'bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background ' \
         'focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
     end

--- a/app/components/global_search/show_view.rb
+++ b/app/components/global_search/show_view.rb
@@ -32,7 +32,7 @@ module Components
             name: 'q',
             type: 'search',
             value: query,
-            class: 'min-h-[44px] flex-1 rounded-md border border-outline-variant bg-surface-container-low px-4',
+            class: 'min-h-[44px] flex-1 rounded-shape-sm border border-outline-variant bg-surface-container-low px-4',
             placeholder: t('global_search.placeholder')
           )
           m3_button(type: :submit) { t('global_search.page_submit') }

--- a/app/components/locations/form_view.rb
+++ b/app/components/locations/form_view.rb
@@ -102,7 +102,7 @@ module Components
             value: location.name,
             required: true,
             placeholder: t('forms.locations.name_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest ' \
                    'py-4 px-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all ' \
                    "#{field_error_class(location, :name)}",
@@ -123,7 +123,7 @@ module Components
             id: 'location_description',
             rows: 3,
             placeholder: t('forms.locations.description_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest ' \
                    'p-4 focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all resize-none'
           ) { location.description }

--- a/app/components/m3/input.rb
+++ b/app/components/m3/input.rb
@@ -20,7 +20,7 @@ module Components
               h-14
               min-h-[56px]
               w-full
-              rounded-shape-xs
+              rounded-shape-sm
               border
               bg-transparent
               px-4

--- a/app/components/medication_assignments/form.rb
+++ b/app/components/medication_assignments/form.rb
@@ -176,7 +176,7 @@ module Components
             name: 'medication_assignment[dose_option]',
             required: true,
             disabled: assignment.medication_id.blank?,
-            class: 'w-full rounded-md border border-outline bg-background px-3 py-2 text-sm',
+            class: 'w-full rounded-shape-sm border border-outline bg-background px-3 py-2 text-sm',
             data: {
               medication_assignment_form_target: 'doseOptionInput',
               action: 'change->medication-assignment-form#selectDose'

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -206,7 +206,7 @@ module Components
           render RubyUI::Combobox.new(class: 'w-full') do
             render RubyUI::ComboboxTrigger.new(
               placeholder: selected_location_name || t('forms.medications.select_location'),
-              class: "rounded-md #{field_error_class(medication, :location)}"
+              class: "rounded-shape-sm #{field_error_class(medication, :location)}"
             )
 
             render RubyUI::ComboboxPopover.new do
@@ -252,7 +252,7 @@ module Components
             value: medication.name,
             required: true,
             placeholder: t('forms.medications.name_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    "focus:border-primary transition-all #{field_error_class(medication, :name)}",
             **field_error_attributes(medication, :name, input_id: 'medication_name')
@@ -273,7 +273,7 @@ module Components
             id: 'medication_friendly_name',
             value: medication.friendly_name,
             placeholder: t('forms.medications.friendly_name_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 focus:border-primary transition-all'
           )
           m3_text(variant: :body_small, class: 'text-on-surface-variant ml-1') do
@@ -291,7 +291,7 @@ module Components
           render RubyUI::Combobox.new(class: 'w-full') do
             render RubyUI::ComboboxTrigger.new(
               placeholder: medication.category.presence || t('forms.medications.select_category'),
-              class: "rounded-md #{field_error_class(medication, :category)}"
+              class: "rounded-shape-sm #{field_error_class(medication, :category)}"
             )
 
             render RubyUI::ComboboxPopover.new do
@@ -341,7 +341,7 @@ module Components
             id: 'medication_description',
             rows: 3,
             placeholder: t('forms.medications.description_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest p-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest p-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all resize-none'
           ) { medication.description }
@@ -580,7 +580,7 @@ module Components
           select(
             name: dosage_field_name(index, 'unit'),
             id: "medication_dosage_records_attributes_#{index}_unit",
-            class: 'flex h-9 w-full rounded-md border border-outline bg-transparent px-3 py-1 text-sm shadow-sm'
+            class: 'flex h-9 w-full rounded-shape-sm border border-outline bg-transparent px-3 py-1 text-sm shadow-sm'
           ) do
             option(value: '', selected: dosage.unit.blank?) { 'Select unit' }
             dosage_units.each do |unit|
@@ -642,7 +642,7 @@ module Components
           select(
             name: dosage_field_name(index, 'default_dose_cycle'),
             id: "medication_dosage_records_attributes_#{index}_default_dose_cycle",
-            class: 'flex h-9 w-full rounded-md border border-outline bg-transparent px-3 py-1 text-sm shadow-sm',
+            class: 'flex h-9 w-full rounded-shape-sm border border-outline bg-transparent px-3 py-1 text-sm shadow-sm',
             required: dosage_row_requires_input?(dosage),
             data: { 'frequency-suggestions-target': 'doseCycle' }
           ) do
@@ -717,7 +717,7 @@ module Components
             min: '0',
             step: '0.01',
             placeholder: t('forms.medications.current_supply_placeholder', default: 'e.g., 30'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all'
           )
@@ -738,7 +738,7 @@ module Components
             min: '0',
             step: '0.01',
             placeholder: t('forms.medications.reorder_threshold_placeholder', default: 'e.g., 5'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all'
           )

--- a/app/components/medications/wizard/field_helpers.rb
+++ b/app/components/medications/wizard/field_helpers.rb
@@ -20,7 +20,7 @@ module Components
             render RubyUI::Combobox.new(class: 'w-full') do
               render RubyUI::ComboboxTrigger.new(
                 placeholder: selected_location_name || t('forms.medications.select_location'),
-                class: "rounded-md #{field_error_class(medication, :location)}"
+                class: "rounded-shape-sm #{field_error_class(medication, :location)}"
               )
 
               render RubyUI::ComboboxPopover.new do
@@ -67,7 +67,7 @@ module Components
               required: true,
               placeholder: t('forms.medications.name_placeholder'),
               title: 'Medication name, e.g. Ibuprofen',
-              class: "rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 #{field_error_class(
+              class: "rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 #{field_error_class(
                 medication, :name
               )}"
             )
@@ -84,7 +84,7 @@ module Components
             render RubyUI::Combobox.new(class: 'w-full') do
               render RubyUI::ComboboxTrigger.new(
                 placeholder: medication.category.presence || t('forms.medications.select_category'),
-                class: "rounded-md #{field_error_class(medication, :category)}"
+                class: "rounded-shape-sm #{field_error_class(medication, :category)}"
               )
 
               render RubyUI::ComboboxPopover.new do
@@ -134,7 +134,7 @@ module Components
               id: 'medication_description',
               rows: 3,
               placeholder: t('forms.medications.description_placeholder'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest p-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest p-4 ' \
                      'focus:ring-2 focus:ring-primary/10 ' \
                      'focus:border-primary transition-all resize-none'
             ) { medication.description }
@@ -156,7 +156,7 @@ module Components
               min: '1',
               title: 'Standard dose amount, e.g. 500',
               placeholder: t('forms.medications.standard_dosage_placeholder', default: 'e.g., 500'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      'focus:ring-2 focus:ring-primary/10 ' \
                      'focus:border-primary transition-all'
             )
@@ -173,7 +173,7 @@ module Components
             render RubyUI::Combobox.new(class: 'w-full') do
               render RubyUI::ComboboxTrigger.new(
                 placeholder: medication.dosage_unit.presence || t('forms.medications.select_unit'),
-                class: "rounded-md #{field_error_class(medication, :dosage_unit)}"
+                class: "rounded-shape-sm #{field_error_class(medication, :dosage_unit)}"
               )
 
               render RubyUI::ComboboxPopover.new do
@@ -285,7 +285,7 @@ module Components
               step: '0.01',
               title: 'Starting supply for a new medication',
               placeholder: t('forms.medications.current_supply_placeholder', default: 'e.g., 30'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      'focus:ring-2 focus:ring-primary/10 ' \
                      'focus:border-primary transition-all'
             )
@@ -307,7 +307,7 @@ module Components
               step: '0.01',
               title: 'Reorder when supply falls below this level',
               placeholder: t('forms.medications.reorder_threshold_placeholder', default: 'e.g., 5'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                      'focus:ring-2 focus:ring-primary/10 ' \
                      'focus:border-primary transition-all'
             )
@@ -325,7 +325,7 @@ module Components
               id: 'medication_warnings',
               rows: 3,
               placeholder: t('forms.medications.warnings_placeholder'),
-              class: 'rounded-md border-error/20 bg-error-container/10 p-4 ' \
+              class: 'rounded-shape-sm border-error/20 bg-error-container/10 p-4 ' \
                      'text-on-error-container focus:ring-2 ' \
                      'focus:ring-error/10 focus:border-error transition-all resize-none ' \
                      'placeholder:text-on-error-container/50 font-medium'
@@ -498,7 +498,8 @@ module Components
             select(
               name: dosage_field_name(index, 'unit'),
               id: "medication_dosage_records_attributes_#{index}_unit",
-              class: 'flex h-9 w-full rounded-md border border-outline bg-transparent px-3 py-1 text-sm shadow-sm',
+              class: 'flex h-9 w-full rounded-shape-sm border border-outline bg-transparent ' \
+                     'px-3 py-1 text-sm shadow-sm',
               required: true
             ) do
               option(value: '', selected: dosage.unit.blank?) { 'Select unit' }
@@ -573,7 +574,8 @@ module Components
             select(
               name: dosage_field_name(index, 'default_dose_cycle'),
               id: "medication_dosage_records_attributes_#{index}_default_dose_cycle",
-              class: 'flex h-9 w-full rounded-md border border-outline bg-transparent px-3 py-1 text-sm shadow-sm',
+              class: 'flex h-9 w-full rounded-shape-sm border border-outline bg-transparent ' \
+                     'px-3 py-1 text-sm shadow-sm',
               required: true,
               data: { 'frequency-suggestions-target': 'doseCycle' }
             ) do

--- a/app/components/medications/wizard/step_dose_schedule.rb
+++ b/app/components/medications/wizard/step_dose_schedule.rb
@@ -165,7 +165,7 @@ module Components
             end
             select(
               id: 'wizard_schedule_person',
-              class: 'flex h-14 min-h-[56px] w-full rounded-shape-xs border border-outline bg-transparent ' \
+              class: 'flex h-14 min-h-[56px] w-full rounded-shape-sm border border-outline bg-transparent ' \
                      'px-4 py-4 text-base transition-all focus-visible:outline-none focus-visible:ring-2 ' \
                      'focus-visible:ring-primary',
               data: {
@@ -215,7 +215,7 @@ module Components
               end
               select(
                 id: 'wizard_dose_unit',
-                class: 'flex h-14 min-h-[56px] w-full rounded-shape-xs border border-outline bg-transparent ' \
+                class: 'flex h-14 min-h-[56px] w-full rounded-shape-sm border border-outline bg-transparent ' \
                        'px-4 py-4 text-base transition-all focus-visible:outline-none focus-visible:ring-2 ' \
                        'focus-visible:ring-primary',
                 required: true,
@@ -323,7 +323,7 @@ module Components
                 end
                 select(
                   id: 'weekly_day',
-                  class: 'flex h-14 min-h-[56px] w-full rounded-shape-xs border border-outline ' \
+                  class: 'flex h-14 min-h-[56px] w-full rounded-shape-sm border border-outline ' \
                          'bg-transparent px-4 py-4',
                   data: {
                     action: 'change->medication-schedule-wizard#update',
@@ -360,7 +360,7 @@ module Components
                   m3_button(
                     type: :button,
                     variant: :outlined,
-                    class: 'h-14 w-full rounded-shape-xs px-4 sm:w-auto',
+                    class: 'h-14 w-full rounded-shape-sm px-4 sm:w-auto',
                     data: { action: 'click->medication-schedule-wizard#addSpecificDate' }
                   ) do
                     t('forms.medications.wizard.dose.add_specific_date')

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -132,7 +132,7 @@ module Components
             value: person.name,
             required: true,
             placeholder: t('forms.people.name_placeholder', default: 'e.g., Jane Doe'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    "#{field_error_class(person, :name)}",
             **field_error_attributes(person, :name, input_id: 'person_name')
           )
@@ -152,7 +152,7 @@ module Components
             id: 'person_email',
             value: person.email,
             placeholder: t('forms.people.email_placeholder', default: 'e.g., jane@example.com'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    "#{field_error_class(person, :email)}",
             **field_error_attributes(person, :email, input_id: 'person_email')
           )
@@ -173,7 +173,7 @@ module Components
             value: person.date_of_birth&.to_fs(:db),
             required: true,
             placeholder: 'YYYY-MM-DD',
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 ' \
                    'transition-all ' \
                    "#{field_error_class(person, :date_of_birth)}",
             data: {
@@ -184,7 +184,7 @@ module Components
           render RubyUI::Calendar.new(
             input_id: '#person_date_of_birth',
             date_format: 'yyyy-MM-dd',
-            class: 'rounded-md border shadow-elevation-2 bg-surface-container-high'
+            class: 'rounded-shape-sm border shadow-elevation-2 bg-surface-container-high'
           )
           render_field_error(person, :date_of_birth, input_id: 'person_date_of_birth')
         end
@@ -199,7 +199,7 @@ module Components
           render RubyUI::Combobox.new(class: 'w-full') do
             render RubyUI::ComboboxTrigger.new(
               placeholder: selected_person_type&.humanize || t('people.form.select_person_type'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
             )
 
             render RubyUI::ComboboxPopover.new do

--- a/app/components/person_medications/form_fields.rb
+++ b/app/components/person_medications/form_fields.rb
@@ -178,7 +178,7 @@ module Components
             name: 'dose_option',
             required: true,
             disabled: person_medication.medication_id.blank?,
-            class: 'w-full rounded-md border border-outline bg-background px-3 py-2 text-sm',
+            class: 'w-full rounded-shape-sm border border-outline bg-background px-3 py-2 text-sm',
             data: { person_medication_form_target: 'doseOptionInput',
                     action: 'change->person-medication-form#selectDose' }
           ) do

--- a/app/components/ruby_ui/combobox/combobox_search_input.rb
+++ b/app/components/ruby_ui/combobox/combobox_search_input.rb
@@ -25,7 +25,7 @@ module RubyUI
         spellcheck: 'false',
         placeholder: @placeholder,
         class: [
-          'flex h-9 w-full rounded-md bg-transparent py-3 text-sm outline-none border-none',
+          'flex h-9 w-full rounded-shape-sm bg-transparent py-3 text-sm outline-none border-none',
           'focus:ring-0',
           'placeholder:text-on-surface-variant',
           'disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -187,7 +187,7 @@ module Components
             render RubyUI::ComboboxTrigger.new(
               id: 'medication_trigger',
               placeholder: schedule.medication&.name || t('schedules.form.select_medication'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
             )
 
             render RubyUI::ComboboxPopover.new do
@@ -300,7 +300,7 @@ module Components
             SelectTrigger(
               disabled: schedule.medication.nil?,
               aria_disabled: schedule.medication.nil?,
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest',
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest',
               data: { testid: 'dosage-trigger', schedule_form_target: 'dosageTrigger' }
             ) do
               SelectValue(
@@ -337,7 +337,7 @@ module Components
             id: 'schedule_frequency',
             value: schedule.frequency,
             placeholder: t('schedules.form.frequency_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
             data: {
               action: 'input->schedule-form#validate change->schedule-form#validate',
               schedule_form_target: 'frequencyInput'
@@ -362,7 +362,7 @@ module Components
             value: schedule.start_date&.to_fs(:db),
             required: true,
             placeholder: t('schedules.form.select_date'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
             data: {
               controller: 'ruby-ui--calendar-input',
               action: 'input->schedule-form#validate change->schedule-form#validate'
@@ -371,7 +371,7 @@ module Components
           Calendar(
             input_id: '#schedule_start_date',
             date_format: 'yyyy-MM-dd',
-            class: 'rounded-md border shadow-elevation-2 bg-surface-container-high'
+            class: 'rounded-shape-sm border shadow-elevation-2 bg-surface-container-high'
           )
         end
       end
@@ -388,13 +388,13 @@ module Components
             id: 'schedule_end_date',
             value: schedule.end_date&.to_fs(:db),
             placeholder: t('schedules.form.select_date'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
             data: { controller: 'ruby-ui--calendar-input' }
           )
           Calendar(
             input_id: '#schedule_end_date',
             date_format: 'yyyy-MM-dd',
-            class: 'rounded-md border shadow-elevation-2 bg-surface-container-high'
+            class: 'rounded-shape-sm border shadow-elevation-2 bg-surface-container-high'
           )
         end
       end
@@ -415,7 +415,7 @@ module Components
             value: schedule.max_daily_doses,
             placeholder: t('schedules.form.max_doses_placeholder'),
             min: 1,
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
             data: { schedule_form_target: 'maxDosesInput', action: 'input->schedule-form#generateFrequency' }
           )
         end
@@ -438,7 +438,7 @@ module Components
             placeholder: t('schedules.form.min_hours_placeholder'),
             min: 0,
             step: '0.5',
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all',
             data: { schedule_form_target: 'minHoursInput', action: 'input->schedule-form#generateFrequency' }
           )
         end
@@ -456,7 +456,7 @@ module Components
           render RubyUI::Combobox.new(class: 'w-full') do
             render RubyUI::ComboboxTrigger.new(
               placeholder: schedule.dose_cycle&.titleize || t('schedules.form.select_cycle'),
-              class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+              class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
             )
 
             render RubyUI::ComboboxPopover.new do
@@ -494,7 +494,7 @@ module Components
             id: 'schedule_notes',
             placeholder: t('schedules.form.notes_placeholder'),
             value: schedule.notes,
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest p-4 ' \
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest p-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all resize-none'
           )

--- a/app/components/schedules/workflow_view.rb
+++ b/app/components/schedules/workflow_view.rb
@@ -56,8 +56,11 @@ module Components
       def render_schedule_type_field
         FormField do
           render RubyUI::FormFieldLabel.new(for: 'schedule_type', class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1') { t('schedules.workflow.schedule_type_label') }
-          select(name: 'schedule_type', id: 'schedule_type',
-                 class: 'w-full rounded-md border border-outline bg-surface-container-lowest px-3 py-4 text-sm') do
+          select(
+            name: 'schedule_type',
+            id: 'schedule_type',
+            class: 'w-full rounded-shape-sm border border-outline bg-surface-container-lowest px-3 py-4 text-sm'
+          ) do
             option(value: '', selected: schedule_type.blank?) { t('schedules.workflow.schedule_type_placeholder') }
             option(value: 'otc', selected: schedule_type == 'otc') { t('schedules.workflow.schedule_type_options.otc') }
             option(value: 'prescribed', selected: schedule_type == 'prescribed') do
@@ -70,8 +73,12 @@ module Components
       def render_person_field
         FormField do
           render RubyUI::FormFieldLabel.new(for: 'person_id', class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1') { t('schedules.workflow.person_label') }
-          select(name: 'person_id', id: 'person_id', required: true,
-                 class: 'w-full rounded-md border border-outline bg-surface-container-lowest px-3 py-4 text-sm') do
+          select(
+            name: 'person_id',
+            id: 'person_id',
+            required: true,
+            class: 'w-full rounded-shape-sm border border-outline bg-surface-container-lowest px-3 py-4 text-sm'
+          ) do
             option(value: '') { t('schedules.workflow.person_placeholder') }
             people.each do |person|
               option(value: person.id, selected: person.id.to_s == selected_person_id.to_s) { person.name }
@@ -83,8 +90,12 @@ module Components
       def render_medication_field
         FormField do
           render RubyUI::FormFieldLabel.new(for: 'medication_id', class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1') { t('schedules.workflow.medication_label') }
-          select(name: 'medication_id', id: 'medication_id', required: true,
-                 class: 'w-full rounded-md border border-outline bg-surface-container-lowest px-3 py-4 text-sm') do
+          select(
+            name: 'medication_id',
+            id: 'medication_id',
+            required: true,
+            class: 'w-full rounded-shape-sm border border-outline bg-surface-container-lowest px-3 py-4 text-sm'
+          ) do
             option(value: '') { t('schedules.workflow.medication_placeholder') }
             medications.each do |medication|
               option(value: medication.id, selected: medication.id.to_s == selected_medication_id.to_s) do
@@ -104,7 +115,7 @@ module Components
             id: 'frequency',
             value: frequency,
             placeholder: t('schedules.workflow.frequency_placeholder'),
-            class: 'rounded-md border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
+            class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest py-4 px-4 transition-all'
           )
         end
       end

--- a/app/views/reports/index.rb
+++ b/app/views/reports/index.rb
@@ -38,11 +38,11 @@ module Views
           form(action: view_context.reports_path, method: :get, class: 'flex items-end gap-3 rounded-[1.5rem] border border-border/70 bg-popover p-4 shadow-elevation-1') do
             div(class: 'flex flex-col gap-1') do
               label(for: 'start_date', class: 'text-xs font-semibold uppercase tracking-wider text-on-surface-variant') { t('reports.index.start_date_label') }
-              input(type: 'date', name: 'start_date', id: 'start_date', value: @start_date, class: 'form-input rounded-lg border-border bg-background text-sm text-foreground focus:border-primary focus:ring-primary')
+              input(type: 'date', name: 'start_date', id: 'start_date', value: @start_date, class: 'form-input rounded-shape-sm border-border bg-background text-sm text-foreground focus:border-primary focus:ring-primary')
             end
             div(class: 'flex flex-col gap-1') do
               label(for: 'end_date', class: 'text-xs font-semibold uppercase tracking-wider text-on-surface-variant') { t('reports.index.end_date_label') }
-              input(type: 'date', name: 'end_date', id: 'end_date', value: @end_date, class: 'form-input rounded-lg border-border bg-background text-sm text-foreground focus:border-primary focus:ring-primary')
+              input(type: 'date', name: 'end_date', id: 'end_date', value: @end_date, class: 'form-input rounded-shape-sm border-border bg-background text-sm text-foreground focus:border-primary focus:ring-primary')
             end
             m3_button(type: 'submit', class: 'rounded-xl shadow-elevation-1', 'aria-label': t('reports.index.apply_filters_aria_label')) do
               render Icons::ChevronRight.new(size: 20)

--- a/spec/components/m3/input_spec.rb
+++ b/spec/components/m3/input_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Components::M3::Input, type: :component do
   it 'renders an M3 styled input' do
     rendered = render_inline(described_class.new(name: 'test', id: 'test'))
-    expect(rendered.to_html).to include('rounded-shape-xs')
+    expect(rendered.to_html).to include('rounded-shape-sm')
+    expect(rendered.to_html).not_to include('rounded-shape-xs')
     expect(rendered.to_html).to include('border-outline')
     expect(rendered.to_html).to include('h-14')
   end

--- a/spec/components/medications/wizard/step_dose_schedule_spec.rb
+++ b/spec/components/medications/wizard/step_dose_schedule_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::Wizard::StepDoseSchedule, type: :component do
+  let(:person) { create(:person, name: 'Harrison Webb') }
+  let(:medication) { create(:medication) }
+
+  before do
+    create(:dosage, medication:, amount: 2, unit: 'gummy')
+  end
+
+  it 'renders rounded RubyUI-style form controls for dose setup' do
+    rendered = render_inline(described_class.new(medication:, people: [person]))
+
+    expect(rendered.at_css('select#wizard_schedule_person')['class']).to include('rounded-shape-sm')
+    expect(rendered.at_css('input#wizard_dose_amount')['class']).to include('rounded-shape-sm')
+    expect(rendered.at_css('select#wizard_dose_unit')['class']).to include('rounded-shape-sm')
+  end
+end


### PR DESCRIPTION
## Summary
- Switched shared input/select styling to the rounded RubyUI token so form controls read consistently across the app.
- Updated medication, schedule, person, admin, location, search, and reports forms to use the same rounded control shape instead of the squarer overrides.
- Added component coverage for the M3 input wrapper and the medication wizard dose step.

## Testing
- `task rubocop` passed.
- `task test` passed.
- Added focused component specs to verify the rounded control contract in the shared input and wizard dose setup flow.