### PR TITLE
fix: Fix person medication card action widths

### DIFF
--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -151,7 +151,8 @@ module Components
         a(
           href: edit_person_person_medication_path(person, person_medication),
           data: { turbo_frame: 'modal', testid: "edit-person-medication-#{person_medication.id}" },
-          class: 'inline-flex items-center justify-center w-12 h-12 rounded-xl text-on-surface-variant ' \
+          class: 'inline-flex items-center justify-center w-12 min-w-12 h-12 shrink-0 rounded-xl ' \
+                 'text-on-surface-variant ' \
                  'border border-outline hover:text-foreground hover:bg-tertiary-container transition-colors',
           aria_label: t('person_medications.card.edit')
         ) do
@@ -202,7 +203,8 @@ module Components
           AlertDialogTrigger do
             m3_button(
               variant: :text,
-              class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant hover:text-destructive hover:bg-destructive/5',
+              class: 'w-12 min-w-12 h-12 shrink-0 p-0 rounded-xl text-on-surface-variant ' \
+                     'hover:text-destructive hover:bg-destructive/5',
               data: { testid: "delete-person-medication-#{person_medication.id}" },
               aria_label: t('person_medications.card.delete_aria_label')
             ) do

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -40,10 +40,20 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     expect(button.text).to include('Log a past dose')
   end
 
-  def render_person_medication_card
+  it 'keeps the edit action from shrinking in the card footer' do
+    rendered = render_person_medication_card(update: true)
+
+    link = rendered.at_css("a[data-testid='edit-person-medication-#{person_medication.id}']")
+
+    expect(link).not_to be_nil
+    expect(link['class']).to include('shrink-0')
+    expect(link['class']).to include('min-w-12')
+  end
+
+  def render_person_medication_card(update: false, destroy: false)
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }
-    policy_stub = Struct.new(:update?, :take_medication?, :destroy?, :show?).new(false, true, false, true)
+    policy_stub = Struct.new(:update?, :take_medication?, :destroy?, :show?).new(update, true, destroy, true)
     vc.singleton_class.define_method(:policy) { |_record| policy_stub }
     html = vc.render(described_class.new(person_medication: person_medication, person: person))
     Nokogiri::HTML::DocumentFragment.parse(html)


### PR DESCRIPTION
## Summary
- Add a minimum width and `shrink-0` constraint to the person medication edit and delete actions so they stay square in the card footer
- Add a component spec that verifies the edit action keeps those sizing classes

## Testing
- `task test TEST_FILE=spec/components/person_medications/card_spec.rb`
- `task test`
- `task rubocop`