### PR TITLE
fix: prevent deactivated users from authenticating

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -18,7 +18,10 @@ module ApplicationCable
       account = Account.find_by(id: account_id)
       return unless account
 
-      self.current_user = account.person&.user
+      user = account.person&.user
+      return unless user&.active?
+
+      self.current_user = user
     end
   end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,16 +30,36 @@ module Authentication
   end
 
   def authenticated?
-    rodauth.authenticated?
+    rodauth.authenticated? && active_current_user?
   end
 
   def require_authentication
     rodauth.require_authentication
+    return unless rodauth.logged_in?
+    return if active_current_user?
+
+    reset_inactive_session
   end
 
   def request_authentication
     session[:return_to_after_authenticating] = request.url
     redirect_to rodauth.login_path
+  end
+
+  def active_current_user?
+    current_user&.active?
+  end
+
+  def reset_inactive_session
+    reset_session
+    @current_account = nil
+    @current_user = nil
+
+    redirect_to rodauth.login_path, alert: inactive_account_message, status: :see_other
+  end
+
+  def inactive_account_message
+    t('authentication.inactive_account', default: 'Your account has been deactivated. Please contact an administrator.')
   end
 
   def after_authentication_url

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -170,9 +170,30 @@ class RodauthMain < Rodauth::Rails::Auth
         I18n.t('authentication.invite_only',
                default: 'Registration is by invitation only. Please contact an administrator.')
       end
+
+      def account_active?
+        account_record = Account.find_by(id: account&.[](:id))
+        user = account_record&.person&.user
+
+        account_record.nil? || user.nil? || user.active?
+      end
+
+      def inactive_account_message
+        I18n.t('authentication.inactive_account',
+               default: 'Your account has been deactivated. Please contact an administrator.')
+      end
+    end
+
+    before_login do
+      throw_error(login_param, inactive_account_message) unless account_active?
     end
 
     after_login do
+      unless account_active?
+        clear_session
+        throw_error(login_param, inactive_account_message)
+      end
+
       if param_or_nil('remember')
         remember_login
         audit_auth_token('remember_key', 'created')

--- a/spec/requests/deactivated_users_authentication_spec.rb
+++ b/spec/requests/deactivated_users_authentication_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deactivated user authentication' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:jane) }
+  let(:account) { accounts(:jane_doe) }
+
+  it 'does not establish a Rodauth session for an inactive user' do
+    user.deactivate!
+
+    post '/login', params: { email: account.email, password: 'password' }
+
+    expect(session[:account_id]).to be_blank
+    expect(response).not_to redirect_to(dashboard_path)
+  end
+
+  it 'revokes access for an inactive user with an existing session' do
+    sign_in(user)
+    expect(session[:account_id]).to be_present
+
+    user.deactivate!
+    get dashboard_path
+
+    expect(response).to redirect_to(login_path)
+    expect(session[:account_id]).to be_blank
+  end
+end


### PR DESCRIPTION
### Motivation
- Administrators can mark `User.active = false` to deactivate accounts, but authentication and session handling previously only checked Rodauth `Account` state, allowing deactivated users to remain signed in or log in again via their Rodauth credentials.
- The change ensures that a deactivated `User` cannot authenticate or continue to access the application even when their Rodauth `Account` or session remains valid.

### Description
- Require the resolved `current_user` to be active by updating the `Authentication` concern so `authenticated?` and `require_authentication` enforce `current_user.active?`, and reset the Rails session for inactive accounts with a friendly message.
- Add Rodauth hooks (`before_login` and an `after_login` check) to reject login attempts for accounts whose associated `User` is inactive and to clear a session if an account becomes inactive during the login callbacks.
- Reject Action Cable connections for inactive users by refusing to assign `current_user` when the associated `User` is not active in `ApplicationCable::Connection`.
- Add a request spec `spec/requests/deactivated_users_authentication_spec.rb` that covers (1) login attempts when the `User` is already deactivated, and (2) revocation of access when a logged-in `User` is deactivated after an existing session.

### Testing
- Added request-level RSpec coverage in `spec/requests/deactivated_users_authentication_spec.rb` (new file) that asserts inactive users cannot establish Rodauth sessions and that existing sessions are reset after deactivation.
- Ran `git diff --check` and other local static checks which reported no diff errors and the modified files parse cleanly in this workspace.
- Attempted to run `bundle exec rspec spec/requests/deactivated_users_authentication_spec.rb` and `bundle check`, but test execution was blocked by the environment attempting to install Ruby 4.0.4 via `mise` (the install failed while fetching `ruby-build`), so the specs could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b906d308483229a2a48bcb85de06d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->