### PR TITLE
feat: Re-implement passkey registration

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -131,6 +131,19 @@ class RodauthMain < Rodauth::Rails::Auth
         end
       end
 
+      def webauthn_key_insert_hash(webauthn_credential)
+        super.merge(
+          nickname: next_webauthn_key_nickname,
+          created_at: Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def next_webauthn_key_nickname
+        index = AccountWebauthnKey.where(account_id: webauthn_account_id).count + 1
+        "Passkey #{index}"
+      end
+
       def invite_only_registration_required?
         AppSettings.invite_only?
       end
@@ -218,6 +231,7 @@ class RodauthMain < Rodauth::Rails::Auth
     webauthn_invalid_webauthn_id_message { I18n.t('sessions.login.passkey_error') }
 
     # Configure WebAuthn table column mappings for Rails conventions
+    webauthn_keys_account_id_column :account_id
     webauthn_user_ids_account_id_column :account_id
 
     # Allow WebAuthn setup without requiring existing MFA

--- a/app/views/profiles/two_factor_card.rb
+++ b/app/views/profiles/two_factor_card.rb
@@ -200,7 +200,7 @@ module Views
             p(class: 'text-sm text-on-surface-variant') { status_text }
           end
           render RubyUI::Link.new(
-            variant: :default,
+            variant: :outlined,
             size: :sm,
             href: setup_path
           ) { setup_text }

--- a/db/migrate/20260608090000_add_defaults_to_account_webauthn_user_id_timestamps.rb
+++ b/db/migrate/20260608090000_add_defaults_to_account_webauthn_user_id_timestamps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDefaultsToAccountWebauthnUserIdTimestamps < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :account_webauthn_user_ids, :created_at, from: nil, to: -> { 'CURRENT_TIMESTAMP' }
+    change_column_default :account_webauthn_user_ids, :updated_at, from: nil, to: -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -116,8 +116,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
 
   create_table "account_webauthn_user_ids", force: :cascade do |t|
     t.bigint "account_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "webauthn_id", null: false
     t.index ["account_id"], name: "index_account_webauthn_user_ids_on_account_id"
     t.index ["webauthn_id"], name: "index_account_webauthn_user_ids_on_webauthn_id", unique: true

--- a/spec/features/authentication/passkey_spec.rb
+++ b/spec/features/authentication/passkey_spec.rb
@@ -63,4 +63,19 @@ RSpec.describe 'PASSKEY-001: WebAuthn/Passkey configuration' do
       'userVerification' => 'required'
     )
   end
+
+  scenario 'passkey keys are scoped to the Rails account id column' do
+    auth = RodauthApp.rodauth.allocate
+
+    expect(auth.webauthn_keys_account_id_column).to eq(:account_id)
+  end
+
+  scenario 'registered passkeys receive a default display name' do
+    auth = RodauthApp.rodauth.allocate
+    credential = Struct.new(:id, :public_key, :sign_count).new('credential-id', 'public-key', 0)
+
+    allow(auth).to receive(:webauthn_account_id).and_return(accounts(:damacus).id)
+
+    expect(auth.send(:webauthn_key_insert_hash, credential)).to include(nickname: 'Passkey 1')
+  end
 end

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include('Generate recovery codes')
       expect(response.body).to include('No passkeys registered')
       expect(response.body).to include('Add a passkey')
+
+      add_passkey_link = response.parsed_body.at_css('a[href="/webauthn-setup"]')
+      expect(add_passkey_link['class']).to include('border-outline')
     end
 
     it 'renders configured two-factor states without a browser round-trip' do

--- a/spec/requests/webauthn_setup_spec.rb
+++ b/spec/requests/webauthn_setup_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webauthn/fake_client'
+
+RSpec.describe 'WebAuthn setup' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:damacus) }
+  let(:account) { user.person.account }
+
+  before do
+    sign_in(user)
+    account.account_webauthn_user_ids.delete_all
+  end
+
+  it 'renders registration options and stores a WebAuthn user id for the account' do
+    expect do
+      get '/webauthn-setup'
+    end.to change { account.account_webauthn_user_ids.reload.count }.from(0).to(1)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('webauthn-setup-form')
+    expect(response.body).to include('Register a Passkey')
+    expect(response.body).not_to include('Unable to initialize passkey registration')
+  end
+
+  it 'registers a passkey from a valid WebAuthn credential' do
+    get '/webauthn-setup'
+
+    document = response.parsed_body
+    challenge = document.at_css('input[name="webauthn_setup_challenge"]')['value']
+    challenge_hmac = document.at_css('input[name="webauthn_setup_challenge_hmac"]')['value']
+    credential = WebAuthn::FakeClient.new(webauthn_origin).create(challenge: challenge, user_verified: true)
+
+    expect do
+      post '/webauthn-setup',
+           params: {
+             password: 'password',
+             webauthn_setup: credential.to_json,
+             webauthn_setup_challenge: challenge,
+             webauthn_setup_challenge_hmac: challenge_hmac
+           }
+    end.to change { account.account_webauthn_keys.reload.count }.by(1)
+
+    expect(account.account_webauthn_keys.last.nickname).to eq('Passkey 1')
+  end
+
+  def webauthn_origin
+    ENV.fetch('APP_URL', 'http://www.example.com')
+  end
+end


### PR DESCRIPTION
## Summary
- enable WebAuthn setup to initialise user ids and register passkey credentials
- persist Rodauth-created passkeys with account scoping, timestamps, and default display names
- align the profile. Add a passkey action with the outlined button styling used by the page

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->