### PR TITLE
perf: Memoize dashboard blocked reasons

### DIFF
--- a/app/components/dashboard/person_schedule.rb
+++ b/app/components/dashboard/person_schedule.rb
@@ -175,9 +175,11 @@ module Components
 
       def blocked_reason_for(schedule)
         @blocked_reasons ||= {}
-        @blocked_reasons[schedule.id] ||= MedicationStockSourceResolver
-                                          .new(user: current_user, source: schedule)
-                                          .blocked_reason
+        return @blocked_reasons[schedule.id] if @blocked_reasons.key?(schedule.id)
+
+        @blocked_reasons[schedule.id] = MedicationStockSourceResolver
+                                        .new(user: current_user, source: schedule)
+                                        .blocked_reason
       end
     end
   end

--- a/app/components/dashboard/schedule_card.rb
+++ b/app/components/dashboard/schedule_card.rb
@@ -125,7 +125,9 @@ module Components
       end
 
       def blocked_reason
-        @blocked_reason ||= MedicationStockSourceResolver.new(user: current_user, source: schedule).blocked_reason
+        return @blocked_reason if instance_variable_defined?(:@blocked_reason)
+
+        @blocked_reason = MedicationStockSourceResolver.new(user: current_user, source: schedule).blocked_reason
       end
 
       def render_delete_button

--- a/app/components/dashboard/schedule_row.rb
+++ b/app/components/dashboard/schedule_row.rb
@@ -96,7 +96,9 @@ module Components
       end
 
       def blocked_reason
-        @blocked_reason ||= MedicationStockSourceResolver.new(user: current_user, source: schedule).blocked_reason
+        return @blocked_reason if instance_variable_defined?(:@blocked_reason)
+
+        @blocked_reason = MedicationStockSourceResolver.new(user: current_user, source: schedule).blocked_reason
       end
 
       def render_delete_button

--- a/spec/components/dashboard/person_schedule_spec.rb
+++ b/spec/components/dashboard/person_schedule_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 RSpec.describe Components::Dashboard::PersonSchedule, type: :component do
   fixtures :accounts, :people, :users, :locations, :medications, :dosages, :schedules
 
-  subject(:component) { described_class.new(person: person, schedules: schedules) }
+  subject(:component) { described_class.new(person: person, schedules: active_schedules) }
 
   let(:person) { people(:john) }
-  let(:schedules) { person.schedules.where(active: true) }
+  let(:active_schedules) { person.schedules.where(active: true) }
 
   before do
-    MedicationTake.where(schedule: schedules).delete_all
+    MedicationTake.where(schedule: active_schedules).delete_all
   end
 
   it 'renders the person\'s name' do
@@ -22,7 +22,7 @@ RSpec.describe Components::Dashboard::PersonSchedule, type: :component do
   it 'renders each schedule' do
     rendered = render_inline(component)
 
-    schedules.each do |schedule|
+    active_schedules.each do |schedule|
       schedule_element = rendered.css("#schedule_#{schedule.id}")
       expect(schedule_element).to be_present
       expect(rendered.text).to include(schedule.medication.display_name)
@@ -32,10 +32,31 @@ RSpec.describe Components::Dashboard::PersonSchedule, type: :component do
   it 'renders take now links for each schedule' do
     rendered = render_inline(component)
 
-    schedules.each do |schedule|
+    active_schedules.each do |schedule|
       link = rendered.css("[data-test-id='take-medication-#{schedule.id}']")
       expect(link).to be_present
       expect(link.text).to include('Take Now')
     end
+  end
+
+  it 'does not repeat the dashboard blocked-state stock lookup when a schedule is not blocked' do
+    schedule = schedules(:active_schedule)
+
+    expect(count_stock_source_queries do
+      render_inline(described_class.new(person: person, schedules: [schedule]))
+    end).to eq(2)
+  end
+
+  def count_stock_source_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      sql = payload[:sql]
+      count += 1 if sql.include?('FROM "medications"') &&
+                    sql.include?('"medications"."name"') &&
+                    sql.include?('"medications"."dosage_amount"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
   end
 end

--- a/spec/components/dashboard/schedule_card_spec.rb
+++ b/spec/components/dashboard/schedule_card_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe Components::Dashboard::ScheduleCard, type: :component do
 
       expect(rendered.css(selector)).to be_present
     end
+
+    it 'does not repeat the blocked-state stock lookup when a schedule is not blocked' do
+      expect(count_stock_source_queries do
+        render_inline(described_class.new(person: person, schedule: schedule))
+      end).to eq(2)
+    end
   end
 
   describe 'card structure' do
@@ -60,5 +66,18 @@ RSpec.describe Components::Dashboard::ScheduleCard, type: :component do
 
       expect(rendered.text).to include('Ends')
     end
+  end
+
+  def count_stock_source_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      sql = payload[:sql]
+      count += 1 if sql.include?('FROM "medications"') &&
+                    sql.include?('"medications"."name"') &&
+                    sql.include?('"medications"."dosage_amount"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
   end
 end

--- a/spec/components/dashboard/schedule_row_spec.rb
+++ b/spec/components/dashboard/schedule_row_spec.rb
@@ -27,4 +27,21 @@ RSpec.describe Components::Dashboard::ScheduleRow, type: :component do
     expect(rendered.at_css('[data-testid="person-avatar"]')).to be_present
     expect(rendered.text).to include('JD')
   end
+
+  it 'does not repeat the blocked-state stock lookup when a schedule is not blocked' do
+    expect(count_stock_source_queries { render_inline(row) }).to eq(2)
+  end
+
+  def count_stock_source_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      sql = payload[:sql]
+      count += 1 if sql.include?('FROM "medications"') &&
+                    sql.include?('"medications"."name"') &&
+                    sql.include?('"medications"."dosage_amount"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
+  end
 end


### PR DESCRIPTION
## What changed
- Updated `Components::Dashboard::PersonSchedule#blocked_reason_for` to cache `nil` blocked reasons using hash key presence instead of `||=`.
- Added a focused component spec that counts dashboard stock-source medication lookups during one render.

## Why it was a bottleneck
The dashboard calls `blocked_reason_for(schedule)` twice while rendering the take action state. For the common unblocked case, `MedicationStockSourceResolver#blocked_reason` returns `nil`, so `||=` did not memoize the result and repeated the stock-source query in the same render.

## Measurement used
Red/green `ActiveSupport::Notifications` SQL count in `spec/components/dashboard/person_schedule_spec.rb`.

Before the change, the focused spec failed with 3 matching stock-source medication lookups. After the change, it passes with 2 lookups: one dashboard blocked-state lookup plus the existing take dialog stock-source lookup.

## Expected impact
Each unblocked dashboard schedule card avoids one duplicate stock-source lookup during render while preserving behavior for out-of-stock and cooldown states.

## Tests run
- `task test TEST_FILE=spec/components/dashboard/person_schedule_spec.rb`
- `task rubocop`
- `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->