### PR TITLE
fix: preserve invite-only default for household owner deployments

### DIFF
--- a/app/models/app_settings.rb
+++ b/app/models/app_settings.rb
@@ -9,12 +9,12 @@ class AppSettings < ApplicationRecord
   end
 
   # Preserve the pre-settings safety behavior for deployments that have not
-  # created the singleton row yet: once an administrator exists, registration
-  # starts locked down unless an operator/admin explicitly changes it later.
+  # created the singleton row yet: once a household owner exists, registration
+  # starts locked down unless an operator explicitly changes it later.
   def self.default_invite_only?
     return ActiveModel::Type::Boolean.new.cast(ENV.fetch('INVITE_ONLY')) if ENV.key?('INVITE_ONLY')
 
-    User.administrator.exists?
+    HouseholdMembership.owner.active.exists?
   end
 
   # INVITE_ONLY env var takes precedence when set, letting ops pin the value

--- a/app/models/app_settings.rb
+++ b/app/models/app_settings.rb
@@ -5,7 +5,16 @@ class AppSettings < ApplicationRecord
 
   # Always a single row. Access via AppSettings.instance, never instantiate directly.
   def self.instance
-    first_or_create!(invite_only: false)
+    first || create!(invite_only: default_invite_only?)
+  end
+
+  # Preserve the pre-settings safety behavior for deployments that have not
+  # created the singleton row yet: once an administrator exists, registration
+  # starts locked down unless an operator/admin explicitly changes it later.
+  def self.default_invite_only?
+    return ActiveModel::Type::Boolean.new.cast(ENV.fetch('INVITE_ONLY')) if ENV.key?('INVITE_ONLY')
+
+    User.administrator.exists?
   end
 
   # INVITE_ONLY env var takes precedence when set, letting ops pin the value

--- a/db/migrate/20260611120000_preserve_invite_only_for_existing_admin_deployments.rb
+++ b/db/migrate/20260611120000_preserve_invite_only_for_existing_admin_deployments.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class PreserveInviteOnlyForExistingAdminDeployments < ActiveRecord::Migration[8.1]
+  def up
+    return if ENV.key?('INVITE_ONLY')
+    return unless table_exists?(:app_settings)
+    return unless table_exists?(:users)
+    return unless existing_administrators?
+
+    if app_settings_empty?
+      create_default_invite_only_settings
+    else
+      lock_unchanged_default_open_settings
+    end
+  end
+
+  def down
+    # Deliberately irreversible: this migration preserves the secure legacy
+    # invite-only posture for existing administrator deployments.
+  end
+
+  private
+
+  def existing_administrators?
+    select_value("SELECT 1 FROM users WHERE role = 0 LIMIT 1").present?
+  end
+
+  def app_settings_empty?
+    select_value('SELECT 1 FROM app_settings LIMIT 1').blank?
+  end
+
+  def create_default_invite_only_settings
+    now = quote(Time.current)
+    execute <<~SQL.squish
+      INSERT INTO app_settings (invite_only, created_at, updated_at)
+      VALUES (TRUE, #{now}, #{now})
+    SQL
+  end
+
+  def lock_unchanged_default_open_settings
+    execute <<~SQL.squish
+      UPDATE app_settings
+      SET invite_only = TRUE, updated_at = CURRENT_TIMESTAMP
+      WHERE invite_only = FALSE
+        AND created_at = updated_at
+    SQL
+  end
+end

--- a/db/migrate/20260611120000_preserve_invite_only_for_existing_admin_deployments.rb
+++ b/db/migrate/20260611120000_preserve_invite_only_for_existing_admin_deployments.rb
@@ -4,8 +4,8 @@ class PreserveInviteOnlyForExistingAdminDeployments < ActiveRecord::Migration[8.
   def up
     return if ENV.key?('INVITE_ONLY')
     return unless table_exists?(:app_settings)
-    return unless table_exists?(:users)
-    return unless existing_administrators?
+    return unless table_exists?(:household_memberships)
+    return unless existing_household_owners?
 
     if app_settings_empty?
       create_default_invite_only_settings
@@ -16,13 +16,17 @@ class PreserveInviteOnlyForExistingAdminDeployments < ActiveRecord::Migration[8.
 
   def down
     # Deliberately irreversible: this migration preserves the secure legacy
-    # invite-only posture for existing administrator deployments.
+    # invite-only posture for existing household owner deployments.
   end
 
   private
 
-  def existing_administrators?
-    select_value("SELECT 1 FROM users WHERE role = 0 LIMIT 1").present?
+  def existing_household_owners?
+    select_value(<<~SQL.squish).present?
+      SELECT 1 FROM household_memberships
+      WHERE role = 'owner' AND status = 'active'
+      LIMIT 1
+    SQL
   end
 
   def app_settings_empty?

--- a/spec/models/app_settings_spec.rb
+++ b/spec/models/app_settings_spec.rb
@@ -3,6 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe AppSettings do
+  describe '.instance' do
+    before { described_class.delete_all }
+
+    it 'defaults invite-only mode on when an administrator already exists' do
+      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: true))
+
+      expect(described_class.instance).to be_invite_only
+    end
+
+    it 'defaults invite-only mode off when no administrator exists' do
+      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: false))
+
+      expect(described_class.instance).not_to be_invite_only
+    end
+
+    it 'honors an explicit INVITE_ONLY override when creating the settings row' do
+      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: true))
+
+      original_invite_only = ENV.fetch('INVITE_ONLY', nil)
+      ENV['INVITE_ONLY'] = 'false'
+
+      expect(described_class.instance).not_to be_invite_only
+    ensure
+      if original_invite_only.nil?
+        ENV.delete('INVITE_ONLY')
+      else
+        ENV['INVITE_ONLY'] = original_invite_only
+      end
+    end
+  end
+
   describe 'versioning' do
     it 'creates a version when invite-only mode changes' do
       settings = described_class.instance

--- a/spec/models/app_settings_spec.rb
+++ b/spec/models/app_settings_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe AppSettings do
   describe '.instance' do
     before { described_class.delete_all }
 
-    it 'defaults invite-only mode on when an administrator already exists' do
-      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: true))
+    it 'defaults invite-only mode on when a household owner already exists' do
+      create_household_with_owner
 
       expect(described_class.instance).to be_invite_only
     end
 
-    it 'defaults invite-only mode off when no administrator exists' do
-      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: false))
+    it 'defaults invite-only mode off when no household owner exists' do
+      HouseholdMembership.owner.delete_all
 
       expect(described_class.instance).not_to be_invite_only
     end
 
     it 'honors an explicit INVITE_ONLY override when creating the settings row' do
-      allow(User).to receive(:administrator).and_return(instance_double(ActiveRecord::Relation, exists?: true))
+      create_household_with_owner(email: 'env-owner@example.test', name: 'Env Family')
 
       original_invite_only = ENV.fetch('INVITE_ONLY', nil)
       ENV['INVITE_ONLY'] = 'false'
@@ -32,6 +32,20 @@ RSpec.describe AppSettings do
         ENV['INVITE_ONLY'] = original_invite_only
       end
     end
+  end
+
+  def create_household_with_owner(email: 'settings-owner@example.test', name: 'Settings Family')
+    account = Account.create!(email: email, status: :verified)
+    Household.create_with_owner!(
+      name: name,
+      owner_account: account,
+      owner_person_attributes: {
+        name: 'Owner',
+        date_of_birth: 30.years.ago.to_date,
+        person_type: :adult,
+        has_capacity: true
+      }
+    )
   end
 
   describe 'versioning' do


### PR DESCRIPTION
### Motivation
- Prevent inadvertent reopening of public registration on upgraded deployments by restoring the legacy safety behavior that made registration invite-only once an administrator existed.
- Ensure `INVITE_ONLY` environment overrides remain authoritative when operators explicitly pin the behaviour.

### Description
- Change `AppSettings.instance` to create the singleton with `invite_only: default_invite_only?` and add `AppSettings.default_invite_only?` which honors `ENV['INVITE_ONLY']` and otherwise returns `User.administrator.exists?`.
- Add a migration `PreserveInviteOnlyForExistingAdminDeployments` that, unless `INVITE_ONLY` is set, creates a `app_settings` row with `invite_only = true` for deployments that already have administrators, or flips unchanged default-open rows to `invite_only = true`.
- Add focused specs in `spec/models/app_settings_spec.rb` to cover admin/no-admin creation defaults and an explicit `INVITE_ONLY` override.
- Make the admin UI and existing `AppSettings.invite_only?` behaviour unchanged except for the safer default and the new migration/backfill.

### Testing
- Ran `git diff --check` successfully to validate whitespace and diff sanity.
- Attempted command and syntax checks (`ruby -c` on modified files) and running `bundle exec rspec spec/models/app_settings_spec.rb spec/features/authentication/invite_only_signup_spec.rb` but execution was blocked by the environment toolchain failing to install the required Ruby runtime (`mise` could not install `ruby@4.0.4`), so the new specs were added but full test execution is pending in CI or a local environment with Ruby available.
- The new specs are included and ready to run in CI: `spec/models/app_settings_spec.rb` contains tests for admin-backed default, no-admin default, and explicit `INVITE_ONLY` override.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b44c516048322ba70a5845256f754)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->