### PR TITLE
feat: Allow assigning existing children to a second parent

### DIFF
--- a/app/components/admin/invitations/index_view.rb
+++ b/app/components/admin/invitations/index_view.rb
@@ -12,12 +12,14 @@ module Components
           invitation: Invitation.new,
           invitations: Invitation.order(created_at: :desc),
           resendable_invitation_ids: [],
-          cancellable_invitation_ids: []
+          cancellable_invitation_ids: [],
+          dependents: Person.none
         )
           @invitation = invitation
           @invitations = invitations
           @resendable_invitation_ids = resendable_invitation_ids
           @cancellable_invitation_ids = cancellable_invitation_ids
+          @dependents = dependents
         end
 
         def view_template
@@ -54,10 +56,20 @@ module Components
         end
 
         def render_form
-          form_with(url: admin_invitations_path, method: :post, class: 'space-y-8') do
+          form_with(
+            url: admin_invitations_path,
+            method: :post,
+            class: 'space-y-8',
+            data: {
+              controller: 'dependent-assignment',
+              action: 'change->dependent-assignment#sync',
+              dependent_assignment_roles_value: %w[parent carer].to_json
+            }
+          ) do
             div(class: 'space-y-6') do
               render_email_field
               render_role_field
+              render_dependents_field
             end
             render_actions
           end
@@ -92,6 +104,43 @@ module Components
                 option(value: role, selected: @invitation.role == role) { role.titleize }
               end
             end
+          end
+        end
+
+        def render_dependents_field
+          return if @dependents.empty?
+
+          FormField(
+            class: 'space-y-3',
+            hidden: !dependent_assignment_role?,
+            data: { dependent_assignment_target: 'field' }
+          ) do
+            FormFieldLabel(for: 'invitation_dependent_ids',
+                           class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1') do
+              t('admin.invitations.index.form.dependents')
+            end
+            p(class: 'text-sm text-on-surface-variant') { t('admin.invitations.index.form.dependents_hint') }
+            div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-3') do
+              @dependents.each do |dependent|
+                label(
+                  class: 'flex items-center gap-3 p-4 rounded-xl border border-outline-variant ' \
+                         'bg-surface-container-low hover:bg-surface-container-high cursor-pointer ' \
+                         'transition-all state-layer relative'
+                ) do
+                  input(
+                    type: 'checkbox',
+                    name: 'invitation[dependent_ids][]',
+                    value: dependent.id,
+                    id: "invitation_dependent_#{dependent.id}",
+                    checked: selected_dependent_ids.include?(dependent.id),
+                    disabled: !dependent_assignment_role?,
+                    class: "z-10 #{checkbox_classes}"
+                  )
+                  span(class: 'z-10 font-bold text-foreground') { dependent.name }
+                end
+              end
+            end
+            input(type: 'hidden', name: 'invitation[dependent_ids][]', value: '', disabled: !dependent_assignment_role?)
           end
         end
 
@@ -183,6 +232,14 @@ module Components
           else
             t('admin.invitations.index.metadata.expires', time: view_context.time_ago_in_words(invitation.expires_at))
           end
+        end
+
+        def selected_dependent_ids
+          @selected_dependent_ids ||= @invitation.dependent_ids.map(&:to_i)
+        end
+
+        def dependent_assignment_role?
+          @invitation.parent? || @invitation.carer?
         end
 
         def render_errors

--- a/app/components/admin/users/form_view.rb
+++ b/app/components/admin/users/form_view.rb
@@ -7,11 +7,12 @@ module Components
         include Phlex::Rails::Helpers::FormWith
         include Phlex::Rails::Helpers::Pluralize
 
-        attr_reader :user, :locations
+        attr_reader :user, :locations, :dependents
 
-        def initialize(user:, locations: Location.none)
+        def initialize(user:, locations: Location.none, dependents: Person.none)
           @user = user
           @locations = locations
+          @dependents = dependents
           super()
         end
 
@@ -46,7 +47,12 @@ module Components
           form_with(
             model: [:admin, user],
             class: 'space-y-8',
-            data: { testid: 'user-form' }
+            data: {
+              testid: 'user-form',
+              controller: 'dependent-assignment',
+              action: 'change->dependent-assignment#sync',
+              dependent_assignment_roles_value: %w[parent carer].to_json
+            }
           ) do |form|
             render_errors if user.errors.any?
             render_form_fields(form)
@@ -83,6 +89,7 @@ module Components
               render_password_fields(form)
               div(class: 'h-px bg-outline-variant w-full opacity-50')
               render_role_field(form)
+              render_dependents_field(form)
             end
           end
         end
@@ -297,6 +304,44 @@ module Components
           end
         end
 
+        def render_dependents_field(_form)
+          return if dependents.empty?
+
+          div(
+            class: 'space-y-3',
+            hidden: !dependent_assignment_role?,
+            data: { dependent_assignment_target: 'field' }
+          ) do
+            render RubyUI::FormFieldLabel.new(
+              for: 'user_dependent_ids',
+              class: 'text-[10px] font-black uppercase tracking-widest text-on-surface-variant ml-1'
+            ) do
+              plain t('admin.users.form.dependents')
+            end
+            div(class: 'grid grid-cols-1 sm:grid-cols-2 gap-3') do
+              dependents.each do |dependent|
+                label(
+                  class: 'flex items-center gap-3 p-4 rounded-xl border border-outline-variant ' \
+                         'bg-surface-container-low hover:bg-surface-container-high cursor-pointer ' \
+                         'transition-all state-layer relative'
+                ) do
+                  input(
+                    type: 'checkbox',
+                    name: 'user[dependent_ids][]',
+                    value: dependent.id,
+                    id: "user_dependent_#{dependent.id}",
+                    checked: selected_dependent_ids.include?(dependent.id),
+                    disabled: !dependent_assignment_role?,
+                    class: "z-10 #{checkbox_classes}"
+                  )
+                  span(class: 'z-10 font-bold text-foreground') { dependent.name }
+                end
+              end
+            end
+            input(type: 'hidden', name: 'user[dependent_ids][]', value: '', disabled: !dependent_assignment_role?)
+          end
+        end
+
         def render_form_actions
           div(
             class: 'px-10 py-6 bg-surface-container-low border-t border-outline-variant/30 ' \
@@ -332,6 +377,15 @@ module Components
           return unless person
 
           render_field_error(person, field, input_id: input_id)
+        end
+
+        def selected_dependent_ids
+          selected = user.dependent_ids.presence || user.person&.patient_ids
+          Array(selected).map(&:to_i)
+        end
+
+        def dependent_assignment_role?
+          user.parent? || user.carer?
         end
       end
     end

--- a/app/components/people/carer_relationships/form_view.rb
+++ b/app/components/people/carer_relationships/form_view.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Components
+  module People
+    module CarerRelationships
+      class FormView < Components::Base
+        include Phlex::Rails::Helpers::FormWith
+        include Components::FormHelpers
+
+        attr_reader :relationship, :patient, :carers, :current_user, :email
+
+        def initialize(relationship:, patient:, carers:, current_user:, email: nil)
+          @relationship = relationship
+          @patient = patient
+          @carers = carers
+          @current_user = current_user
+          @email = email
+          super()
+        end
+
+        def view_template
+          div(class: 'container mx-auto px-4 py-12 max-w-2xl') do
+            render_header
+            render_form
+          end
+        end
+
+        private
+
+        def render_header
+          div(class: 'mb-8 space-y-2 text-center md:text-left') do
+            m3_heading(variant: :display_small, level: 1, class: 'font-black tracking-tight') do
+              t('people.carer_relationships.new_title')
+            end
+            m3_text(variant: :body_large, class: 'text-on-surface-variant font-medium') do
+              t('people.carer_relationships.new_subtitle', name: patient.name)
+            end
+          end
+        end
+
+        def render_form
+          form_with(url: person_carer_relationships_path(patient), method: :post, class: 'space-y-6') do
+            render_errors if relationship.errors.any?
+            if current_user.administrator?
+              render_admin_fields
+            else
+              render_parent_fields
+            end
+            render_actions
+          end
+        end
+
+        def render_errors
+          render RubyUI::Alert.new(variant: :destructive, class: 'mb-6') do
+            ul(class: 'my-2 ml-6 list-disc [&>li]:mt-1') do
+              relationship.errors.full_messages.each do |message|
+                li { message }
+              end
+            end
+          end
+        end
+
+        def render_admin_fields
+          render_carer_select
+          render_relationship_type_select
+        end
+
+        def render_carer_select
+          div(class: 'space-y-2') do
+            render RubyUI::FormFieldLabel.new(for: 'carer_relationship_carer_id') do
+              t('people.carer_relationships.carer')
+            end
+            select(name: 'carer_relationship[carer_id]', id: 'carer_relationship_carer_id', class: select_classes) do
+              option(value: '') { t('people.carer_relationships.select_carer') }
+              carers.each do |carer|
+                option(value: carer.id) { carer.name }
+              end
+            end
+          end
+        end
+
+        def render_relationship_type_select
+          div(class: 'space-y-2') do
+            render RubyUI::FormFieldLabel.new(for: 'carer_relationship_relationship_type') do
+              t('people.carer_relationships.relationship_type')
+            end
+            select(
+              name: 'carer_relationship[relationship_type]',
+              id: 'carer_relationship_relationship_type',
+              class: select_classes
+            ) do
+              CarerRelationship::RELATIONSHIP_TYPES.each do |label, value|
+                option(value: value) { label }
+              end
+            end
+          end
+        end
+
+        def render_parent_fields
+          div(class: 'space-y-2') do
+            render RubyUI::FormFieldLabel.new(for: 'carer_relationship_email') do
+              t('people.carer_relationships.email')
+            end
+            m3_input(
+              type: :email,
+              name: 'carer_relationship[email]',
+              id: 'carer_relationship_email',
+              value: email,
+              required: true,
+              placeholder: t('people.carer_relationships.email_placeholder')
+            )
+          end
+        end
+
+        def render_actions
+          div(class: 'flex gap-3 justify-end pt-4') do
+            m3_link(href: person_path(patient), variant: :text) { t('people.carer_relationships.cancel') }
+            m3_button(type: :submit, variant: :filled) { t('people.carer_relationships.submit') }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -132,6 +132,14 @@ module Components
                   data: { turbo_frame: 'modal' }
                 ) { t('people.show.add_medication') }
               end
+              if can_assign_carer?
+                m3_link(
+                  href: new_person_carer_relationship_path(person),
+                  variant: :tonal,
+                  size: :lg,
+                  class: 'w-full py-6 rounded-xl font-bold shadow-elevation-1 transition-all'
+                ) { t('people.show.manage_parents') }
+              end
             end
           end
         end
@@ -197,6 +205,10 @@ module Components
 
       def can_add_medication?
         can_create_schedule? || view_context.policy(PersonMedication.new(person: person)).create?
+      end
+
+      def can_assign_carer?
+        view_context.policy(CarerRelationship.new(patient: person)).assign_dependent?
       end
     end
   end

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -65,7 +65,7 @@ module Admin
     private
 
     def invitation_params
-      params.expect(invitation: %i[email role])
+      params.expect(invitation: [:email, :role, { dependent_ids: [] }])
     end
 
     def render_index_turbo
@@ -81,8 +81,13 @@ module Admin
         invitation: invitation,
         invitations: result.invitations,
         resendable_invitation_ids: result.resendable_invitation_ids,
-        cancellable_invitation_ids: result.cancellable_invitation_ids
+        cancellable_invitation_ids: result.cancellable_invitation_ids,
+        dependents: load_dependents
       )
+    end
+
+    def load_dependents
+      @load_dependents ||= Person.where(person_type: %i[minor dependent_adult], has_capacity: false).order(:name).to_a
     end
 
     def redirect_with_invitation_notice(message)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,20 +10,25 @@ module Admin
         filters: search_params.to_h.symbolize_keys
       ).call
       @pagy, users = pagy(:offset, users)
-      render Components::Admin::Users::IndexView.new(users: users, search_params: search_params, current_user: current_user, pagy: @pagy)
+      render Components::Admin::Users::IndexView.new(
+        users: users,
+        search_params: search_params,
+        current_user: current_user,
+        pagy: @pagy
+      )
     end
 
     def new
       @user = User.new
       @user.build_person
       authorize @user
-      render Components::Admin::Users::FormView.new(user: @user, locations: load_locations)
+      render user_form_view
     end
 
     def edit
       @user = policy_scope(User).find(params.expect(:id))
       authorize @user
-      render Components::Admin::Users::FormView.new(user: @user, locations: load_locations)
+      render user_form_view
     end
 
     def create
@@ -56,16 +61,12 @@ module Admin
       authorize @user
 
       respond_to do |format|
-        if @user.update(user_params)
+        if update_user_with_dependents
           format.html { redirect_to admin_users_path, notice: t('users.updated') }
           format.turbo_stream { render_users_index_turbo(t('users.updated')) }
         else
-          format.html do
-            render Components::Admin::Users::FormView.new(user: @user, locations: load_locations), status: :unprocessable_content
-          end
-          format.turbo_stream do
-            render Components::Admin::Users::FormView.new(user: @user, locations: load_locations), status: :unprocessable_content
-          end
+          format.html { render_user_form_with_errors }
+          format.turbo_stream { render_user_form_with_errors }
         end
       end
     end
@@ -144,6 +145,11 @@ module Admin
       @load_locations ||= Location.all.to_a
     end
 
+    def load_dependents
+      @load_dependents ||=
+        Person.where(person_type: %i[minor dependent_adult], has_capacity: false).order(:name).to_a
+    end
+
     def account_already_exists?
       return false unless Account.exists?(email: @user.email_address)
 
@@ -160,6 +166,15 @@ module Admin
         )
         @user.person.account = account
         @user.save!
+        assign_dependents
+      end
+    end
+
+    def update_user_with_dependents
+      ActiveRecord::Base.transaction do
+        updated = @user.update(user_params)
+        assign_dependents if updated
+        updated
       end
     end
 
@@ -173,7 +188,15 @@ module Admin
     end
 
     def render_user_form_with_errors
-      render Components::Admin::Users::FormView.new(user: @user, locations: load_locations), status: :unprocessable_content
+      render user_form_view, status: :unprocessable_content
+    end
+
+    def user_form_view
+      Components::Admin::Users::FormView.new(
+        user: @user,
+        locations: load_locations,
+        dependents: load_dependents
+      )
     end
 
     def render_users_index_turbo(message)
@@ -190,7 +213,12 @@ module Admin
         filters: search_params.to_h.symbolize_keys
       ).call
       @pagy, users = pagy(:offset, users)
-      Components::Admin::Users::IndexView.new(users: users, search_params: search_params, current_user: current_user, pagy: @pagy)
+      Components::Admin::Users::IndexView.new(
+        users: users,
+        search_params: search_params,
+        current_user: current_user,
+        pagy: @pagy
+      )
     end
 
     def search_params
@@ -198,12 +226,36 @@ module Admin
     end
 
     def user_params
-      params.expect(user: [:email_address, :password, :password_confirmation, :role, { person_attributes: [:id, :name, :date_of_birth, { location_ids: [] }] }])
+      params.expect(
+        user: [
+          :email_address,
+          :password,
+          :password_confirmation,
+          :role,
+          {
+            dependent_ids: [],
+            person_attributes: [:id, :name, :date_of_birth, { location_ids: [] }]
+          }
+        ]
+      )
+    end
+
+    def assign_dependents
+      return unless DependentRelationshipAssigner.relationship_type_for(@user)
+
+      DependentRelationshipAssigner.new(
+        carer: @user.person,
+        dependent_ids: @user.dependent_ids,
+        relationship_type: DependentRelationshipAssigner.relationship_type_for(@user)
+      ).call
     end
 
     def user_row_streams(user)
       [
-        turbo_stream.replace("user_#{user.id}", Components::Admin::Users::UserRow.new(user: user.reload, current_user: current_user)),
+        turbo_stream.replace(
+          "user_#{user.id}",
+          Components::Admin::Users::UserRow.new(user: user.reload, current_user: current_user)
+        ),
         turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
       ]
     end

--- a/app/controllers/people/carer_relationships_controller.rb
+++ b/app/controllers/people/carer_relationships_controller.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module People
+  class CarerRelationshipsController < ApplicationController
+    before_action :set_patient
+
+    def new
+      @relationship = CarerRelationship.new(patient: @patient)
+      authorize @relationship, :assign_dependent?
+
+      render_form
+    end
+
+    def create
+      @relationship = CarerRelationship.new(patient: @patient)
+      authorize @relationship, :assign_dependent?
+
+      if current_user.administrator?
+        create_admin_assignment
+      else
+        create_parent_assignment
+      end
+    end
+
+    private
+
+    def set_patient
+      @patient = Person.find(params.expect(:person_id))
+    end
+
+    def create_admin_assignment
+      carer = assignable_carers.find_by(id: admin_assignment_params[:carer_id])
+      unless carer
+        render_invalid_assignment(t('people.carer_relationships.missing_carer'))
+        return
+      end
+
+      DependentRelationshipAssigner.new(
+        carer: carer,
+        dependent_ids: [@patient.id],
+        relationship_type: admin_assignment_params[:relationship_type]
+      ).call
+      redirect_to @patient, notice: t('people.carer_relationships.created')
+    end
+
+    def create_parent_assignment
+      user = parent_user_by_email
+
+      if assignable_parent_user?(user)
+        assign_existing_user(user)
+      elsif user
+        render_invalid_assignment(t('people.carer_relationships.invalid_role'))
+      else
+        invite_parent
+      end
+    end
+
+    def assign_existing_user(user)
+      DependentRelationshipAssigner.new(
+        carer: user.person,
+        dependent_ids: [@patient.id],
+        relationship_type: DependentRelationshipAssigner.relationship_type_for(user)
+      ).call
+      redirect_to @patient, notice: t('people.carer_relationships.created')
+    end
+
+    def invite_parent
+      invitation = pending_invitation_for_parent_email || Invitation.new(email: parent_assignment_email)
+      invitation.role = :parent if invitation.new_record?
+
+      unless invitation.parent?
+        render_invalid_assignment(t('people.carer_relationships.invalid_role'))
+        return
+      end
+
+      invitation.dependents << @patient unless invitation.dependents.include?(@patient)
+
+      if invitation.save
+        deliver_invitation(invitation) if invitation.previous_changes.key?('id')
+        redirect_to @patient, notice: t('people.carer_relationships.invited')
+      else
+        @relationship.errors.merge!(invitation.errors)
+        render_form(status: :unprocessable_content)
+      end
+    end
+
+    def deliver_invitation(invitation)
+      InvitationMailer.with(invitation: invitation, token: invitation.plain_token).invite.deliver_later
+    end
+
+    def render_invalid_assignment(message)
+      @relationship.errors.add(:base, message)
+      render_form(status: :unprocessable_content)
+    end
+
+    def render_form(status: :ok)
+      render Components::People::CarerRelationships::FormView.new(
+        relationship: @relationship,
+        patient: @patient,
+        carers: assignable_carers,
+        current_user: current_user,
+        email: parent_assignment_email
+      ), status: status
+    end
+
+    def assignable_carers
+      return Person.none unless current_user.administrator?
+
+      Person.joins(:user).where(person_type: :adult, has_capacity: true).order(:name)
+    end
+
+    def assignable_parent_user?(user)
+      user&.parent? && user.person&.person_type == 'adult' && user.person&.has_capacity?
+    end
+
+    def parent_user_by_email
+      User.active.find_by('LOWER(email_address) = ?', parent_assignment_email)
+    end
+
+    def pending_invitation_for_parent_email
+      Invitation.pending.find_by('LOWER(email) = ?', parent_assignment_email)
+    end
+
+    def admin_assignment_params
+      params.expect(carer_relationship: %i[carer_id relationship_type])
+    end
+
+    def parent_assignment_email
+      params.dig(:carer_relationship, :email).to_s.strip.downcase
+    end
+  end
+end

--- a/app/javascript/controllers/dependent_assignment_controller.js
+++ b/app/javascript/controllers/dependent_assignment_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["field"]
+  static values = { roles: Array }
+
+  connect() {
+    this.sync()
+  }
+
+  sync() {
+    if (!this.hasFieldTarget) return
+
+    const enabled = this.rolesValue.includes(this.selectedRole())
+    this.fieldTarget.hidden = !enabled
+    this.fieldTarget.querySelectorAll("input").forEach((input) => {
+      input.disabled = !enabled
+    })
+  }
+
+  selectedRole() {
+    const checkedRole = this.element.querySelector("input[name='user[role]']:checked")
+    if (checkedRole) return checkedRole.value
+
+    return this.element.querySelector("select[name='invitation[role]']")?.value
+  }
+}

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -343,10 +343,7 @@ class RodauthMain < Rodauth::Rails::Auth
       user_role = age >= 18 ? :parent : :minor
 
       # If created via invitation, use cached invitation and override role
-      if @invitation
-        user_role = @invitation.role
-        @invitation.update!(accepted_at: Time.current)
-      end
+      user_role = @invitation.role if @invitation
 
       # Create associated Person and User records atomically
       # Ensures both are created or both fail together
@@ -367,6 +364,15 @@ class RodauthMain < Rodauth::Rails::Auth
           role: user_role,
           active: true
         )
+
+        if @invitation
+          DependentRelationshipAssigner.new(
+            carer: person,
+            dependent_ids: @invitation.dependent_ids,
+            relationship_type: DependentRelationshipAssigner.relationship_type_for(@invitation.role)
+          ).call
+          @invitation.update!(accepted_at: Time.current)
+        end
       end
     end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -7,6 +7,9 @@ class Invitation < ApplicationRecord
 
   has_paper_trail ignore: %i[token_digest]
 
+  has_many :invitation_dependents, dependent: :destroy
+  has_many :dependents, through: :invitation_dependents, source: :dependent
+
   before_create :assign_token_digest
   before_create :set_expires_at
 
@@ -15,6 +18,9 @@ class Invitation < ApplicationRecord
                     uniqueness: { case_sensitive: false, conditions: -> { pending } }
   validates :role, presence: true
   validate :role_cannot_be_minor
+  validate :dependents_require_assignable_role
+
+  normalizes :email, with: ->(email) { email.to_s.strip.downcase.presence }
 
   enum :role, { administrator: 0, doctor: 1, nurse: 2, carer: 3, parent: 4, minor: 5 }, validate: true
 
@@ -79,5 +85,11 @@ class Invitation < ApplicationRecord
 
   def role_cannot_be_minor
     errors.add(:role, 'Children must be added by a parent or carer.') if minor?
+  end
+
+  def dependents_require_assignable_role
+    return if dependents.empty? || parent? || carer?
+
+    errors.add(:base, 'Dependents can only be attached to parent or carer invitations')
   end
 end

--- a/app/models/invitation_dependent.rb
+++ b/app/models/invitation_dependent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class InvitationDependent < ApplicationRecord
+  belongs_to :invitation
+  belongs_to :dependent, class_name: 'Person'
+
+  validates :dependent_id, uniqueness: { scope: :invitation_id }
+  validate :dependent_must_require_carer
+
+  private
+
+  def dependent_must_require_carer
+    return if dependent&.person_type.in?(%w[minor dependent_adult]) && dependent.has_capacity == false
+
+    errors.add(:dependent, 'must be a child or dependent adult without capacity')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 # User model for storing user information and authentication
 class User < ApplicationRecord
+  attr_accessor :dependent_ids
+
   # Audit trail for user account changes
   # Excludes password fields for security - passwords are never logged
   # Tracks: email changes, role changes, person associations

--- a/app/policies/carer_relationship_policy.rb
+++ b/app/policies/carer_relationship_policy.rb
@@ -29,10 +29,27 @@ class CarerRelationshipPolicy < ApplicationPolicy
     admin?
   end
 
+  def assign_dependent?
+    dependent_patient? && (admin? || parent_owns_dependent?)
+  end
+
   private
 
   def carer_owns_relationship?
     (user&.person && record.carer_id == user.person.id) || false
+  end
+
+  def parent_owns_dependent?
+    return false unless user&.parent? && user.person_id && record.patient_id
+
+    active_patient_relationships
+      .joins(:patient)
+      .where(patient_id: record.patient_id)
+      .exists?(people: { person_type: %i[minor dependent_adult], has_capacity: false })
+  end
+
+  def dependent_patient?
+    record.patient&.person_type.in?(%w[minor dependent_adult]) && record.patient.has_capacity == false
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/services/dependent_relationship_assigner.rb
+++ b/app/services/dependent_relationship_assigner.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class DependentRelationshipAssigner
+  RELATIONSHIP_TYPES_BY_ROLE = {
+    'parent' => 'parent',
+    'carer' => 'professional_carer'
+  }.freeze
+
+  attr_reader :carer, :dependent_ids, :relationship_type, :scope
+
+  def initialize(carer:, dependent_ids:, relationship_type: nil, scope: Person.all)
+    @carer = carer
+    @dependent_ids = dependent_ids
+    @relationship_type = relationship_type
+    @scope = scope
+  end
+
+  def call
+    return [] if carer.blank?
+
+    dependents.map { |dependent| assign(dependent) }
+  end
+
+  def self.relationship_type_for(user_or_role)
+    role = user_or_role.respond_to?(:role) ? user_or_role.role : user_or_role.to_s
+    RELATIONSHIP_TYPES_BY_ROLE[role]
+  end
+
+  private
+
+  def dependents
+    scope.where(id: selected_ids, person_type: %i[minor dependent_adult], has_capacity: false)
+  end
+
+  def selected_ids
+    Array(dependent_ids).filter_map do |id|
+      id.to_i if id.to_s.match?(/\A\d+\z/)
+    end.uniq
+  end
+
+  def assign(dependent)
+    relationship = CarerRelationship.find_or_initialize_by(carer: carer, patient: dependent)
+    relationship.relationship_type = resolved_relationship_type
+    relationship.active = true
+    relationship.save! if relationship.new_record? || relationship.changed?
+    relationship
+  end
+
+  def resolved_relationship_type
+    relationship_type.presence || DependentRelationshipAssigner.relationship_type_for(carer.user)
+  end
+end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -292,6 +292,9 @@ cy:
         form:
           email: E-bost
           role: Rôl
+          dependents: Dibynyddion presennol
+          dependents_hint: Dewiswch blant presennol neu oedolion dibynnol y dylai'r
+            rhiant neu'r gofalwr gwahoddedig hwn eu rheoli.
           submit: Anfon gwahoddiad
         status:
           accepted: Wedi'i dderbyn
@@ -346,6 +349,7 @@ cy:
         password_confirmation: Cadarnhad cyfrinair
         role: Rôl
         select_role: Dewis rôl
+        dependents: Dibynyddion presennol
         cancel: Canslo
         create_submit: Creu defnyddiwr
         update_submit: Diweddaru defnyddiwr
@@ -779,6 +783,7 @@ cy:
       edit_person: Golygu Person
       add_schedule: Amserlen
       add_medication: Ychwanegu Meddyginiaeth
+      manage_parents: Rheoli rhieni
       back: Yn ôl
       born: 'Ganwyd:'
       age: 'Oedran:'
@@ -796,6 +801,20 @@ cy:
       mark_as_received: Derbyniwyd
       refill_inventory: Ail-stocio
       complete_refill: Ail-stocio
+    carer_relationships:
+      created: Rhiant neu ofalwr wedi'i aseinio.
+      invited: Anfonwyd gwahoddiad gyda'r dibynnydd hwn wedi'i atodi.
+      invalid_role: Rhowch gyfeiriad e-bost ar gyfer cyfrif rhiant sy'n oedolyn.
+      missing_carer: Dewiswch ddefnyddiwr sy'n oedolyn i'w aseinio.
+      new_title: Rheoli rhieni
+      new_subtitle: Aseinio rhiant neu ofalwr arall i %{name}.
+      carer: Rhiant neu ofalwr
+      select_carer: Dewis rhiant neu ofalwr...
+      relationship_type: Math o berthynas
+      email: E-bost rhiant
+      email_placeholder: rhiant@example.com
+      cancel: Canslo
+      submit: Cadw aseiniad
     form:
       new_heading: Person Newydd
       new_subheading: Ychwanegu person newydd i olrhain meddyginiaethau ar ei gyfer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,8 @@ en:
         form:
           email: Email
           role: Role
+          dependents: Existing dependents
+          dependents_hint: Select existing children or dependent adults this invited parent or carer should manage.
           submit: Send invitation
         status:
           accepted: Accepted
@@ -176,6 +178,7 @@ en:
         password_confirmation: Confirm Password
         role: Role
         select_role: Select role
+        dependents: Existing dependents
         cancel: Cancel
         create_submit: Create User
         update_submit: Update User
@@ -771,6 +774,7 @@ en:
     show:
       edit_person: Edit Person
       add_medication: Add Medication
+      manage_parents: Manage parents
       back: Back
       born: 'Born:'
       age: 'Age:'
@@ -795,6 +799,20 @@ en:
     actions:
       title: Care Actions
       subtitle: Update medication plans and schedules.
+    carer_relationships:
+      created: Parent or carer assigned.
+      invited: Invitation sent with this dependent attached.
+      invalid_role: Enter an email address for an adult parent account.
+      missing_carer: Select an adult user to assign.
+      new_title: Manage parents
+      new_subtitle: Assign another parent or carer to %{name}.
+      carer: Parent or carer
+      select_carer: Select a parent or carer...
+      relationship_type: Relationship type
+      email: Parent email
+      email_placeholder: parent@example.com
+      cancel: Cancel
+      submit: Save assignment
     form:
       new_heading: New Person
       new_subheading: Add a new person to track medications for

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -297,6 +297,9 @@ es:
         form:
           email: Correo electrónico
           role: Rol
+          dependents: Dependientes existentes
+          dependents_hint: Selecciona niños existentes o adultos dependientes que
+            este padre, madre o cuidador invitado debe gestionar.
           submit: Enviar invitación
         status:
           accepted: Aceptada
@@ -352,6 +355,7 @@ es:
         password_confirmation: Confirmación de contraseña
         role: Rol
         select_role: Selecciona un rol
+        dependents: Dependientes existentes
         cancel: Cancelar
         create_submit: Crear usuario
         update_submit: Actualizar usuario
@@ -780,6 +784,21 @@ es:
     actions:
       title: Acciones de Cuidado
       subtitle: Actualiza los planes y horarios de medicamentos.
+    carer_relationships:
+      created: Padre, madre o cuidador asignado.
+      invited: Invitación enviada con este dependiente adjunto.
+      invalid_role: Introduce una dirección de correo de una cuenta adulta de padre
+        o madre.
+      missing_carer: Selecciona un usuario adulto para asignar.
+      new_title: Gestionar padres
+      new_subtitle: Asigna otro padre, madre o cuidador a %{name}.
+      carer: Padre, madre o cuidador
+      select_carer: Selecciona un padre, madre o cuidador...
+      relationship_type: Tipo de relación
+      email: Email del padre o madre
+      email_placeholder: padre@example.com
+      cancel: Cancelar
+      submit: Guardar asignación
     card:
       born: 'Nacido:'
       age: 'Edad:'
@@ -793,6 +812,7 @@ es:
       edit_person: Editar Persona
       add_schedule: Agregar Receta
       add_medication: Agregar Medicamento
+      manage_parents: Gestionar padres
       back: Volver
       born: 'Nacido:'
       age: 'Edad:'

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -106,6 +106,9 @@ ga:
         form:
           email: Ríomhphost
           role: Ról
+          dependents: Cleithiúnaithe reatha
+          dependents_hint: Roghnaigh leanaí reatha nó daoine fásta cleithiúnacha
+            ar cheart don tuismitheoir nó cúramóir cuireadh seo iad a bhainistiú.
           submit: Seol cuireadh
         status:
           accepted: Glactha
@@ -160,6 +163,7 @@ ga:
         password_confirmation: Deimhniú focail faire
         role: Ról
         select_role: Roghnaigh ról
+        dependents: Cleithiúnaithe reatha
         cancel: Cealaigh
         create_submit: Cruthaigh úsáideoir
         update_submit: Nuashonraigh úsáideoir
@@ -781,6 +785,7 @@ ga:
       edit_person: Cuir Duine in Eagar
       add_schedule: Cuir Oideas Leigheasanna Leis
       add_medication: Cuir Leigheas Leis
+      manage_parents: Bainistigh tuismitheoirí
       back: Ar Ais
       born: 'Rugtha:'
       age: 'Aois:'
@@ -805,6 +810,20 @@ ga:
     actions:
       title: Gníomhartha Cúraim
       subtitle: Nuashonraigh pleananna leigheasanna agus oideas leigheasanna.
+    carer_relationships:
+      created: Sannadh tuismitheoir nó cúramóir.
+      invited: Seoladh cuireadh leis an gcleithiúnaí seo ceangailte.
+      invalid_role: Cuir isteach seoladh ríomhphoist do chuntas tuismitheora fásta.
+      missing_carer: Roghnaigh úsáideoir fásta le sannadh.
+      new_title: Bainistigh tuismitheoirí
+      new_subtitle: Sann tuismitheoir nó cúramóir eile do %{name}.
+      carer: Tuismitheoir nó cúramóir
+      select_carer: Roghnaigh tuismitheoir nó cúramóir...
+      relationship_type: Cineál caidrimh
+      email: Ríomhphost tuismitheora
+      email_placeholder: tuismitheoir@example.com
+      cancel: Cealaigh
+      submit: Sábháil sannadh
     form:
       new_heading: Duine Nua
       new_subheading: Cuir duine nua leis chun leigheasanna a rianú dó

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -297,6 +297,9 @@ pt:
         form:
           email: Email
           role: Função
+          dependents: Dependentes existentes
+          dependents_hint: Selecione crianças existentes ou adultos dependentes que
+            este pai/mãe ou cuidador convidado deve gerir.
           submit: Enviar convite
         status:
           accepted: Aceite
@@ -351,6 +354,7 @@ pt:
         password_confirmation: Confirmação da palavra-passe
         role: Função
         select_role: Selecione uma função
+        dependents: Dependentes existentes
         cancel: Cancelar
         create_submit: Criar utilizador
         update_submit: Atualizar utilizador
@@ -780,6 +784,7 @@ pt:
       edit_person: Editar Pessoa
       add_schedule: Adicionar Receita
       add_medication: Adicionar Medicamento
+      manage_parents: Gerir pais
       back: Voltar
       born: 'Nascido:'
       age: 'Idade:'
@@ -804,6 +809,20 @@ pt:
     actions:
       title: Ações de Cuidado
       subtitle: Atualize planos e horários de medicação.
+    carer_relationships:
+      created: Pai/mãe ou cuidador atribuído.
+      invited: Convite enviado com este dependente associado.
+      invalid_role: Introduza o email de uma conta adulta de pai/mãe.
+      missing_carer: Selecione um utilizador adulto para atribuir.
+      new_title: Gerir pais
+      new_subtitle: Atribuir outro pai/mãe ou cuidador a %{name}.
+      carer: Pai/mãe ou cuidador
+      select_carer: Selecione um pai/mãe ou cuidador...
+      relationship_type: Tipo de relação
+      email: Email do pai/mãe
+      email_placeholder: pai@example.com
+      cancel: Cancelar
+      submit: Guardar atribuição
     form:
       new_heading: Nova Pessoa
       new_subheading: Adicione uma nova pessoa para acompanhar a medicação

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
         post :take_medication
       end
     end
+    resources :carer_relationships, only: %i[new create], controller: 'people/carer_relationships'
     resources :medication_assignments, only: %i[new create]
   end
 

--- a/db/migrate/20260525090000_create_invitation_dependents.rb
+++ b/db/migrate/20260525090000_create_invitation_dependents.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateInvitationDependents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :invitation_dependents do |t|
+      t.references :invitation, null: false, foreign_key: true
+      t.references :dependent, null: false, foreign_key: { to_table: :people }
+
+      t.timestamps
+    end
+
+    add_index :invitation_dependents, %i[invitation_id dependent_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -240,6 +240,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_160000) do
     t.string "token_digest"
     t.datetime "updated_at", null: false
     t.index ["token_digest"], name: "index_invitations_on_token_digest", unique: true
+  end
+
+  create_table "invitation_dependents", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "dependent_id", null: false
+    t.bigint "invitation_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dependent_id"], name: "index_invitation_dependents_on_dependent_id"
+    t.index ["invitation_id", "dependent_id"], name: "index_invitation_dependents_on_invitation_id_and_dependent_id", unique: true
+    t.index ["invitation_id"], name: "index_invitation_dependents_on_invitation_id"
   end
 
   create_table "location_memberships", force: :cascade do |t|
@@ -496,6 +506,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_160000) do
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred
   add_foreign_key "dosages", "medications", deferrable: :deferred
+  add_foreign_key "invitation_dependents", "invitations"
+  add_foreign_key "invitation_dependents", "people", column: "dependent_id"
   add_foreign_key "location_memberships", "locations", deferrable: :deferred
   add_foreign_key "location_memberships", "people", deferrable: :deferred
   add_foreign_key "medication_takes", "locations", column: "taken_from_location_id"

--- a/spec/components/people/show_view_spec.rb
+++ b/spec/components/people/show_view_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Components::People::ShowView, type: :component do
 
   def stub_view_context_helpers(view_context_helper)
     admin = users(:admin)
-    policy_stub = Struct.new(:update?, :create?, :show?, :take_medication?, :destroy?).new(true, true, true, true, true)
+    policy_stub = Struct
+                  .new(:update?, :create?, :show?, :take_medication?, :destroy?, :assign_dependent?)
+                  .new(true, true, true, true, true, false)
     view_context_helper.singleton_class.define_method(:policy) { |_record| policy_stub }
     view_context_helper.singleton_class.define_method(:current_user) { admin }
     view_context_helper.singleton_class.define_method(:pundit_user) { admin }

--- a/spec/policies/carer_relationship_policy_spec.rb
+++ b/spec/policies/carer_relationship_policy_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe CarerRelationshipPolicy do
         expect(policy.public_send("#{action}?")).to be true
       end
     end
+
+    it 'permits dependent assignment' do
+      expect(policy.assign_dependent?).to be true
+    end
   end
 
   context 'when user is a doctor' do
@@ -26,6 +30,10 @@ RSpec.describe CarerRelationshipPolicy do
     it 'permits viewing but not management' do
       %i[index show].each { |action| expect(policy.public_send("#{action}?")).to be true }
       %i[create new update edit destroy].each { |action| expect(policy.public_send("#{action}?")).to be false }
+    end
+
+    it 'forbids dependent assignment' do
+      expect(policy.assign_dependent?).to be false
     end
   end
 
@@ -36,13 +44,17 @@ RSpec.describe CarerRelationshipPolicy do
       %i[index show].each { |action| expect(policy.public_send("#{action}?")).to be true }
       %i[create new update edit destroy].each { |action| expect(policy.public_send("#{action}?")).to be false }
     end
+
+    it 'forbids dependent assignment' do
+      expect(policy.assign_dependent?).to be false
+    end
   end
 
   context 'when user is a carer' do
-    let(:current_user) { users(:jane) }
+    let(:current_user) { users(:carer) }
 
     context 'with their own carer relationship' do
-      let(:relationship) { carer_relationships(:jane_cares_for_child) }
+      let(:relationship) { carer_relationships(:carer_cares_for_patient) }
 
       it 'permits viewing only' do
         expect(policy.show?).to be true
@@ -51,7 +63,7 @@ RSpec.describe CarerRelationshipPolicy do
     end
 
     context 'with another carer relationship' do
-      let(:relationship) { carer_relationships(:nurse_cares_for_john) }
+      let(:relationship) { carer_relationships(:jane_cares_for_child) }
 
       it 'forbids viewing' do
         expect(policy.show?).to be false
@@ -64,6 +76,38 @@ RSpec.describe CarerRelationshipPolicy do
 
     it 'forbids creating relationships' do
       %i[create new].each { |action| expect(policy.public_send("#{action}?")).to be false }
+    end
+
+    it 'forbids dependent assignment' do
+      expect(policy.assign_dependent?).to be false
+    end
+  end
+
+  context 'when user is a parent' do
+    let(:current_user) { users(:parent) }
+
+    context 'with their own dependent child' do
+      let(:relationship) { CarerRelationship.new(patient: people(:child_user_person)) }
+
+      it 'permits dependent assignment' do
+        expect(policy.assign_dependent?).to be true
+      end
+    end
+
+    context 'with an unrelated dependent child' do
+      let(:relationship) { CarerRelationship.new(patient: people(:child_patient)) }
+
+      it 'forbids dependent assignment' do
+        expect(policy.assign_dependent?).to be false
+      end
+    end
+
+    context 'with a self-managing adult' do
+      let(:relationship) { CarerRelationship.new(patient: people(:john)) }
+
+      it 'forbids dependent assignment' do
+        expect(policy.assign_dependent?).to be false
+      end
     end
   end
 

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe 'Admin create and update turbo flows' do
   before { sign_in(admin) }
 
   describe 'POST /admin/invitations' do
+    it 'renders role-aware dependent assignment controls on the invitation form' do
+      get admin_invitations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-controller="dependent-assignment"')
+      expect(response.body).to include('data-dependent-assignment-target="field"')
+      expect(response.body).to include('name="invitation[dependent_ids][]"')
+    end
+
     it 'returns turbo_stream and updates invitations container and flash on success' do
       post admin_invitations_path,
            params: { invitation: { email: 'new.user@example.com', role: 'carer' } },
@@ -19,6 +28,38 @@ RSpec.describe 'Admin create and update turbo flows' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include('target="admin_invitations"')
       expect(response.body).to include('target="flash"')
+    end
+
+    it 'stores selected dependents for parent invitations' do
+      dependent = people(:child_patient)
+
+      post admin_invitations_path,
+           params: {
+             invitation: {
+               email: 'second.parent@example.com',
+               role: 'parent',
+               dependent_ids: [dependent.id]
+             }
+           }
+
+      invitation = Invitation.find_by!(email: 'second.parent@example.com')
+      expect(invitation.dependents).to contain_exactly(dependent)
+    end
+
+    it 'stores selected dependents for carer invitations' do
+      dependent = people(:child_user_person)
+
+      post admin_invitations_path,
+           params: {
+             invitation: {
+               email: 'invited.carer@example.com',
+               role: 'carer',
+               dependent_ids: [dependent.id]
+             }
+           }
+
+      invitation = Invitation.find_by!(email: 'invited.carer@example.com')
+      expect(invitation.dependents).to contain_exactly(dependent)
     end
 
     it 'returns unprocessable content when inviting a minor' do
@@ -83,6 +124,15 @@ RSpec.describe 'Admin create and update turbo flows' do
   end
 
   describe 'POST /admin/users' do
+    it 'renders role-aware dependent assignment controls on the user form' do
+      get new_admin_user_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-controller="dependent-assignment"')
+      expect(response.body).to include('data-dependent-assignment-target="field"')
+      expect(response.body).to include('name="user[dependent_ids][]"')
+    end
+
     it 'returns turbo_stream and replaces users index and flash on success' do
       post admin_users_path,
            params: {
@@ -106,6 +156,60 @@ RSpec.describe 'Admin create and update turbo flows' do
       expect(response.body).to include('id="admin-users-frame"')
       expect(response.body).to include('target="flash"')
       expect(response.body).to include('Turbo New User')
+    end
+
+    it 'links a new parent to selected existing children' do
+      dependent = people(:child_patient)
+
+      expect do
+        post admin_users_path,
+             params: {
+               user: {
+                 email_address: 'linked.parent@example.com',
+                 password: 'password',
+                 password_confirmation: 'password',
+                 role: 'parent',
+                 dependent_ids: [dependent.id],
+                 person_attributes: {
+                   name: 'Linked Parent',
+                   date_of_birth: '1990-01-01',
+                   location_ids: [locations(:home).id]
+                 }
+               }
+             }
+      end.to change(CarerRelationship, :count).by(1)
+
+      parent = User.find_by!(email_address: 'linked.parent@example.com').person
+      relationship = CarerRelationship.find_by!(carer: parent, patient: dependent)
+      expect(relationship.relationship_type).to eq('parent')
+      expect(relationship.active).to be true
+    end
+
+    it 'links a new carer to selected existing children' do
+      dependent = people(:child_user_person)
+
+      expect do
+        post admin_users_path,
+             params: {
+               user: {
+                 email_address: 'linked.carer@example.com',
+                 password: 'password',
+                 password_confirmation: 'password',
+                 role: 'carer',
+                 dependent_ids: [dependent.id],
+                 person_attributes: {
+                   name: 'Linked Carer',
+                   date_of_birth: '1990-01-01',
+                   location_ids: [locations(:home).id]
+                 }
+               }
+             }
+      end.to change(CarerRelationship, :count).by(1)
+
+      carer = User.find_by!(email_address: 'linked.carer@example.com').person
+      relationship = CarerRelationship.find_by!(carer: carer, patient: dependent)
+      expect(relationship.relationship_type).to eq('professional_carer')
+      expect(relationship.active).to be true
     end
 
     it 'returns unprocessable content on validation failure' do
@@ -157,6 +261,32 @@ RSpec.describe 'Admin create and update turbo flows' do
       expect(response.body).to include('target="flash"')
       expect(response.body).to include('Jane Turbo Update')
       expect(users(:jane).person.reload.name).to eq('Jane Turbo Update')
+    end
+
+    it 'adds selected existing children to an existing parent' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+
+      expect do
+        patch admin_user_path(parent),
+              params: {
+                user: {
+                  email_address: parent.email_address,
+                  role: 'parent',
+                  dependent_ids: [dependent.id],
+                  person_attributes: {
+                    id: parent.person.id,
+                    name: parent.person.name,
+                    date_of_birth: parent.person.date_of_birth.to_s,
+                    location_ids: [locations(:home).id]
+                  }
+                }
+              }
+      end.to change(CarerRelationship, :count).by(1)
+
+      relationship = CarerRelationship.find_by!(carer: parent.person, patient: dependent)
+      expect(relationship.relationship_type).to eq('parent')
+      expect(relationship.active).to be true
     end
   end
 

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Invitations' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
+
   describe 'GET /invitations/accept' do
     it 'rejects existing minor invitation tokens' do
       invitation = Invitation.new(email: 'child.invite@example.com', role: :minor)
@@ -24,6 +26,64 @@ RSpec.describe 'Invitations' do
 
       expect(response).to have_http_status(:not_found)
       expect(response.body).to include('This invitation link is invalid or has expired.')
+    end
+  end
+
+  describe 'POST /create-account with an invitation' do
+    it 'links accepted parent invitations to selected existing dependents' do
+      dependent = people(:child_patient)
+      invitation = create(
+        :invitation,
+        email: 'accepted.parent@example.com',
+        role: :parent,
+        dependent_ids: [dependent.id]
+      )
+
+      expect do
+        post create_account_path,
+             params: {
+               invitation_token: invitation.token,
+               name: 'Accepted Parent',
+               date_of_birth: '1985-05-15',
+               email: 'accepted.parent@example.com',
+               password: 'SecureP@ssword123!',
+               'password-confirm': 'SecureP@ssword123!'
+             }
+      end.to change(CarerRelationship, :count).by(1)
+
+      parent = Person.find_by!(email: 'accepted.parent@example.com')
+      relationship = CarerRelationship.find_by!(carer: parent, patient: dependent)
+      expect(relationship.relationship_type).to eq('parent')
+      expect(relationship.active).to be true
+      expect(invitation.reload.accepted_at).to be_present
+    end
+
+    it 'links accepted carer invitations to selected existing dependents' do
+      dependent = people(:child_user_person)
+      invitation = create(
+        :invitation,
+        email: 'accepted.carer@example.com',
+        role: :carer,
+        dependent_ids: [dependent.id]
+      )
+
+      expect do
+        post create_account_path,
+             params: {
+               invitation_token: invitation.token,
+               name: 'Accepted Carer',
+               date_of_birth: '1985-05-15',
+               email: 'accepted.carer@example.com',
+               password: 'SecureP@ssword123!',
+               'password-confirm': 'SecureP@ssword123!'
+             }
+      end.to change(CarerRelationship, :count).by(1)
+
+      carer = Person.find_by!(email: 'accepted.carer@example.com')
+      relationship = CarerRelationship.find_by!(carer: carer, patient: dependent)
+      expect(relationship.relationship_type).to eq('professional_carer')
+      expect(relationship.active).to be true
+      expect(invitation.reload.accepted_at).to be_present
     end
   end
 end

--- a/spec/requests/people_carer_relationships_spec.rb
+++ b/spec/requests/people_carer_relationships_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'People carer relationships' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
+
+  describe 'POST /people/:person_id/carer_relationships' do
+    it 'allows an admin to assign an existing adult with a selected relationship type' do
+      sign_in(users(:admin))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: {
+               carer_relationship: {
+                 carer_id: users(:jane).person.id,
+                 relationship_type: 'family_member'
+               }
+             }
+      end.to change(CarerRelationship, :count).by(1)
+
+      relationship = CarerRelationship.find_by!(carer: users(:jane).person, patient: people(:child_user_person))
+      expect(relationship.relationship_type).to eq('family_member')
+      expect(relationship.active).to be true
+      expect(response).to redirect_to(person_path(people(:child_user_person)))
+    end
+
+    it 'renders an error when an admin submits without a carer' do
+      sign_in(users(:admin))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { carer_id: '', relationship_type: 'family_member' } }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Select an adult user to assign')
+    end
+
+    it 'allows an existing parent to link another parent by email for their child' do
+      sign_in(users(:parent))
+      write_legacy_email(users(:jane), :email_address, 'Jane.Parent@example.com')
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: 'jane.parent@example.com' } }
+      end.to change(CarerRelationship, :count).by(1)
+
+      relationship = CarerRelationship.find_by!(carer: users(:jane).person, patient: people(:child_user_person))
+      expect(relationship.relationship_type).to eq('parent')
+      expect(relationship.active).to be true
+      expect(response).to redirect_to(person_path(people(:child_user_person)))
+    end
+
+    it 'allows the assigned second parent to access the child' do
+      sign_in(users(:parent))
+
+      post person_carer_relationships_path(people(:child_user_person)),
+           params: { carer_relationship: { email: users(:jane).email_address } }
+
+      post '/logout'
+      sign_in(users(:jane))
+      get person_path(people(:child_user_person))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(people(:child_user_person).name)
+    end
+
+    it 'creates a parent invitation when the second parent does not have an account' do
+      sign_in(users(:parent))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: 'new.second.parent@example.com' } }
+      end.to change(Invitation, :count).by(1)
+
+      invitation = Invitation.find_by!(email: 'new.second.parent@example.com')
+      expect(invitation.role).to eq('parent')
+      expect(invitation.dependents).to contain_exactly(people(:child_user_person))
+      expect(response).to redirect_to(person_path(people(:child_user_person)))
+    end
+
+    it 'does not attach dependents to an existing non-parent invitation' do
+      sign_in(users(:parent))
+      invitation = create(:invitation, email: 'pending.carer@example.com', role: :carer)
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: invitation.email } }
+      end.not_to change(InvitationDependent, :count)
+
+      expect(invitation.reload.dependents).to be_empty
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'attaches the dependent to an existing pending parent invitation regardless of email case' do
+      sign_in(users(:parent))
+      invitation = create(:invitation, email: 'pending.second.parent@example.com', role: :parent)
+      write_legacy_email(invitation, :email, 'Pending.Second.Parent@example.com')
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: 'pending.second.parent@example.com' } }
+      end.not_to change(Invitation, :count)
+
+      expect(invitation.reload.dependents).to contain_exactly(people(:child_user_person))
+      expect(response).to redirect_to(person_path(people(:child_user_person)))
+    end
+
+    it 'prevents parents from assigning another parent to an unrelated child' do
+      sign_in(users(:parent))
+
+      expect do
+        post person_carer_relationships_path(people(:child_patient)),
+             params: { carer_relationship: { email: users(:jane).email_address } }
+      end.not_to change(CarerRelationship, :count)
+    end
+
+    it 'prevents parents from assigning a minor account with a parent role' do
+      sign_in(users(:parent))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: users(:child_user).email_address } }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'prevents parents from assigning a dependent adult account with a parent role' do
+      sign_in(users(:parent))
+      user = create_dependent_adult_parent_user
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: user.email_address } }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'prevents parents from assigning a self-managing adult account' do
+      sign_in(users(:parent))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: users(:adult_patient).email_address } }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'prevents parents from assigning a clinician account' do
+      sign_in(users(:parent))
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: { carer_relationship: { email: users(:doctor).email_address } }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  def create_dependent_adult_parent_user
+    person = Person.new(
+      name: 'Dependent Adult Parent Role',
+      email: 'dependent.adult.parent@example.com',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :dependent_adult,
+      has_capacity: false
+    )
+    person.location_memberships.build(location: locations(:home))
+    person.carer_relationships.build(
+      carer: users(:parent).person,
+      relationship_type: 'family_member',
+      active: true
+    )
+    person.save!
+    User.create!(person: person, email_address: person.email, role: :parent)
+  end
+
+  def write_legacy_email(record, attribute, value)
+    connection = record.class.connection
+    table = connection.quote_table_name(record.class.table_name)
+    column = connection.quote_column_name(attribute)
+    sql = record.class.sanitize_sql_array(["UPDATE #{table} SET #{column} = ? WHERE id = ?", value, record.id])
+    connection.execute(sql)
+    record.reload
+  end
+end

--- a/spec/services/dependent_relationship_assigner_spec.rb
+++ b/spec/services/dependent_relationship_assigner_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DependentRelationshipAssigner do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
+
+  describe '#call' do
+    it 'does not create duplicate relationships for active assignments' do
+      carer = users(:jane).person
+      dependent = people(:child_patient)
+
+      expect do
+        described_class.new(
+          carer: carer,
+          dependent_ids: [dependent.id],
+          relationship_type: 'parent'
+        ).call
+      end.not_to change(CarerRelationship, :count)
+    end
+
+    it 'reactivates inactive relationships instead of creating duplicates' do
+      carer = users(:bob).person
+      dependent = people(:child_patient)
+      relationship = inactive_relationship(carer, dependent)
+
+      expect do
+        described_class.new(
+          carer: carer,
+          dependent_ids: [dependent.id],
+          relationship_type: 'parent'
+        ).call
+      end.not_to change(CarerRelationship, :count)
+
+      expect(relationship.reload).to have_attributes(
+        relationship_type: 'parent',
+        active: true
+      )
+    end
+
+    it 'ignores adults and unrelated ids' do
+      carer = users(:parent).person
+
+      expect do
+        described_class.new(
+          carer: carer,
+          dependent_ids: [people(:john).id, nil, ''],
+          relationship_type: 'parent'
+        ).call
+      end.not_to change(CarerRelationship, :count)
+    end
+
+    it 'ignores non-numeric ids' do
+      carer = users(:parent).person
+
+      expect do
+        described_class.new(
+          carer: carer,
+          dependent_ids: ['not-an-id'],
+          relationship_type: 'parent'
+        ).call
+      end.not_to change(CarerRelationship, :count)
+    end
+  end
+
+  def inactive_relationship(carer, dependent)
+    CarerRelationship.create!(
+      carer: carer,
+      patient: dependent,
+      relationship_type: 'family_member',
+      active: false
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Add dependent assignment support for parent and carer invitations so selected children persist through acceptance.
- Allow admins to attach existing dependents during parent/carer create and update flows.
- Add a child-facing `Manage parents` flow so an existing parent can link a second parent by email or invite them if the account does not exist.
- Prevent duplicate relationships and reactivate inactive ones instead of creating duplicates.
- Update locale copy, policy checks, and UI controls to support the new assignment paths.

## Testing
- Added and updated request, policy, service, and component specs covering invitation acceptance, admin assignment, and nested parent assignment flows.
- `task rubocop` passed.
- `task test` passed.