### PR TITLE
fix: trim production image packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl libpq-dev unzip \
+  && apt-get install -y --no-install-recommends libpq5 unzip \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
   && apt-get clean \
   && groupadd -g "${GID}" ruby \

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(dockerfile).to include('BUNDLE_WITH')
   end
 
+  it 'keeps development database headers out of the production image stage' do
+    app_stage = dockerfile.split('FROM ruby:4.0.4-slim-trixie AS app').fetch(1)
+
+    expect(app_stage).to include('libpq5')
+    expect(app_stage).not_to include('libpq-dev')
+    expect(app_stage).not_to match(/apt-get install[^\n]+curl/)
+  end
+
   def gemfile
     Rails.root.join('Gemfile').read
   end


### PR DESCRIPTION
## Summary
- replace production image libpq-dev with runtime libpq5
- remove curl from the production runtime image stage
- add regression coverage for production-stage package choices

## Verification
- task test TEST_FILE=spec/config/application_harness_dependencies_spec.rb
- task rubocop
- task test
- task prod:build
- cnspec vuln container med-tracker-web-prod:latest --output json => 0 advisories, 0 vulnerable packages