### PR TITLE
fix: honor TZ for Rails time zone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,7 @@ module MedTracker
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
+    config.time_zone = ENV.fetch('TZ', 'UTC')
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
   end

--- a/spec/config/med_tracker/application_spec.rb
+++ b/spec/config/med_tracker/application_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedTracker::Application do
+  it 'configures Rails time helpers from the TZ environment variable' do
+    expect(Rails.application.config.time_zone).to eq(ENV.fetch('TZ', 'UTC'))
+    expect(Rails.root.join('config/application.rb').read).to include("config.time_zone = ENV.fetch('TZ', 'UTC')")
+  end
+end


### PR DESCRIPTION
## Summary
- configure Rails time zone from the TZ environment variable with UTC fallback
- add a focused config spec for the environment-driven setting

## Verification
- env TZ=Europe/London task test TEST_FILE=spec/config/med_tracker/application_spec.rb
- task rubocop
- task test