### PR TITLE
fix: Memoize audit log user label

### DIFF
--- a/app/components/admin/audit_logs/show_view.rb
+++ b/app/components/admin/audit_logs/show_view.rb
@@ -101,10 +101,15 @@ module Components
         end
 
         def user_name
-          return I18n.t('admin.audit_logs.show.system') if version.whodunnit.blank?
+          return @user_name if defined?(@user_name)
 
-          user = User.find_by(id: version.whodunnit)
-          user ? user.name : "User ##{version.whodunnit}"
+          @user_name = if version.whodunnit.blank?
+                         I18n.t('admin.audit_logs.show.system')
+                       else
+                         user = User.find_by(id: version.whodunnit)
+
+                         user ? user.name : "User ##{version.whodunnit}"
+                       end
         end
 
         def render_changes_section

--- a/spec/components/admin/audit_logs/show_view_spec.rb
+++ b/spec/components/admin/audit_logs/show_view_spec.rb
@@ -207,6 +207,12 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
       expect(payload['logged_by_name']).to eq(admin.name)
     end
 
+    it 'looks up the logged-by user once per render' do
+      version = medication_take_version
+
+      expect(count_user_queries { render_inline(described_class.new(version: version)) }).to eq(1)
+    end
+
     def medication_take_summary
       rendered = render_inline(described_class.new(version: medication_take_version))
 
@@ -216,6 +222,20 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
     def medication_take_payload
       rendered = render_inline(described_class.new(version: medication_take_version))
       JSON.parse(rendered.css('pre code').last.text)
+    end
+
+    def count_user_queries(&)
+      count = 0
+
+      subscriber = lambda do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        count += 1 if sql.include?('"users"') && sql.include?('"users"."id"')
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      count
     end
   end
 end


### PR DESCRIPTION
## What changed
- Memoized `Components::Admin::AuditLogs::ShowView#user_name` for each component render.
- Added a focused component spec that counts logged-by user lookups during medication-take audit detail rendering.

## Why it was a bottleneck
Medication-take audit detail rendering asks for the same logged-by user label from the event summary, raw payload enrichment, and event details. Each call previously performed its own `User.find_by` lookup.

## Measurement used
- Red spec: `task test TEST_FILE=spec/components/admin/audit_logs/show_view_spec.rb` failed with 6 `users` lookups during one render.
- Green spec: the same focused spec now enforces 1 `users` lookup during one render.

## Expected impact
Admin audit-log detail pages avoid duplicate logged-by user queries during a single render, especially for medication-take audit entries that render summary and enriched payload sections.

## Tests run
- `task test TEST_FILE=spec/components/admin/audit_logs/show_view_spec.rb`
- `task rubocop`
- `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->