### PR TITLE
fix(timeline): scope refresh streams to authorized records

### DIFF
--- a/app/controllers/concerns/timeline_refreshable.rb
+++ b/app/controllers/concerns/timeline_refreshable.rb
@@ -45,7 +45,12 @@ module TimelineRefreshable
   end
 
   def other_timeline_streams(taken_source, medication)
-    related_sources = MedicationTimelineQuery.new(medication: medication, excluding: taken_source).call
+    related_sources = MedicationTimelineQuery.new(
+      medication: medication,
+      excluding: taken_source,
+      schedules_scope: policy_scope(Schedule),
+      person_medications_scope: policy_scope(PersonMedication)
+    ).call
     streams = []
 
     related_sources.schedules.each do |p|

--- a/app/services/medication_timeline_query.rb
+++ b/app/services/medication_timeline_query.rb
@@ -3,11 +3,14 @@
 class MedicationTimelineQuery
   Result = Data.define(:schedules, :person_medications)
 
-  attr_reader :medication, :excluding
+  attr_reader :medication, :excluding, :schedules_scope, :person_medications_scope
 
-  def initialize(medication:, excluding: nil)
+  def initialize(medication:, excluding: nil, schedules_scope: Schedule.all,
+                 person_medications_scope: PersonMedication.all)
     @medication = medication
     @excluding = excluding
+    @schedules_scope = schedules_scope
+    @person_medications_scope = person_medications_scope
   end
 
   def call
@@ -20,12 +23,12 @@ class MedicationTimelineQuery
   private
 
   def schedules
-    relation = Schedule.active.where(medication: medication).includes(:person, :medication)
+    relation = schedules_scope.active.where(medication: medication).includes(:person, :medication)
     excluding.is_a?(Schedule) ? relation.where.not(id: excluding.id) : relation
   end
 
   def person_medications
-    relation = PersonMedication.active.where(medication: medication).includes(:person, :medication)
+    relation = person_medications_scope.active.where(medication: medication).includes(:person, :medication)
     excluding.is_a?(PersonMedication) ? relation.where.not(id: excluding.id) : relation
   end
 end

--- a/spec/requests/timeline_refresh_spec.rb
+++ b/spec/requests/timeline_refresh_spec.rb
@@ -49,6 +49,30 @@ RSpec.describe 'Timeline refresh after taking medication' do
 
       expect(response.body).to include('Taken')
     end
+
+    it 'does not include unauthorized same-medication timeline items in the response' do
+      unauthorized_schedule = schedules(:john_paracetamol)
+      child_paracetamol = Schedule.create!(
+        person: person,
+        medication: medication,
+        dose_amount: 250,
+        dose_unit: 'mg',
+        start_date: Time.zone.today - 1.day,
+        end_date: Time.zone.today + 30.days,
+        max_daily_doses: 4,
+        min_hours_between_doses: 1
+      )
+
+      scoped_schedules = SchedulePolicy::Scope.new(users(:carer), Schedule.all).resolve
+      expect(scoped_schedules).not_to include(unauthorized_schedule)
+
+      post take_medication_person_schedule_path(person, child_paracetamol),
+           headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response.body).to include("timeline_schedule_#{child_paracetamol.id}")
+      expect(response.body).not_to include("timeline_schedule_#{unauthorized_schedule.id}")
+      expect(response.body).not_to include('John Doe')
+    end
   end
 
   describe 'POST take_medication for a person_medication (turbo_stream)' do

--- a/spec/services/medication_timeline_query_spec.rb
+++ b/spec/services/medication_timeline_query_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe MedicationTimelineQuery do
       expect(result.schedules).not_to include(paused_schedule)
       expect(result.person_medications).not_to include(paused_person_medication)
     end
+
+    it 'limits results to provided authorization scopes' do
+      medication = create(:medication)
+      authorized_person = create(:person)
+      unauthorized_person = create(:person)
+      authorized_schedule = create(:schedule, person: authorized_person, medication: medication)
+      authorized_person_medication = create(:person_medication, person: authorized_person, medication: medication)
+      create(:schedule, person: unauthorized_person, medication: medication)
+      create(:person_medication, person: unauthorized_person, medication: medication)
+
+      result = described_class.new(
+        medication: medication,
+        schedules_scope: Schedule.where(person: authorized_person),
+        person_medications_scope: PersonMedication.where(person: authorized_person)
+      ).call
+
+      expect(result.schedules).to contain_exactly(authorized_schedule)
+      expect(result.person_medications).to contain_exactly(authorized_person_medication)
+    end
   end
 
   def create_timeline_data_for(medication:, other_medication:)


### PR DESCRIPTION
### Motivation
- The timeline refresh fan-out previously queried all `Schedule` and `PersonMedication` records for the same medication and rendered Turbo Stream replacements globally, bypassing Pundit scopes and leaking other patients' PHI.

### Description
- Pass `policy_scope(Schedule)` and `policy_scope(PersonMedication)` into the timeline fan-out so only authorized records are considered in refresh streams (`app/controllers/concerns/timeline_refreshable.rb`).
- Update `MedicationTimelineQuery` to accept caller-provided `schedules_scope` and `person_medications_scope` (defaults preserve prior behavior) and use those scopes for its queries (`app/services/medication_timeline_query.rb`).
- Add a service spec asserting `MedicationTimelineQuery` respects provided scopes (`spec/services/medication_timeline_query_spec.rb`).
- Add a request spec regression that ensures a carer’s timeline refresh response does not include an unauthorized patient’s schedule or name (`spec/requests/timeline_refresh_spec.rb`).

### Testing
- Ran `git diff --check` to validate whitespace and basic diff hygiene (passed).
- Added/updated specs: `spec/services/medication_timeline_query_spec.rb` and `spec/requests/timeline_refresh_spec.rb`, but running `bundle exec rspec spec/services/medication_timeline_query_spec.rb spec/requests/timeline_refresh_spec.rb` in this environment failed because the toolchain attempted to install `ruby@4.0.4` via `mise` and the installation failed (network/fetch error), so RSpec could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b7e76f018832287cc9fa54a70fd5f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->