### PR TITLE
fix: limit medication reminders to due doses

### DIFF
--- a/.windsurf/check_gemfile.rb
+++ b/.windsurf/check_gemfile.rb
@@ -11,13 +11,13 @@ def main
   file_path = input_data.dig('tool_info', 'file_path') || ''
 
   # Check if the modified file is Gemfile
-  if file_path.include?('Gemfile') || file_path.end_with?('/Gemfile')
-    # Run bundle install
-    unless system('bundle install')
-      puts '❌ Bundle install failed'
-      exit 1
-    end
-  end
+  return unless file_path.include?('Gemfile') || file_path.end_with?('/Gemfile')
+
+  # Run bundle install
+  return if system('bundle install')
+
+  puts '❌ Bundle install failed'
+  exit 1
 rescue StandardError => e
   puts "Error in check_gemfile.rb: #{e.message}"
   exit 1

--- a/app/jobs/medication_reminder_job.rb
+++ b/app/jobs/medication_reminder_job.rb
@@ -15,7 +15,7 @@ class MedicationReminderJob < ApplicationJob
     return unless person
     return unless person.account
 
-    med_names = active_medication_names(person, scheduled_time)
+    med_names = MedicationReminderEligibilityQuery.new(person: person, scheduled_time: scheduled_time).medication_names
     return if med_names.empty?
 
     period_label = scheduled_time.presence || PERIOD_LABELS[period.to_sym] || period.to_s.humanize
@@ -27,26 +27,5 @@ class MedicationReminderJob < ApplicationJob
       body: body,
       path: '/'
     )
-  end
-
-  private
-
-  def active_medication_names(person, scheduled_time)
-    schedule_meds = active_schedules(person, scheduled_time).map(&:medication_name)
-    person_meds = scheduled_time.present? ? [] : active_person_medication_names(person)
-    (schedule_meds + person_meds).uniq
-  end
-
-  def active_schedules(person, scheduled_time)
-    schedules = person.schedules.active.includes(:medication)
-    return schedules if scheduled_time.blank?
-
-    schedules.select do |schedule|
-      Array(schedule.schedule_config.to_h['times']).compact_blank.include?(scheduled_time)
-    end
-  end
-
-  def active_person_medication_names(person)
-    person.person_medications.includes(:medication).map { |pm| pm.medication.display_name }
   end
 end

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -44,9 +44,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def configured_times_for(person)
-    person.schedules.active.flat_map do |schedule|
-      Array(schedule.schedule_config.to_h['times']).compact_blank
-    end.uniq
+    MedicationReminderEligibilityQuery.new(person: person).configured_times
   end
 
   def build_send_time(time)

--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class MedicationReminderEligibilityQuery
+  def initialize(person:, scheduled_time: nil, now: Time.current)
+    @person = person
+    @scheduled_time = scheduled_time.presence
+    @now = now
+  end
+
+  def medication_names
+    (due_schedule_names + due_person_medication_names).uniq
+  end
+
+  def configured_times
+    due_schedules.flat_map { |schedule| due_configured_times_for(schedule) }.uniq
+  end
+
+  private
+
+  attr_reader :person, :scheduled_time, :now
+
+  def due_schedule_names
+    due_schedules.map(&:medication_name)
+  end
+
+  def due_person_medication_names
+    return [] if scheduled_time.present?
+
+    person_medications.select { |person_medication| due_person_medication?(person_medication) }
+                      .map { |person_medication| person_medication.medication.display_name }
+  end
+
+  def due_schedules
+    @due_schedules ||= schedules.select { |schedule| due_schedule?(schedule) }
+  end
+
+  def schedules
+    @schedules ||= person.schedules.active.includes(:medication, :medication_takes).to_a
+  end
+
+  def person_medications
+    @person_medications ||= person.person_medications.routine.includes(:medication, :medication_takes).to_a
+  end
+
+  def due_schedule?(schedule)
+    return false if as_needed_schedule?(schedule)
+    return false unless schedule.applies_on?(today)
+
+    if scheduled_time.present?
+      scheduled_occurrence_due?(schedule)
+    else
+      remaining_schedule_doses?(schedule)
+    end
+  end
+
+  def due_person_medication?(person_medication)
+    taken_count_for_cycle(person_medication) < expected_person_medication_doses(person_medication)
+  end
+
+  def scheduled_occurrence_due?(schedule)
+    configured_times_for(schedule).each_with_index.any? do |time, index|
+      time == scheduled_time && taken_count_for_cycle(schedule) <= index
+    end
+  end
+
+  def due_configured_times_for(schedule)
+    configured_times_for(schedule).filter.with_index do |_time, index|
+      taken_count_for_cycle(schedule) <= index
+    end
+  end
+
+  def remaining_schedule_doses?(schedule)
+    expected = schedule.expected_doses_on(today)
+    expected.positive? && taken_count_for_cycle(schedule) < expected
+  end
+
+  def expected_person_medication_doses(person_medication)
+    person_medication.max_daily_doses.presence || 1
+  end
+
+  def taken_count_for_cycle(source)
+    cycle = DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
+    source.medication_takes.count { |take| cycle.range_for(now).cover?(take.taken_at) }
+  end
+
+  def as_needed_schedule?(schedule)
+    schedule.schedule_type_prn? ||
+      schedule_config_value(schedule, 'as_needed') == true ||
+      schedule.frequency.to_s.casecmp('as needed').zero?
+  end
+
+  def configured_times_for(schedule)
+    Array(schedule_config_value(schedule, 'times')).compact_blank
+  end
+
+  def schedule_config_value(schedule, key)
+    config = schedule.schedule_config.to_h
+    config[key] || config[key.to_sym]
+  end
+
+  def today
+    now.to_date
+  end
+end

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe MedicationReminderJob do
   let(:person) { people(:john) }
 
   before do
+    person.schedules.destroy_all
+    person.person_medications.destroy_all
     allow(PushNotificationService).to receive(:send_to_account)
   end
 
   it 'sends scheduled-time reminders only for active schedules configured at that time' do
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                      schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+                      frequency: 'Once daily', schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
     create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
-                      schedule_type: :daily, schedule_config: { 'times' => ['19:45'] })
+                      frequency: 'Once daily', schedule_type: :daily, schedule_config: { 'times' => ['19:45'] })
 
     described_class.perform_now(person.id, :scheduled, '07:15')
 
@@ -27,18 +29,53 @@ RSpec.describe MedicationReminderJob do
     )
   end
 
-  it 'preserves period reminders for all active medications' do
-    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                      schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+  it 'does not send scheduled-time reminders for doses already taken today' do
+    schedule = create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                                 frequency: 'Once daily', schedule_type: :daily,
+                                 schedule_config: { 'times' => ['07:15'] })
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.today.noon)
+
+    described_class.perform_now(person.id, :scheduled, '07:15')
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'does not send scheduled-time reminders for as-needed schedules' do
     create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
-                      schedule_type: :daily, schedule_config: { 'times' => ['19:45'] })
+                      schedule_type: :prn, frequency: 'As needed', schedule_config: { 'times' => ['07:15'] })
+
+    described_class.perform_now(person.id, :scheduled, '07:15')
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'sends period reminders only for due routine medications' do
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once daily', schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+    create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
+                      schedule_type: :prn, frequency: 'As needed', schedule_config: { 'times' => ['19:45'] })
+    create(:person_medication, :as_needed, person: person, medication: medications(:paracetamol),
+                                           dosage: dosages(:paracetamol_adult))
 
     described_class.perform_now(person.id, :morning)
 
     expect(PushNotificationService).to have_received(:send_to_account) do |_account, payload|
       expect(payload[:body]).to include('Morning medications:')
       expect(payload[:body]).to include('Vitamin D')
-      expect(payload[:body]).to include('Ibuprofen')
+      expect(payload[:body]).not_to include('Ibuprofen')
+      expect(payload[:body]).not_to include('Paracetamol')
     end
+  end
+
+  it 'does not send period reminders when routine medications have already been taken today' do
+    schedule = create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                                 frequency: 'Once daily', schedule_type: :daily,
+                                 schedule_config: { 'times' => ['07:15'] },
+                                 max_daily_doses: 1)
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.today.noon)
+
+    described_class.perform_now(person.id, :morning)
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 end

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe ScheduleDailyRemindersJob do
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil)
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                      schedule_type: :multiple_daily, schedule_config: { 'times' => %w[07:15 19:45] })
+                      frequency: 'Twice daily', schedule_type: :multiple_daily,
+                      schedule_config: { 'times' => %w[07:15 19:45] })
 
     expect do
       described_class.perform_now
@@ -50,10 +51,35 @@ RSpec.describe ScheduleDailyRemindersJob do
       .at(Time.zone.local(2026, 5, 12, 19, 45))
   end
 
+  it 'does not enqueue exact reminders for as-needed schedules' do
+    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil)
+    create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
+                      schedule_type: :prn, frequency: 'As needed', schedule_config: { 'times' => ['07:15'] })
+
+    expect do
+      described_class.perform_now
+    end.not_to have_enqueued_job(MedicationReminderJob)
+      .with(person.id, :scheduled, '07:15')
+  end
+
+  it 'does not enqueue exact reminders for schedules that do not apply today' do
+    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil)
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once weekly', schedule_type: :weekly,
+                      schedule_config: { 'weekdays' => ['wednesday'], 'times' => ['07:15'] })
+
+    expect do
+      described_class.perform_now
+    end.not_to have_enqueued_job(MedicationReminderJob)
+      .with(person.id, :scheduled, '07:15')
+  end
+
   it 'does not enqueue schedule-time reminders when notification preferences are disabled' do
     create(:notification_preference, person: person, enabled: false)
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                      schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+                      frequency: 'Once daily', schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
 
     expect do
       described_class.perform_now


### PR DESCRIPTION
## Summary
- add shared reminder eligibility query for due-only medication notifications
- exclude PRN/as-needed medications from scheduled reminder payloads and enqueueing
- suppress reminders once the relevant dose has already been taken
- clean up the existing Lefthook RuboCop offense so pre-commit passes locally

## Verification
- `git diff --check`
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache-med-tracker lefthook run pre-commit`
- `task test` blocked locally: Docker daemon unavailable at `/var/run/docker.sock`