### PR TITLE
🎨 Palette: Fix icon-only button and link ARIA labels

### DIFF
--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -27,14 +27,16 @@ module Components
       def view_template
         Dialog do
           DialogTrigger do
-            m3_button(variant: button_variant, size: button_size, class: button_class) do
+            button_args = { variant: button_variant, size: button_size, class: button_class }
+            button_args[:aria_label] = t('medications.refill_modal.refill_inventory') if icon_only
+
+            m3_button(**button_args) do
               if icon_only
-                render Icons::RefreshCw.new(size: 16)
-                span(class: 'sr-only') { t('medications.refill_modal.refill_inventory') }
+                render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
               else
                 if icon
                   icon_class = button_variant == :outlined ? 'mr-2 text-primary' : 'mr-2'
-                  render icon.new(size: 18, class: icon_class)
+                  render icon.new(size: 18, class: icon_class, aria_hidden: 'true')
                 end
                 span { button_label || t('medications.refill_modal.refill_inventory') }
               end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -28,7 +28,7 @@ module Components
         Dialog do
           DialogTrigger do
             button_args = { variant: button_variant, size: button_size, class: button_class }
-            button_args[:aria_label] = button_label || t('medications.refill_modal.refill_inventory') if icon_only
+            button_args[:aria_label] = button_label || t('medications.refill_modal.refill_inventory')
 
             m3_button(**button_args) do
               if icon_only

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -28,7 +28,7 @@ module Components
         Dialog do
           DialogTrigger do
             button_args = { variant: button_variant, size: button_size, class: button_class }
-            button_args[:aria_label] = t('medications.refill_modal.refill_inventory') if icon_only
+            button_args[:aria_label] = button_label || t('medications.refill_modal.refill_inventory') if icon_only
 
             m3_button(**button_args) do
               if icon_only

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -47,10 +47,10 @@ module Components
             size: :lg,
             class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
                    'hover:text-primary hover:border-primary/50 transition-all',
-            data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" }
+            data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" },
+            aria_label: t('schedules.card.edit', default: 'Edit schedule')
           ) do
-            span(class: 'sr-only') { t('schedules.card.edit', default: 'Edit schedule') }
-            render Icons::Pencil.new(size: 20)
+            render Icons::Pencil.new(size: 20, aria_hidden: 'true')
           end
           render_delete_dialog
         end
@@ -67,9 +67,9 @@ module Components
               m3_button(variant: :text,
                         class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
                                'hover:text-error hover:bg-error/5 transition-all',
-                        data: { testid: "delete-schedule-#{schedule.id}" }) do
-                span(class: 'sr-only') { t('schedules.card.delete', default: 'Delete schedule') }
-                render Icons::Trash.new(size: 20)
+                        data: { testid: "delete-schedule-#{schedule.id}" },
+                        aria_label: t('schedules.card.delete', default: 'Delete schedule')) do
+                render Icons::Trash.new(size: 20, aria_hidden: 'true')
               end
             end
             AlertDialogContent(class: 'rounded-[2rem] border-none shadow-elevation-5 bg-surface-container-high') do


### PR DESCRIPTION
🎨 Palette: Fix icon-only button and link ARIA labels

💡 What
Added `aria_label` prop usage directly to `m3_button` and `m3_link` in `ActionsComponent` (schedules) and `RefillModal` (medications). Removed the previously nested visually hidden `sr-only` spans. Added `aria_hidden: 'true'` to the icon SVGs rendered within them.

🎯 Why
Using standard `aria-label` attributes on button elements is a more direct, semantic, and robust way to provide an accessible name for assistive technology than nesting screen-reader-only spans. Additionally, explicitly marking the icon SVGs as `aria-hidden="true"` ensures they aren't redundantly announced, making the screen reader experience cleaner.

📸 Before/After
No visual changes.

♿ Accessibility
Improves accessibility of icon-only action buttons by moving from `span.sr-only` to direct `aria-label` attribute usage and explicitly hiding purely decorative icons from screen reader APIs.

---
*PR created automatically by Jules for task [9223266218756676791](https://jules.google.com/task/9223266218756676791) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->