### PR TITLE
refactor: simplify audit context lookup

### DIFF
--- a/app/services/auth_token_audit_logger.rb
+++ b/app/services/auth_token_audit_logger.rb
@@ -50,10 +50,13 @@ class AuthTokenAuditLogger
   end
 
   def paper_trail_context
+    request = PaperTrail.request
+    controller_info = request.controller_info
+
     {
-      whodunnit: PaperTrail.request.whodunnit,
-      ip: PaperTrail.request.controller_info&.dig(:ip),
-      request_id: PaperTrail.request.controller_info&.dig(:request_id)
+      whodunnit: request.whodunnit,
+      ip: controller_info&.dig(:ip),
+      request_id: controller_info&.dig(:request_id)
     }
   end
 


### PR DESCRIPTION
## What changed
- Cached `PaperTrail.request` and its `controller_info` once inside `AuthTokenAuditLogger#paper_trail_context`.
- Reused those locals when building the audit context hash.

## Why this improves maintainability/readability
- Removes repeated framework request lookups from a small audit helper.
- Addresses the targeted RubyCritic duplicate-call signal without changing the public API.

## How behavior was preserved
- The method still reads the same PaperTrail request fields and returns the same keys.
- Existing `AuthTokenAuditLogger` specs cover explicit context fallback, request metadata, and missing PaperTrail context.

## Verification commands run
- `task rubycritic TARGET=app/services/auth_token_audit_logger.rb` (RubyCritic smell count improved 19 to 17; task still exits nonzero because targeted SimpleCov reports 0% coverage)
- `task test TEST_FILE=spec/services/auth_token_audit_logger_spec.rb`
- `task rubocop`
- `task test`
- After rebasing on origin/main: `task test TEST_FILE=spec/services/auth_token_audit_logger_spec.rb`, `task rubocop`, `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->