### PR TITLE
fix: render schedule frequency preview with turbo

### DIFF
--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -67,6 +67,7 @@ module Components
               render_min_hours_field(f)
               render_dose_cycle_field(f)
             end
+            render_frequency_preview
             render_notes_field(f)
           end
         end
@@ -120,6 +121,7 @@ module Components
               render_min_hours_field(nil)
               render_dose_cycle_field(nil)
             end
+            render_frequency_preview
             render_notes_field(nil)
           end
         end
@@ -497,6 +499,16 @@ module Components
             class: 'rounded-shape-sm border-outline-variant bg-surface-container-lowest p-4 ' \
                    'focus:ring-2 focus:ring-primary/10 ' \
                    'focus:border-primary transition-all resize-none'
+          )
+        end
+      end
+
+      def render_frequency_preview
+        div(class: 'md:col-span-2') do
+          render Components::Schedules::FrequencyPreview.new(
+            max_daily_doses: schedule.max_daily_doses,
+            min_hours_between_doses: schedule.min_hours_between_doses,
+            dose_cycle: schedule.dose_cycle
           )
         end
       end

--- a/app/components/schedules/frequency_preview.rb
+++ b/app/components/schedules/frequency_preview.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Components
+  module Schedules
+    class FrequencyPreview < Components::Base
+      include Phlex::Rails::Helpers::TurboFrameTag
+
+      FRAME_ID = 'schedule_frequency_preview'
+
+      attr_reader :max_daily_doses, :min_hours_between_doses, :dose_cycle
+
+      def initialize(max_daily_doses:, min_hours_between_doses:, dose_cycle:)
+        @max_daily_doses = max_daily_doses
+        @min_hours_between_doses = min_hours_between_doses
+        @dose_cycle = dose_cycle
+        super()
+      end
+
+      def view_template
+        turbo_frame_tag(FRAME_ID, data: { schedule_form_target: 'frequencyPreview' }) do
+          render_preview if phrase.present?
+        end
+      end
+
+      private
+
+      def render_preview
+        div(
+          class: 'rounded-shape-sm border border-outline-variant/40 bg-surface-container-low px-4 py-3',
+          data: { testid: 'schedule-frequency-preview' }
+        ) do
+          m3_text(variant: :body_medium, class: 'text-on-surface-variant font-medium') do
+            span(class: 'font-bold text-foreground') { t('schedules.frequency_phrase.preview_label') }
+            plain " #{phrase}"
+          end
+        end
+      end
+
+      def phrase
+        @phrase ||= ScheduleFrequencyPhrase.new(
+          max_daily_doses: max_daily_doses,
+          min_hours_between_doses: min_hours_between_doses,
+          dose_cycle: dose_cycle
+        ).to_s
+      end
+    end
+  end
+end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -9,7 +9,7 @@ class SchedulesController < ApplicationController
   include MedicationWorkflowBackPathable
 
   before_action :redirect_direct_new_schedule, only: :new
-  before_action :set_person, except: %i[index workflow start_workflow]
+  before_action :set_person, except: %i[index workflow start_workflow frequency_preview]
   before_action :set_schedule, only: %i[edit update destroy take_medication]
 
   def index
@@ -26,6 +26,15 @@ class SchedulesController < ApplicationController
   def start_workflow
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
     redirect_to selected_schedule_workflow_path
+  end
+
+  def frequency_preview
+    authorize Schedule.new(person: current_user&.person || Person.new), :create?
+    render plain: ScheduleFrequencyPhrase.new(
+      max_daily_doses: params[:max_daily_doses],
+      min_hours_between_doses: params[:min_hours_between_doses],
+      dose_cycle: params[:dose_cycle]
+    ).to_s
   end
 
   def new

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -30,11 +30,11 @@ class SchedulesController < ApplicationController
 
   def frequency_preview
     authorize Schedule.new(person: current_user&.person || Person.new), :create?
-    render plain: ScheduleFrequencyPhrase.new(
+    render Components::Schedules::FrequencyPreview.new(
       max_daily_doses: params[:max_daily_doses],
       min_hours_between_doses: params[:min_hours_between_doses],
       dose_cycle: params[:dose_cycle]
-    ).to_s
+    ), layout: false
   end
 
   def new

--- a/app/domain/schedule_frequency_phrase.rb
+++ b/app/domain/schedule_frequency_phrase.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class ScheduleFrequencyPhrase
+  CYCLE_KEYS = {
+    'daily' => :day,
+    'weekly' => :week,
+    'monthly' => :month
+  }.freeze
+
+  attr_reader :max_daily_doses, :min_hours_between_doses, :dose_cycle
+
+  def initialize(max_daily_doses:, min_hours_between_doses:, dose_cycle:)
+    @max_daily_doses = normalize_number(max_daily_doses)
+    @min_hours_between_doses = normalize_number(min_hours_between_doses)
+    @dose_cycle = DoseCycle.new(dose_cycle).to_s
+  end
+
+  def to_s
+    parts = []
+    parts << dose_limit_phrase if max_daily_doses.present?
+    parts << spacing_phrase(parts.any?) if min_hours_between_doses.present?
+    parts.join(', ')
+  end
+
+  private
+
+  def dose_limit_phrase
+    if max_daily_doses == 1
+      I18n.t('schedules.frequency_phrase.once_per_cycle', cycle: cycle_name)
+    else
+      I18n.t('schedules.frequency_phrase.up_to_per_cycle', count: format_number(max_daily_doses), cycle: cycle_name)
+    end
+  end
+
+  def spacing_phrase(lowercase)
+    key = lowercase ? :with_minimum_spacing : :minimum_spacing
+    I18n.t("schedules.frequency_phrase.#{key}", duration: duration_phrase)
+  end
+
+  def duration_phrase
+    if whole_minutes?
+      I18n.t('schedules.frequency_phrase.durations.minutes', count: format_number(min_hours_between_doses * 60))
+    else
+      I18n.t('schedules.frequency_phrase.durations.hours', count: format_number(min_hours_between_doses))
+    end
+  end
+
+  def whole_minutes?
+    min_hours_between_doses < 1 && (min_hours_between_doses * 60) == (min_hours_between_doses * 60).to_i
+  end
+
+  def cycle_name
+    I18n.t("schedules.frequency_phrase.cycles.#{CYCLE_KEYS.fetch(dose_cycle)}")
+  end
+
+  def normalize_number(value)
+    return if value.blank?
+
+    BigDecimal(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def format_number(value)
+    value.to_i == value ? value.to_i : value.to_f
+  end
+end

--- a/app/javascript/controllers/schedule_form_controller.js
+++ b/app/javascript/controllers/schedule_form_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
     "submit", "dosageSelect", "medicationSelect", "dosageContent",
     "dosageValue", "dosageTrigger", "frequencyInput",
     "maxDosesInput", "minHoursInput",
-    "doseAmountInput", "doseUnitInput", "sourceDosageOptionIdInput"
+    "doseAmountInput", "doseUnitInput", "sourceDosageOptionIdInput",
+    "frequencyPreview"
   ]
 
   connect() {
@@ -60,6 +61,7 @@ export default class extends Controller {
         this.frequencyInputTarget.value = dosage.frequency
       }
       this.#fillSchedulingDefaults(dosage)
+      this.generateFrequency()
       this.validate()
       return
     }
@@ -73,21 +75,23 @@ export default class extends Controller {
         this.frequencyInputTarget.value = dosage.frequency
       }
       this.#fillSchedulingDefaults(dosage)
+      this.generateFrequency()
     }
     this.validate()
   }
 
-  async generateFrequency() {
+  generateFrequency() {
     const max = parseInt(this.hasMaxDosesInputTarget ? this.maxDosesInputTarget.value : '') || null
     const hours = parseFloat(this.hasMinHoursInputTarget ? this.minHoursInputTarget.value : '') || null
     const cycle = this.#selectedDoseCycleValue()
 
     if (!max && !hours) {
+      this.#clearFrequencyPreview()
       this.validate()
       return
     }
 
-    if (!this.hasFrequencyPreviewUrlValue) {
+    if (!this.hasFrequencyPreviewUrlValue || !this.hasFrequencyPreviewTarget) {
       this.validate()
       return
     }
@@ -97,18 +101,7 @@ export default class extends Controller {
     if (hours) url.searchParams.set('min_hours_between_doses', hours)
     if (cycle) url.searchParams.set('dose_cycle', cycle)
 
-    try {
-      const response = await fetch(url, { headers: { Accept: "text/plain" } })
-      if (!response.ok) return
-
-      const frequency = await response.text()
-      if (frequency && this.hasFrequencyInputTarget) {
-        this.frequencyInputTarget.value = frequency
-      }
-    } catch (error) {
-      console.error('Error loading frequency preview:', error)
-    }
-
+    this.frequencyPreviewTarget.src = url.toString()
     this.validate()
   }
 
@@ -266,6 +259,13 @@ export default class extends Controller {
     if (this.hasDoseAmountInputTarget) this.doseAmountInputTarget.value = ''
     if (this.hasDoseUnitInputTarget) this.doseUnitInputTarget.value = ''
     if (this.hasSourceDosageOptionIdInputTarget) this.sourceDosageOptionIdInputTarget.value = ''
+  }
+
+  #clearFrequencyPreview() {
+    if (!this.hasFrequencyPreviewTarget) return
+
+    this.frequencyPreviewTarget.removeAttribute('src')
+    this.frequencyPreviewTarget.innerHTML = ''
   }
 
   #selectedMedicationId() {

--- a/app/javascript/controllers/schedule_form_controller.js
+++ b/app/javascript/controllers/schedule_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { nextUrl: String, translations: Object, doseOptions: Object, frameId: String }
+  static values = { nextUrl: String, frequencyPreviewUrl: String, translations: Object, doseOptions: Object, frameId: String }
   static targets = [
     "submit", "dosageSelect", "medicationSelect", "dosageContent",
     "dosageValue", "dosageTrigger", "frequencyInput",
@@ -77,7 +77,7 @@ export default class extends Controller {
     this.validate()
   }
 
-  generateFrequency() {
+  async generateFrequency() {
     const max = parseInt(this.hasMaxDosesInputTarget ? this.maxDosesInputTarget.value : '') || null
     const hours = parseFloat(this.hasMinHoursInputTarget ? this.minHoursInputTarget.value : '') || null
     const cycle = this.#selectedDoseCycleValue()
@@ -87,17 +87,28 @@ export default class extends Controller {
       return
     }
 
-    const parts = []
-    if (max && cycle) {
-      parts.push(max === 1 ? this.t('frequencyOncePerCycle').replace('%{cycle}', cycle) : this.t('frequencyUpToPerCycle').replace('%{count}', max).replace('%{cycle}', cycle))
-    } else if (max) {
-      parts.push(max === 1 ? this.t('frequencyOnce') : this.t('frequencyUpTo').replace('%{count}', max))
+    if (!this.hasFrequencyPreviewUrlValue) {
+      this.validate()
+      return
     }
-    if (hours) parts.push(this.t('frequencyAtLeastHours').replace('%{hours}', hours))
 
-    if (parts.length && this.hasFrequencyInputTarget) {
-      this.frequencyInputTarget.value = parts.join(', ')
+    const url = new URL(this.frequencyPreviewUrlValue, window.location.origin)
+    if (max) url.searchParams.set('max_daily_doses', max)
+    if (hours) url.searchParams.set('min_hours_between_doses', hours)
+    if (cycle) url.searchParams.set('dose_cycle', cycle)
+
+    try {
+      const response = await fetch(url, { headers: { Accept: "text/plain" } })
+      if (!response.ok) return
+
+      const frequency = await response.text()
+      if (frequency && this.hasFrequencyInputTarget) {
+        this.frequencyInputTarget.value = frequency
+      }
+    } catch (error) {
+      console.error('Error loading frequency preview:', error)
     }
+
     this.validate()
   }
 

--- a/app/presenters/schedules/form_payload_presenter.rb
+++ b/app/presenters/schedules/form_payload_presenter.rb
@@ -22,8 +22,15 @@ module Schedules
         ).to_h.to_json,
         schedule_form_frame_id_value: frame_id,
         schedule_form_next_url_value: next_url,
+        schedule_form_frequency_preview_url_value: frequency_preview_url,
         schedule_form_translations_value: translations.to_json
       }
+    end
+
+    private
+
+    def frequency_preview_url
+      Rails.application.routes.url_helpers.schedules_frequency_preview_path
     end
   end
 end

--- a/app/services/spec_fixture_loader.rb
+++ b/app/services/spec_fixture_loader.rb
@@ -3,6 +3,20 @@
 # Utility to load RSpec fixtures directly into the database outside the test framework helpers.
 class SpecFixtureLoader
   FIXTURES_PATH = Rails.root.join('spec/fixtures')
+  ACCOUNT_DEPENDENT_TABLES = %w[
+    account_active_session_keys
+    account_identities
+    account_lockouts
+    account_login_change_keys
+    account_login_failures
+    account_otp_keys
+    account_password_reset_keys
+    account_recovery_codes
+    account_remember_keys
+    account_verification_keys
+    account_webauthn_keys
+    account_webauthn_user_ids
+  ].freeze
 
   class << self
     def load(*fixture_names)
@@ -16,6 +30,7 @@ class SpecFixtureLoader
 
   def load
     ActiveRecord::FixtureSet.reset_cache
+    clear_account_dependent_tables
     # Load fixtures - foreign keys are deferrable so order doesn't matter within a transaction
     ActiveRecord::FixtureSet.create_fixtures(FIXTURES_PATH, fixture_names)
   end
@@ -23,4 +38,15 @@ class SpecFixtureLoader
   private
 
   attr_reader :fixture_names
+
+  def clear_account_dependent_tables
+    return unless fixture_names.include?('accounts')
+
+    connection = ActiveRecord::Base.connection
+    ACCOUNT_DEPENDENT_TABLES.each do |table_name|
+      next unless connection.data_source_exists?(table_name)
+
+      connection.delete("DELETE FROM #{connection.quote_table_name(table_name)}")
+    end
+  end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1034,6 +1034,22 @@ cy:
       frequency_once: Unwaith y cylch
       frequency_up_to: Hyd at %{count} gwaith y cylch
       frequency_at_least_hours: o leiaf %{hours} awr ar wahân
+    frequency_phrase:
+      cycles:
+        day: diwrnod
+        week: wythnos
+        month: mis
+      once_per_cycle: Unwaith bob %{cycle}
+      up_to_per_cycle: Hyd at %{count} gwaith bob %{cycle}
+      minimum_spacing: O leiaf %{duration} rhwng dosau
+      with_minimum_spacing: gydag o leiaf %{duration} rhwng dosau
+      durations:
+        hours:
+          one: "%{count} awr"
+          other: "%{count} awr"
+        minutes:
+          one: "%{count} munud"
+          other: "%{count} munud"
     workflow:
       eyebrow: Lif gwaith yr amserlen
       title: Creu amserlen meddyginiaeth

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1035,6 +1035,7 @@ cy:
       frequency_up_to: Hyd at %{count} gwaith y cylch
       frequency_at_least_hours: o leiaf %{hours} awr ar wahân
     frequency_phrase:
+      preview_label: 'Mae hyn yn golygu:'
       cycles:
         day: diwrnod
         week: wythnos

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1022,6 +1022,22 @@ en:
       frequency_once: Once per cycle
       frequency_up_to: Up to %{count} times per cycle
       frequency_at_least_hours: at least %{hours}h apart
+    frequency_phrase:
+      cycles:
+        day: day
+        week: week
+        month: month
+      once_per_cycle: Once per %{cycle}
+      up_to_per_cycle: Up to %{count} times per %{cycle}
+      minimum_spacing: At least %{duration} between doses
+      with_minimum_spacing: with at least %{duration} between doses
+      durations:
+        hours:
+          one: "%{count} hour"
+          other: "%{count} hours"
+        minutes:
+          one: "%{count} minute"
+          other: "%{count} minutes"
     workflow:
       eyebrow: Schedule workflow
       title: Create a medication schedule

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1023,6 +1023,7 @@ en:
       frequency_up_to: Up to %{count} times per cycle
       frequency_at_least_hours: at least %{hours}h apart
     frequency_phrase:
+      preview_label: 'This means:'
       cycles:
         day: day
         week: week

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1015,6 +1015,7 @@ es:
       frequency_up_to: Hasta %{count} veces por ciclo
       frequency_at_least_hours: al menos %{hours}h entre dosis
     frequency_phrase:
+      preview_label: 'Esto significa:'
       cycles:
         day: día
         week: semana

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1014,6 +1014,22 @@ es:
       frequency_once: Una vez por ciclo
       frequency_up_to: Hasta %{count} veces por ciclo
       frequency_at_least_hours: al menos %{hours}h entre dosis
+    frequency_phrase:
+      cycles:
+        day: día
+        week: semana
+        month: mes
+      once_per_cycle: Una vez por %{cycle}
+      up_to_per_cycle: Hasta %{count} veces por %{cycle}
+      minimum_spacing: Al menos %{duration} entre dosis
+      with_minimum_spacing: con al menos %{duration} entre dosis
+      durations:
+        hours:
+          one: "%{count} hora"
+          other: "%{count} horas"
+        minutes:
+          one: "%{count} minuto"
+          other: "%{count} minutos"
     workflow:
       eyebrow: Flujo de programación
       title: Crear una receta de medicamentos

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1009,6 +1009,22 @@ ga:
       frequency_once: Uair amháin sa timthriall
       frequency_up_to: Suas le %{count} uair sa timthriall
       frequency_at_least_hours: ar a laghad %{hours}h óna chéile
+    frequency_phrase:
+      cycles:
+        day: lá
+        week: seachtain
+        month: mí
+      once_per_cycle: Uair amháin sa %{cycle}
+      up_to_per_cycle: Suas le %{count} uair sa %{cycle}
+      minimum_spacing: Ar a laghad %{duration} idir dáileoga
+      with_minimum_spacing: le %{duration} ar a laghad idir dáileoga
+      durations:
+        hours:
+          one: "%{count} uair an chloig"
+          other: "%{count} uair an chloig"
+        minutes:
+          one: "%{count} nóiméad"
+          other: "%{count} nóiméad"
     workflow:
       eyebrow: Sreabhadh oibre sceidealaithe
       title: Cruthaigh sceideal leigheas

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1010,6 +1010,7 @@ ga:
       frequency_up_to: Suas le %{count} uair sa timthriall
       frequency_at_least_hours: ar a laghad %{hours}h óna chéile
     frequency_phrase:
+      preview_label: 'Ciallaíonn sé seo:'
       cycles:
         day: lá
         week: seachtain

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1007,6 +1007,7 @@ pt:
       frequency_up_to: Até %{count} vezes por ciclo
       frequency_at_least_hours: com pelo menos %{hours}h de intervalo
     frequency_phrase:
+      preview_label: 'Isto significa:'
       cycles:
         day: dia
         week: semana

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1006,6 +1006,22 @@ pt:
       frequency_once: Uma vez por ciclo
       frequency_up_to: Até %{count} vezes por ciclo
       frequency_at_least_hours: com pelo menos %{hours}h de intervalo
+    frequency_phrase:
+      cycles:
+        day: dia
+        week: semana
+        month: mês
+      once_per_cycle: Uma vez por %{cycle}
+      up_to_per_cycle: Até %{count} vezes por %{cycle}
+      minimum_spacing: Pelo menos %{duration} entre doses
+      with_minimum_spacing: com pelo menos %{duration} entre doses
+      durations:
+        hours:
+          one: "%{count} hora"
+          other: "%{count} horas"
+        minutes:
+          one: "%{count} minuto"
+          other: "%{count} minutos"
     workflow:
       eyebrow: Fluxo de trabalho da receita
       title: Criar uma receita de medicação

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
 
   get 'schedules/workflow', to: 'schedules#workflow', as: :schedules_workflow
   post 'schedules/workflow', to: 'schedules#start_workflow', as: :start_schedules_workflow
+  get 'schedules/frequency_preview', to: 'schedules#frequency_preview', as: :schedules_frequency_preview
   resources :schedules do
     resources :medication_takes, only: [:create]
   end

--- a/spec/components/schedules/form_translations_spec.rb
+++ b/spec/components/schedules/form_translations_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe Components::Schedules::Form, type: :component do
       'frequencyOncePerCycle' => I18n.t('schedules.form.frequency_once_per_cycle')
     )
   end
+
+  it 'renders the derived frequency preview in a Turbo frame' do
+    schedule.assign_attributes(max_daily_doses: 3, min_hours_between_doses: 12, dose_cycle: 'weekly')
+
+    rendered = render_inline(described_class.new(schedule:, person:, medications: [medication]))
+    preview = rendered.at_css('turbo-frame#schedule_frequency_preview')
+
+    expect(preview).to be_present
+    expect(preview['data-schedule-form-target']).to eq('frequencyPreview')
+    expect(preview.text).to include('This means:')
+    expect(preview.text).to include('Up to 3 times per week, with at least 12 hours between doses')
+  end
 end

--- a/spec/domain/schedule_frequency_phrase_spec.rb
+++ b/spec/domain/schedule_frequency_phrase_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScheduleFrequencyPhrase do
+  describe '#to_s' do
+    it 'describes weekly limits in plain English' do
+      phrase = described_class.new(max_daily_doses: 3, min_hours_between_doses: 12, dose_cycle: 'weekly')
+
+      expect(phrase.to_s).to eq('Up to 3 times per week, with at least 12 hours between doses')
+    end
+
+    it 'uses singular wording for one dose per cycle' do
+      phrase = described_class.new(max_daily_doses: 1, min_hours_between_doses: nil, dose_cycle: 'daily')
+
+      expect(phrase.to_s).to eq('Once per day')
+    end
+
+    it 'describes minimum spacing without a dose limit' do
+      phrase = described_class.new(max_daily_doses: nil, min_hours_between_doses: 6, dose_cycle: 'daily')
+
+      expect(phrase.to_s).to eq('At least 6 hours between doses')
+    end
+  end
+end

--- a/spec/presenters/schedules/form_payload_presenter_spec.rb
+++ b/spec/presenters/schedules/form_payload_presenter_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Schedules::FormPayloadPresenter do
         turbo_stream: true,
         person_type: 'adult',
         schedule_form_frame_id_value: 'schedule_frame',
-        schedule_form_next_url_value: '/people/1/schedules/new'
+        schedule_form_next_url_value: '/people/1/schedules/new',
+        schedule_form_frequency_preview_url_value: '/schedules/frequency_preview'
       )
     end
 

--- a/spec/requests/schedules_workflow_spec.rb
+++ b/spec/requests/schedules_workflow_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Schedules workflow' do
   end
 
   describe 'GET /schedules/frequency_preview' do
-    it 'renders schedule frequency wording from Rails' do
+    it 'renders schedule frequency wording in a Turbo frame from Rails' do
       get schedules_frequency_preview_path, params: {
         max_daily_doses: 3,
         min_hours_between_doses: 12,
@@ -72,8 +72,11 @@ RSpec.describe 'Schedules workflow' do
       }
 
       expect(response).to have_http_status(:ok)
-      expect(response.media_type).to eq('text/plain')
-      expect(response.body).to eq('Up to 3 times per week, with at least 12 hours between doses')
+      expect(response.media_type).to eq('text/html')
+      frame = Nokogiri::HTML.fragment(response.body).at_css('turbo-frame#schedule_frequency_preview')
+      expect(frame).to be_present
+      expect(response.body).to include('This means:')
+      expect(response.body).to include('Up to 3 times per week, with at least 12 hours between doses')
     end
   end
 end

--- a/spec/requests/schedules_workflow_spec.rb
+++ b/spec/requests/schedules_workflow_spec.rb
@@ -62,4 +62,18 @@ RSpec.describe 'Schedules workflow' do
       expect(response.body).to include('Twice daily')
     end
   end
+
+  describe 'GET /schedules/frequency_preview' do
+    it 'renders schedule frequency wording from Rails' do
+      get schedules_frequency_preview_path, params: {
+        max_daily_doses: 3,
+        min_hours_between_doses: 12,
+        dose_cycle: 'weekly'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/plain')
+      expect(response.body).to eq('Up to 3 times per week, with at least 12 hours between doses')
+    end
+  end
 end

--- a/spec/services/spec_fixture_loader_spec.rb
+++ b/spec/services/spec_fixture_loader_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe SpecFixtureLoader do
+  self.use_transactional_tests = false
+
   describe '.load' do
     # This test needs to run outside of transactional fixtures because
     # SpecFixtureLoader is designed for seeding, not for use within tests.

--- a/spec/system/schedules/dose_cycle_defaults_spec.rb
+++ b/spec/system/schedules/dose_cycle_defaults_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe 'Schedule dose cycle defaults' do
 
     fill_in 'Max doses per cycle', with: '3'
 
-    expect(find_field('Frequency').value).to include('weekly')
-    expect(find_field('Frequency').value).to include('12h')
+    expect(page).to have_field('Frequency', with: 'Up to 3 times per week, with at least 12 hours between doses')
   end
 end

--- a/spec/system/schedules/dose_cycle_defaults_spec.rb
+++ b/spec/system/schedules/dose_cycle_defaults_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe 'Schedule dose cycle defaults' do
 
     fill_in 'Max doses per cycle', with: '3'
 
-    expect(page).to have_field('Frequency', with: 'Up to 3 times per week, with at least 12 hours between doses')
+    expect(page).to have_css(
+      '[data-testid="schedule-frequency-preview"]',
+      text: 'This means: Up to 3 times per week, with at least 12 hours between doses'
+    )
   end
 end


### PR DESCRIPTION
## Summary
- render schedule frequency wording as a Rails/Turbo preview instead of rewriting the editable frequency field from JavaScript
- add translated preview labels and coverage for the component, request endpoint, and live schedule flow
- harden fixture loading around Rodauth account-dependent tables so the full suite can run reliably

## Verification
- task rubocop
- git diff --check
- task test