### PR TITLE
Add dependent access request workflow (model, controllers, policy, routes)

### DIFF
--- a/app/controllers/admin/dependent_access_requests_controller.rb
+++ b/app/controllers/admin/dependent_access_requests_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Admin
+  # Reviews parent requests for access to dependents.
+  class DependentAccessRequestsController < ApplicationController
+    def index
+      authorize DependentAccessRequest
+      requests = policy_scope(DependentAccessRequest).pending.recent_first.includes(:requester, :carer, :patient)
+
+      render plain: requests.map { |request| request_summary(request) }.join("\n")
+    end
+
+    def approve
+      request_record = policy_scope(DependentAccessRequest).find(params.expect(:id))
+      authorize request_record
+      request_record.approve!(reviewer: current_user)
+
+      redirect_to admin_dependent_access_requests_path,
+                  notice: t('admin.dependent_access_requests.approved', default: 'Dependent access request approved.')
+    end
+
+    def reject
+      request_record = policy_scope(DependentAccessRequest).find(params.expect(:id))
+      authorize request_record
+      request_record.reject!(reviewer: current_user)
+
+      redirect_to admin_dependent_access_requests_path,
+                  notice: t('admin.dependent_access_requests.rejected', default: 'Dependent access request rejected.')
+    end
+
+    private
+
+    def request_summary(request)
+      "##{request.id}: #{request.carer.name} requested access to #{request.patient.name}"
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -226,21 +226,24 @@ module Admin
     end
 
     def user_params
-      params.expect(
-        user: [
-          :email_address,
-          :password,
-          :password_confirmation,
-          :role,
-          {
-            dependent_ids: [],
-            person_attributes: [:id, :name, :date_of_birth, { location_ids: [] }]
-          }
-        ]
-      )
+      params.expect(user: permitted_user_attributes)
+    end
+
+    def permitted_user_attributes
+      attributes = %i[email_address password password_confirmation]
+      attributes << :role if current_user.administrator?
+      attributes << dependent_assignment_attributes
+      attributes
+    end
+
+    def dependent_assignment_attributes
+      attributes = { person_attributes: [:id, :name, :date_of_birth, { location_ids: [] }] }
+      attributes[:dependent_ids] = [] if current_user.administrator?
+      attributes
     end
 
     def assign_dependents
+      return unless current_user.administrator?
       return unless DependentRelationshipAssigner.relationship_type_for(@user)
 
       DependentRelationshipAssigner.new(

--- a/app/controllers/people/dependent_access_requests_controller.rb
+++ b/app/controllers/people/dependent_access_requests_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module People
+  # Allows parents to request administrator approval for dependent access.
+  class DependentAccessRequestsController < ApplicationController
+    def create
+      patient = Person.find(params.expect(:person_id))
+      request_record = DependentAccessRequest.new(
+        requester: current_user,
+        carer: current_user.person,
+        patient: patient,
+        relationship_type: 'parent'
+      )
+      authorize request_record
+
+      if request_record.save
+        redirect_to dashboard_path,
+                    notice: t('dependent_access_requests.created',
+                              default: 'Access request sent for administrator approval.')
+      else
+        redirect_to dashboard_path, alert: request_record.errors.full_messages.to_sentence
+      end
+    end
+  end
+end

--- a/app/models/dependent_access_request.rb
+++ b/app/models/dependent_access_request.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# DependentAccessRequest captures a parent-initiated request for access to a dependent.
+# Requests do not grant access until an administrator approves them.
+class DependentAccessRequest < ApplicationRecord
+  belongs_to :requester, class_name: 'User'
+  belongs_to :reviewer, class_name: 'User', optional: true
+  belongs_to :carer, class_name: 'Person'
+  belongs_to :patient, class_name: 'Person'
+
+  has_paper_trail
+
+  enum :status, { pending: 0, approved: 1, rejected: 2 }, validate: true
+
+  validates :relationship_type, presence: true, inclusion: { in: %w[parent] }
+  validates :patient_id, uniqueness: {
+    scope: :carer_id,
+    conditions: -> { pending },
+    message: 'already has a pending access request for this parent'
+  }
+  validate :requester_must_be_parent
+  validate :requester_must_match_carer
+  validate :carer_must_be_adult_with_capacity
+  validate :patient_must_require_carer
+  validate :active_relationship_must_not_exist, on: :create
+
+  scope :recent_first, -> { order(created_at: :desc) }
+
+  def approve!(reviewer:)
+    ensure_pending!
+    ensure_reviewer_is_not_requester!(reviewer)
+
+    transaction do
+      DependentRelationshipAssigner.new(
+        carer: carer,
+        dependent_ids: [patient_id],
+        relationship_type: relationship_type
+      ).call
+
+      update!(status: :approved, reviewer: reviewer, reviewed_at: Time.current)
+    end
+  end
+
+  def reject!(reviewer:)
+    ensure_pending!
+
+    update!(status: :rejected, reviewer: reviewer, reviewed_at: Time.current)
+  end
+
+  private
+
+  def ensure_pending!
+    return if pending?
+
+    errors.add(:status, 'must be pending')
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def ensure_reviewer_is_not_requester!(reviewer)
+    return unless reviewer == requester
+
+    errors.add(:reviewer, 'must be different from the requesting parent')
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def requester_must_be_parent
+    errors.add(:requester, 'must be a parent') unless requester&.parent?
+  end
+
+  def requester_must_match_carer
+    return if requester&.person_id.present? && requester.person_id == carer_id
+
+    errors.add(:carer, 'must belong to the requesting parent')
+  end
+
+  def carer_must_be_adult_with_capacity
+    return if carer&.person_type == 'adult' && carer.has_capacity?
+
+    errors.add(:carer, 'must be an adult with capacity')
+  end
+
+  def patient_must_require_carer
+    return if patient&.person_type.in?(%w[minor dependent_adult]) && patient.has_capacity == false
+
+    errors.add(:patient, 'must be a child or dependent adult without capacity')
+  end
+
+  def active_relationship_must_not_exist
+    return unless CarerRelationship.active.exists?(carer_id: carer_id, patient_id: patient_id)
+
+    errors.add(:base, 'An active relationship already exists for this dependent')
+  end
+end

--- a/app/policies/dependent_access_request_policy.rb
+++ b/app/policies/dependent_access_request_policy.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class DependentAccessRequestPolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
+
+  def create?
+    parent_requester? && requester_matches_record? && dependent_patient?
+  end
+
+  def approve?
+    admin? && record.pending? && record.requester != user
+  end
+
+  def reject?
+    admin? && record.pending?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none unless user
+      return scope.all if admin?
+
+      scope.where(requester_id: user.id)
+    end
+  end
+
+  private
+
+  def parent_requester?
+    user&.parent? && user.person&.person_type == 'adult' && user.person.has_capacity?
+  end
+
+  def requester_matches_record?
+    record.requester == user && record.carer_id == user.person_id
+  end
+
+  def dependent_patient?
+    record.patient&.person_type.in?(%w[minor dependent_adult]) && record.patient.has_capacity == false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,12 @@ Rails.application.routes.draw do
         post :activate
       end
     end
+    resources :dependent_access_requests, only: %i[index] do
+      member do
+        post :approve
+        post :reject
+      end
+    end
     resources :people, only: %i[index]
     resources :audit_logs, only: %i[index show]
     resource :settings, only: %i[show update]
@@ -121,6 +127,7 @@ Rails.application.routes.draw do
       end
     end
     resources :carer_relationships, only: %i[new create], controller: 'people/carer_relationships'
+    resources :dependent_access_requests, only: %i[create], controller: 'people/dependent_access_requests'
     resources :medication_assignments, only: %i[new create]
   end
 

--- a/db/migrate/20260611230000_create_dependent_access_requests.rb
+++ b/db/migrate/20260611230000_create_dependent_access_requests.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateDependentAccessRequests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :dependent_access_requests do |t|
+      t.references :requester, null: false, foreign_key: { to_table: :users }
+      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :carer, null: false, foreign_key: { to_table: :people }, index: true
+      t.references :patient, null: false, foreign_key: { to_table: :people }, index: true
+      t.integer :status, null: false, default: 0
+      t.string :relationship_type, null: false, default: 'parent'
+      t.datetime :reviewed_at
+
+      t.timestamps
+    end
+
+    add_index :dependent_access_requests, :status
+    add_index :dependent_access_requests,
+              %i[carer_id patient_id],
+              unique: true,
+              where: 'status = 0',
+              name: 'index_dependent_access_requests_on_pending_pair'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_230000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -209,6 +209,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_090000) do
     t.index ["carer_id", "patient_id"], name: "index_carer_relationships_on_carer_id_and_patient_id", unique: true
     t.index ["carer_id"], name: "index_carer_relationships_on_carer_id"
     t.index ["patient_id"], name: "index_carer_relationships_on_patient_id"
+  end
+
+  create_table "dependent_access_requests", force: :cascade do |t|
+    t.bigint "carer_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "patient_id", null: false
+    t.integer "status", default: 0, null: false
+    t.string "relationship_type", default: "parent", null: false
+    t.datetime "reviewed_at"
+    t.bigint "reviewer_id"
+    t.bigint "requester_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["carer_id", "patient_id"], name: "index_dependent_access_requests_on_pending_pair", unique: true, where: "(status = 0)"
+    t.index ["carer_id"], name: "index_dependent_access_requests_on_carer_id"
+    t.index ["patient_id"], name: "index_dependent_access_requests_on_patient_id"
+    t.index ["requester_id"], name: "index_dependent_access_requests_on_requester_id"
+    t.index ["reviewer_id"], name: "index_dependent_access_requests_on_reviewer_id"
+    t.index ["status"], name: "index_dependent_access_requests_on_status"
   end
 
   create_table "dosages", force: :cascade do |t|
@@ -505,6 +523,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_090000) do
   add_foreign_key "api_sessions", "accounts"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred
+  add_foreign_key "dependent_access_requests", "people", column: "carer_id"
+  add_foreign_key "dependent_access_requests", "people", column: "patient_id"
+  add_foreign_key "dependent_access_requests", "users", column: "requester_id"
+  add_foreign_key "dependent_access_requests", "users", column: "reviewer_id"
   add_foreign_key "dosages", "medications", deferrable: :deferred
   add_foreign_key "invitation_dependents", "invitations"
   add_foreign_key "invitation_dependents", "people", column: "dependent_id"

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -288,6 +288,32 @@ RSpec.describe 'Admin create and update turbo flows' do
       expect(relationship.relationship_type).to eq('parent')
       expect(relationship.active).to be true
     end
+
+    it 'does not allow non-admin self-updates to assign arbitrary dependents or change role' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+      sign_in(parent)
+
+      expect do
+        patch admin_user_path(parent),
+              params: {
+                user: {
+                  email_address: parent.email_address,
+                  role: 'administrator',
+                  dependent_ids: [dependent.id],
+                  person_attributes: {
+                    id: parent.person.id,
+                    name: parent.person.name,
+                    date_of_birth: parent.person.date_of_birth.to_s,
+                    location_ids: [locations(:home).id]
+                  }
+                }
+              }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(CarerRelationship.find_by(carer: parent.person, patient: dependent)).to be_nil
+      expect(parent.reload.role).to eq('parent')
+    end
   end
 
   describe 'POST /admin/carer_relationships' do

--- a/spec/requests/dependent_access_requests_spec.rb
+++ b/spec/requests/dependent_access_requests_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Dependent access requests' do
+  fixtures :accounts, :people, :users, :locations, :carer_relationships
+
+  describe 'POST /people/:person_id/dependent_access_requests' do
+    it 'allows a parent to request access without creating a carer relationship' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+      sign_in(parent)
+
+      expect do
+        post person_dependent_access_requests_path(dependent)
+      end.to change(DependentAccessRequest, :count).by(1)
+        .and change(CarerRelationship, :count).by(0)
+
+      request_record = DependentAccessRequest.last
+      expect(request_record).to be_pending
+      expect(request_record.requester).to eq(parent)
+      expect(request_record.carer).to eq(parent.person)
+      expect(request_record.patient).to eq(dependent)
+    end
+  end
+
+  describe 'POST /admin/dependent_access_requests/:id/approve' do
+    it 'allows an administrator to approve a parent request and create the relationship' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+      request_record = DependentAccessRequest.create!(
+        requester: parent,
+        carer: parent.person,
+        patient: dependent,
+        relationship_type: 'parent'
+      )
+      sign_in(users(:admin))
+
+      expect do
+        post approve_admin_dependent_access_request_path(request_record)
+      end.to change(CarerRelationship, :count).by(1)
+
+      relationship = CarerRelationship.find_by!(carer: parent.person, patient: dependent)
+      expect(relationship.relationship_type).to eq('parent')
+      expect(relationship.active).to be true
+      expect(request_record.reload).to be_approved
+      expect(request_record.reviewer).to eq(users(:admin))
+      expect(request_record.reviewed_at).to be_present
+    end
+
+    it 'does not allow a parent to approve their own request' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+      request_record = DependentAccessRequest.create!(
+        requester: parent,
+        carer: parent.person,
+        patient: dependent,
+        relationship_type: 'parent'
+      )
+      sign_in(parent)
+
+      expect do
+        post approve_admin_dependent_access_request_path(request_record)
+      end.not_to change(CarerRelationship, :count)
+
+      expect(request_record.reload).to be_pending
+    end
+  end
+
+  describe 'POST /admin/dependent_access_requests/:id/reject' do
+    it 'allows an administrator to reject a parent request without creating a relationship' do
+      parent = users(:parent)
+      dependent = people(:child_patient)
+      request_record = DependentAccessRequest.create!(
+        requester: parent,
+        carer: parent.person,
+        patient: dependent,
+        relationship_type: 'parent'
+      )
+      sign_in(users(:admin))
+
+      expect do
+        post reject_admin_dependent_access_request_path(request_record)
+      end.not_to change(CarerRelationship, :count)
+
+      expect(request_record.reload).to be_rejected
+      expect(request_record.reviewer).to eq(users(:admin))
+      expect(request_record.reviewed_at).to be_present
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide a workflow for parents to request administrator approval to access dependents and for admins to review and act on those requests.
- Prevent non-administrators from mass-assigning arbitrary dependents or changing roles via the admin user update flow.

### Description

- Introduces the `DependentAccessRequest` model with validations, `status` enum, `approve!`/`reject!` methods, and a migration `CreateDependentAccessRequests` with appropriate indexes and foreign keys.
- Adds `People::DependentAccessRequestsController#create` to allow parents to create requests and `Admin::DependentAccessRequestsController` to list pending requests and to `approve`/`reject` them, plus a simple index render helper `request_summary`.
- Adds `DependentAccessRequestPolicy` with access rules and a scoped `Scope` class, and wires routes for `people/:person_id/dependent_access_requests` and `admin/dependent_access_requests` with `approve`/`reject` member actions in `config/routes.rb`.
- Restricts admin user parameter handling by refactoring `user_params` in `Admin::UsersController` to use `permitted_user_attributes` and `dependent_assignment_attributes`, and guards `assign_dependents` so only administrators can perform dependent assignments.
- Updates `db/schema.rb` to reflect the new table and foreign keys and adds request specs and a spec tweak: new `spec/requests/dependent_access_requests_spec.rb` and an added assertion in `spec/requests/admin_create_update_turbo_spec.rb` to verify non-admin self-updates cannot assign dependents or change role.

### Testing

- Added request specs in `spec/requests/dependent_access_requests_spec.rb` covering creation, approval, and rejection workflows and they passed when run.
- Extended `spec/requests/admin_create_update_turbo_spec.rb` with a test ensuring non-admins cannot assign dependents or change role and it passed when run.
- Ran the relevant RSpec request suite including the new and modified specs and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3479f0f08322a4204aa7c194cdb9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->