### PR TITLE
fix(🎨 Palette): Hide decorative modal icons from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-03-05 - Add Descriptive Placeholders for Better Guidance
 **Learning:** Form fields lacking `placeholder` attributes (such as the Medication form inputs) can cause user friction since it’s not immediately clear what expected format or type of data to provide, especially on larger, empty textareas like `warnings` or `description`. Adding placeholder text does not break existing test locators compared to changing ARIA labels.
 **Action:** When working with forms or input fields via `RubyUI::Input` or `RubyUI::Textarea`, add a corresponding translated placeholder where appropriate to guide users effectively without cluttering the UI with additional helper text.
+## 2024-05-18 - Component icon-only `aria-label` conventions
+**Learning:** When adding `aria_label` to buttons containing icons, the inner icon component must still receive `aria_hidden: 'true'` to prevent the screen reader from announcing "Graphic" or a generic icon name after reading the custom label.
+**Action:** When working with `<Button>` or `<Link>`, default to setting `aria_label` directly on the component rather than nesting an `sr-only` span, AND always pass `aria_hidden: 'true'` to the embedded icon class.

--- a/app/components/medications/adjust_inventory_modal.rb
+++ b/app/components/medications/adjust_inventory_modal.rb
@@ -20,7 +20,7 @@ module Components
         Dialog do
           DialogTrigger do
             m3_button(variant: button_variant, size: button_size, class: button_class) do
-              render Icons::Pencil.new(size: 18, class: 'mr-2 text-primary')
+              render Icons::Pencil.new(size: 18, class: 'mr-2 text-primary', aria_hidden: 'true')
               span { button_label || t('medications.adjust_inventory_modal.adjust_inventory') }
             end
           end

--- a/app/components/medications/inventory_scan_modal.rb
+++ b/app/components/medications/inventory_scan_modal.rb
@@ -13,7 +13,7 @@ module Components
               size: :lg,
               class: 'max-w-full justify-center font-bold text-sm'
             ) do
-              render Icons::Camera.new(size: 20, class: 'mr-2 text-primary')
+              render Icons::Camera.new(size: 20, class: 'mr-2 text-primary', aria_hidden: 'true')
               span { t('medications.index.scan_stock') }
             end
           end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -27,14 +27,15 @@ module Components
       def view_template
         Dialog do
           DialogTrigger do
-            m3_button(variant: button_variant, size: button_size, class: button_class) do
-              if icon_only
-                render Icons::RefreshCw.new(size: 16)
-                span(class: 'sr-only') { t('medications.refill_modal.refill_inventory') }
-              else
+            if icon_only
+              m3_button(variant: button_variant, size: button_size, class: button_class, aria_label: t('medications.refill_modal.refill_inventory')) do
+                render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
+              end
+            else
+              m3_button(variant: button_variant, size: button_size, class: button_class) do
                 if icon
                   icon_class = button_variant == :outlined ? 'mr-2 text-primary' : 'mr-2'
-                  render icon.new(size: 18, class: icon_class)
+                  render icon.new(size: 18, class: icon_class, aria_hidden: 'true')
                 end
                 span { button_label || t('medications.refill_modal.refill_inventory') }
               end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -28,7 +28,12 @@ module Components
         Dialog do
           DialogTrigger do
             if icon_only
-              m3_button(variant: button_variant, size: button_size, class: button_class, aria_label: t('medications.refill_modal.refill_inventory')) do
+              m3_button(
+                variant: button_variant,
+                size: button_size,
+                class: button_class,
+                aria_label: t('medications.refill_modal.refill_inventory')
+              ) do
                 render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
               end
             else

--- a/spec/components/medications/index_view_spec.rb
+++ b/spec/components/medications/index_view_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Components::Medications::IndexView, type: :component do
       policy_stub: Struct.new(:create?, :update?, :refill?, :destroy?).new(false, false, true, false)
     )
 
-    expect(rendered.css('button').map(&:text).join).to include('Restock')
+    expect(rendered.css("button[aria-label='Restock']")).not_to be_empty
     edit_path = Rails.application.routes.url_helpers.edit_medication_path(medication)
 
     expect(rendered.css("a[href^='#{edit_path}']")).to be_empty

--- a/spec/system/medications/refill_inventory_spec.rb
+++ b/spec/system/medications/refill_inventory_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Refill medication inventory' do
 
   it 'shows refill actions on inventory pages' do
     visit medications_path
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
 
     visit location_path(medication.location)
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
 
     visit medication_path(medication)
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
   end
 
   it 'opens medication details from inventory card view action at the top level' do


### PR DESCRIPTION
## 💡 What

Added `aria_hidden: 'true'` to decorative icons within buttons on the Refill, Adjust Inventory, and Inventory Scan modals. Refactored the `RefillModal` icon-only button to use an `aria_label` parameter on the button directly instead of using a child `sr-only` span.

## 🎯 Why

To improve screen reader experience. Previously, screen readers would read the visible text label (or the `sr-only` text), and then also announce the icon as a separate element (e.g., "Graphic"). Hiding decorative icons ensures the UI is spoken exactly as it is presented. Using `aria_label` directly on the button provides a robust accessible name without relying on nested DOM spans.

## 📸 Before/After

No visual changes.

## ♿ Accessibility

* **Screen Readers:** Removed redundant element announcements.
* **Semantic HTML:** Promoted direct labeling on interactive controls over hidden inner text nodes.

---
*PR created automatically by Jules for task [2675890299749915733](https://jules.google.com/task/2675890299749915733) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->