### PR TITLE
fix(perf): Memoize person card carer state

### DIFF
--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -25,7 +25,7 @@ module Components
         m3_card_header(class: 'pb-4 pt-8 px-8') do
           div(class: 'flex items-start justify-between') do
             render_person_icon
-            render_needs_carer_badge if person.needs_carer?
+            render_needs_carer_badge if needs_carer?
           end
           div(class: 'space-y-1 mt-6') do
             m3_link(
@@ -122,7 +122,7 @@ module Components
               ) { t('people.card.view_medications') }
             end
 
-            render_assign_carer_link if person.needs_carer? && can_create?(CarerRelationship)
+            render_assign_carer_link if needs_carer? && can_create?(CarerRelationship)
           end
         end
       end
@@ -139,6 +139,12 @@ module Components
       def can_add_medication?
         can_create?(Schedule.new(person: person)) ||
           can_create?(PersonMedication.new(person: person))
+      end
+
+      def needs_carer?
+        return @needs_carer if instance_variable_defined?(:@needs_carer)
+
+        @needs_carer = person.needs_carer?
       end
 
       def render_assign_carer_link

--- a/spec/components/people/person_card_spec.rb
+++ b/spec/components/people/person_card_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Components::People::PersonCard, type: :component do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
   let(:person) do
     build(:person, :dependent_adult, id: 1, name: 'Jane Doe')
   end
@@ -15,5 +17,26 @@ RSpec.describe Components::People::PersonCard, type: :component do
     expect(badge.name).to eq('span')
     expect(badge['class']).to include('border-warning/50'),
                               'Expected badge to use M3 badge tokens'
+  end
+
+  it 'checks carer relationship state once per render' do
+    needs_carer = people(:one)
+    needs_carer.association(:carers).reset
+
+    expect(count_carer_relationship_queries { render_inline(described_class.new(person: needs_carer)) }).to eq(1)
+  end
+
+  def count_carer_relationship_queries(&)
+    count = 0
+
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      count += 1 if sql.include?('"carer_relationships"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
   end
 end


### PR DESCRIPTION
## What changed

- Memoized `Components::People::PersonCard#needs_carer?` for the duration of a card render.
- Updated both the badge and footer action checks to reuse the memoized result.
- Added a component query-count spec for the needs-carer render path.

## Why it was a bottleneck

`PersonCard` called `person.needs_carer?` in both the header and footer. For minors/dependent adults, that predicate checks the `carers` association, which can issue `carer_relationships` SQL each time during a single render.

## Measurement used

- Red: `task test TEST_FILE=spec/components/people/person_card_spec.rb` failed with 2 `carer_relationships` queries for one card render.
- Green: the same focused spec passed with 1 `carer_relationships` query.

## Expected impact

Dependent/minor person cards that need carer assignment avoid one duplicate relationship query per render while preserving the existing UI and authorization behavior.

## Tests run

- `task test TEST_FILE=spec/components/people/person_card_spec.rb`
- `task rubocop`
- `task test`
