### PR TITLE
refactor: Refactor user policy spec expectations

### DIFF
--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -77,25 +77,20 @@ RSpec.describe UserPolicy do
     end
 
     it 'forbids administrative actions' do
-      expect(policy.index?).to be false
-      expect(policy.create?).to be false
-      expect(policy.destroy?).to be false
-      expect(policy.verify?).to be false
+      %i[index create destroy verify].each { |action| expect(policy.public_send("#{action}?")).to be false }
     end
 
     context 'when viewing own profile' do
       let(:user) { current_user }
 
       it 'permits viewing and updating' do
-        expect(policy.show?).to be true
-        expect(policy.update?).to be true
+        %i[show update].each { |action| expect(policy.public_send("#{action}?")).to be true }
       end
     end
 
     context 'when viewing another user' do
       it 'forbids viewing and updating' do
-        expect(policy.show?).to be false
-        expect(policy.update?).to be false
+        %i[show update].each { |action| expect(policy.public_send("#{action}?")).to be false }
       end
     end
   end
@@ -106,25 +101,20 @@ RSpec.describe UserPolicy do
     end
 
     it 'forbids administrative actions' do
-      expect(policy.index?).to be false
-      expect(policy.create?).to be false
-      expect(policy.destroy?).to be false
-      expect(policy.verify?).to be false
+      %i[index create destroy verify].each { |action| expect(policy.public_send("#{action}?")).to be false }
     end
 
     context 'when viewing own profile' do
       let(:user) { current_user }
 
       it 'permits viewing and updating' do
-        expect(policy.show?).to be true
-        expect(policy.update?).to be true
+        %i[show update].each { |action| expect(policy.public_send("#{action}?")).to be true }
       end
     end
 
     context 'when viewing another user' do
       it 'forbids viewing and updating' do
-        expect(policy.show?).to be false
-        expect(policy.update?).to be false
+        %i[show update].each { |action| expect(policy.public_send("#{action}?")).to be false }
       end
     end
   end


### PR DESCRIPTION
## What changed

- Simplified repeated `UserPolicy` carer and parent expectations by using the action-list assertion style already used earlier in the spec.
- Kept the change limited to `spec/policies/user_policy_spec.rb`.

## Why this improves maintainability/readability

- The repeated per-action assertions now read as one permission set per example.
- The carer and parent examples now follow the same local pattern as the administrator, doctor, and nurse examples.

## How behavior was preserved

- This is a spec-only refactor.
- The same policy predicate methods are still exercised with the same expected boolean values.

## Verification commands run

- `task test TEST_FILE=spec/policies/user_policy_spec.rb`
- `task rubocop`
- `task test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->