### PR TITLE
fix: restrict location inventory access

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,6 +4,7 @@ class LocationsController < ApplicationController
   before_action :set_location, only: %i[show edit update destroy]
 
   def index
+    authorize Location
     render locations_index_view
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -107,10 +107,27 @@ class Person < ApplicationRecord
       return
     end
 
-    home = Location.find_or_create_by!(name: 'Home') do |l|
-      l.description = 'Primary home location'
+    location_memberships.build(location: default_personal_location)
+  end
+
+  def default_personal_location
+    Location.create!(
+      name: unique_default_location_name,
+      description: 'Primary home location'
+    )
+  end
+
+  def unique_default_location_name
+    base_name = "#{name}'s Home"
+    candidate = base_name
+    suffix = 2
+
+    while Location.where('lower(name) = ?', candidate.downcase).exists?
+      candidate = "#{base_name} #{suffix}"
+      suffix += 1
     end
-    location_memberships.build(location: home)
+
+    candidate
   end
 
   def set_capacity_from_person_type

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -2,13 +2,11 @@
 
 class LocationPolicy < ApplicationPolicy
   def index?
-    user.present?
+    admin_or_clinician?
   end
 
   def show?
-    return false unless user
-
-    admin_or_clinician? || accessible_location_ids.include?(record.id)
+    admin_or_clinician?
   end
 
   def create?

--- a/db/migrate/20260223221637_backfill_default_location.rb
+++ b/db/migrate/20260223221637_backfill_default_location.rb
@@ -2,26 +2,43 @@
 
 class BackfillDefaultLocation < ActiveRecord::Migration[8.1]
   def up
-    location = Location.find_or_create_by!(name: 'Home') do |loc|
-      loc.description = 'Default home location'
-    end
+    default_location = Location.create!(
+      name: unique_home_location_name('Medication'),
+      description: 'Default medication location'
+    )
 
-    Medicine.where(location_id: nil).update_all(location_id: location.id) # rubocop:disable Rails/SkipsModelValidations
+    Medicine.where(location_id: nil).update_all(location_id: default_location.id) # rubocop:disable Rails/SkipsModelValidations
 
     person_ids = Prescription.distinct.pluck(:person_id) |
                  PersonMedicine.distinct.pluck(:person_id)
 
     person_ids.each do |person_id|
+      person = Person.find(person_id)
+      location = Location.create!(
+        name: unique_home_location_name(person.name),
+        description: 'Primary home location'
+      )
       LocationMembership.find_or_create_by!(location: location, person_id: person_id)
     end
   end
 
   def down
-    location = Location.find_by(name: 'Home')
-    return unless location
+    # No-op: these isolated default locations may have been selected for later
+    # medication inventory, so do not delete them during rollback.
+  end
 
-    LocationMembership.where(location: location).delete_all
-    Medicine.where(location: location).update_all(location_id: nil) # rubocop:disable Rails/SkipsModelValidations
-    location.destroy
+  private
+
+  def unique_home_location_name(owner_name)
+    base_name = "#{owner_name}'s Home"
+    candidate = base_name
+    suffix = 2
+
+    while Location.where('lower(name) = ?', candidate.downcase).exists?
+      candidate = "#{base_name} #{suffix}"
+      suffix += 1
+    end
+
+    candidate
   end
 end

--- a/db/migrate/20260225105418_ensure_everyone_has_home_location.rb
+++ b/db/migrate/20260225105418_ensure_everyone_has_home_location.rb
@@ -2,19 +2,37 @@
 
 class EnsureEveryoneHasHomeLocation < ActiveRecord::Migration[8.1]
   def up
-    location = Location.find_or_create_by!(name: 'Home') do |loc|
-      loc.description = 'Primary home location'
-    end
-
-    # Find people who don't have any location membership
+    # Find people who don't have any location membership and give each one an
+    # isolated default location. Sharing a single global "Home" location would
+    # collapse the location boundary used by inventory authorization.
     people_without_location = Person.where.not(id: LocationMembership.select(:person_id))
 
-    people_without_location.each do |person|
+    people_without_location.find_each do |person|
+      location = Location.create!(
+        name: unique_home_location_name(person.name),
+        description: 'Primary home location'
+      )
       LocationMembership.find_or_create_by!(location: location, person: person)
     end
   end
 
   def down
-    # No-op: we don't want to remove memberships that might have been intentional
+    # No-op: dropping memberships/locations created here could remove locations
+    # that have since been used for medication inventory.
+  end
+
+  private
+
+  def unique_home_location_name(person_name)
+    base_name = "#{person_name}'s Home"
+    candidate = base_name
+    suffix = 2
+
+    while Location.where('lower(name) = ?', candidate.downcase).exists?
+      candidate = "#{base_name} #{suffix}"
+      suffix += 1
+    end
+
+    candidate
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -130,6 +130,21 @@ RSpec.describe Person do
   describe 'default location assignment' do
     let(:school_location) { Location.create!(name: 'Spec School', description: 'School') }
 
+
+    it 'creates an isolated personal home when no primary location is provided' do
+      carer = described_class.create!(name: 'Default Location Carer', date_of_birth: 40.years.ago, person_type: :adult)
+      child = described_class.new(
+        name: 'Default Location Child',
+        date_of_birth: 8.years.ago,
+        person_type: :minor
+      )
+      child.carer_relationships.build(carer: carer, relationship_type: 'parent')
+
+      child.save!
+
+      expect(child.locations.map(&:name)).to contain_exactly("Default Location Child's Home")
+    end
+
     it 'assigns primary location when provided' do
       person_with_primary_location = described_class.new(
         name: 'Primary Location Child',

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe LocationPolicy, type: :policy do
   describe 'for carer' do
     let(:current_user) { users(:carer) }
 
-    it 'permits viewing only' do
+    it 'forbids direct location pages' do
       aggregate_failures do
-        expect(policy.index?).to be true
-        expect(policy.show?).to be true
+        expect(policy.index?).to be false
+        expect(policy.show?).to be false
         expect(policy.create?).to be false
         expect(policy.destroy?).to be false
       end
@@ -107,16 +107,16 @@ RSpec.describe LocationPolicy, type: :policy do
   describe 'for parent' do
     let(:current_user) { users(:parent) }
 
-    it 'permits viewing only' do
+    it 'forbids direct location pages' do
       aggregate_failures do
-        expect(policy.index?).to be true
-        expect(policy.show?).to be true
+        expect(policy.index?).to be false
+        expect(policy.show?).to be false
         expect(policy.create?).to be false
         expect(policy.destroy?).to be false
       end
     end
 
-    it 'permits viewing a dependent adult patient location' do
+    it 'forbids direct viewing of a dependent adult patient location' do
       dependent_adult = Person.new(
         name: 'Dependent Adult',
         date_of_birth: 70.years.ago.to_date,
@@ -127,7 +127,7 @@ RSpec.describe LocationPolicy, type: :policy do
       dependent_adult.carer_relationships.build(carer: current_user.person, relationship_type: :parent, active: true)
       dependent_adult.save!
 
-      expect(described_class.new(current_user, locations(:school)).show?).to be true
+      expect(described_class.new(current_user, locations(:school)).show?).to be false
     end
   end
 

--- a/spec/policies/medication_policy_spec.rb
+++ b/spec/policies/medication_policy_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe MedicationPolicy, type: :policy do
         expect(policy.finder?).to be true
       end
     end
+
+    it 'forbids creating medication at an inaccessible location' do
+      foreign_location = Location.create!(name: 'Foreign Parent Policy Location')
+      foreign_medication = Medication.new(name: 'Foreign Stock', location: foreign_location)
+
+      expect(described_class.new(current_user, foreign_medication).create?).to be false
+    end
   end
 
   describe 'for patient (carer role managing own care)' do

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -30,21 +30,9 @@ RSpec.describe 'Locations' do
 
       before { post '/login', params: { email: carer.email_address, password: 'password' } }
 
-      it 'returns success with empty list' do
+      it 'redirects away from direct location index access' do
         get locations_path
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    context 'when authenticated as carer with household locations' do
-      let(:carer) { users(:carer) }
-
-      before { post '/login', params: { email: carer.email_address, password: 'password' } }
-
-      it 'renders only accessible locations' do
-        get locations_path
-        expect(response.body).to include('Home')
-        expect(response.body).not_to include('School')
+        expect(response).to redirect_to(root_path)
       end
     end
   end
@@ -68,9 +56,9 @@ RSpec.describe 'Locations' do
 
       before { post '/login', params: { email: carer.email_address, password: 'password' } }
 
-      it 'returns HTTP success' do
+      it 'redirects away from direct location detail access' do
         get location_path(location)
-        expect(response).to have_http_status(:success)
+        expect(response).to redirect_to(root_path)
       end
     end
 


### PR DESCRIPTION
### Motivation
- Prevent low-privileged authenticated users from enumerating locations and viewing sensitive membership and medication inventory data via the web UI/API. 
- Prevent assignment of inventory to locations that a requester should not control when creating medications. 
- Avoid collapsing location boundaries by creating a single global `Home` location for unrelated people during backfills and person creation.

### Description
- Tighten `LocationPolicy` so `index?` and `show?` require `admin_or_clinician?` (admins, doctors, nurses) while preserving the scoped resolution for other flows. (`app/policies/location_policy.rb`)
- Explicitly authorize the web locations index action with `authorize Location` in `LocationsController#index` to enforce the updated policy check. (`app/controllers/locations_controller.rb`)
- Replace the shared global `Home` default assignment with per-person isolated default locations by adding `default_personal_location` and `unique_default_location_name` helpers in `Person#assign_default_location`. (`app/models/person.rb`)
- Update two backfill migrations to create isolated default locations instead of reusing/creating a single global `Home`, and make them idempotent/no-op on down to avoid removing locations used for inventory. (`db/migrate/20260225105418_ensure_everyone_has_home_location.rb`, `db/migrate/20260223221637_backfill_default_location.rb`)
- Add/adjust regression specs to assert denied direct location index/show access for low-privileged users, prevent parents from creating medications at inaccessible locations, and verify isolated default-location assignment. (`spec/policies/location_policy_spec.rb`, `spec/policies/medication_policy_spec.rb`, `spec/models/person_spec.rb`, `spec/requests/locations_spec.rb`)

### Testing
- Ran `git diff --check` to validate no whitespace/formatting errors and it passed.
- Attempted to run targeted specs with `bundle exec rspec spec/policies/location_policy_spec.rb spec/policies/medication_policy_spec.rb spec/models/person_spec.rb spec/requests/locations_spec.rb`, but the test run was blocked because the environment attempted to install Ruby via `mise` (Ruby 4.0.4) and could not fetch the required build metadata; therefore the specs could not be executed here. 
- Static inspection and existing unit tests in the repository were reviewed and the changed policies/controllers/models align with the intended authorization/scoping design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6f0e23a083229e35f12668d57564)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->