### PR TITLE
fix: cover direct medication onboarding authorization

### DIFF
--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -577,6 +577,51 @@ RSpec.describe 'Medication creation scope' do
       expect(response.body).not_to include('has already been taken')
     end
 
+    it 'rejects onboarding direct plans that fail PersonMedication authorization' do
+      adult_patient = people(:adult_patient_person)
+      CarerRelationship.create!(
+        carer: parent_user.person,
+        patient: adult_patient,
+        relationship_type: 'parent',
+        active: true
+      )
+
+      expect do
+        post medications_path, params: {
+          wizard: 'true',
+          medication: {
+            name: 'Unauthorized PRN Plan',
+            category: 'Analgesic',
+            dosage_records_attributes: {
+              '0' => {
+                amount: '1',
+                unit: 'tablet',
+                frequency: 'As needed',
+                default_for_adults: '1',
+                default_max_daily_doses: '2',
+                default_min_hours_between_doses: '8',
+                default_dose_cycle: 'daily'
+              }
+            },
+            current_supply: 10,
+            reorder_threshold: 1,
+            location_id: locations(:home).id
+          },
+          onboarding_schedule: {
+            person_id: adult_patient.id,
+            schedule_type: 'prn',
+            max_daily_doses: '2',
+            min_hours_between_doses: '8',
+            start_date: Time.zone.today.to_s,
+            end_date: 1.month.from_now.to_date.to_s
+          }
+        }
+      end.not_to change(PersonMedication, :count)
+
+      expect(Medication.find_by(name: 'Unauthorized PRN Plan')).to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+
     it 'rejects a forged foreign location_id' do
       expect do
         post medications_path, params: {

--- a/spec/services/medication_onboarding_create_service_spec.rb
+++ b/spec/services/medication_onboarding_create_service_spec.rb
@@ -224,13 +224,16 @@ RSpec.describe MedicationOnboardingCreateService do
     end
 
     context 'with a PRN schedule type (results in PersonMedication)' do
+      let(:plan_authorizer) { ->(_record) {} }
+
       it 'does NOT create a Schedule' do
         medication = medication_with_dosage(category: 'Analgesic')
         schedule_count = Schedule.count
         call_service(
           medication: medication,
           schedule_attributes: schedule_attrs(type: 'prn'),
-          people_scope: people_scope
+          people_scope: people_scope,
+          plan_authorizer: plan_authorizer
         )
         expect(Schedule.count).to eq(schedule_count)
       end
@@ -241,9 +244,24 @@ RSpec.describe MedicationOnboardingCreateService do
           call_service(
             medication: medication,
             schedule_attributes: schedule_attrs(type: 'prn'),
-            people_scope: people_scope
+            people_scope: people_scope,
+            plan_authorizer: plan_authorizer
           )
         end.to change(PersonMedication, :count).by(1)
+      end
+
+      it 'authorizes the PersonMedication before saving' do
+        medication = medication_with_dosage(category: 'Analgesic')
+        authorized_records = []
+
+        call_service(
+          medication: medication,
+          schedule_attributes: schedule_attrs(type: 'prn'),
+          people_scope: people_scope,
+          plan_authorizer: ->(record) { authorized_records << record }
+        )
+
+        expect(authorized_records).to contain_exactly(PersonMedication.last)
       end
 
       it 'requires a plan authorizer before saving a PersonMedication record' do
@@ -269,7 +287,8 @@ RSpec.describe MedicationOnboardingCreateService do
         result = call_service(
           medication: medication,
           schedule_attributes: schedule_attrs(type: 'prn'),
-          people_scope: people_scope
+          people_scope: people_scope,
+          plan_authorizer: plan_authorizer
         )
         expect(result.schedule).to be_nil
       end


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass where medication onboarding could create direct `PersonMedication` plans (PRN/supplement) without invoking `PersonMedicationPolicy#create?`.
- Ensure onboarding and restock flows apply the same per-record authorization checks used by the normal `PersonMedicationsController#create` path for safety-critical patient medication plans.

### Description
- Pass the controller Pundit authorizer into onboarding: `MedicationOnboardingCreateService` is now initialized with `plan_authorizer: method(:authorize)` from `MedicationsController#create`.
- Add a `plan_authorizer` attribute and `authorize_direct_plan_record(record)` helper in `MedicationOnboardingCreateService` that raises `Pundit::NotAuthorizedError` if no authorizer is provided and calls the authorizer for `PersonMedication` records before they are saved.
- Invoke the authorization check before persisting the built plan in both the new-medication path (`persist_medication_with_plan`) and the restock path (`restock_existing_medication`).
- Update specs: `spec/services/medication_onboarding_create_service_spec.rb` was extended to accept a `plan_authorizer` and to assert that the authorizer is called (and that omission raises), and `spec/requests/medications_create_scope_spec.rb` gains a request test ensuring unauthorized onboarding PRN plans are rejected.

### Testing
- Ran `git diff --check` to validate workspace diffs which reported no whitespace errors.
- Attempted to run `bundle exec rspec spec/services/medication_onboarding_create_service_spec.rb spec/requests/medications_create_scope_spec.rb`, but execution was blocked because the environment tool `mise` could not install Ruby 4.0.4 due to failing network fetches for `ruby-build`/GitHub resources, so the specs could not be executed here.
- Updated and added automated specs to cover the new authorization behavior (service and request specs), but their execution remains unverified in this environment due to the Ruby install failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b2e26f3848322b5b0588d12fd2bd7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->