### PR TITLE
feat: Add dose progress and audit context

### DIFF
--- a/app/components/admin/audit_logs/show_view.rb
+++ b/app/components/admin/audit_logs/show_view.rb
@@ -177,25 +177,42 @@ module Components
         end
 
         def medication_take_summary_items
-          take = medication_take_record
-          return [] unless take
+          return [] unless medication_take_record
 
+          medication_take_summary_values.filter_map { |label, value| [label, value] if value.present? }
+        end
+
+        def medication_take_summary_values
           {
-            I18n.t('admin.audit_logs.show.medication') => take.medication&.display_name,
-            I18n.t('admin.audit_logs.show.patient') => take.person&.name,
-            I18n.t('admin.audit_logs.show.dose') => DoseAmount.new(take.dose_amount, take.dose_unit).to_s,
-            I18n.t('admin.audit_logs.show.administered_at') => take.taken_at&.strftime('%Y-%m-%d %H:%M %Z'),
+            I18n.t('admin.audit_logs.show.medication') => medication_take_record.medication&.display_name,
+            I18n.t('admin.audit_logs.show.patient') => medication_take_record.person&.name,
+            I18n.t('admin.audit_logs.show.dose') => medication_take_dose,
+            I18n.t('admin.audit_logs.show.administered_at') => medication_take_administered_at,
             I18n.t('admin.audit_logs.show.logged_by') => user_name,
-            I18n.t('admin.audit_logs.show.stock_source') => take.inventory_medication&.display_name
-          }.filter_map { |label, value| [label, value] if value.present? }
+            I18n.t('admin.audit_logs.show.stock_source') => medication_take_record.inventory_medication&.display_name
+          }
+        end
+
+        def medication_take_dose
+          DoseAmount.new(medication_take_record.dose_amount, medication_take_record.dose_unit).to_s
+        end
+
+        def medication_take_administered_at
+          medication_take_record.taken_at&.strftime('%Y-%m-%d %H:%M %Z')
         end
 
         def medication_take_record
-          return unless version.item_type == 'MedicationTake' && version.item_id.present?
+          return @medication_take_record if defined?(@medication_take_record)
 
+          @medication_take_record = if version.item_type == 'MedicationTake' && version.item_id.present?
+                                      medication_take_relation.find_by(id: version.item_id)
+                                    end
+        end
+
+        def medication_take_relation
           MedicationTake.includes(:taken_from_medication, :taken_from_location,
                                   schedule: %i[medication person],
-                                  person_medication: %i[medication person]).find_by(id: version.item_id)
+                                  person_medication: %i[medication person])
         end
 
         def external_lookup?

--- a/app/components/admin/audit_logs/show_view.rb
+++ b/app/components/admin/audit_logs/show_view.rb
@@ -78,7 +78,8 @@ module Components
         end
 
         def render_event_summary
-          section(class: 'rounded-lg border border-outline-variant bg-surface-container-low p-4') do
+          section(class: 'rounded-lg border border-outline-variant bg-surface-container-low p-4',
+                  data: { testid: event_summary_testid }) do
             h3(class: 'text-sm font-semibold text-foreground') { t('admin.audit_logs.show.event_summary') }
             dl(class: 'mt-4 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2') do
               event_summary_items.each do |label, value|
@@ -86,6 +87,10 @@ module Components
               end
             end
           end
+        end
+
+        def event_summary_testid
+          version.item_type == 'MedicationTake' ? 'audit-log-medication-take-summary' : 'audit-log-event-summary'
         end
 
         def render_detail_item(label, value)
@@ -159,6 +164,7 @@ module Components
         end
 
         def event_summary_items
+          return medication_take_summary_items if medication_take_summary_items.any?
           return [] unless external_lookup_data
 
           {
@@ -168,6 +174,28 @@ module Components
             I18n.t('admin.audit_logs.show.matched_guidance') => external_lookup_data['matched_title'],
             I18n.t('admin.audit_logs.show.matched_url') => external_lookup_data['matched_url']
           }.filter_map { |label, value| [label, value] if value.present? }
+        end
+
+        def medication_take_summary_items
+          take = medication_take_record
+          return [] unless take
+
+          {
+            I18n.t('admin.audit_logs.show.medication') => take.medication&.display_name,
+            I18n.t('admin.audit_logs.show.patient') => take.person&.name,
+            I18n.t('admin.audit_logs.show.dose') => DoseAmount.new(take.dose_amount, take.dose_unit).to_s,
+            I18n.t('admin.audit_logs.show.administered_at') => take.taken_at&.strftime('%Y-%m-%d %H:%M %Z'),
+            I18n.t('admin.audit_logs.show.logged_by') => user_name,
+            I18n.t('admin.audit_logs.show.stock_source') => take.inventory_medication&.display_name
+          }.filter_map { |label, value| [label, value] if value.present? }
+        end
+
+        def medication_take_record
+          return unless version.item_type == 'MedicationTake' && version.item_id.present?
+
+          MedicationTake.includes(:taken_from_medication, :taken_from_location,
+                                  schedule: %i[medication person],
+                                  person_medication: %i[medication person]).find_by(id: version.item_id)
         end
 
         def external_lookup?

--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -27,6 +27,7 @@ module Components
               render_supply_levels
             end
             div(class: 'lg:col-span-2') do
+              render_today_dose_history
               render_health_insights
             end
           end
@@ -326,6 +327,73 @@ module Components
             end
           end
         end
+      end
+
+      def render_today_dose_history
+        history = today_dose_history_by_person
+        return if history.empty?
+
+        section(class: 'space-y-4 pt-4', data: { testid: 'dashboard-today-dose-history' }) do
+          m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
+            t('dashboard.dose_history.title')
+          end
+          div(class: 'space-y-3') do
+            history.each do |person, takes|
+              render_person_dose_history(person, takes)
+            end
+          end
+        end
+      end
+
+      def render_person_dose_history(person, takes)
+        m3_card(
+          variant: :elevated,
+          class: 'rounded-[2rem] border-none bg-surface-container-low p-5 shadow-elevation-1'
+        ) do
+          div(class: 'mb-4 flex items-center gap-3') do
+            render Components::Shared::PersonAvatar.new(person: person, size: :sm)
+            m3_heading(variant: :title_medium, level: 3, class: 'font-black tracking-tight') { person.name }
+          end
+          div(class: 'space-y-2') do
+            takes.each { |take| render_dose_history_row(take) }
+          end
+        end
+      end
+
+      def render_dose_history_row(take)
+        div(class: 'flex items-center justify-between gap-3 rounded-shape-xl bg-surface-container px-4 py-3') do
+          div(class: 'min-w-0') do
+            m3_text(variant: :body_medium, class: 'truncate font-bold text-foreground') do
+              take.medication.display_name
+            end
+            m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium') do
+              DoseAmount.new(take.dose_amount, take.dose_unit).to_s
+            end
+          end
+          span(class: 'shrink-0 text-sm font-black tabular-nums text-primary') do
+            take.taken_at.strftime('%H:%M')
+          end
+        end
+      end
+
+      def today_dose_history_by_person
+        people.each_with_object({}) do |person, history|
+          takes = today_takes_for_person(person)
+          history[person] = takes if takes.any?
+        end
+      end
+
+      def today_takes_for_person(person)
+        rows = routine_tasks_by_person.fetch(person, []) + as_needed_by_person.fetch(person, [])
+        rows.flat_map { |row| row[:today_takes].to_a }
+            .uniq { |take| dose_history_key(take) }
+            .sort_by(&:taken_at)
+      end
+
+      def dose_history_key(take)
+        return [take.class.name, take.id] if take.is_a?(ApplicationRecord) && take.id.present?
+
+        take.object_id
       end
 
       def render_dashboard_insight_content

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -176,7 +176,9 @@ module Components
         return if row[:daily_dose_limit].blank?
 
         limit = row[:daily_dose_limit].to_i
-        div(class: 'mt-2 flex flex-wrap items-center gap-1.5') do
+        div(
+          class: 'mt-2 inline-flex max-w-full items-center gap-2 rounded-shape-full bg-surface-container px-2.5 py-1'
+        ) do
           limit.times do |index|
             span(
               class: dose_pip_classes(index < row[:daily_dose_count].to_i),
@@ -184,16 +186,21 @@ module Components
               aria: { hidden: 'true' }
             )
           end
-          span(class: 'ml-1 text-[11px] font-black uppercase tracking-wide text-on-surface-variant') do
-            t('dashboard.dose_progress.today',
-              count: row[:daily_dose_count].to_i,
-              limit: limit)
+          span(class: 'text-[11px] font-black uppercase tracking-wide text-on-surface-variant') do
+            dose_progress_label(row, limit)
           end
         end
       end
 
+      def dose_progress_label(row, limit)
+        remaining = [limit - row[:daily_dose_count].to_i, 0].max
+        return t('dashboard.dose_progress.complete') if remaining.zero?
+
+        t('dashboard.dose_progress.remaining', count: remaining)
+      end
+
       def dose_pip_classes(filled)
-        base = 'inline-block h-2.5 w-2.5 rounded-shape-full border'
+        base = 'inline-block h-2 w-2 rounded-shape-full border'
         color = filled ? 'border-primary bg-primary' : 'border-outline-variant bg-surface-container-low'
 
         "#{base} #{color}"

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -177,8 +177,8 @@ module Components
 
         limit = row[:daily_dose_limit].to_i
         div(
-          class: 'mt-1.5 grid max-w-full gap-[3px] rounded-shape-full border border-outline-variant/80 ' \
-                 'bg-surface-container-low p-[3px]',
+          class: 'mt-1.5 grid max-w-full gap-1 rounded-shape-full border border-outline-variant/80 ' \
+                 'bg-surface-container-low p-1 shadow-sm',
           style: dose_meter_style(limit),
           role: 'img',
           data: { testid: 'dashboard-dose-meter' },
@@ -195,7 +195,7 @@ module Components
       end
 
       def dose_meter_style(limit)
-        width = ((limit * 18) + ((limit - 1) * 3) + 8).clamp(40, 132)
+        width = ((limit * 22) + ((limit - 1) * 3) + 8).clamp(56, 148)
 
         "grid-template-columns: repeat(#{limit}, minmax(0, 1fr)); width: min(#{width}px, 100%);"
       end
@@ -209,7 +209,7 @@ module Components
       end
 
       def dose_segment_classes(filled)
-        base = 'h-[5px] min-w-0 rounded-shape-full'
+        base = 'h-1.5 min-w-0 rounded-shape-full'
         color = filled ? 'bg-primary' : 'bg-outline-variant/70'
 
         "#{base} #{color}"

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -84,8 +84,7 @@ module Components
               m3_text(variant: :title_medium, class: 'font-bold tracking-tight break-words') do
                 row[:source].medication.display_name
               end
-              m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium') { dose_label(row[:source]) }
-              render_dose_progress(row)
+              render_dose_metadata(row)
             end
           end
           div(class: 'flex shrink-0 items-center gap-2 sm:justify-end') do
@@ -172,13 +171,22 @@ module Components
         end
       end
 
+      def render_dose_metadata(row)
+        div(class: 'mt-1.5 flex flex-col items-start gap-1.5',
+            data: { testid: 'dashboard-dose-metadata' }) do
+          m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium leading-none') do
+            dose_label(row[:source])
+          end
+          render_dose_progress(row)
+        end
+      end
+
       def render_dose_progress(row)
         return if row[:daily_dose_limit].blank?
 
         limit = row[:daily_dose_limit].to_i
         div(
-          class: 'mt-1.5 grid max-w-full gap-1 rounded-shape-full border border-outline-variant/80 ' \
-                 'bg-surface-container-low p-1 shadow-sm',
+          class: 'grid max-w-full shrink-0 gap-1 self-center',
           style: dose_meter_style(limit),
           role: 'img',
           data: { testid: 'dashboard-dose-meter' },
@@ -195,7 +203,7 @@ module Components
       end
 
       def dose_meter_style(limit)
-        width = ((limit * 22) + ((limit - 1) * 3) + 8).clamp(56, 148)
+        width = ((limit * 16) + ((limit - 1) * 4)).clamp(28, 96)
 
         "grid-template-columns: repeat(#{limit}, minmax(0, 1fr)); width: min(#{width}px, 100%);"
       end
@@ -209,7 +217,7 @@ module Components
       end
 
       def dose_segment_classes(filled)
-        base = 'h-1.5 min-w-0 rounded-shape-full'
+        base = 'h-1 min-w-0 rounded-shape-full'
         color = filled ? 'bg-primary' : 'bg-outline-variant/70'
 
         "#{base} #{color}"

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -85,6 +85,7 @@ module Components
                 row[:source].medication.display_name
               end
               m3_text(variant: :body_small, class: 'text-on-surface-variant font-medium') { dose_label(row[:source]) }
+              render_dose_progress(row)
             end
           end
           div(class: 'flex shrink-0 items-center gap-2 sm:justify-end') do
@@ -169,6 +170,33 @@ module Components
         when :out_of_stock then t('dashboard.statuses.out_of_stock')
         else t("dashboard.statuses.#{row[:status]}")
         end
+      end
+
+      def render_dose_progress(row)
+        return if row[:daily_dose_limit].blank?
+
+        limit = row[:daily_dose_limit].to_i
+        div(class: 'mt-2 flex flex-wrap items-center gap-1.5') do
+          limit.times do |index|
+            span(
+              class: dose_pip_classes(index < row[:daily_dose_count].to_i),
+              data: { testid: 'dashboard-dose-pip' },
+              aria: { hidden: 'true' }
+            )
+          end
+          span(class: 'ml-1 text-[11px] font-black uppercase tracking-wide text-on-surface-variant') do
+            t('dashboard.dose_progress.today',
+              count: row[:daily_dose_count].to_i,
+              limit: limit)
+          end
+        end
+      end
+
+      def dose_pip_classes(filled)
+        base = 'inline-block h-2.5 w-2.5 rounded-shape-full border'
+        color = filled ? 'border-primary bg-primary' : 'border-outline-variant bg-surface-container-low'
+
+        "#{base} #{color}"
       end
 
       def cooldown_label(row)

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -177,31 +177,40 @@ module Components
 
         limit = row[:daily_dose_limit].to_i
         div(
-          class: 'mt-2 inline-flex max-w-full items-center gap-2 rounded-shape-full bg-surface-container px-2.5 py-1'
+          class: 'mt-1.5 grid max-w-full gap-[3px] rounded-shape-full border border-outline-variant/80 ' \
+                 'bg-surface-container-low p-[3px]',
+          style: dose_meter_style(limit),
+          role: 'img',
+          data: { testid: 'dashboard-dose-meter' },
+          aria: { label: dose_progress_aria_label(row, limit) }
         ) do
           limit.times do |index|
             span(
-              class: dose_pip_classes(index < row[:daily_dose_count].to_i),
-              data: { testid: 'dashboard-dose-pip' },
+              class: dose_segment_classes(index < row[:daily_dose_count].to_i),
+              data: { testid: 'dashboard-dose-segment' },
               aria: { hidden: 'true' }
             )
-          end
-          span(class: 'text-[11px] font-black uppercase tracking-wide text-on-surface-variant') do
-            dose_progress_label(row, limit)
           end
         end
       end
 
-      def dose_progress_label(row, limit)
-        remaining = [limit - row[:daily_dose_count].to_i, 0].max
-        return t('dashboard.dose_progress.complete') if remaining.zero?
+      def dose_meter_style(limit)
+        width = ((limit * 18) + ((limit - 1) * 3) + 8).clamp(40, 132)
 
-        t('dashboard.dose_progress.remaining', count: remaining)
+        "grid-template-columns: repeat(#{limit}, minmax(0, 1fr)); width: min(#{width}px, 100%);"
       end
 
-      def dose_pip_classes(filled)
-        base = 'inline-block h-2 w-2 rounded-shape-full border'
-        color = filled ? 'border-primary bg-primary' : 'border-outline-variant bg-surface-container-low'
+      def dose_progress_aria_label(row, limit)
+        count = row[:daily_dose_count].to_i
+        given = count.zero? ? 'No doses given today' : "#{count} #{'dose'.pluralize(count)} given today"
+        slots = "#{limit} #{'dose slot'.pluralize(limit)} today"
+
+        "#{given}. #{slots}."
+      end
+
+      def dose_segment_classes(filled)
+        base = 'h-[5px] min-w-0 rounded-shape-full'
+        color = filled ? 'bg-primary' : 'bg-outline-variant/70'
 
         "#{base} #{color}"
       end

--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -210,8 +210,8 @@ module Components
 
       def dose_progress_aria_label(row, limit)
         count = row[:daily_dose_count].to_i
-        given = count.zero? ? 'No doses given today' : "#{count} #{'dose'.pluralize(count)} given today"
-        slots = "#{limit} #{'dose slot'.pluralize(limit)} today"
+        given = t('dashboard.dose_progress.aria_given', count: count)
+        slots = t('dashboard.dose_progress.aria_slots', count: limit)
 
         "#{given}. #{slots}."
       end

--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -90,7 +90,8 @@ module FamilyDashboard
 
       MedicationTake.where(taken_at: range, schedule_id: schedule_ids)
                     .or(MedicationTake.where(taken_at: range, person_medication_id: pm_ids))
-                    .includes(:taken_from_location, :taken_from_medication)
+                    .includes(:taken_from_location, :taken_from_medication,
+                              schedule: :medication, person_medication: :medication)
                     .to_a
     end
 

--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -154,20 +154,21 @@ module FamilyDashboard
         scheduled_at: routine_scheduled_at(source, takes.length),
         taken_at: nil,
         status: MedicationStockSourceResolver.new(user: current_user, source: source).blocked_reason || :upcoming
-      }
+      }.merge(dose_progress_for(takes, expected_routine_doses_for(source)))
     end
 
     def generate_as_needed_rows_for(source, person)
       return [] unless as_needed_source?(source)
 
       status = as_needed_status_for(source)
+      takes = todays_takes(source)
       [{
         person: person,
         source: source,
         scheduled_at: as_needed_scheduled_at(source, status),
         taken_at: nil,
         status: status
-      }]
+      }.merge(dose_progress_for(takes, daily_dose_limit_for(source)))]
     end
 
     def generate_taken_doses(takes, source, person)
@@ -179,8 +180,16 @@ module FamilyDashboard
           taken_at: take.taken_at,
           status: :taken,
           taken_from_location_name: take.inventory_location&.name
-        }
+        }.merge(dose_progress_for(takes, expected_routine_doses_for(source)))
       end
+    end
+
+    def dose_progress_for(takes, limit)
+      {
+        daily_dose_count: takes.size,
+        daily_dose_limit: limit,
+        today_takes: takes.sort_by(&:taken_at)
+      }
     end
 
     def expected_routine_doses_for(source)
@@ -225,6 +234,12 @@ module FamilyDashboard
         cycle: source_cycle(source),
         check_time: Time.current
       )
+    end
+
+    def daily_dose_limit_for(source)
+      return source.effective_max_daily_doses(Date.current) if source.is_a?(Schedule)
+
+      source.max_daily_doses
     end
 
     def source_cycle(source)

--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -138,9 +138,7 @@ module FamilyDashboard
       doses
     end
 
-    def todays_takes(source)
-      source.medication_takes.select { |take| Time.current.all_day.cover?(take.taken_at) }
-    end
+    def todays_takes(source) = source.medication_takes.select { |take| Time.current.all_day.cover?(take.taken_at) }
 
     def upcoming_routine_row?(source)
       expected_doses = expected_routine_doses_for(source)
@@ -185,17 +183,11 @@ module FamilyDashboard
     end
 
     def dose_progress_for(takes, limit)
-      {
-        daily_dose_count: takes.size,
-        daily_dose_limit: limit,
-        today_takes: takes.sort_by(&:taken_at)
-      }
+      { daily_dose_count: takes.size, daily_dose_limit: limit, today_takes: takes.sort_by(&:taken_at) }
     end
 
     def expected_routine_doses_for(source)
-      return expected_schedule_doses_for(source) if source.is_a?(Schedule)
-
-      source.max_daily_doses.presence || 1
+      source.is_a?(Schedule) ? expected_schedule_doses_for(source) : source.max_daily_doses.presence || 1
     end
 
     def expected_schedule_doses_for(schedule)
@@ -237,20 +229,12 @@ module FamilyDashboard
     end
 
     def daily_dose_limit_for(source)
-      return source.effective_max_daily_doses(Date.current) if source.is_a?(Schedule)
-
-      source.max_daily_doses
+      source.is_a?(Schedule) ? source.effective_max_daily_doses(Date.current) : source.max_daily_doses
     end
 
-    def source_cycle(source)
-      DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
-    end
+    def source_cycle(source) = DoseCycle.new(source.respond_to?(:dose_cycle) ? source.dose_cycle : 'daily')
 
-    def as_needed_source?(source)
-      return schedule_as_needed?(source) if source.is_a?(Schedule)
-
-      source.as_needed?
-    end
+    def as_needed_source?(source) = source.is_a?(Schedule) ? schedule_as_needed?(source) : source.as_needed?
 
     def schedule_as_needed?(schedule)
       schedule.schedule_type_prn? || schedule_config_as_needed?(schedule) || frequency_as_needed?(schedule)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -436,6 +436,12 @@ cy:
         matches: Cyfatebiadau
         matched_guidance: Canllaw cyfatebol
         matched_url: URL cyfatebol
+        medication: Meddyginiaeth
+        patient: Claf
+        dose: Dos
+        administered_at: Gweinyddwyd am
+        logged_by: Cofnodwyd gan
+        stock_source: Ffynhonnell stoc
         audit_payload: Llwyth archwilio
         audit_payload_description: Y manylion chwilio strwythuredig a gofnodwyd ar gyfer y digwyddiad hwn
         na: Amh
@@ -1446,6 +1452,10 @@ cy:
     add_schedules_hint: Ychwanegwch bresgripsiynau i'w gweld yma
     dose_taken_at: "%{person} • Cymerwyd am %{time}"
     empty_state: Dim meddyginiaethau wedi'u trefnu ar gyfer heddiw.
+    dose_progress:
+      today: "%{count}/%{limit} dos heddiw"
+    dose_history:
+      title: Dosau blaenorol heddiw
     routine:
       anytime: Unrhyw bryd
       done_short: Wedi gorffen

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1454,6 +1454,13 @@ cy:
     empty_state: Dim meddyginiaethau wedi'u trefnu ar gyfer heddiw.
     dose_progress:
       complete: Wedi cwblhau heddiw
+      aria_given:
+        zero: Dim dosau wedi'u rhoi heddiw
+        one: 1 dos wedi'i roi heddiw
+        other: "%{count} dos wedi'u rhoi heddiw"
+      aria_slots:
+        one: 1 slot dos heddiw
+        other: "%{count} slot dos heddiw"
       remaining:
         one: 1 ar agor heddiw
         other: "%{count} ar agor heddiw"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1453,7 +1453,10 @@ cy:
     dose_taken_at: "%{person} • Cymerwyd am %{time}"
     empty_state: Dim meddyginiaethau wedi'u trefnu ar gyfer heddiw.
     dose_progress:
-      today: "%{count}/%{limit} dos heddiw"
+      complete: Wedi cwblhau heddiw
+      remaining:
+        one: 1 ar agor heddiw
+        other: "%{count} ar agor heddiw"
     dose_history:
       title: Dosau blaenorol heddiw
     routine:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1597,7 +1597,10 @@ en:
     dose_taken_at: "%{person} • Taken at %{time}"
     empty_state: No medications scheduled for today.
     dose_progress:
-      today: "%{count}/%{limit} doses today"
+      complete: Complete today
+      remaining:
+        one: 1 open today
+        other: "%{count} open today"
     dose_history:
       title: Previous Doses Today
     routine:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1598,6 +1598,13 @@ en:
     empty_state: No medications scheduled for today.
     dose_progress:
       complete: Complete today
+      aria_given:
+        zero: No doses given today
+        one: 1 dose given today
+        other: "%{count} doses given today"
+      aria_slots:
+        one: 1 dose slot today
+        other: "%{count} dose slots today"
       remaining:
         one: 1 open today
         other: "%{count} open today"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,12 @@ en:
         matches: Matches
         matched_guidance: Matched guidance
         matched_url: Matched URL
+        medication: Medication
+        patient: Patient
+        dose: Dose
+        administered_at: Administered at
+        logged_by: Logged by
+        stock_source: Stock source
         audit_payload: Audit Payload
         audit_payload_description: The structured lookup details recorded for this event
         na: N/A
@@ -1590,6 +1596,10 @@ en:
     add_schedules_hint: Add schedules to see them here
     dose_taken_at: "%{person} • Taken at %{time}"
     empty_state: No medications scheduled for today.
+    dose_progress:
+      today: "%{count}/%{limit} doses today"
+    dose_history:
+      title: Previous Doses Today
     routine:
       anytime: Anytime
       done_short: Done

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1424,7 +1424,10 @@ es:
       %{person}.'
     empty_state: No hay medicamentos programados para hoy.
     dose_progress:
-      today: "%{count}/%{limit} dosis hoy"
+      complete: Completo hoy
+      remaining:
+        one: 1 disponible hoy
+        other: "%{count} disponibles hoy"
     dose_history:
       title: Dosis anteriores de hoy
     routine:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1425,6 +1425,13 @@ es:
     empty_state: No hay medicamentos programados para hoy.
     dose_progress:
       complete: Completo hoy
+      aria_given:
+        zero: No se han administrado dosis hoy
+        one: 1 dosis administrada hoy
+        other: "%{count} dosis administradas hoy"
+      aria_slots:
+        one: 1 espacio de dosis hoy
+        other: "%{count} espacios de dosis hoy"
       remaining:
         one: 1 disponible hoy
         other: "%{count} disponibles hoy"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -442,6 +442,12 @@ es:
         matches: Coincidencias
         matched_guidance: Guía coincidente
         matched_url: URL coincidente
+        medication: Medicamento
+        patient: Paciente
+        dose: Dosis
+        administered_at: Administrado a las
+        logged_by: Registrado por
+        stock_source: Origen del stock
         audit_payload: Datos de auditoría
         audit_payload_description: Los detalles estructurados de búsqueda registrados para este evento
         na: N/D
@@ -1417,6 +1423,10 @@ es:
     out_of_stock_alert: 'Sin stock: %{medication}. No se pueden registrar dosis para
       %{person}.'
     empty_state: No hay medicamentos programados para hoy.
+    dose_progress:
+      today: "%{count}/%{limit} dosis hoy"
+    dose_history:
+      title: Dosis anteriores de hoy
     routine:
       anytime: En cualquier momento
       done_short: Hecho

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1540,6 +1540,13 @@ ga:
     empty_state: Gan leigheasanna sceidealta inniu.
     dose_progress:
       complete: Críochnaithe inniu
+      aria_given:
+        zero: Níor tugadh aon dáileog inniu
+        one: Tugadh 1 dáileog inniu
+        other: Tugadh %{count} dáileog inniu
+      aria_slots:
+        one: 1 sliotán dáileoige inniu
+        other: "%{count} sliotán dáileoige inniu"
       remaining:
         one: 1 ar fáil inniu
         other: "%{count} ar fáil inniu"

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -1539,7 +1539,10 @@ ga:
     dose_taken_at: "%{person} • Tógtha ag %{time}"
     empty_state: Gan leigheasanna sceidealta inniu.
     dose_progress:
-      today: "%{count}/%{limit} dáileog inniu"
+      complete: Críochnaithe inniu
+      remaining:
+        one: 1 ar fáil inniu
+        other: "%{count} ar fáil inniu"
     dose_history:
       title: Dáileoga roimhe seo inniu
     routine:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -250,6 +250,12 @@ ga:
         matches: Meaitseálacha
         matched_guidance: Treoir mheaitseáilte
         matched_url: URL meaitseáilte
+        medication: Cógas
+        patient: Othar
+        dose: Dáileog
+        administered_at: Tugtha ag
+        logged_by: Taifeadta ag
+        stock_source: Foinse stoic
         audit_payload: Ualach iniúchta
         audit_payload_description: Na sonraí cuardaigh struchtúrtha a taifeadadh don imeacht seo
         na: N/A
@@ -1532,6 +1538,10 @@ ga:
     add_schedules_hint: Cuir oideas leigheasanna leis chun iad a fheiceáil anseo
     dose_taken_at: "%{person} • Tógtha ag %{time}"
     empty_state: Gan leigheasanna sceidealta inniu.
+    dose_progress:
+      today: "%{count}/%{limit} dáileog inniu"
+    dose_history:
+      title: Dáileoga roimhe seo inniu
     routine:
       anytime: Am ar bith
       done_short: Déanta

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -441,6 +441,12 @@ pt:
         matches: Correspondências
         matched_guidance: Orientação correspondente
         matched_url: URL correspondente
+        medication: Medicamento
+        patient: Paciente
+        dose: Dose
+        administered_at: Administrado às
+        logged_by: Registado por
+        stock_source: Origem do stock
         audit_payload: Dados de auditoria
         audit_payload_description: Os detalhes estruturados da pesquisa registados para este evento
         na: N/D
@@ -1623,6 +1629,10 @@ pt:
     add_schedules_hint: Adicione prescrições para vê-las aqui
     dose_taken_at: "%{person} • Tomado às %{time}"
     empty_state: Nenhum medicamento agendado para hoje.
+    dose_progress:
+      today: "%{count}/%{limit} doses hoje"
+    dose_history:
+      title: Doses anteriores de hoje
     routine:
       anytime: A qualquer momento
       done_short: Feito

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1630,7 +1630,10 @@ pt:
     dose_taken_at: "%{person} • Tomado às %{time}"
     empty_state: Nenhum medicamento agendado para hoje.
     dose_progress:
-      today: "%{count}/%{limit} doses hoje"
+      complete: Completo hoje
+      remaining:
+        one: 1 disponível hoje
+        other: "%{count} disponíveis hoje"
     dose_history:
       title: Doses anteriores de hoje
     routine:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1631,6 +1631,13 @@ pt:
     empty_state: Nenhum medicamento agendado para hoje.
     dose_progress:
       complete: Completo hoje
+      aria_given:
+        zero: Nenhuma dose administrada hoje
+        one: 1 dose administrada hoje
+        other: "%{count} doses administradas hoje"
+      aria_slots:
+        one: 1 espaço de dose hoje
+        other: "%{count} espaços de dose hoje"
       remaining:
         one: 1 disponível hoje
         other: "%{count} disponíveis hoje"

--- a/spec/components/admin/audit_logs/show_view_spec.rb
+++ b/spec/components/admin/audit_logs/show_view_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
-  fixtures :accounts, :people, :users, :locations, :location_memberships
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
 
   let(:admin) { users(:admin) }
   let(:person) { people(:john) }
@@ -161,6 +161,34 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
           ['Matched URL', 'https://www.nhs.uk/medicines/paracetamol-for-adults/']
         )
       end
+    end
+  end
+
+  describe 'medication take summary' do
+    it 'promotes medication, patient, administered time, and logger details' do
+      schedule = schedules(:john_paracetamol)
+      schedule.medication.update!(current_supply: 100)
+      PaperTrail.request.whodunnit = admin.id
+      take = MedicationTake.create!(
+        schedule: schedule,
+        taken_at: Time.zone.parse('2026-06-07 12:10:00'),
+        dose_amount: schedule.dose_amount,
+        dose_unit: schedule.dose_unit
+      )
+      version = PaperTrail::Version.where(item_type: 'MedicationTake', item_id: take.id).last
+
+      rendered = render_inline(described_class.new(version: version))
+      summary = rendered.at_css('[data-testid="audit-log-medication-take-summary"]')
+
+      expect(summary).to be_present
+      expect(summary.text).to include('Medication')
+      expect(summary.text).to include(schedule.medication.display_name)
+      expect(summary.text).to include('Patient')
+      expect(summary.text).to include(schedule.person.name)
+      expect(summary.text).to include('Administered at')
+      expect(summary.text).to include('12:10')
+      expect(summary.text).to include('Logged by')
+      expect(summary.text).to include(admin.name)
     end
   end
 end

--- a/spec/components/admin/audit_logs/show_view_spec.rb
+++ b/spec/components/admin/audit_logs/show_view_spec.rb
@@ -165,30 +165,38 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
   end
 
   describe 'medication take summary' do
-    it 'promotes medication, patient, administered time, and logger details' do
-      schedule = schedules(:john_paracetamol)
-      schedule.medication.update!(current_supply: 100)
+    let(:medication_take_schedule) { schedules(:john_paracetamol) }
+    let(:medication_take_version) do
+      medication_take_schedule.medication.update!(current_supply: 100)
       PaperTrail.request.whodunnit = admin.id
       take = MedicationTake.create!(
-        schedule: schedule,
+        schedule: medication_take_schedule,
         taken_at: Time.zone.parse('2026-06-07 12:10:00'),
-        dose_amount: schedule.dose_amount,
-        dose_unit: schedule.dose_unit
+        dose_amount: medication_take_schedule.dose_amount,
+        dose_unit: medication_take_schedule.dose_unit
       )
-      version = PaperTrail::Version.where(item_type: 'MedicationTake', item_id: take.id).last
+      PaperTrail::Version.where(item_type: 'MedicationTake', item_id: take.id).last
+    end
 
-      rendered = render_inline(described_class.new(version: version))
-      summary = rendered.at_css('[data-testid="audit-log-medication-take-summary"]')
+    it 'promotes medication and patient details', :aggregate_failures do
+      expect(medication_take_summary).to be_present
+      expect(medication_take_summary.text).to include('Medication')
+      expect(medication_take_summary.text).to include(medication_take_schedule.medication.display_name)
+      expect(medication_take_summary.text).to include('Patient')
+      expect(medication_take_summary.text).to include(medication_take_schedule.person.name)
+    end
 
-      expect(summary).to be_present
-      expect(summary.text).to include('Medication')
-      expect(summary.text).to include(schedule.medication.display_name)
-      expect(summary.text).to include('Patient')
-      expect(summary.text).to include(schedule.person.name)
-      expect(summary.text).to include('Administered at')
-      expect(summary.text).to include('12:10')
-      expect(summary.text).to include('Logged by')
-      expect(summary.text).to include(admin.name)
+    it 'promotes administered time and logger details', :aggregate_failures do
+      expect(medication_take_summary.text).to include('Administered at')
+      expect(medication_take_summary.text).to include('12:10')
+      expect(medication_take_summary.text).to include('Logged by')
+      expect(medication_take_summary.text).to include(admin.name)
+    end
+
+    def medication_take_summary
+      rendered = render_inline(described_class.new(version: medication_take_version))
+
+      rendered.at_css('[data-testid="audit-log-medication-take-summary"]')
     end
   end
 end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -308,6 +308,39 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
 
       expect(routine_task.text).not_to include('Upcoming')
     end
+
+    it 'renders dose progress pips for routine tasks with daily limits' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter))
+      routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
+
+      expect(routine_task.text).to include('0/1 doses today')
+      expect(routine_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(1)
+    end
+
+    it 'renders dose progress pips for as-needed items with daily limits' do
+      rendered = render_inline(described_class.new(presenter: person_task_presenter))
+      as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
+
+      expect(as_needed_task.text).to include('1/4 doses today')
+      expect(as_needed_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(4)
+    end
+  end
+
+  describe 'today dose history' do
+    it 'renders previous doses grouped by person before Smart Insights' do
+      presenter = person_task_presenter
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+      history = rendered.at_css('[data-testid="dashboard-today-dose-history"]')
+      html = rendered.to_html
+
+      expect(history).to be_present
+      expect(history.text).to include('Previous Doses Today')
+      expect(history.text).to include('John Doe')
+      expect(history.text).to include('Paracetamol')
+      expect(history.text).to include('09:15')
+      expect(html.index('Previous Doses Today')).to be < html.index('Smart Insights')
+    end
   end
 
   describe 'dashboard density' do
@@ -392,17 +425,31 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       source: person_medications(:john_vitamin_d),
       scheduled_at: nil,
       taken_at: nil,
-      status: status
+      status: status,
+      daily_dose_count: 0,
+      daily_dose_limit: 1,
+      today_takes: []
     }
   end
 
   def as_needed_dashboard_row(person)
+    today_take = instance_double(
+      MedicationTake,
+      taken_at: Time.zone.parse('2026-05-05 09:15:00'),
+      medication: medications(:paracetamol),
+      dose_amount: 1000,
+      dose_unit: 'mg'
+    )
+
     {
       person: person,
       source: schedules(:john_paracetamol),
       scheduled_at: Time.current,
       taken_at: nil,
-      status: :available
+      status: :available,
+      daily_dose_count: 1,
+      daily_dose_limit: 4,
+      today_takes: [today_take]
     }
   end
 end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(routine_task.text).not_to include('Upcoming')
     end
 
-    it 'renders a dense dose meter for routine tasks with daily limits' do
+    it 'renders a dense dose meter for routine tasks with daily limits', :aggregate_failures do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
       meter = routine_task.at_css('[data-testid="dashboard-dose-meter"]')
@@ -317,10 +317,12 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(routine_task.text).not_to include('open today')
       expect(routine_task.text).not_to include('0/1 doses today')
       expect(meter['aria-label']).to eq('No doses given today. 1 dose slot today.')
+      expect(meter['style']).to include('width: min(56px, 100%)')
+      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1.5')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(1)
     end
 
-    it 'renders a dense dose meter for as-needed items with daily limits' do
+    it 'renders a dense dose meter for as-needed items with daily limits', :aggregate_failures do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
       meter = as_needed_task.at_css('[data-testid="dashboard-dose-meter"]')
@@ -328,6 +330,8 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(as_needed_task.text).not_to include('open today')
       expect(as_needed_task.text).not_to include('1/4 doses today')
       expect(meter['aria-label']).to eq('1 dose given today. 4 dose slots today.')
+      expect(meter['style']).to include('width: min(105px, 100%)')
+      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1.5')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(4)
     end
   end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -313,7 +313,8 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
 
-      expect(routine_task.text).to include('0/1 doses today')
+      expect(routine_task.text).to include('1 open today')
+      expect(routine_task.text).not_to include('0/1 doses today')
       expect(routine_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(1)
     end
 
@@ -321,13 +322,14 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
 
-      expect(as_needed_task.text).to include('1/4 doses today')
+      expect(as_needed_task.text).to include('3 open today')
+      expect(as_needed_task.text).not_to include('1/4 doses today')
       expect(as_needed_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(4)
     end
   end
 
   describe 'today dose history' do
-    it 'renders previous doses grouped by person before Smart Insights' do
+    it 'renders previous doses grouped by person before Smart Insights', :aggregate_failures do
       presenter = person_task_presenter
 
       rendered = render_inline(described_class.new(presenter: presenter))
@@ -433,14 +435,6 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
   end
 
   def as_needed_dashboard_row(person)
-    today_take = instance_double(
-      MedicationTake,
-      taken_at: Time.zone.parse('2026-05-05 09:15:00'),
-      medication: medications(:paracetamol),
-      dose_amount: 1000,
-      dose_unit: 'mg'
-    )
-
     {
       person: person,
       source: schedules(:john_paracetamol),
@@ -449,7 +443,17 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       status: :available,
       daily_dose_count: 1,
       daily_dose_limit: 4,
-      today_takes: [today_take]
+      today_takes: [dashboard_today_take]
     }
+  end
+
+  def dashboard_today_take
+    instance_double(
+      MedicationTake,
+      taken_at: Time.zone.parse('2026-05-05 09:15:00'),
+      medication: medications(:paracetamol),
+      dose_amount: 1000,
+      dose_unit: 'mg'
+    )
   end
 end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -342,6 +342,21 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(4)
     end
+
+    it 'localizes dose meter aria labels', :aggregate_failures do
+      I18n.with_locale(:es) do
+        rendered = render_inline(described_class.new(presenter: person_task_presenter))
+        routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
+        as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
+
+        expect(routine_task.at_css('[data-testid="dashboard-dose-meter"]')['aria-label']).to(
+          eq('No se han administrado dosis hoy. 1 espacio de dosis hoy.')
+        )
+        expect(as_needed_task.at_css('[data-testid="dashboard-dose-meter"]')['aria-label']).to(
+          eq('1 dosis administrada hoy. 4 espacios de dosis hoy.')
+        )
+      end
+    end
   end
 
   describe 'today dose history' do

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -312,26 +312,34 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
     it 'renders a dense dose meter for routine tasks with daily limits', :aggregate_failures do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
+      metadata = routine_task.at_css('[data-testid="dashboard-dose-metadata"]')
       meter = routine_task.at_css('[data-testid="dashboard-dose-meter"]')
 
       expect(routine_task.text).not_to include('open today')
       expect(routine_task.text).not_to include('0/1 doses today')
+      expect(metadata['class']).to include('mt-1.5 flex flex-col items-start gap-1.5')
       expect(meter['aria-label']).to eq('No doses given today. 1 dose slot today.')
-      expect(meter['style']).to include('width: min(56px, 100%)')
-      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1.5')
+      expect(meter['class']).not_to include('border')
+      expect(meter['class']).not_to include('shadow')
+      expect(meter['style']).to include('width: min(28px, 100%)')
+      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(1)
     end
 
     it 'renders a dense dose meter for as-needed items with daily limits', :aggregate_failures do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
+      metadata = as_needed_task.at_css('[data-testid="dashboard-dose-metadata"]')
       meter = as_needed_task.at_css('[data-testid="dashboard-dose-meter"]')
 
       expect(as_needed_task.text).not_to include('open today')
       expect(as_needed_task.text).not_to include('1/4 doses today')
+      expect(metadata['class']).to include('mt-1.5 flex flex-col items-start gap-1.5')
       expect(meter['aria-label']).to eq('1 dose given today. 4 dose slots today.')
-      expect(meter['style']).to include('width: min(105px, 100%)')
-      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1.5')
+      expect(meter['class']).not_to include('border')
+      expect(meter['class']).not_to include('shadow')
+      expect(meter['style']).to include('width: min(76px, 100%)')
+      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(4)
     end
   end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -309,22 +309,26 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(routine_task.text).not_to include('Upcoming')
     end
 
-    it 'renders dose progress pips for routine tasks with daily limits' do
+    it 'renders a dense dose meter for routine tasks with daily limits' do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       routine_task = rendered.at_css('[data-testid="dashboard-routine-task"]')
+      meter = routine_task.at_css('[data-testid="dashboard-dose-meter"]')
 
-      expect(routine_task.text).to include('1 open today')
+      expect(routine_task.text).not_to include('open today')
       expect(routine_task.text).not_to include('0/1 doses today')
-      expect(routine_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(1)
+      expect(meter['aria-label']).to eq('No doses given today. 1 dose slot today.')
+      expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(1)
     end
 
-    it 'renders dose progress pips for as-needed items with daily limits' do
+    it 'renders a dense dose meter for as-needed items with daily limits' do
       rendered = render_inline(described_class.new(presenter: person_task_presenter))
       as_needed_task = rendered.at_css('[data-testid="dashboard-as-needed-task"]')
+      meter = as_needed_task.at_css('[data-testid="dashboard-dose-meter"]')
 
-      expect(as_needed_task.text).to include('3 open today')
+      expect(as_needed_task.text).not_to include('open today')
       expect(as_needed_task.text).not_to include('1/4 doses today')
-      expect(as_needed_task.css('[data-testid="dashboard-dose-pip"]').count).to eq(4)
+      expect(meter['aria-label']).to eq('1 dose given today. 4 dose slots today.')
+      expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(4)
     end
   end
 

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -127,6 +127,37 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       expect(rows.pluck(:status)).to eq([:max_reached])
     end
 
+    it 'adds daily dose progress to routine and as-needed rows' do
+      travel_to Time.zone.parse('2026-05-05 12:00:00') do
+        routine_medication = create_routine_person_medication
+        prn_schedule = create_prn_schedule(max_daily_doses: 4)
+        MedicationTake.create!(person_medication: routine_medication, taken_at: 1.hour.ago, dose_amount: 500,
+                               dose_unit: 'mg')
+        MedicationTake.create!(schedule: prn_schedule, taken_at: 2.hours.ago, dose_amount: 1000, dose_unit: 'mg')
+
+        query = described_class.new([people(:john)])
+        routine_rows = query.call.select { |row| row[:source] == routine_medication }
+        prn_rows = query.as_needed_by_person.fetch(people(:john)).select { |row| row[:source] == prn_schedule }
+
+        expect(routine_rows.first).to include(daily_dose_count: 1, daily_dose_limit: 1)
+        expect(prn_rows.first).to include(daily_dose_count: 1, daily_dose_limit: 4)
+      end
+    end
+
+    it 'exposes today take history for each source row' do
+      travel_to Time.zone.parse('2026-05-05 12:00:00') do
+        prn_schedule = create_prn_schedule(max_daily_doses: 4)
+        take = MedicationTake.create!(schedule: prn_schedule, taken_at: Time.zone.parse('2026-05-05 09:15:00'),
+                                      dose_amount: 1000, dose_unit: 'mg')
+
+        query = described_class.new([people(:john)])
+        query.call
+        row = query.as_needed_by_person.fetch(people(:john)).find { |candidate| candidate[:source] == prn_schedule }
+
+        expect(row[:today_takes]).to contain_exactly(take)
+      end
+    end
+
     it 'returns doses sorted by scheduled_at' do
       results = query.call
       times = results.pluck(:scheduled_at).compact

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -158,6 +158,24 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
     end
 
+    it 'preloads medication sources for today take history' do
+      travel_to Time.zone.parse('2026-05-05 12:00:00') do
+        routine_medication = create_routine_person_medication
+        prn_schedule = create_prn_schedule(max_daily_doses: 4)
+        MedicationTake.create!(person_medication: routine_medication, taken_at: 1.hour.ago, dose_amount: 500,
+                               dose_unit: 'mg')
+        MedicationTake.create!(schedule: prn_schedule, taken_at: 2.hours.ago, dose_amount: 1000, dose_unit: 'mg')
+
+        query = described_class.new([people(:john)])
+        query.call
+        rows = query.routine_tasks_by_person.fetch(people(:john)) +
+               query.as_needed_by_person.fetch(people(:john))
+        takes = rows.flat_map { |row| row[:today_takes] }
+
+        expect(takes).to all(satisfy { |take| medication_source_preloaded?(take) })
+      end
+    end
+
     it 'returns doses sorted by scheduled_at' do
       results = query.call
       times = results.pluck(:scheduled_at).compact
@@ -356,5 +374,13 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       min_hours_between_doses: 24,
       dose_cycle: :daily
     )
+  end
+
+  def medication_source_preloaded?(take)
+    if take.schedule_id.present?
+      take.association(:schedule).loaded? && take.schedule.association(:medication).loaded?
+    else
+      take.association(:person_medication).loaded? && take.person_medication.association(:medication).loaded?
+    end
   end
 end


### PR DESCRIPTION
## Summary

- add dashboard dose progress metadata for routine and as-needed medications
- render previous doses today per patient before Smart Insights
- replace dose progress copy with a compact dense segmented meter
- enrich medication-take audit log details with readable patient, medication, and logger context

## Verification

- `task rubocop`
- `task test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->