### PR TITLE
fix: disable Active Storage direct uploads

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module MedTracker
     # in config/environments, which are processed later.
     #
     config.time_zone = ENV.fetch('TZ', 'UTC')
+    config.active_storage.draw_routes = false
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,93 @@ Rails.application.routes.draw do
     end
   end
 
+  scope ActiveStorage.routes_prefix do
+    get '/blobs/redirect/:signed_id/*filename',
+        to: 'active_storage/blobs/redirect#show', as: :rails_service_blob
+    get '/blobs/proxy/:signed_id/*filename',
+        to: 'active_storage/blobs/proxy#show', as: :rails_service_blob_proxy
+    get '/blobs/:signed_id/*filename', to: 'active_storage/blobs/redirect#show'
+    get '/representations/redirect/:signed_blob_id/:variation_key/*filename',
+        to: 'active_storage/representations/redirect#show', as: :rails_blob_representation
+    get '/representations/proxy/:signed_blob_id/:variation_key/*filename',
+        to: 'active_storage/representations/proxy#show', as: :rails_blob_representation_proxy
+    get '/representations/:signed_blob_id/:variation_key/*filename',
+        to: 'active_storage/representations/redirect#show'
+    get '/disk/:encoded_key/*filename', to: 'active_storage/disk#show', as: :rails_disk_service
+  end
+
+  direct :rails_representation do |representation, options|
+    route_for(ActiveStorage.resolve_model_to_route, representation, options)
+  end
+
+  resolve('ActiveStorage::Variant') do |variant, options|
+    route_for(ActiveStorage.resolve_model_to_route, variant, options)
+  end
+
+  resolve('ActiveStorage::VariantWithRecord') do |variant, options|
+    route_for(ActiveStorage.resolve_model_to_route, variant, options)
+  end
+
+  resolve('ActiveStorage::Preview') do |preview, options|
+    route_for(ActiveStorage.resolve_model_to_route, preview, options)
+  end
+
+  direct :rails_blob do |blob, options|
+    route_for(ActiveStorage.resolve_model_to_route, blob, options)
+  end
+
+  resolve('ActiveStorage::Blob') do |blob, options|
+    route_for(ActiveStorage.resolve_model_to_route, blob, options)
+  end
+
+  resolve('ActiveStorage::Attachment') do |attachment, options|
+    route_for(ActiveStorage.resolve_model_to_route, attachment.blob, options)
+  end
+
+  direct :rails_storage_proxy do |model, options|
+    expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+    expires_at = options.delete(:expires_at)
+
+    if model.respond_to?(:signed_id)
+      route_for(
+        :rails_service_blob_proxy,
+        model.signed_id(expires_in:, expires_at:),
+        model.filename,
+        options
+      )
+    else
+      route_for(
+        :rails_blob_representation_proxy,
+        model.blob.signed_id(expires_in:, expires_at:),
+        model.variation.key,
+        model.blob.filename,
+        options
+      )
+    end
+  end
+
+  direct :rails_storage_redirect do |model, options|
+    expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+    expires_at = options.delete(:expires_at)
+
+    if model.respond_to?(:signed_id)
+      route_for(
+        :rails_service_blob,
+        model.signed_id(expires_in:, expires_at:),
+        model.filename,
+        options
+      )
+    else
+      route_for(
+        :rails_blob_representation,
+        model.blob.signed_id(expires_in:, expires_at:),
+        model.variation.key,
+        model.blob.filename,
+        options
+      )
+    end
+  end
+
   # Defines the root path route ("/")
   root 'household_redirects#show'
 

--- a/spec/routing/active_storage_routes_spec.rb
+++ b/spec/routing/active_storage_routes_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActiveStorage::Blob do
+  it 'does not expose the direct upload blob creation endpoint' do
+    expect(post: '/rails/active_storage/direct_uploads').not_to be_routable
+  end
+
+  it 'does not expose the disk direct upload write endpoint' do
+    expect(put: '/rails/active_storage/disk/test-token').not_to be_routable
+  end
+end


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated actors from creating unattached Active Storage blobs via the default direct upload endpoints and exhausting disk/storage.
- Preserve existing avatar rendering and URL helpers while removing write endpoints that bypass model validations.

### Description
- Disable Rails' automatic Active Storage route drawing by setting `config.active_storage.draw_routes = false` in `config/application.rb`.
- Re-declare only the read-oriented Active Storage routes (blob, representation, and disk `#show`) under `ActiveStorage.routes_prefix` in `config/routes.rb` so `url_for(person.avatar)` and variant URLs continue to work.
- Add `spec/routing/active_storage_routes_spec.rb` asserting that the direct-upload creation endpoint (`POST /rails/active_storage/direct_uploads`) and the disk write endpoint (`PUT /rails/active_storage/disk/:token`) are not routable.

### Testing
- Added routing spec `spec/routing/active_storage_routes_spec.rb` to cover the regression and prove write endpoints are not exposed. (Spec file present in the changes.)
- Ran `git diff --check` with no reported problems. 
- Attempted `bundle exec rspec spec/routing/active_storage_routes_spec.rb` but execution was blocked by the environment's toolchain provisioning (`mise` failed to install the required Ruby toolchain), so the spec could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b357ffb4883228e0d369a366fcc97)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->