### PR TITLE
perf: preload reminder schedules

### DIFF
--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -6,7 +6,9 @@ class ScheduleDailyRemindersJob < ApplicationJob
   PERIODS = NotificationPreference::PERIODS
 
   def perform
-    NotificationPreference.where(enabled: true).includes(person: :account).find_each do |pref|
+    NotificationPreference.where(enabled: true)
+                          .includes(person: [:account, { schedules: %i[medication medication_takes] }])
+                          .find_each do |pref|
       next unless pref.person&.account
 
       enqueue_reminders_for(pref)

--- a/app/services/medication_assignment_creator.rb
+++ b/app/services/medication_assignment_creator.rb
@@ -60,11 +60,14 @@ class MedicationAssignmentCreator
   end
 
   def selected_dosage_option
+    return @selected_dosage_option if instance_variable_defined?(:@selected_dosage_option)
+
+    @selected_dosage_option = nil
     return if assignment.source_dosage_option_id.blank?
 
-    dosage = medication&.dosage_records&.find_by(id: assignment.source_dosage_option_id)
-    assignment.errors.add(:source_dosage_option, 'Select a valid predefined dose') if dosage.blank?
-    dosage
+    @selected_dosage_option = medication&.dosage_records&.find_by(id: assignment.source_dosage_option_id)
+    assignment.errors.add(:source_dosage_option, 'Select a valid predefined dose') if @selected_dosage_option.blank?
+    @selected_dosage_option
   end
 
   def selected_legacy_dose

--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -35,7 +35,17 @@ class MedicationReminderEligibilityQuery
   end
 
   def schedules
-    @schedules ||= person.schedules.active.includes(:medication, :medication_takes).to_a
+    @schedules ||= if person.schedules.loaded?
+                     loaded_active_schedules
+                   else
+                     person.schedules.active.includes(:medication, :medication_takes).to_a
+                   end
+  end
+
+  def loaded_active_schedules
+    person.schedules.select(&:active?).tap do |schedules|
+      ActiveRecord::Associations::Preloader.new(records: schedules, associations: %i[medication medication_takes]).call
+    end
   end
 
   def person_medications

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe ScheduleDailyRemindersJob do
     travel_to Time.zone.local(2026, 5, 12, 6, 0)
   end
 
+  def count_schedule_queries(&)
+    count = 0
+
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      count += 1 if sql.include?('FROM "schedules"') && sql.include?('"schedules"."person_id"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
+  end
+
   it 'preserves period reminders from enabled notification preferences' do
     create(:notification_preference, person: person, morning_time: '08:00:00', afternoon_time: nil,
                                      evening_time: nil, night_time: nil)
@@ -74,6 +88,19 @@ RSpec.describe ScheduleDailyRemindersJob do
       described_class.perform_now
     end.not_to have_enqueued_job(MedicationReminderJob)
       .with(person.id, :scheduled, '07:15')
+  end
+
+  it 'loads schedule times once for enabled notification preferences' do
+    create(:notification_preference, person: people(:john), morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil)
+    create(:notification_preference, person: people(:jane), morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil)
+    create(:schedule, person: people(:john), medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+    create(:schedule, person: people(:jane), medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      schedule_type: :daily, schedule_config: { 'times' => ['07:45'] })
+
+    expect(count_schedule_queries { described_class.perform_now }).to eq(1)
   end
 
   it 'does not enqueue schedule-time reminders when notification preferences are disabled' do

--- a/spec/services/medication_assignment_creator_spec.rb
+++ b/spec/services/medication_assignment_creator_spec.rb
@@ -54,9 +54,31 @@ RSpec.describe MedicationAssignmentCreator do
       assert_schedule_attributes(medication, dosage)
     end
 
+    it 'looks up the selected predefined dose once' do
+      medication = create(:medication, category: 'Vitamin', default_schedule_type: :daily)
+      dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', default_max_daily_doses: 1,
+                               default_min_hours_between_doses: 24)
+
+      expect(count_dosage_option_queries { call_creator(medication, dosage) }).to eq(1)
+    end
+
     def call_creator(medication, dosage)
       assignment = MedicationAssignment.new(medication_id: medication.id, source_dosage_option_id: dosage.id)
       described_class.new(person: person, medication_scope: Medication.all, assignment: assignment).call
+    end
+
+    def count_dosage_option_queries(&)
+      count = 0
+
+      subscriber = lambda do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        count += 1 if sql.include?('FROM "dosages"') && sql.include?('"dosages"."id"')
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      count
     end
 
     def assert_person_medication_result(result, kind)


### PR DESCRIPTION
## What changed
- Preload each enabled notification preference person with their schedules in `ScheduleDailyRemindersJob`.
- Reuse loaded schedules and filter active schedules in memory when building exact schedule-time reminders.
- Memoize `MedicationAssignmentCreator#selected_dosage_option` so validation and persistence reuse the same predefined dose lookup.
- Added focused query-count specs for both paths.

## Why it was a bottleneck
`ScheduleDailyRemindersJob` already iterates all enabled notification preferences, but each preference called `person.schedules.active` separately. That created one schedule query per preference while collecting configured reminder times.

`MedicationAssignmentCreator` validates the selected predefined dose and then builds either a schedule or direct person medication from the same selection. The selected dosage row was queried twice in that request path.

## Measurement used
Focused RSpec query-count tests using `ActiveSupport::Notifications` around `sql.active_record`.

Reminder schedules red: two enabled preferences produced 2 schedule queries.
Reminder schedules green: the same batch now produces 1 schedule query.

Assignment dosage red: one predefined assignment produced 2 dosage row lookups.
Assignment dosage green: the same assignment now produces 1 dosage row lookup.

## Expected impact
Daily reminder scheduling avoids per-person schedule lookups and scales schedule-time reminder collection with the batch instead of the number of enabled preferences.

Medication assignment avoids a duplicate predefined dose lookup on the add-medication flow while preserving the existing validation and persistence behavior.

## Tests run
- `task test TEST_FILE=spec/jobs/schedule_daily_reminders_job_spec.rb`
- `task test TEST_FILE=spec/services/medication_assignment_creator_spec.rb`
- `task rubocop`
- `task test` (2454 examples, 0 failures, 2 pending)