### PR TITLE
refactor: Refactor barcode candidate branching

### DIFF
--- a/app/services/nhs_dmd/barcode_lookup.rb
+++ b/app/services/nhs_dmd/barcode_lookup.rb
@@ -30,8 +30,12 @@ module NhsDmd
       normalized = NhsDmdBarcode.normalize_gtin(barcode)
 
       candidates = [normalized]
-      candidates << normalized.rjust(14, '0') if normalized.length == 13
-      candidates << normalized.delete_prefix('0') if normalized.length == 14 && normalized.start_with?('0')
+      case normalized.length
+      when 13
+        candidates << normalized.rjust(14, '0')
+      when 14
+        candidates << normalized.delete_prefix('0') if normalized.start_with?('0')
+      end
       candidates.uniq
     end
 


### PR DESCRIPTION
## What changed

- Reworked NhsDmd::BarcodeLookup.candidates_for to branch on normalized.length once with a case expression.

## Why this improves maintainability/readability

- Removes the repeated length check called out by RubyCritic while keeping the 13-digit and 14-digit barcode candidate paths explicit.

## How behavior was preserved

- The same normalized barcode value is used.
- The 13-digit path still adds a zero-left-padded 14-digit candidate.
- The zero-prefixed 14-digit path still adds the 13-digit candidate.
- Existing service specs cover both lookup paths.

## Verification commands run

- task rubycritic TARGET=app/services
- task test TEST_FILE=spec/services/nhs_dmd/barcode_lookup_spec.rb
- task rubycritic TARGET=app/services/nhs_dmd/barcode_lookup.rb
- task rubocop
- task test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->