### PR TITLE
fix: stabilize dose meter styling

### DIFF
--- a/app/components/dashboard/person_task_card.rb
+++ b/app/components/dashboard/person_task_card.rb
@@ -186,15 +186,17 @@ module Components
 
         limit = row[:daily_dose_limit].to_i
         div(
-          class: 'grid max-w-full shrink-0 gap-1 self-center',
+          class: 'grid max-w-full shrink-0',
           style: dose_meter_style(limit),
           role: 'img',
           data: { testid: 'dashboard-dose-meter' },
           aria: { label: dose_progress_aria_label(row, limit) }
         ) do
           limit.times do |index|
+            filled = index < row[:daily_dose_count].to_i
             span(
-              class: dose_segment_classes(index < row[:daily_dose_count].to_i),
+              class: dose_segment_classes,
+              style: dose_segment_style(filled),
               data: { testid: 'dashboard-dose-segment' },
               aria: { hidden: 'true' }
             )
@@ -203,9 +205,15 @@ module Components
       end
 
       def dose_meter_style(limit)
-        width = ((limit * 16) + ((limit - 1) * 4)).clamp(28, 96)
+        width = ((limit * 18) + ((limit - 1) * 4)).clamp(32, 112)
 
-        "grid-template-columns: repeat(#{limit}, minmax(0, 1fr)); width: min(#{width}px, 100%);"
+        [
+          "grid-template-columns: repeat(#{limit}, minmax(0, 1fr))",
+          "width: #{width}px",
+          'max-width: 100%',
+          'gap: 4px',
+          'align-self: flex-start'
+        ].join('; ')
       end
 
       def dose_progress_aria_label(row, limit)
@@ -216,11 +224,14 @@ module Components
         "#{given}. #{slots}."
       end
 
-      def dose_segment_classes(filled)
-        base = 'h-1 min-w-0 rounded-shape-full'
-        color = filled ? 'bg-primary' : 'bg-outline-variant/70'
+      def dose_segment_classes
+        'min-w-0 rounded-shape-full'
+      end
 
-        "#{base} #{color}"
+      def dose_segment_style(filled)
+        color = filled ? 'var(--primary)' : 'var(--outline-variant)'
+
+        "height: 6px; background-color: #{color};"
       end
 
       def cooldown_label(row)

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -319,10 +319,9 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(routine_task.text).not_to include('0/1 doses today')
       expect(metadata['class']).to include('mt-1.5 flex flex-col items-start gap-1.5')
       expect(meter['aria-label']).to eq('No doses given today. 1 dose slot today.')
-      expect(meter['class']).not_to include('border')
-      expect(meter['class']).not_to include('shadow')
-      expect(meter['style']).to include('width: min(28px, 100%)')
-      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1')
+      expect_dense_meter(meter, width: 32)
+      segment = meter.at_css('[data-testid="dashboard-dose-segment"]')
+      expect_dose_segment(segment, background: 'var(--outline-variant)')
       expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(1)
     end
 
@@ -336,11 +335,11 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(as_needed_task.text).not_to include('1/4 doses today')
       expect(metadata['class']).to include('mt-1.5 flex flex-col items-start gap-1.5')
       expect(meter['aria-label']).to eq('1 dose given today. 4 dose slots today.')
-      expect(meter['class']).not_to include('border')
-      expect(meter['class']).not_to include('shadow')
-      expect(meter['style']).to include('width: min(76px, 100%)')
-      expect(meter.at_css('[data-testid="dashboard-dose-segment"]')['class']).to include('h-1')
-      expect(meter.css('[data-testid="dashboard-dose-segment"]').count).to eq(4)
+      expect_dense_meter(meter, width: 84)
+      segments = meter.css('[data-testid="dashboard-dose-segment"]')
+      expect(segments.count).to eq(4)
+      expect_dose_segment(segments.first, background: 'var(--primary)')
+      expect_dose_segment(segments.last, background: 'var(--outline-variant)')
     end
 
     it 'localizes dose meter aria labels', :aggregate_failures do
@@ -486,5 +485,30 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       dose_amount: 1000,
       dose_unit: 'mg'
     )
+  end
+
+  def expect_dense_meter(meter, width:)
+    expect_meter_classes(meter)
+    expect_meter_style(meter, width:)
+  end
+
+  def expect_meter_classes(meter)
+    expect(meter['class']).to include('grid')
+    expect(meter['class']).not_to include('border')
+    expect(meter['class']).not_to include('shadow')
+  end
+
+  def expect_meter_style(meter, width:)
+    expect(meter['style']).to include("width: #{width}px")
+    expect(meter['style']).to include('max-width: 100%')
+    expect(meter['style']).to include('gap: 4px')
+    expect(meter['style']).to include('align-self: flex-start')
+  end
+
+  def expect_dose_segment(segment, background:)
+    expect(segment['style']).to include('height: 6px')
+    expect(segment['style']).to include("background-color: #{background}")
+    expect(segment['class']).not_to include('h-1')
+    expect(segment['class']).not_to include('bg-outline-variant/70')
   end
 end


### PR DESCRIPTION
## Summary
- give dashboard dose meters fixed token-based inline sizing
- move segment fill colors to semantic CSS variables
- update component specs to assert meter width, gap, alignment, and segment styling

## Verification
- task rubocop
- task test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->