### PR TITLE
fix: Require review for Renovate-managed Actions, lockfiles, and dependency/container updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,41 +6,41 @@
   "automerge": false,
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true,
+    "automerge": false,
     "automergeType": "pr",
     "ignoreTests": false
   },
   "packageRules": [
     {
-      "description": "Auto-merge GitHub Actions non-major updates after checks pass",
+      "description": "Require review for GitHub Actions non-major updates",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "pr",
       "ignoreTests": false
     },
     {
-      "description": "Auto-merge npm development dependency non-major updates after checks pass",
+      "description": "Require review for npm development dependency non-major updates",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "pr",
       "ignoreTests": false
     },
     {
-      "description": "Auto-merge Bundler patch updates after checks pass",
+      "description": "Require review for Bundler patch updates",
       "matchManagers": ["bundler"],
       "matchUpdateTypes": ["patch"],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "pr",
       "ignoreTests": false
     },
     {
-      "description": "Auto-merge Docker patch and digest updates after checks pass",
+      "description": "Require review for Docker patch and digest updates",
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["patch", "digest"],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "pr",
       "ignoreTests": false
     },

--- a/spec/config/json_spec.rb
+++ b/spec/config/json_spec.rb
@@ -15,45 +15,45 @@ RSpec.describe JSON do
     expect(config.fetch('automerge')).to be(false)
   end
 
-  it 'automerges GitHub Actions non-major updates after checks pass' do
-    rule = rule_for('Auto-merge GitHub Actions non-major updates after checks pass')
+  it 'requires review for GitHub Actions non-major updates' do
+    rule = rule_for('Require review for GitHub Actions non-major updates')
 
     expect(rule.fetch('matchManagers')).to eq(['github-actions'])
     expect(rule.fetch('matchUpdateTypes')).to contain_exactly('minor', 'patch', 'digest')
-    expect(rule.fetch('automerge')).to be(true)
+    expect(rule.fetch('automerge')).to be(false)
     expect(rule.fetch('ignoreTests')).to be(false)
   end
 
-  it 'automerges npm development dependency non-major updates after checks pass' do
-    rule = rule_for('Auto-merge npm development dependency non-major updates after checks pass')
+  it 'requires review for npm development dependency non-major updates' do
+    rule = rule_for('Require review for npm development dependency non-major updates')
 
     expect(rule.fetch('matchManagers')).to eq(['npm'])
     expect(rule.fetch('matchDepTypes')).to eq(['devDependencies'])
     expect(rule.fetch('matchUpdateTypes')).to contain_exactly('minor', 'patch')
-    expect(rule.fetch('automerge')).to be(true)
+    expect(rule.fetch('automerge')).to be(false)
   end
 
-  it 'automerges Bundler patch updates after checks pass' do
-    rule = rule_for('Auto-merge Bundler patch updates after checks pass')
+  it 'requires review for Bundler patch updates' do
+    rule = rule_for('Require review for Bundler patch updates')
 
     expect(rule.fetch('matchManagers')).to eq(['bundler'])
     expect(rule.fetch('matchUpdateTypes')).to eq(['patch'])
-    expect(rule.fetch('automerge')).to be(true)
+    expect(rule.fetch('automerge')).to be(false)
   end
 
-  it 'automerges Docker patch and digest updates after checks pass' do
-    rule = rule_for('Auto-merge Docker patch and digest updates after checks pass')
+  it 'requires review for Docker patch and digest updates' do
+    rule = rule_for('Require review for Docker patch and digest updates')
 
     expect(rule.fetch('matchManagers')).to contain_exactly('dockerfile', 'docker-compose')
     expect(rule.fetch('matchUpdateTypes')).to contain_exactly('patch', 'digest')
-    expect(rule.fetch('automerge')).to be(true)
+    expect(rule.fetch('automerge')).to be(false)
   end
 
-  it 'automerges lockfile maintenance after checks pass' do
+  it 'requires review for lockfile maintenance' do
     lockfile_maintenance = config.fetch('lockFileMaintenance')
 
     expect(lockfile_maintenance.fetch('enabled')).to be(true)
-    expect(lockfile_maintenance.fetch('automerge')).to be(true)
+    expect(lockfile_maintenance.fetch('automerge')).to be(false)
     expect(lockfile_maintenance.fetch('ignoreTests')).to be(false)
   end
 


### PR DESCRIPTION
### Motivation
- Prevent automated merges of security-sensitive Renovate updates that could introduce unreviewed changes into privileged CI/CD workflows handling PHI.
- Ensure GitHub Actions, lockfile maintenance, dev dependencies, Bundler, and Docker updates remain review-gated to reduce supply-chain attack surface.

### Description
- Set `lockFileMaintenance.automerge` to `false` in `renovate.json` to prevent automatic lockfile merges.
- Change `packageRules` in `renovate.json` so `automerge: false` for `github-actions`, `npm` (devDependencies), `bundler`, and `dockerfile`/`docker-compose` update rules and update their descriptions to indicate review is required.
- Update `spec/config/json_spec.rb` tests to assert the new review-gated behavior (expect `automerge` to be `false` and rename descriptions accordingly).
- Keep top-level `automerge: false` and the existing rule that keeps major updates manual.

### Testing
- Validated JSON formatting with `python -m json.tool renovate.json` and performed a programmatic assertion that `automerge` is `false` for the top-level, `lockFileMaintenance`, and all `packageRules`, which succeeded and printed `renovate automerge disabled`.
- Ran `git diff --check` and inspected diffs to confirm only the intended config and spec changes were made.
- Attempted to run `bundle exec rspec spec/config/json_spec.rb`, but the run was blocked by the environment toolchain (`mise`) failing to install `ruby@4.0.4` due to transient remote fetch errors, so the RSpec execution did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a78ceb6908322888469aaf899eaa7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->