### PR TITLE
fix: add medication dosages separately

### DIFF
--- a/app/components/medications/dose_history_component.rb
+++ b/app/components/medications/dose_history_component.rb
@@ -20,6 +20,7 @@ module Components
               m3_link(
                 href: view_context.edit_medication_path(
                   medication,
+                  add_dosage: true,
                   return_to: view_context.medication_path(medication)
                 ),
                 variant: :outlined,

--- a/app/components/medications/form_view.rb
+++ b/app/components/medications/form_view.rb
@@ -379,7 +379,9 @@ module Components
 
       def dosage_form_rows
         @dosage_form_rows ||= begin
-          rows = medication.dosage_records.to_a.sort_by { |dosage| [dosage.amount.to_f, dosage.id || 0] }
+          rows = medication.dosage_records.to_a.sort_by do |dosage|
+            [dosage.persisted? ? 0 : 1, dosage.amount.to_f, dosage.id || 0]
+          end
           rows
         end
       end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -60,6 +60,7 @@ class MedicationsController < ApplicationController
   def edit
     authorize @medication
     @return_to = url_from(params[:return_to])
+    @medication.dosage_records.build if params[:add_dosage].present?
     render Components::Medications::FormView.new(
       medication: @medication,
       locations: available_locations,

--- a/spec/components/medications/dose_history_component_spec.rb
+++ b/spec/components/medications/dose_history_component_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Components::Medications::DoseHistoryComponent, type: :component d
   it 'links dose management back to the medication editor' do
     expected_href = Rails.application.routes.url_helpers.edit_medication_path(
       medication,
+      add_dosage: true,
       return_to: Rails.application.routes.url_helpers.medication_path(medication)
     )
     component = described_class.new(medication: medication)
@@ -33,7 +34,7 @@ RSpec.describe Components::Medications::DoseHistoryComponent, type: :component d
 
     rendered = render_inline(component)
 
-    expect(rendered.to_html).to include(%(href="#{expected_href}"))
+    expect(rendered.at_css('a', text: 'Add Dosage')['href']).to eq(expected_href)
   end
 
   it 'does not render dosage route links' do

--- a/spec/requests/medications_edit_return_to_spec.rb
+++ b/spec/requests/medications_edit_return_to_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe 'Medications edit return_to sanitization' do
       expect(response.body).to include('href="/medications"')
     end
 
+    it 'renders a new dosage row without editing the existing dosage when adding a dosage' do
+      medication = Medication.create!(
+        name: 'Multi Dose Medication',
+        location: locations(:home),
+        reorder_threshold: 5
+      )
+      medication.dosage_records.create!(
+        amount: 2,
+        unit: 'sachet',
+        frequency: 'Once daily',
+        default_for_children: true,
+        default_max_daily_doses: 1,
+        default_min_hours_between_doses: 24,
+        default_dose_cycle: :daily
+      )
+
+      get edit_medication_path(medication, add_dosage: true)
+
+      expect(response.body).to include('name="medication[dosage_records_attributes][0][id]"')
+      expect(response.body).to include('name="medication[dosage_records_attributes][1][amount]"')
+      expect(response.body).not_to include('name="medication[dosage_records_attributes][1][id]"')
+    end
+
     it 'strips an external return_to url from rendered links' do
       get edit_medication_path(medication, return_to: 'https://evil.com/phish')
       expect(response.body).not_to include('evil.com')


### PR DESCRIPTION
## Summary
- route the medication show Add Dosage action into an explicit add-dosage edit mode
- build a new unsaved dosage row in that mode so existing dosage records are not overwritten
- keep persisted dosage rows ordered before the new blank row and add regression coverage

## Verification
- task rubocop
- task test TEST_FILE=spec/components/medications/dose_history_component_spec.rb
- task test TEST_FILE=spec/requests/medications_edit_return_to_spec.rb
- task test initially reported 2 unrelated stock-locking failures; both failed files passed when rerun individually:
  - task test TEST_FILE=spec/features/admin/audit_logs_spec.rb
  - task test TEST_FILE=spec/requests/timeline_refresh_spec.rb