### PR TITLE
fix(docs): Remove seeded admin credentials from public setup docs

### DIFF
--- a/docs/families/adding-first-medicine.md
+++ b/docs/families/adding-first-medicine.md
@@ -6,9 +6,9 @@ one of your family members.
 ## Step 1: Log in
 Open [http://localhost:3000](http://localhost:3000) in your web browser.
 
-**Use these login details to start:**
-- **Email:** `admin@example.com`
-- **Password:** `password`
+Sign in with the local demo account you selected during setup, or with the
+account your administrator invited. Do not use development fixture accounts on
+a public or shared server.
 
 ## Step 2: Open the Dashboard
 The **Dashboard** is the main page where you see your family. You'll see

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -37,7 +37,9 @@ To quickly populate the database with example users, people, and medicines:
 task dev:seed
 ```
 
-*The default password for all example users (e.g., `admin@example.com`) is `password`.*
+> **Local development only:** fixture data includes sample accounts with known
+> passwords. Do not expose a seeded development stack to a public or shared
+> network, and remove or reset sample accounts before using any real records.
 
 ## 4. Open the app
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,6 +1,6 @@
 # Self-Hosting Setup
 
-This guide walks through running MedTracker on your own computer or server.
+This guide walks through running MedTracker on your own computer for local evaluation only.
 
 ## 🏁 Before you begin
 
@@ -30,6 +30,12 @@ cd med-tracker
 
 ## 2. Start the App
 
+> **Local evaluation only:** `task dev:up` starts the development stack. Do not run
+> this stack on a public or shared network, and do not use it as a production
+> server for real medication or person records. For a reachable server, use a
+> production deployment and create your first administrator through the
+> bootstrap/invitation flow instead of loading development fixtures.
+
 Now, let's start the app's services:
 
 ```bash
@@ -40,7 +46,9 @@ task dev:up
 
 ## 3. Add Some Example Data
 
-To make it easier to see how it works, we'll add some "dummy" data (like example people and medicines):
+To make it easier to see how it works, you can add local-only "dummy" data
+(like example people and medicines). These fixtures include sample accounts and
+known passwords, so only run this command on a private development machine:
 
 ```bash
 task dev:seed
@@ -52,10 +60,10 @@ Now, open your web browser (like Chrome or Safari) and go to:
 
 👉 **[http://localhost:3000](http://localhost:3000)**
 
-**You can log in with:**
-
-- **Email:** `admin@example.com`
-- **Password:** `password`
+Sign in with a local demo account from the seed output, or use the account your
+administrator invited for a production deployment. If you loaded fixture data,
+change or remove any sample accounts before exposing the app beyond your own
+computer.
 
 ---
 
@@ -63,5 +71,5 @@ Now, open your web browser (like Chrome or Safari) and go to:
 
 Now that the app is running, you can:
 
-- [**Add your first medicine**](adding-first-medicine.md)
-- [**Record a dose**](taking-first-dose.md)
+- [**Add your first medicine**](families/adding-first-medicine.md)
+- [**Record a dose**](families/taking-first-dose.md)


### PR DESCRIPTION
### Motivation
- The self-hosting and quick-start documentation instructed operators to run the development seed flow and published known seeded administrator credentials, which can grant administrator access on reachable hosts. 
- The change aims to prevent accidental promotion of development fixtures as a production setup path and to steer reachable deployments to the safe bootstrap/invitation flow.

### Description
- Reframe `docs/self-hosting.md` as a local evaluation guide and add a clear warning not to run the development stack on public or shared networks and to use the production bootstrap/invitation flow for reachable servers. 
- Remove the explicit seeded administrator credentials and replace the login copy with guidance to use the seed output or invited accounts and to change/remove sample accounts before exposing the app. 
- Update `docs/families/adding-first-medicine.md` to remove repeated fixture credentials and warn against using development fixture accounts on public/shared servers. 
- Add a local-development warning to `docs/quick-start.md` explaining that fixture data contains sample accounts with known passwords and must not be exposed beyond local development.

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace and it completed without errors. 
- Executed a `python3` static check that searches for the previously published credential strings in the modified docs and it confirmed the seeded admin credentials were removed. 
- Attempted `uv run zensical build --clean` to exercise docs build, but it failed due to an external PyPI download error (network/tunnel) unrelated to the documentation edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5d8f72a48322b5f6c01f6eb691e8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->