### PR TITLE
fix: suppress reminders after medication taken

### DIFF
--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -84,11 +84,53 @@ class MedicationReminderEligibilityQuery
 
   def taken_count_for_cycle(source)
     cycle = DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
-    source.medication_takes.count { |take| cycle.range_for(now).cover?(take.taken_at) }
+    medication_takes_for(source).count { |take| cycle.range_for(now).cover?(take.taken_at) }
   end
 
   def taken_in_current_cycle?(source)
     taken_count_for_cycle(source).positive?
+  end
+
+  def medication_takes_for(source)
+    takes_by_medication_id.fetch(source.medication_id, [])
+  end
+
+  def takes_by_medication_id
+    @takes_by_medication_id ||= begin
+      medication_ids = reminder_source_medication_ids
+
+      if medication_ids.blank?
+        {}
+      else
+        (schedule_takes_for(medication_ids) + person_medication_takes_for(medication_ids)).group_by do |take|
+          take.schedule&.medication_id || take.person_medication&.medication_id
+        end
+      end
+    end
+  end
+
+  def reminder_source_medication_ids
+    (schedules + person_medications).map(&:medication_id).compact.uniq
+  end
+
+  def schedule_takes_for(medication_ids)
+    MedicationTake.joins(:schedule)
+                  .where(taken_at: medication_take_lookup_range,
+                         schedules: { person_id: person.id, medication_id: medication_ids })
+                  .includes(:schedule)
+                  .to_a
+  end
+
+  def person_medication_takes_for(medication_ids)
+    MedicationTake.joins(:person_medication)
+                  .where(taken_at: medication_take_lookup_range,
+                         person_medications: { person_id: person.id, medication_id: medication_ids })
+                  .includes(:person_medication)
+                  .to_a
+  end
+
+  def medication_take_lookup_range
+    (now - 1.month).beginning_of_day..now.end_of_day
   end
 
   def as_needed_schedule?(schedule)

--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -44,6 +44,8 @@ class MedicationReminderEligibilityQuery
 
   def due_schedule?(schedule)
     return false if as_needed_schedule?(schedule)
+    return false if configured_times_for(schedule).blank?
+    return false if taken_in_current_cycle?(schedule)
     return false unless schedule.applies_on?(today)
 
     if scheduled_time.present?
@@ -54,6 +56,8 @@ class MedicationReminderEligibilityQuery
   end
 
   def due_person_medication?(person_medication)
+    return false if taken_in_current_cycle?(person_medication)
+
     taken_count_for_cycle(person_medication) < expected_person_medication_doses(person_medication)
   end
 
@@ -81,6 +85,10 @@ class MedicationReminderEligibilityQuery
   def taken_count_for_cycle(source)
     cycle = DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
     source.medication_takes.count { |take| cycle.range_for(now).cover?(take.taken_at) }
+  end
+
+  def taken_in_current_cycle?(source)
+    taken_count_for_cycle(source).positive?
   end
 
   def as_needed_schedule?(schedule)

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe MedicationReminderJob do
     expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 
+  it 'does not send scheduled-time reminders when the medication was taken today through a direct assignment' do
+    create_vitamin_schedule(time: '19:45')
+    person_medication = create_routine_vitamin
+    take_person_medication(person_medication)
+
+    travel_to Time.zone.today.beginning_of_day + 19.hours + 45.minutes do
+      described_class.perform_now(person.id, :scheduled, '19:45')
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
   it 'does not send scheduled-time reminders for as-needed schedules' do
     create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
                       schedule_type: :prn, frequency: 'As needed', schedule_config: { 'times' => ['07:15'] })
@@ -104,6 +116,18 @@ RSpec.describe MedicationReminderJob do
     expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 
+  it 'does not send period reminders when a direct medication was taken today through a schedule' do
+    schedule = create_vitamin_schedule(time: '07:15')
+    create_routine_vitamin
+    take_schedule(schedule)
+
+    travel_to Time.zone.today.beginning_of_day + 14.hours do
+      described_class.perform_now(person.id, :afternoon)
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
   it 'does not send period reminders when routine medications have already been taken today' do
     schedule = create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
                                  frequency: 'Once daily', schedule_type: :daily,
@@ -114,5 +138,39 @@ RSpec.describe MedicationReminderJob do
     described_class.perform_now(person.id, :morning)
 
     expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  def create_vitamin_schedule(time:)
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once daily', schedule_type: :daily,
+                      schedule_config: { 'times' => [time] })
+  end
+
+  def create_routine_vitamin
+    create(
+      :person_medication,
+      :routine,
+      person: person,
+      medication: medications(:vitamin_d),
+      dosage: dosages(:vitamin_d_daily)
+    )
+  end
+
+  def take_person_medication(person_medication)
+    create(
+      :medication_take,
+      :for_person_medication,
+      person_medication: person_medication,
+      taken_at: Time.zone.today.beginning_of_day + 8.hours
+    )
+  end
+
+  def take_schedule(schedule)
+    create(
+      :medication_take,
+      :for_schedule,
+      schedule: schedule,
+      taken_at: Time.zone.today.beginning_of_day + 8.hours
+    )
   end
 end

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -40,11 +40,34 @@ RSpec.describe MedicationReminderJob do
     expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 
+  it 'does not send later scheduled-time reminders after the medication was taken today' do
+    schedule = create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                                 frequency: 'Twice daily', schedule_type: :multiple_daily,
+                                 schedule_config: { 'times' => %w[07:15 19:45] })
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.today.beginning_of_day + 8.hours)
+
+    travel_to Time.zone.today.beginning_of_day + 19.hours + 45.minutes do
+      described_class.perform_now(person.id, :scheduled, '19:45')
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
   it 'does not send scheduled-time reminders for as-needed schedules' do
     create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
                       schedule_type: :prn, frequency: 'As needed', schedule_config: { 'times' => ['07:15'] })
 
     described_class.perform_now(person.id, :scheduled, '07:15')
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'does not send period reminders for schedules without configured times' do
+    create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
+                      frequency: 'Every 6-8 hours', schedule_type: :daily, schedule_config: {},
+                      max_daily_doses: 3, min_hours_between_doses: 6)
+
+    described_class.perform_now(person.id, :afternoon)
 
     expect(PushNotificationService).not_to have_received(:send_to_account)
   end
@@ -65,6 +88,20 @@ RSpec.describe MedicationReminderJob do
       expect(payload[:body]).not_to include('Ibuprofen')
       expect(payload[:body]).not_to include('Paracetamol')
     end
+  end
+
+  it 'does not send period reminders after a medication was taken today even when more doses are allowed' do
+    schedule = create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
+                                 frequency: 'Every 6 hours', schedule_type: :multiple_daily,
+                                 schedule_config: { 'times' => %w[08:00 14:00 20:00] },
+                                 max_daily_doses: 3, min_hours_between_doses: 6)
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.today.beginning_of_day + 8.hours)
+
+    travel_to Time.zone.today.beginning_of_day + 14.hours do
+      described_class.perform_now(person.id, :afternoon)
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 
   it 'does not send period reminders when routine medications have already been taken today' do


### PR DESCRIPTION
## Summary
- suppress reminder notifications for a medication once any same-person dose has been taken in the current dose cycle, even if the take was recorded through another reminder source
- exclude schedules without explicit configured times from reminder notifications
- add regressions for cross-source scheduled notifications, direct routine medications, later same-day scheduled notifications, and period reminders after a morning dose

## Verification
- `task test TEST_FILE=spec/jobs/medication_reminder_job_spec.rb`
- `task test TEST_FILE=spec/jobs/schedule_daily_reminders_job_spec.rb`
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache-med-tracker lefthook run pre-commit`
- `task rubocop`
- `task test`