### PR TITLE
fix: Normalize medication dose default handoff on update

### DIFF
--- a/app/controllers/concerns/medication_form_context.rb
+++ b/app/controllers/concerns/medication_form_context.rb
@@ -70,7 +70,7 @@ module MedicationFormContext
         reorder_threshold
         _destroy
       ]
-    ).tap { |permitted| normalize_default_schedule_config(permitted) }
+    ).tap { |permitted| MedicationParamsNormalizer.call(permitted, schedule_config_keys: SCHEDULE_CONFIG_KEYS) }
   end
 
   def onboarding_schedule_params
@@ -86,22 +86,6 @@ module MedicationFormContext
       :schedule_config,
       schedule_config: SCHEDULE_CONFIG_KEYS
     )
-  end
-
-  def normalize_default_schedule_config(permitted)
-    return unless permitted.key?(:default_schedule_config)
-
-    permitted[:default_schedule_config] = normalized_schedule_config_value(permitted[:default_schedule_config])
-  end
-
-  def normalized_schedule_config_value(raw)
-    return {} if raw.blank?
-    return raw.permit(*SCHEDULE_CONFIG_KEYS).to_h if raw.respond_to?(:permit)
-    return raw.to_h if raw.respond_to?(:to_h)
-
-    JSON.parse(raw.to_s)
-  rescue JSON::ParserError
-    {}
   end
 
   def onboarding_builder

--- a/app/services/medication_params_normalizer.rb
+++ b/app/services/medication_params_normalizer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class MedicationParamsNormalizer
+  BOOLEAN = ActiveModel::Type::Boolean.new
+
+  def self.call(permitted, schedule_config_keys:)
+    new(permitted, schedule_config_keys).call
+  end
+
+  def initialize(permitted, schedule_config_keys)
+    @permitted = permitted
+    @schedule_config_keys = schedule_config_keys
+  end
+
+  def call
+    normalize_default_schedule_config
+    normalize_dosage_record_defaults
+  end
+
+  private
+
+  attr_reader :permitted, :schedule_config_keys
+
+  def normalize_default_schedule_config
+    return unless permitted.key?(:default_schedule_config)
+
+    permitted[:default_schedule_config] = normalized_schedule_config_value(permitted[:default_schedule_config])
+  end
+
+  def normalize_dosage_record_defaults
+    dosage_records = permitted[:dosage_records_attributes]
+    return if dosage_records.blank?
+
+    %i[default_for_adults default_for_children].each do |field|
+      normalize_dosage_record_default(dosage_records, field)
+    end
+  end
+
+  def normalize_dosage_record_default(dosage_records, field)
+    selected_records = dosage_records.values
+                                     .reject { |attributes| truthy_param?(attributes[:_destroy]) }
+                                     .select { |attributes| truthy_param?(attributes[field]) }
+    selected_records[0...-1].each { |attributes| attributes[field] = '0' }
+  end
+
+  def normalized_schedule_config_value(raw)
+    return {} if raw.blank?
+    return raw.permit(*schedule_config_keys).to_h if raw.respond_to?(:permit)
+    return raw.to_h if raw.respond_to?(:to_h)
+
+    JSON.parse(raw.to_s)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def truthy_param?(value)
+    BOOLEAN.cast(value)
+  end
+end

--- a/spec/requests/medications_dose_options_update_spec.rb
+++ b/spec/requests/medications_dose_options_update_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medication dose option updates' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  before { sign_in(users(:admin)) }
+
+  it 'replaces the existing child default when a newly added fractional dose is submitted as the child default' do
+    medication = Medication.create!(
+      name: 'Wellbaby Multivitamin drops (Vitabiotics Ltd) 30 ml',
+      friendly_name: 'Wellbaby Multivitamin drops',
+      category: 'Vitamin',
+      location: locations(:home),
+      current_supply: 21,
+      reorder_threshold: 0
+    )
+    existing_dosage = medication.dosage_records.create!(
+      amount: 1.0,
+      unit: 'ml',
+      frequency: 'Once daily',
+      default_for_children: true,
+      default_max_daily_doses: 1,
+      default_min_hours_between_doses: 24,
+      default_dose_cycle: :daily
+    )
+
+    expect do
+      patch medication_path(medication),
+            params: {
+              return_to: medication_path(medication),
+              medication: {
+                name: medication.name,
+                friendly_name: medication.friendly_name,
+                category: medication.category,
+                location_id: medication.location_id,
+                current_supply: '21',
+                reorder_threshold: '0',
+                dosage_records_attributes: {
+                  '0' => {
+                    id: existing_dosage.id,
+                    amount: '1.0',
+                    unit: 'ml',
+                    frequency: 'Once daily',
+                    description: '',
+                    default_for_adults: '0',
+                    default_for_children: '1',
+                    default_max_daily_doses: '1',
+                    default_min_hours_between_doses: '24',
+                    default_dose_cycle: 'daily',
+                    current_supply: '',
+                    reorder_threshold: '',
+                    _destroy: '0'
+                  },
+                  '1' => {
+                    amount: '0.5',
+                    unit: 'ml',
+                    frequency: 'Twice daily',
+                    description: '',
+                    default_for_adults: '0',
+                    default_for_children: '1',
+                    default_max_daily_doses: '2',
+                    default_min_hours_between_doses: '12',
+                    default_dose_cycle: 'daily',
+                    current_supply: '',
+                    reorder_threshold: '',
+                    _destroy: '0'
+                  }
+                }
+              }
+            }
+    end.to change { medication.dosage_records.count }.by(1)
+
+    expect(response).to redirect_to(medication_path(medication))
+    expect(existing_dosage.reload.default_for_children).to be(false)
+    expect(medication.dosage_records.find_by!(amount: BigDecimal('0.5'), unit: 'ml')).to be_default_for_children
+  end
+end


### PR DESCRIPTION
## Summary
- Normalized submitted medication dose params so only the last selected adult/child default stays active before save.
- Moved the param normalization into a small service to keep the controller concern focused.
- Added a regression spec covering the fractional child-default handoff case that was triggering the 500.

## Testing
- `task rubocop` passed.
- `task test` passed, including the new request spec and the full suite.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->