### PR TITLE
feat: share non-prescribed meds directly

### DIFF
--- a/app/controllers/medication_assignments_controller.rb
+++ b/app/controllers/medication_assignments_controller.rb
@@ -26,9 +26,9 @@ class MedicationAssignmentsController < ApplicationController
 
     if result.success
       respond_to do |format|
-        format.html { redirect_to person_path(@person), notice: t('schedules.created') }
+        format.html { redirect_to person_path(@person), notice: assignment_success_message(result) }
         format.turbo_stream do
-          flash.now[:notice] = t('schedules.created')
+          flash.now[:notice] = assignment_success_message(result)
           render turbo_stream: [
             turbo_stream.update('modal', ''),
             turbo_stream.replace("person_#{@person.id}", Components::People::PersonCard.new(person: @person.reload)),
@@ -118,5 +118,9 @@ class MedicationAssignmentsController < ApplicationController
         ), status: status
       end
     end
+  end
+
+  def assignment_success_message(result)
+    result.record.is_a?(PersonMedication) ? t('person_medications.created') : t('schedules.created')
   end
 end

--- a/app/services/medication_assignment_creator.rb
+++ b/app/services/medication_assignment_creator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MedicationAssignmentCreator
-  Result = Data.define(:success, :assignment, :schedule)
+  Result = Data.define(:success, :assignment, :record, :schedule)
 
   attr_reader :person, :medication_scope, :assignment
 
@@ -14,21 +14,35 @@ class MedicationAssignmentCreator
   def call
     return failure unless valid_assignment?
 
-    persist_schedule
+    persist_record
   end
 
   private
 
-  def persist_schedule
-    schedule = person.schedules.build(schedule_attributes)
-    return Result.new(success: true, assignment: assignment, schedule: schedule) if schedule.save
-
-    copy_schedule_errors(schedule)
-    Result.new(success: false, assignment: assignment, schedule: schedule)
+  def persist_record
+    direct_assignment? ? persist_person_medication : persist_schedule
   end
 
-  def copy_schedule_errors(schedule)
-    schedule.errors.full_messages.each { |message| assignment.errors.add(:base, message) }
+  def persist_person_medication
+    person_medication = person.person_medications.build(person_medication_attributes)
+    if person_medication.save
+      return Result.new(success: true, assignment: assignment, record: person_medication, schedule: nil)
+    end
+
+    copy_record_errors(person_medication)
+    Result.new(success: false, assignment: assignment, record: person_medication, schedule: nil)
+  end
+
+  def persist_schedule
+    schedule = person.schedules.build(schedule_attributes)
+    return Result.new(success: true, assignment: assignment, record: schedule, schedule: schedule) if schedule.save
+
+    copy_record_errors(schedule)
+    Result.new(success: false, assignment: assignment, record: schedule, schedule: schedule)
+  end
+
+  def copy_record_errors(record)
+    record.errors.full_messages.each { |message| assignment.errors.add(:base, message) }
   end
 
   def valid_assignment?
@@ -91,6 +105,19 @@ class MedicationAssignmentCreator
     schedule_dose_attributes.merge(schedule_timing_attributes)
   end
 
+  def person_medication_attributes
+    {
+      medication: medication,
+      source_dosage_option: selected_dosage_option,
+      dose_amount: selected_dose.amount,
+      dose_unit: selected_dose.unit,
+      administration_kind: person_medication_administration_kind,
+      max_daily_doses: selected_dose.default_max_daily_doses,
+      min_hours_between_doses: selected_dose.default_min_hours_between_doses,
+      dose_cycle: selected_dose.default_dose_cycle.presence || 'daily'
+    }
+  end
+
   def schedule_dose_attributes
     {
       medication: medication,
@@ -117,6 +144,18 @@ class MedicationAssignmentCreator
     medication.default_schedule_type.presence || 'multiple_daily'
   end
 
+  def person_medication_administration_kind
+    supplement_category? ? 'routine' : 'as_needed'
+  end
+
+  def direct_assignment?
+    supplement_category? || schedule_type == 'prn'
+  end
+
+  def supplement_category?
+    %w[vitamin supplement mineral].include?(medication.category.to_s.downcase)
+  end
+
   def schedule_config
     config = medication.default_schedule_config.to_h.deep_dup
     config['schedule_type'] = schedule_type
@@ -131,7 +170,7 @@ class MedicationAssignmentCreator
 
   def failure
     add_failure_errors
-    Result.new(success: false, assignment: assignment, schedule: nil)
+    Result.new(success: false, assignment: assignment, record: nil, schedule: nil)
   end
 
   def add_failure_errors

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -923,7 +923,7 @@ cy:
       subtitle: Ychwanegwch fanylion meddyginiaeth o'r rhagosodiadau sydd wedi'u cadw
     form:
       review_title: Adolygu
-      review_description: Gwiriwch y dos a ddewiswyd a'r rhagosodiadau amserlen sydd
+      review_description: Gwiriwch y dos a ddewiswyd a'r rhagosodiadau meddyginiaeth sydd
         wedi'u cadw.
       frequency: Amlder
       schedule_type: Math o amserlen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -913,7 +913,7 @@ en:
       subtitle: Add medication details from saved defaults
     form:
       review_title: Review
-      review_description: Check the selected dose and saved schedule defaults.
+      review_description: Check the selected dose and saved medication defaults.
       frequency: Frequency
       schedule_type: Schedule type
       active_dates: Active dates

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -923,7 +923,7 @@ es:
       subtitle: Añade detalles del medicamento desde los valores guardados
     form:
       review_title: Revisar
-      review_description: Comprueba la dosis seleccionada y los valores de programación
+      review_description: Comprueba la dosis seleccionada y los valores del medicamento
         guardados.
       frequency: Frecuencia
       schedule_type: Tipo de programación

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -924,7 +924,7 @@ ga:
       subtitle: Cuir sonraí leighis leis ó na réamhshocruithe sábháilte
     form:
       review_title: Athbhreithniú
-      review_description: Seiceáil an dáileog roghnaithe agus na réamhshocruithe sceidil
+      review_description: Seiceáil an dáileog roghnaithe agus na réamhshocruithe leighis
         sábháilte.
       frequency: Minicíocht
       schedule_type: Cineál sceidil

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -922,7 +922,7 @@ pt:
       subtitle: Adicione detalhes do medicamento a partir das predefinições guardadas
     form:
       review_title: Rever
-      review_description: Confirme a dose selecionada e as predefinições da agenda
+      review_description: Confirme a dose selecionada e as predefinições do medicamento
         guardadas.
       frequency: Frequência
       schedule_type: Tipo de agenda

--- a/db/seeds/medications.yml
+++ b/db/seeds/medications.yml
@@ -3,6 +3,7 @@
   category: Analgesic
   dosage_amount: 500
   dosage_unit: mg
+  default_schedule_type: prn
   current_supply: 80
   reorder_threshold: 20
   description: >-
@@ -15,6 +16,7 @@
   category: Anti-Inflammatory
   dosage_amount: 200
   dosage_unit: mg
+  default_schedule_type: prn
   current_supply: 60
   reorder_threshold: 15
   description: >-

--- a/db/seeds/seed_medications.rb
+++ b/db/seeds/seed_medications.rb
@@ -14,6 +14,7 @@ medications_data.each do |attrs|
     category: attrs['category'],
     dosage_amount: attrs['dosage_amount'],
     dosage_unit: attrs['dosage_unit'],
+    default_schedule_type: attrs.fetch('default_schedule_type', medication.default_schedule_type),
     current_supply: attrs['current_supply'],
     supply_at_last_restock: attrs['current_supply'],
     reorder_threshold: attrs['reorder_threshold'],

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Person Medications', type: :system do
 
       click_button 'Add Medication'
 
-      expect(page).to have_text('Schedule was successfully created.')
+      expect(page).to have_text('Medication added successfully.')
       expect(page).to have_text(new_medication.name)
     end
   end

--- a/spec/fixtures/medications.yml
+++ b/spec/fixtures/medications.yml
@@ -24,6 +24,7 @@ ibuprofen:
   category: Analgesic
   dosage_amount: 200
   dosage_unit: "mg"
+  default_schedule_type: 4
   current_supply: 30
   supply_at_last_restock: 30
   expiry_date: <%= 1.year.from_now.to_date %>

--- a/spec/requests/medication_assignments_spec.rb
+++ b/spec/requests/medication_assignments_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe 'Medication assignments' do
   end
 
   describe 'POST /people/:person_id/medication_assignments' do
-    it 'creates a PRN schedule from medication metadata and the selected predefined dose' do
+    it 'creates an as-needed person medication from PRN medication metadata and the selected predefined dose' do
       medication = medications(:paracetamol)
       dosage = dosages(:paracetamol_child)
-      person_medication_count = PersonMedication.count
+      schedule_count = Schedule.count
 
       expect do
         post person_medication_assignments_path(person),
@@ -38,27 +38,55 @@ RSpec.describe 'Medication assignments' do
                  source_dosage_option_id: dosage.id
                }
              }
-      end.to change(Schedule, :count).by(1)
+      end.to change(PersonMedication, :count).by(1)
 
-      expect(PersonMedication.count).to eq(person_medication_count)
+      expect(Schedule.count).to eq(schedule_count)
       expect(response).to redirect_to(person_path(person))
-      schedule = Schedule.order(:id).last
+      person_medication = PersonMedication.order(:id).last
 
-      expect(schedule).to have_attributes(
+      expect(person_medication).to have_attributes(
         person: person,
         medication: medication,
         source_dosage_option: dosage,
         dose_amount: BigDecimal('250.0'),
         dose_unit: 'mg',
-        frequency: 'Every 4-6 hours',
         max_daily_doses: 4,
-        min_hours_between_doses: 4,
-        start_date: Time.zone.today,
-        end_date: 1.month.from_now.to_date
+        min_hours_between_doses: 4
       )
-      expect(schedule.dose_cycle).to eq('daily')
-      expect(schedule.schedule_type).to eq('prn')
-      expect(schedule.schedule_config).to include('as_needed' => true)
+      expect(person_medication.dose_cycle).to eq('daily')
+      expect(person_medication.administration_kind).to eq('as_needed')
+    end
+
+    it 'creates an as-needed person medication from ibuprofen PRN metadata' do
+      medication = medications(:ibuprofen)
+      dosage = dosages(:ibuprofen_child)
+      medication.update!(default_schedule_type: :prn)
+      schedule_count = Schedule.count
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 source_dosage_option_id: dosage.id
+               }
+             }
+      end.to change(PersonMedication, :count).by(1)
+
+      expect(Schedule.count).to eq(schedule_count)
+      person_medication = PersonMedication.order(:id).last
+
+      expect(person_medication).to have_attributes(
+        person: person,
+        medication: medication,
+        source_dosage_option: dosage,
+        dose_amount: BigDecimal('200.0'),
+        dose_unit: 'mg',
+        max_daily_doses: 4,
+        min_hours_between_doses: 6
+      )
+      expect(person_medication.dose_cycle).to eq('daily')
+      expect(person_medication.administration_kind).to eq('as_needed')
     end
 
     it 'creates a non-PRN schedule when medication metadata is not as needed' do
@@ -101,8 +129,9 @@ RSpec.describe 'Medication assignments' do
       )
     end
 
-    it 'creates a schedule from a matching legacy dose fallback' do
+    it 'creates a routine person medication for a vitamin from a matching legacy dose fallback' do
       medication = medications(:vitamin_c)
+      schedule_count = Schedule.count
 
       expect do
         post person_medication_assignments_path(person),
@@ -113,22 +142,55 @@ RSpec.describe 'Medication assignments' do
                  dose_unit: 'mg'
                }
              }
-      end.to change(Schedule, :count).by(1)
+      end.to change(PersonMedication, :count).by(1)
 
-      schedule = Schedule.order(:id).last
+      expect(Schedule.count).to eq(schedule_count)
+      person_medication = PersonMedication.order(:id).last
 
-      expect(schedule).to have_attributes(
+      expect(person_medication).to have_attributes(
+        person: person,
         medication: medication,
         source_dosage_option: nil,
         dose_amount: BigDecimal('500.0'),
-        dose_unit: 'mg',
-        frequency: 'As directed'
+        dose_unit: 'mg'
       )
+      expect(person_medication.administration_kind).to eq('routine')
+    end
+
+    it 'creates a routine person medication for a vitamin with a selected predefined dose' do
+      medication = medications(:vitamin_d)
+      dosage = dosages(:vitamin_d_daily)
+      schedule_count = Schedule.count
+
+      expect do
+        post person_medication_assignments_path(person),
+             params: {
+               medication_assignment: {
+                 medication_id: medication.id,
+                 source_dosage_option_id: dosage.id
+               }
+             }
+      end.to change(PersonMedication, :count).by(1)
+
+      expect(Schedule.count).to eq(schedule_count)
+      person_medication = PersonMedication.order(:id).last
+
+      expect(person_medication).to have_attributes(
+        person: person,
+        medication: medication,
+        source_dosage_option: dosage,
+        dose_amount: BigDecimal('1000.0'),
+        dose_unit: 'IU',
+        max_daily_doses: 1
+      )
+      expect(person_medication.dose_cycle).to eq('daily')
+      expect(person_medication.administration_kind).to eq('routine')
     end
 
     it 'ignores submitted timing overrides and uses the selected dose defaults' do
       medication = medications(:ibuprofen)
       dosage = dosages(:ibuprofen_child)
+      medication.update!(default_schedule_type: :prn)
 
       post person_medication_assignments_path(person),
            params: {
@@ -141,11 +203,11 @@ RSpec.describe 'Medication assignments' do
              }
            }
 
-      schedule = Schedule.order(:id).last
+      person_medication = PersonMedication.order(:id).last
 
-      expect(schedule.max_daily_doses).to eq(4)
-      expect(schedule.min_hours_between_doses).to eq(6)
-      expect(schedule.dose_cycle).to eq('daily')
+      expect(person_medication.max_daily_doses).to eq(4)
+      expect(person_medication.min_hours_between_doses).to eq(6)
+      expect(person_medication.dose_cycle).to eq('daily')
     end
 
     it 'rejects a forged inaccessible medication id' do

--- a/spec/services/medication_assignment_creator_spec.rb
+++ b/spec/services/medication_assignment_creator_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationAssignmentCreator do
+  describe '#call' do
+    let(:person) { create(:person) }
+
+    it 'creates a routine person medication for vitamins' do
+      medication = create(:medication, category: 'Vitamin', default_schedule_type: :daily)
+      dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', default_max_daily_doses: 1,
+                               default_min_hours_between_doses: 24)
+      schedule_count = Schedule.count
+
+      expect do
+        assert_person_medication_result(call_creator(medication, dosage), :routine)
+      end.to change(PersonMedication, :count).by(1)
+
+      expect(Schedule.count).to eq(schedule_count)
+      assert_person_medication_attributes(
+        medication, dosage, dose_amount: '1000.0', dose_unit: 'IU', max_daily_doses: 1
+      )
+    end
+
+    it 'creates an as-needed person medication for PRN medication metadata' do
+      medication = create(:medication, category: 'Analgesic', default_schedule_type: :prn)
+      dosage = create(:dosage, medication: medication, amount: 250, unit: 'mg', default_max_daily_doses: 4,
+                               default_min_hours_between_doses: 4)
+      schedule_count = Schedule.count
+
+      expect do
+        assert_person_medication_result(call_creator(medication, dosage), :as_needed)
+      end.to change(PersonMedication, :count).by(1)
+
+      expect(Schedule.count).to eq(schedule_count)
+      assert_person_medication_attributes(
+        medication, dosage, dose_amount: '250.0', dose_unit: 'mg',
+                            max_daily_doses: 4, min_hours_between_doses: 4
+      )
+    end
+
+    it 'keeps prescribed scheduled medication as a schedule' do
+      medication = create(:medication, category: 'Analgesic', default_schedule_type: :multiple_daily,
+                                       default_schedule_config: { 'times' => %w[08:00 20:00] })
+      dosage = create(:dosage, medication: medication, amount: 200, unit: 'mg', frequency: 'Twice daily',
+                               default_max_daily_doses: 2, default_min_hours_between_doses: 8)
+      person_medication_count = PersonMedication.count
+
+      expect do
+        assert_schedule_result(call_creator(medication, dosage))
+      end.to change(Schedule, :count).by(1)
+
+      expect(PersonMedication.count).to eq(person_medication_count)
+      assert_schedule_attributes(medication, dosage)
+    end
+
+    def call_creator(medication, dosage)
+      assignment = MedicationAssignment.new(medication_id: medication.id, source_dosage_option_id: dosage.id)
+      described_class.new(person: person, medication_scope: Medication.all, assignment: assignment).call
+    end
+
+    def assert_person_medication_result(result, kind)
+      expect(result.success).to be(true)
+      expect(result.record).to be_a(PersonMedication)
+      expect(result.schedule).to be_nil
+      expect(result.record.public_send("#{kind}?")).to be(true)
+    end
+
+    def assert_schedule_result(result)
+      expect(result.success).to be(true)
+      expect(result.record).to be_a(Schedule)
+      expect(result.schedule).to eq(result.record)
+    end
+
+    def assert_person_medication_attributes(medication, dosage, attributes)
+      person_medication = PersonMedication.order(:id).last
+      expect(person_medication).to have_attributes(
+        attributes.merge(
+          person: person,
+          medication: medication,
+          source_dosage_option: dosage,
+          dose_amount: BigDecimal(attributes[:dose_amount])
+        )
+      )
+      expect(person_medication.dose_cycle).to eq('daily')
+    end
+
+    def assert_schedule_attributes(medication, dosage)
+      schedule = Schedule.order(:id).last
+      expect(schedule).to have_attributes(
+        person: person,
+        medication: medication,
+        source_dosage_option: dosage,
+        dose_amount: BigDecimal('200.0'),
+        dose_unit: 'mg',
+        frequency: 'Twice daily',
+        max_daily_doses: 2,
+        min_hours_between_doses: 8
+      )
+      expect(schedule.schedule_type).to eq('multiple_daily')
+    end
+  end
+end

--- a/spec/system/authorization/person_medications_authorization_spec.rb
+++ b/spec/system/authorization/person_medications_authorization_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Person Medications Authorization' do
       expect(page).to have_text('Review')
       click_button 'Add Medication'
 
-      expect(page).to have_text('Schedule was successfully created.')
+      expect(page).to have_text('Medication added successfully.')
     end
 
     it 'allows doctors to open the unified medication assignment flow', :js do
@@ -101,7 +101,7 @@ RSpec.describe 'Person Medications Authorization' do
       expect(page).to have_text('Review')
       click_button 'Add Medication'
 
-      expect(page).to have_text('Schedule was successfully created.')
+      expect(page).to have_text('Medication added successfully.')
       expect(page).to have_text(medication.name)
     end
 

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe 'Person medication workflow' do
 
     click_button 'Add Medication'
 
-    expect(page).to have_text('Schedule was successfully created.')
+    expect(page).to have_text('Medication added successfully.')
     expect(page).to have_no_text("Add Medication for #{person.name}")
     expect(page).to have_text(person.name)
     expect(page).to have_text('Paracetamol')
 
-    created_schedule = person.schedules.order(:id).last
-    expect(created_schedule.schedule_type).to eq('prn')
-    expect(created_schedule.source_dosage_option).to eq(dosages(:paracetamol_child))
+    created_medication = person.person_medications.order(:id).last
+    expect(created_medication.administration_kind).to eq('as_needed')
+    expect(created_medication.source_dosage_option).to eq(dosages(:paracetamol_child))
   end
 
   it 'does not leave a blank page when cancelled' do


### PR DESCRIPTION
## Summary
- Route vitamin, supplement, and mineral assignments to routine person medications
- Route PRN medication metadata such as paracetamol and ibuprofen to as-needed person medications
- Preserve scheduled medication creation for prescribed schedule-style assignments

## Verification
- task rubocop
- task test TEST_FILE=spec/requests/medication_assignments_spec.rb
- task test