### PR TITLE
fix: Fix passkey removal MFA return flow

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -242,6 +242,7 @@ class RodauthMain < Rodauth::Rails::Auth
     # This fixes the chicken-and-egg problem where users can't set up TOTP
     # because they don't have any 2FA method yet
     two_factor_auth_required_redirect { two_factor_auth_path }
+    two_factor_auth_return_to_requested_location? true
     before_otp_setup_route do
       # Allow OTP setup if user has no 2FA methods configured yet
       # Only require 2FA auth if they already have a method set up

--- a/app/views/rodauth/recovery_auth.rb
+++ b/app/views/rodauth/recovery_auth.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Views
+  module Rodauth
+    class RecoveryAuth < Views::Rodauth::Base
+      def view_template
+        page_layout do
+          render_page_header(
+            title: t('rodauth.views.two_factor_auth.page_title'),
+            subtitle: t('rodauth.views.two_factor_auth.page_subtitle')
+          )
+          form_section
+        end
+      end
+
+      private
+
+      def form_section
+        render_auth_card(title: rodauth.recovery_auth_page_title) do
+          flash_section
+          recovery_auth_form
+        end
+      end
+
+      def flash_section
+        return if flash_message.blank?
+
+        render_m3_alert(flash_message)
+      end
+
+      def flash_message
+        view_context.flash[:alert] || view_context.rodauth.field_error(rodauth.recovery_codes_param)
+      end
+
+      def recovery_auth_form
+        render RubyUI::Form.new(
+          action: rodauth.recovery_auth_path, method: :post,
+          class: 'space-y-6', data_turbo: 'false'
+        ) do
+          additional_tags = rodauth.recovery_auth_additional_form_tags
+          safe(additional_tags) if additional_tags.present?
+          authenticity_token_field
+          recovery_code_field
+          submit_button
+        end
+      end
+
+      def recovery_code_field
+        render_m3_form_field(
+          label: rodauth.recovery_codes_label,
+          input_attrs: {
+            type: :text,
+            name: rodauth.recovery_codes_param,
+            id: 'recovery-code',
+            required: true,
+            autocomplete: 'one-time-code',
+            placeholder: rodauth.recovery_codes_label
+          },
+          error: view_context.rodauth.field_error(rodauth.recovery_codes_param)
+        )
+      end
+
+      def submit_button
+        render_m3_submit_button(rodauth.recovery_auth_button)
+      end
+    end
+  end
+end

--- a/spec/components/views/rodauth/recovery_auth_spec.rb
+++ b/spec/components/views/rodauth/recovery_auth_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Views::Rodauth::RecoveryAuth, type: :component do
+  it 'renders the recovery code authentication form' do
+    rodauth = recovery_auth
+    controller.request.env['rodauth'] = rodauth
+    allow(view_context).to receive_messages(rodauth: rodauth, form_authenticity_token: 'token', flash: {})
+
+    rendered = render_inline(described_class.new)
+
+    expect(rendered.text).to include('Additional authentication required')
+    expect(rendered.text).to include('Recovery Code')
+    expect(rendered.to_html).to include('/recovery-auth')
+    expect(rendered.to_html).to include('recovery-code')
+    expect(rendered.to_html).to include('min-h-screen')
+  end
+
+  def recovery_auth
+    RodauthApp.rodauth.allocate.tap do |rodauth|
+      allow(rodauth).to receive_messages(
+        recovery_auth_path: '/recovery-auth',
+        recovery_auth_page_title: 'Recovery Code',
+        recovery_auth_button: 'Verify code',
+        recovery_auth_additional_form_tags: '',
+        recovery_codes_param: 'recovery-code',
+        recovery_codes_label: 'Recovery Code',
+        field_error: nil
+      )
+    end
+  end
+end

--- a/spec/lib/rodauth_main_spec.rb
+++ b/spec/lib/rodauth_main_spec.rb
@@ -40,4 +40,12 @@ RSpec.describe RodauthMain do
       expect(auth).to have_received(:redirect).with(auth.login_path)
     end
   end
+
+  describe '#two_factor_auth_return_to_requested_location?' do
+    it 'returns users to the protected action after additional authentication' do
+      auth = RodauthApp.rodauth.allocate
+
+      expect(auth.two_factor_auth_return_to_requested_location?).to be true
+    end
+  end
 end

--- a/spec/requests/webauthn_remove_spec.rb
+++ b/spec/requests/webauthn_remove_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'WebAuthn removal' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:damacus) }
+  let(:account) { user.person.account }
+  let(:passkey) do
+    account.account_webauthn_keys.create!(
+      webauthn_id: 'existing-credential-id',
+      public_key: 'existing-public-key',
+      sign_count: 0,
+      nickname: 'Existing Passkey'
+    )
+  end
+
+  before do
+    sign_in(user)
+  end
+
+  it 'removes the selected passkey through Rodauth built-in removal' do
+    passkey
+
+    expect do
+      post '/webauthn-remove',
+           params: {
+             password: 'password',
+             webauthn_remove: 'existing-credential-id'
+           }
+    end.to change { account.account_webauthn_keys.reload.count }.by(-1)
+
+    expect(response).to redirect_to('/')
+  end
+end


### PR DESCRIPTION
## Summary
- enable Rodauth's MFA return-to-requested-location flow so passkey removal resumes at the protected remove form after additional authentication
- add the styled RecoveryAuth view so /recovery-auth matches the app's auth card layout
- cover built-in WebAuthn removal and the recovery-code auth view

## Verification
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->