### PR TITLE
fix: secure mutation and API auth boundaries

### DIFF
--- a/app/components/shared/person_avatar.rb
+++ b/app/components/shared/person_avatar.rb
@@ -82,8 +82,9 @@ module Components
 
       def uploaded_avatar_url
         return unless person.avatar.attached?
+        return unless person.household
 
-        view_context.url_for(person.avatar)
+        view_context.person_avatar_path(household_slug: person.household.slug, person_id: person.id)
       end
 
       def gravatar_url

--- a/app/controllers/ai_medication_suggestions_controller.rb
+++ b/app/controllers/ai_medication_suggestions_controller.rb
@@ -2,10 +2,10 @@
 
 class AiMedicationSuggestionsController < ApplicationController
   def create
+    authorize Medication, :finder?
+
     head :not_found unless PaidFeature.enabled?(:ai_medication_help, user: current_user)
     return if performed?
-
-    authorize Medication, :finder?
 
     suggestion = AiMedication::SuggestionService.new.call(
       medication_identity: medication_identity_params.to_h.deep_symbolize_keys,

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -13,10 +13,6 @@ module Api
             render_invalid_credentials
             return
           end
-          if ApiAuthState.mfa_configured?(account)
-            render_mfa_required
-            return
-          end
 
           api_session, access_token, refresh_token = ApiSession.issue_for(
             account: account,
@@ -91,6 +87,7 @@ module Api
         def login_permitted?(account, household_membership, password)
           ApiAuthState.password_authenticated?(account, password) &&
             !ApiAuthState.locked_out?(account) &&
+            !ApiAuthState.mfa_configured?(account) &&
             account.person&.user&.active? &&
             household_membership.present?
         end
@@ -159,11 +156,6 @@ module Api
 
         def render_invalid_credentials
           render json: { error: { code: 'invalid_credentials', message: 'Email or password is invalid' } },
-                 status: :unauthorized
-        end
-
-        def render_mfa_required
-          render json: { error: { code: 'mfa_required', message: 'Use an app token for API access.' } },
                  status: :unauthorized
         end
 

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -7,9 +7,14 @@ module Api
         def create
           account = Account.find_by(email: params.expect(:email).to_s.strip.downcase)
           household_membership = requested_household_membership(account)
+          password = params.expect(:password).to_s
 
-          unless login_permitted?(account, household_membership)
+          unless login_permitted?(account, household_membership, password)
             render_invalid_credentials
+            return
+          end
+          if ApiAuthState.mfa_configured?(account)
+            render_mfa_required
             return
           end
 
@@ -46,8 +51,8 @@ module Api
 
         def destroy
           token = request.headers['Authorization'].to_s.split(' ', 2).last
-          api_session = ApiSession.lookup_by_access_token(token)
-          api_session&.revoke!(audit_context: audit_context(api_session.account))
+          api_credential = ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
+          api_credential&.revoke!(audit_context: audit_context(api_credential.account))
 
           head :no_content
         end
@@ -83,17 +88,9 @@ module Api
           )
         end
 
-        def authenticated_account?(account, password)
-          return false if account.blank? || password.blank?
-          return false unless account.verified?
-
-          BCrypt::Password.new(account.password_hash).is_password?(password)
-        rescue BCrypt::Errors::InvalidHash
-          false
-        end
-
-        def login_permitted?(account, household_membership)
-          authenticated_account?(account, params.expect(:password).to_s) &&
+        def login_permitted?(account, household_membership, password)
+          ApiAuthState.password_authenticated?(account, password) &&
+            !ApiAuthState.locked_out?(account) &&
             account.person&.user&.active? &&
             household_membership.present?
         end
@@ -101,7 +98,8 @@ module Api
         def refresh_permitted?(api_session)
           api_session&.active_refresh_token? &&
             api_session.account.verified? &&
-            api_session.account.person&.user&.active?
+            api_session.account.person&.user&.active? &&
+            !ApiAuthState.locked_out?(api_session.account)
         end
 
         def household_requested?
@@ -161,6 +159,11 @@ module Api
 
         def render_invalid_credentials
           render json: { error: { code: 'invalid_credentials', message: 'Email or password is invalid' } },
+                 status: :unauthorized
+        end
+
+        def render_mfa_required
+          render json: { error: { code: 'mfa_required', message: 'Use an app token for API access.' } },
                  status: :unauthorized
         end
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -43,9 +43,10 @@ module Api
       end
 
       def authenticate_api_request!
-        @current_api_session = ApiSession.lookup_by_access_token(bearer_token)
+        @current_api_session = lookup_api_credential
         return render_unauthorized('Authentication required') unless valid_session?
         return render_unauthorized('Authentication required') unless valid_account_and_user?
+        return render_unauthorized('Authentication required') if ApiAuthState.locked_out?(current_account)
 
         Current.account = current_account
         Current.request_id = request.request_id
@@ -53,9 +54,10 @@ module Api
       end
 
       def valid_session?
-        @current_api_session.present? &&
-          @current_api_session.revoked_at.nil? &&
-          @current_api_session.access_expires_at&.future?
+        return false if @current_api_session.blank? || @current_api_session.revoked_at.present?
+        return @current_api_session.access_expires_at.future? if @current_api_session.is_a?(ApiSession)
+
+        @current_api_session.is_a?(ApiAppToken)
       end
 
       def valid_account_and_user?
@@ -93,6 +95,11 @@ module Api
         return nil unless scheme == 'Bearer'
 
         token
+      end
+
+      def lookup_api_credential
+        token = bearer_token
+        ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
       end
 
       def render_collection(scope, serializer:, includes: nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_paper_trail_whodunnit
   around_action :with_current_context
+  after_action :verify_pundit_authorization, if: :pundit_verification_required?
   helper_method :current_household, :current_membership
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
@@ -31,6 +32,14 @@ class ApplicationController < ActionController::Base
 
   def pundit_user
     AuthorizationContext.current || current_user
+  end
+
+  def verify_pundit_authorization
+    verify_authorized
+  end
+
+  def pundit_verification_required?
+    !request.get? && !request.head?
   end
 
   def with_current_context

--- a/app/controllers/household_redirects_controller.rb
+++ b/app/controllers/household_redirects_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HouseholdRedirectsController < ApplicationController
+  skip_after_action :verify_pundit_authorization
+
   def show
     membership = current_account&.first_active_household_membership
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,6 +3,7 @@
 class InvitationsController < ApplicationController
   allow_unauthenticated_access
   layout false
+  skip_after_action :verify_pundit_authorization
 
   def accept
     token_value = params.expect(:token).to_s

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -364,7 +364,8 @@ class MedicationsController < ApplicationController
       medication: @medication,
       schedule_attributes: onboarding_schedule_params_for_create,
       people_scope: policy_scope(Person),
-      medication_scope: policy_scope(Medication)
+      medication_scope: policy_scope(Medication),
+      plan_authorizer: ->(record) { authorize(record, :create?) }
     ).call
   end
 

--- a/app/controllers/native_device_tokens_controller.rb
+++ b/app/controllers/native_device_tokens_controller.rb
@@ -5,6 +5,7 @@ class NativeDeviceTokensController < ApplicationController
     token = current_account.native_device_tokens.find_or_initialize_by(device_token: params[:device_token])
     new_token = token.new_record?
     token.assign_attributes(platform: params[:platform], user_agent: request.user_agent)
+    authorize token, :create?
 
     if token.save
       record_auth_token_event('created', token) if new_token
@@ -17,7 +18,12 @@ class NativeDeviceTokensController < ApplicationController
 
   def destroy
     token = current_account.native_device_tokens.find_by(device_token: params[:id])
-    return head :no_content unless token
+    unless token
+      authorize NativeDeviceToken.new(account: current_account), :destroy?
+      return head :no_content
+    end
+
+    authorize token, :destroy?
 
     if token.destroy
       record_auth_token_event('revoked', token)

--- a/app/controllers/notification_preferences_controller.rb
+++ b/app/controllers/notification_preferences_controller.rb
@@ -4,6 +4,8 @@ class NotificationPreferencesController < ApplicationController
   def update
     @preference = current_user.person.notification_preference ||
                   current_user.person.build_notification_preference
+    authorize @preference
+
     if @preference.update(preference_params)
       respond_to do |format|
         format.html { redirect_to profile_path, notice: t('notification_preferences.updated') }

--- a/app/controllers/offline_controller.rb
+++ b/app/controllers/offline_controller.rb
@@ -23,7 +23,10 @@ class OfflineController < ApplicationController
 
     if client_uuid.present?
       existing_take = policy_scope(MedicationTake).find_by(client_uuid: client_uuid)
-      return render_synced_take(existing_take, status: :ok) if existing_take
+      if existing_take
+        authorize existing_take, :create?
+        return render_synced_take(existing_take, status: :ok)
+      end
     end
 
     source = offline_take_source(source_type, source_id)
@@ -47,7 +50,10 @@ class OfflineController < ApplicationController
     return render_take_failure(result.error) unless result.success
 
     render_synced_take(result.take, status: :created)
-  rescue ActiveRecord::RecordNotFound, Pundit::NotAuthorizedError
+  rescue ActiveRecord::RecordNotFound
+    skip_authorization
+    render_unprocessable(t('.source_unavailable', default: 'Queued dose source is no longer available.'))
+  rescue Pundit::NotAuthorizedError
     render_unprocessable(t('.source_unavailable', default: 'Queued dose source is no longer available.'))
   end
 

--- a/app/controllers/people/avatars_controller.rb
+++ b/app/controllers/people/avatars_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module People
+  class AvatarsController < ApplicationController
+    before_action :require_authentication
+    before_action :check_two_factor_setup
+
+    def show
+      person = policy_scope(Person).find(params.expect(:person_id))
+      authorize person, :show?
+
+      return head :not_found unless person.avatar.attached?
+
+      send_data person.avatar.download,
+                type: person.avatar.content_type,
+                disposition: 'inline',
+                filename: person.avatar.filename.to_s
+    end
+  end
+end

--- a/app/controllers/profiles/api_tokens_controller.rb
+++ b/app/controllers/profiles/api_tokens_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Profiles
+  class ApiTokensController < ApplicationController
+    before_action :require_authentication
+    before_action :check_two_factor_setup
+
+    def create
+      authorize current_user.person, :update?
+      if ApiAuthState.locked_out?(current_account)
+        return redirect_to(profile_path, alert: t('profiles.api_tokens.locked'))
+      end
+      return redirect_to(profile_path, alert: t('profiles.api_tokens.mfa_required')) unless mfa_satisfied?
+
+      membership = token_household_membership
+      _app_token, raw_token = ApiAppToken.issue_for(
+        account: current_account,
+        household_membership: membership,
+        name: token_params.fetch(:name).to_s.strip,
+        audit_context: audit_context(membership)
+      )
+
+      render Views::Profiles::Show.new(
+        person: current_user.person,
+        account: current_account,
+        new_api_app_token: raw_token,
+        api_app_tokens: current_account.api_app_tokens.active.order(created_at: :desc).to_a
+      ), status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to profile_path, alert: e.record.errors.full_messages.to_sentence
+    end
+
+    def destroy
+      authorize current_user.person, :update?
+      app_token = current_account.api_app_tokens.find(params.expect(:id))
+      app_token.revoke!(audit_context: audit_context(app_token.household_membership))
+
+      redirect_to profile_path, notice: t('profiles.api_tokens.revoked')
+    end
+
+    private
+
+    def token_params
+      params.expect(api_app_token: %i[name household_membership_id])
+    end
+
+    def token_household_membership
+      current_account.household_memberships.active.find(token_params.fetch(:household_membership_id))
+    end
+
+    def mfa_satisfied?
+      ApiAuthState.web_session_mfa_satisfied?(session, current_account)
+    end
+
+    def audit_context(membership)
+      {
+        whodunnit: current_user.id,
+        ip: request.remote_ip,
+        request_id: request.request_id,
+        household_id: membership.household_id,
+        actor_membership_id: membership.id
+      }
+    end
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,6 +8,7 @@ class ProfilesController < ApplicationController
   def show
     @person = current_user.person
     @account = current_account
+    authorize @person, :show?
 
     respond_to do |format|
       format.html do
@@ -19,6 +20,7 @@ class ProfilesController < ApplicationController
   def update
     @person = current_user.person
     @account = current_account
+    authorize @person, :update?
 
     attributes = person_params
     return update_person_profile(attributes) if attributes.present?
@@ -30,6 +32,7 @@ class ProfilesController < ApplicationController
   end
 
   def avatar
+    authorize current_user.person, :update?
     current_user.person.avatar.purge
     @person = current_user.person
     @account = current_account
@@ -47,6 +50,7 @@ class ProfilesController < ApplicationController
   end
 
   def experiments
+    authorize current_user.person, :update?
     variant = params.dig(:account, :wizard_variant).to_s
     variant = 'fullpage' unless Account::WIZARD_VARIANTS.include?(variant)
 

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -6,6 +6,8 @@ class PushSubscriptionsController < ApplicationController
     new_subscription = sub.new_record?
     sub.assign_attributes(p256dh: params.dig(:keys, :p256dh), auth: params.dig(:keys, :auth),
                           user_agent: request.user_agent)
+    authorize sub, :create?
+
     if sub.save
       record_auth_token_event('created', sub) if new_subscription
       head :created
@@ -17,7 +19,12 @@ class PushSubscriptionsController < ApplicationController
 
   def destroy
     sub = current_account.push_subscriptions.find_by(endpoint: params[:endpoint])
-    return head :no_content unless sub
+    unless sub
+      authorize PushSubscription.new(account: current_account), :destroy?
+      return head :no_content
+    end
+
+    authorize sub, :destroy?
 
     if sub.destroy
       record_auth_token_event('revoked', sub)
@@ -29,6 +36,8 @@ class PushSubscriptionsController < ApplicationController
   end
 
   def test
+    authorize PushSubscription.new(account: current_account), :test?
+
     PushNotificationService.send_to_account(
       current_account,
       title: 'MedTracker Test',

--- a/app/controllers/pwa_controller.rb
+++ b/app/controllers/pwa_controller.rb
@@ -4,6 +4,7 @@
 class PwaController < ApplicationController
   layout false
   allow_unauthenticated_access only: %i[manifest service_worker]
+  skip_after_action :verify_pundit_authorization
 
   def manifest
     render body: manifest_payload.to_json

--- a/app/controllers/rodauth_controller.rb
+++ b/app/controllers/rodauth_controller.rb
@@ -3,6 +3,7 @@
 class RodauthController < ApplicationController
   # Skip authentication for Rodauth routes to prevent redirect loops
   allow_unauthenticated_access
+  skip_after_action :verify_pundit_authorization
 
   # Used by Rodauth for rendering views, CSRF protection, running any
   # registered action callbacks and rescue handlers, instrumentation etc.

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -15,6 +15,7 @@ class Account < ApplicationRecord
   has_many :household_memberships, dependent: :destroy
   has_many :households, through: :household_memberships
   has_many :api_sessions, dependent: :destroy
+  has_many :api_app_tokens, dependent: :destroy
   has_many :push_subscriptions, dependent: :destroy
   has_many :native_device_tokens, dependent: :destroy
   has_many :account_webauthn_keys, dependent: :destroy

--- a/app/models/account_lockout.rb
+++ b/app/models/account_lockout.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AccountLockout < ApplicationRecord
+  self.primary_key = :account_id
+
+  belongs_to :account, inverse_of: false
+
+  scope :active, -> { where(arel_table[:deadline].gt(Time.current)) }
+end

--- a/app/models/api_app_token.rb
+++ b/app/models/api_app_token.rb
@@ -2,6 +2,7 @@
 
 class ApiAppToken < ApplicationRecord
   TOKEN_PREFIX = 'mt_app_'
+  LAST_USED_TOUCH_INTERVAL = 5.minutes
 
   belongs_to :account
   belongs_to :household_membership
@@ -77,6 +78,8 @@ class ApiAppToken < ApplicationRecord
   end
 
   def touch_last_used!
+    return if last_used_at.present? && last_used_at >= LAST_USED_TOUCH_INTERVAL.ago
+
     update!(last_used_at: Time.current)
   end
 

--- a/app/models/api_app_token.rb
+++ b/app/models/api_app_token.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class ApiAppToken < ApplicationRecord
+  TOKEN_PREFIX = 'mt_app_'
+
+  belongs_to :account
+  belongs_to :household_membership
+
+  validates :name, :token_digest, :last_used_at, presence: true
+  validates :token_digest, uniqueness: true
+  validate :household_membership_must_belong_to_account
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  class << self
+    def issue_for(account:, household_membership:, name:, audit_context: nil)
+      raw_token = build_token
+      app_token = create!(
+        account: account,
+        household_membership: household_membership,
+        permissions_version: household_membership.permissions_version,
+        name: name,
+        token_digest: digest(raw_token),
+        last_used_at: Time.current
+      )
+
+      record_audit(app_token, 'created', audit_context)
+
+      [app_token, raw_token]
+    end
+
+    def lookup_by_token(token)
+      active.find_by(token_digest: digest(token))
+    end
+
+    def digest(token)
+      Digest::SHA256.hexdigest(token.to_s)
+    end
+
+    def record_audit(app_token, action, audit_context)
+      audit_logger.record(
+        account: app_token.account,
+        token_type: 'api_app_token',
+        action: action,
+        metadata: app_token.send(:audit_metadata),
+        context: audit_context_with_tenant(app_token, audit_context)
+      )
+    end
+
+    private
+
+    def build_token
+      "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(48)}"
+    end
+
+    def audit_logger
+      AuthTokenAuditLogger.new
+    end
+
+    def audit_context_with_tenant(app_token, audit_context)
+      {
+        household_id: app_token.household_membership&.household_id,
+        actor_membership_id: app_token.household_membership_id
+      }.merge(audit_context.to_h).compact
+    end
+  end
+
+  def active_for_membership?
+    return false if household_membership.blank?
+
+    revoked_at.nil? && household_membership.active? && permissions_version == household_membership.permissions_version
+  end
+
+  def revoke!(audit_context: nil, action: 'revoked')
+    update!(revoked_at: Time.current)
+    self.class.record_audit(self, action, audit_context)
+  end
+
+  def touch_last_used!
+    update!(last_used_at: Time.current)
+  end
+
+  private
+
+  def audit_metadata
+    {
+      device_name: name,
+      household_membership_id: household_membership_id,
+      permissions_version: permissions_version
+    }
+  end
+
+  def household_membership_must_belong_to_account
+    return if household_membership.blank? || household_membership.account_id == account_id
+
+    errors.add(:household_membership, 'must belong to the account')
+  end
+end

--- a/app/policies/native_device_token_policy.rb
+++ b/app/policies/native_device_token_policy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class NativeDeviceTokenPolicy < ApplicationPolicy
+  def create?
+    account_owned?
+  end
+
+  def destroy?
+    account_owned?
+  end
+
+  private
+
+  def account_owned?
+    actor_account.present? && record.account_id == actor_account.id
+  end
+
+  def actor_account
+    account || user&.person&.account
+  end
+end

--- a/app/policies/notification_preference_policy.rb
+++ b/app/policies/notification_preference_policy.rb
@@ -5,6 +5,10 @@ class NotificationPreferencePolicy < ApplicationPolicy
     person_grant_allows?(record.person, :view)
   end
 
+  def update?
+    person_grant_allows?(record.person, :manage)
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       household_notification_preference_scope

--- a/app/policies/push_subscription_policy.rb
+++ b/app/policies/push_subscription_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PushSubscriptionPolicy < ApplicationPolicy
+  def create?
+    account_owned?
+  end
+
+  def destroy?
+    account_owned?
+  end
+
+  def test?
+    account_owned?
+  end
+
+  private
+
+  def account_owned?
+    actor_account.present? && record.account_id == actor_account.id
+  end
+
+  def actor_account
+    account || user&.person&.account
+  end
+end

--- a/app/services/api_auth_state.rb
+++ b/app/services/api_auth_state.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ApiAuthState
+  MFA_METHODS = %w[totp webauthn sms_code recovery_code otp].freeze
+
+  class << self
+    def password_authenticated?(account, password)
+      return false if account.blank? || password.blank?
+      return false unless account.verified?
+
+      BCrypt::Password.new(account.password_hash).is_password?(password)
+    rescue BCrypt::Errors::InvalidHash
+      false
+    end
+
+    def locked_out?(account)
+      return false if account.blank?
+
+      AccountLockout.active.exists?(account_id: account.id)
+    end
+
+    def mfa_configured?(account)
+      return false if account.blank?
+
+      AccountOtpKey.exists?(id: account.id) || account.account_webauthn_keys.exists?
+    end
+
+    def web_session_mfa_satisfied?(session, account)
+      return true unless mfa_configured?(account)
+      return true if session[:oidc_mfa_verified] == true || session['oidc_mfa_verified'] == true
+
+      authenticated_by = Array(session[:authenticated_by]) | Array(session['authenticated_by'])
+      authenticated_by.intersect?(MFA_METHODS)
+    end
+  end
+end

--- a/app/services/medication_onboarding_create_service.rb
+++ b/app/services/medication_onboarding_create_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MedicationOnboardingCreateService
+  class MissingPlanAuthorizer < StandardError; end
+
   Result = Data.define(:success, :medication, :schedule, :restocked) do
     def restocked?
       restocked
@@ -26,13 +28,14 @@ class MedicationOnboardingCreateService
     ] }
   ].freeze
 
-  attr_reader :medication, :schedule_attributes, :people_scope, :medication_scope
+  attr_reader :medication, :schedule_attributes, :people_scope, :medication_scope, :plan_authorizer
 
-  def initialize(medication:, schedule_attributes: nil, people_scope: nil, medication_scope: nil)
+  def initialize(medication:, schedule_attributes: nil, people_scope: nil, medication_scope: nil, plan_authorizer: nil)
     @medication = medication
     @schedule_attributes = schedule_attributes
     @people_scope = people_scope
     @medication_scope = medication_scope
+    @plan_authorizer = plan_authorizer
   end
 
   def call
@@ -72,6 +75,7 @@ class MedicationOnboardingCreateService
     raise ActiveRecord::Rollback unless medication.save
 
     record = build_plan_record(medication)
+    authorize_plan_record!(record)
     return [record, true] if record.save
 
     copy_record_errors(record)
@@ -107,6 +111,12 @@ class MedicationOnboardingCreateService
       schedule_attributes: schedule_attributes,
       schedule_config: normalized_schedule_config
     ).record
+  end
+
+  def authorize_plan_record!(record)
+    raise MissingPlanAuthorizer unless plan_authorizer
+
+    plan_authorizer.call(record)
   end
 
   def assign_medication_schedule_defaults
@@ -152,6 +162,7 @@ class MedicationOnboardingCreateService
     ActiveRecord::Base.transaction do
       merge_stock_into_existing_medication(existing_medication)
       record = build_plan_record(existing_medication) if schedule_requested?
+      authorize_plan_record!(record) if record
 
       if record.blank? || record.save
         success = true

--- a/app/views/profiles/api_tokens_card.rb
+++ b/app/views/profiles/api_tokens_card.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Views
+  module Profiles
+    class ApiTokensCard < Components::Base
+      include Phlex::Rails::Helpers::ButtonTo
+      include Phlex::Rails::Helpers::FormWith
+      include Phlex::Rails::Helpers::L
+      include Phlex::Rails::Helpers::Routes
+
+      def initialize(account:, api_app_tokens:, new_api_app_token:)
+        @account = account
+        @api_app_tokens = api_app_tokens
+        @new_api_app_token = new_api_app_token
+        super()
+      end
+
+      def view_template
+        m3_card(class: 'border-border/70 shadow-elevation-2', data: { testid: 'profile-api-tokens-card' }) do
+          render CardHeader.new do
+            render(CardTitle.new { t('profiles.api_tokens.title') })
+            render(CardDescription.new { t('profiles.api_tokens.description') })
+          end
+          render CardContent.new(class: 'space-y-4') do
+            render_new_token
+            render_create_form
+            render_token_list
+          end
+        end
+      end
+
+      private
+
+      attr_reader :account, :api_app_tokens, :new_api_app_token
+
+      def render_new_token
+        return if new_api_app_token.blank?
+
+        div(class: 'rounded-shape-lg border border-primary/30 bg-primary-container p-4 text-on-primary-container') do
+          p(class: 'text-sm font-bold') { t('profiles.api_tokens.created_title') }
+          code(class: 'mt-2 block break-all rounded-shape-md bg-surface px-3 py-2 text-xs text-foreground') do
+            new_api_app_token
+          end
+        end
+      end
+
+      def render_create_form
+        membership = account.first_active_household_membership
+        return if membership.blank?
+
+        form_with(url: profile_api_tokens_path, method: :post, class: 'space-y-3') do
+          input(type: 'hidden', name: 'api_app_token[household_membership_id]', value: membership.id)
+          label(class: 'block text-sm font-bold text-foreground', for: 'api_app_token_name') do
+            t('profiles.api_tokens.name_label')
+          end
+          input(
+            id: 'api_app_token_name',
+            type: 'text',
+            name: 'api_app_token[name]',
+            maxlength: 120,
+            required: true,
+            class: 'block w-full rounded-shape-md border border-outline-variant bg-surface px-3 py-2 text-sm text-on-surface'
+          )
+          m3_button(type: :submit, variant: :filled, size: :sm) { t('profiles.api_tokens.create') }
+        end
+      end
+
+      def render_token_list
+        if api_app_tokens.empty?
+          p(class: 'text-sm text-on-surface-variant') { t('profiles.api_tokens.empty') }
+        else
+          div(class: 'space-y-3') do
+            api_app_tokens.each { |app_token| render_token_row(app_token) }
+          end
+        end
+      end
+
+      def render_token_row(app_token)
+        div(class: 'rounded-shape-lg border border-border/70 bg-popover p-4 shadow-elevation-1') do
+          div(class: 'flex items-start justify-between gap-4') do
+            div(class: 'min-w-0') do
+              h3(class: 'truncate text-sm font-medium text-foreground') { app_token.name }
+              p(class: 'mt-1 text-xs text-on-surface-variant') do
+                t('profiles.api_tokens.last_used_at', time: l(app_token.last_used_at, format: :short))
+              end
+            end
+            button_to(
+              t('profiles.api_tokens.revoke'),
+              profile_api_token_path(app_token),
+              method: :delete,
+              class: 'rounded-shape-md border border-outline px-3 py-1.5 text-sm font-medium text-foreground'
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -8,12 +8,14 @@ module Views
       include Phlex::Rails::Helpers::FormWith
       include Phlex::Rails::Helpers::ButtonTo
 
-      attr_reader :person, :account
+      attr_reader :person, :account, :api_app_tokens, :new_api_app_token
 
-      def initialize(person:, account:)
+      def initialize(person:, account:, api_app_tokens: nil, new_api_app_token: nil)
         super()
         @person = person
         @account = account
+        @api_app_tokens = api_app_tokens || account.api_app_tokens.active.order(created_at: :desc).to_a
+        @new_api_app_token = new_api_app_token
       end
 
       def view_template
@@ -78,11 +80,20 @@ module Views
       def render_right_column
         div(class: 'space-y-6') do
           render AccountSecurityCard.new(account: account)
+          render_api_tokens_card
           render NotificationsCard.new(person: person)
           render ExperimentsCard.new(account: account)
           render DangerZoneCard.new
           render VersionInfo.new
         end
+      end
+
+      def render_api_tokens_card
+        render ApiTokensCard.new(
+          account: account,
+          api_app_tokens: api_app_tokens,
+          new_api_app_token: new_api_app_token
+        )
       end
 
       def render_personal_info_card

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ module MedTracker
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks med_tracker])
+    config.active_storage.draw_routes = false
 
     # Configure Phlex autoloading
     Rails.autoloaders.main.push_dir(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1412,6 +1412,18 @@ en:
       change_password_title: Change Password
       change_password_description: Update your password to keep your account secure
       change_button: Change
+    api_tokens:
+      title: API Tokens
+      description: Create revocable tokens for scripts and trusted integrations.
+      created_title: Copy this token now. It will not be shown again.
+      name_label: Token name
+      create: Create token
+      empty: No API tokens yet.
+      last_used_at: 'Last used: %{time}'
+      revoke: Revoke
+      revoked: API token revoked.
+      locked: Your account is locked. API tokens cannot be changed right now.
+      mfa_required: Complete two-factor authentication before creating an API token.
     password_sheet:
       change_button: Change
       title: Change Password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
     resource :profile, only: %i[show update] do
       patch :experiments, on: :member
+      resources :api_tokens, only: %i[create destroy], controller: 'profiles/api_tokens'
     end
     delete 'profile/avatar', to: 'profiles#avatar', as: :profile_avatar
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
       resources :medication_takes, only: [:create]
     end
 
+    get 'people/:person_id/avatar', to: 'people/avatars#show', as: :person_avatar
     resources :people do
       member do
         get :add_medication

--- a/db/migrate/20260623090000_create_api_app_tokens.rb
+++ b/db/migrate/20260623090000_create_api_app_tokens.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateApiAppTokens < ActiveRecord::Migration[8.1]
+  def change
+    create_table :api_app_tokens do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :household_membership, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.string :name, null: false
+      t.integer :permissions_version, null: false, default: 1
+      t.datetime :last_used_at, null: false
+      t.datetime :revoked_at
+
+      t.timestamps
+    end
+
+    add_index :api_app_tokens, :token_digest, unique: true
+    add_index :api_app_tokens, %i[household_membership_id revoked_at],
+              name: 'index_api_app_tokens_on_membership_and_revoked_at'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_001300) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -163,6 +163,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_001300) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "api_app_tokens", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "household_membership_id", null: false
+    t.datetime "last_used_at", null: false
+    t.string "name", null: false
+    t.integer "permissions_version", default: 1, null: false
+    t.datetime "revoked_at"
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_api_app_tokens_on_account_id"
+    t.index ["household_membership_id", "revoked_at"], name: "index_api_app_tokens_on_membership_and_revoked_at"
+    t.index ["household_membership_id"], name: "index_api_app_tokens_on_household_membership_id"
+    t.index ["token_digest"], name: "index_api_app_tokens_on_token_digest", unique: true
   end
 
   create_table "api_sessions", force: :cascade do |t|
@@ -621,6 +637,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_001300) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_attachments", "households"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "api_app_tokens", "accounts"
+  add_foreign_key "api_app_tokens", "household_memberships"
   add_foreign_key "api_sessions", "accounts"
   add_foreign_key "api_sessions", "household_memberships"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred

--- a/spec/architecture/tenant_safety_spec.rb
+++ b/spec/architecture/tenant_safety_spec.rb
@@ -87,6 +87,44 @@ RSpec.describe 'tenant safety architecture' do
     expect(offenders).to be_empty
   end
 
+  it 'keeps default Active Storage routes disabled for tenant-owned attachments' do
+    expect(Rails.application.config.active_storage.draw_routes).to be(false)
+    expect(route_paths).not_to include('/rails/active_storage/direct_uploads(.:format)')
+  end
+
+  it 'serves avatars through an application-owned household route' do
+    expect(route_paths).to include('/households/:household_slug/people/:person_id/avatar(.:format)')
+    expect(Rails.root.join('app/components/shared/person_avatar.rb').read).not_to include('url_for(person.avatar)')
+  end
+
+  it 'requires onboarding services to authorize derived plan records before saving' do
+    source = Rails.root.join('app/services/medication_onboarding_create_service.rb').read
+
+    expect(source).to include('plan_authorizer:')
+    expect(source).to include('authorize_plan_record!(record)')
+    expect(source.index('authorize_plan_record!(record)')).to be < source.index('record.save')
+    expect(Rails.root.join('app/controllers/medications_controller.rb').read).to include(
+      'plan_authorizer: ->(record) { authorize(record, :create?) }'
+    )
+  end
+
+  it 'keeps unsafe Pundit verification skips out of mutating app controllers' do
+    skipped_controllers = Rails.root.glob('app/controllers/**/*.rb').filter_map do |path|
+      next unless path.read.include?('skip_after_action :verify_pundit_authorization')
+
+      path.relative_path_from(Rails.root).to_s
+    end
+
+    expect(skipped_controllers).to match_array(
+      %w[
+        app/controllers/household_redirects_controller.rb
+        app/controllers/invitations_controller.rb
+        app/controllers/pwa_controller.rb
+        app/controllers/rodauth_controller.rb
+      ]
+    )
+  end
+
   it 'keeps Pundit policies off legacy User role predicates' do
     offenders = Rails.root.glob('app/policies/**/*.rb').filter_map do |path|
       relative_path = path.relative_path_from(Rails.root).to_s
@@ -115,6 +153,10 @@ RSpec.describe 'tenant safety architecture' do
 
   def connection_column_names(table_name)
     ActiveRecord::Base.connection.columns(table_name).map(&:name)
+  end
+
+  def route_paths
+    Rails.application.routes.routes.map { |route| route.path.spec.to_s }
   end
 
   def unsafe_turbo_target_pattern

--- a/spec/architecture/tenant_safety_spec.rb
+++ b/spec/architecture/tenant_safety_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe 'tenant safety architecture' do
     )
   end
 
+  it 'keeps API password verification behind the shared auth state boundary' do
+    source = Rails.root.join('app/controllers/api/v1/auth/sessions_controller.rb').read
+
+    expect(source).not_to include('BCrypt::Password')
+    expect(source).to include('ApiAuthState')
+  end
+
+  it 'requires API bearer authentication to reject locked accounts and support app tokens' do
+    source = Rails.root.join('app/controllers/api/v1/base_controller.rb').read
+
+    expect(source).to include('ApiAppToken.lookup_by_token')
+    expect(source).to include('ApiAuthState.locked_out?')
+  end
+
   it 'keeps unsafe Pundit verification skips out of mutating app controllers' do
     skipped_controllers = Rails.root.glob('app/controllers/**/*.rb').filter_map do |path|
       next unless path.read.include?('skip_after_action :verify_pundit_authorization')

--- a/spec/components/shared/person_avatar_spec.rb
+++ b/spec/components/shared/person_avatar_spec.rb
@@ -42,11 +42,13 @@ RSpec.describe Components::Shared::PersonAvatar, type: :component do
 
   it 'prefers uploaded avatars over Gravatar' do
     person.account.update!(gravatar_enabled: '1')
+    person.update!(household: Household.create!(name: 'Avatar Component Household'))
     person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
 
     rendered = render_inline(described_class.new(person: person))
 
     expect(rendered.at_css("img[alt='Damacus User']")).to be_present
+    expect(rendered.at_css("img[src*='/households/#{person.household.slug}/people/#{person.id}/avatar']")).to be_present
     expect(rendered.to_html).not_to include('gravatar.com/avatar')
   end
 

--- a/spec/models/api_app_token_spec.rb
+++ b/spec/models/api_app_token_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiAppToken do
+  fixtures :accounts
+
+  describe '#touch_last_used!' do
+    let(:account) { accounts(:jane_doe) }
+    let(:membership) { api_membership_for(account) }
+    let(:issued_at) { Time.zone.parse('2026-04-21 10:00:00') }
+
+    it 'skips the write when the token was used recently' do
+      app_token = issue_app_token_at_issued_time
+
+      travel_to(issued_at + 1.minute) do
+        expect do
+          app_token.touch_last_used!
+        end.not_to(change { app_token.reload.updated_at })
+      end
+    end
+
+    it 'updates the timestamp when the token has not been used recently' do
+      app_token = issue_app_token_at_issued_time
+
+      travel_to(issued_at + 10.minutes) do
+        expect do
+          app_token.touch_last_used!
+        end.to change { app_token.reload.last_used_at }.from(issued_at).to(Time.current)
+      end
+    end
+  end
+
+  def issue_app_token_at_issued_time
+    travel_to(issued_at) do
+      described_class.issue_for(
+        account: account,
+        household_membership: membership,
+        name: 'RSpec token'
+      ).first
+    end
+  end
+
+  def api_membership_for(account)
+    household = api_household
+    household.household_memberships.create!(
+      account: account,
+      person: api_person_for(account, household),
+      role: :owner,
+      status: :active
+    )
+  end
+
+  def api_household
+    Household.create!(name: "API App Token Spec #{SecureRandom.hex(4)}",
+                      slug: "api-app-token-spec-#{SecureRandom.hex(4)}")
+  end
+
+  def api_person_for(account, household)
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'API App Token Person',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+end

--- a/spec/requests/active_storage_direct_uploads_spec.rb
+++ b/spec/requests/active_storage_direct_uploads_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Active Storage direct uploads' do
+  it 'does not expose the default unauthenticated direct upload endpoint' do
+    expect do
+      post '/rails/active_storage/direct_uploads', params: {
+        blob: {
+          filename: 'avatar.png',
+          byte_size: 6,
+          checksum: Base64.strict_encode64(Digest::MD5.digest('avatar')),
+          content_type: 'image/png'
+        }
+      }, as: :json
+    end.not_to change(ActiveStorage::Blob, :count)
+
+    expect(response).to have_http_status(:not_found).or have_http_status(:unauthorized).or have_http_status(:forbidden)
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -148,9 +148,17 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
     end
 
-    it 'requires an app token instead of password-only login when TOTP is configured' do
+    it 'returns the generic invalid credentials response when TOTP is configured' do
       create_api_household_for(user)
       AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+
+      post api_v1_auth_login_path,
+           params: {
+             email: user.email_address,
+             password: 'wrong-password'
+           },
+           as: :json
+      invalid_credentials_response = [response.status, response.parsed_body]
 
       expect do
         post api_v1_auth_login_path,
@@ -161,11 +169,10 @@ RSpec.describe 'API v1 auth sessions' do
              as: :json
       end.not_to change(ApiSession, :count)
 
-      expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body.dig('error', 'code')).to eq('mfa_required')
+      expect([response.status, response.parsed_body]).to eq(invalid_credentials_response)
     end
 
-    it 'requires an app token instead of password-only login when WebAuthn is configured' do
+    it 'returns the generic invalid credentials response when WebAuthn is configured' do
       create_api_household_for(user)
       account.account_webauthn_keys.create!(
         webauthn_id: 'api-login-passkey',
@@ -174,6 +181,14 @@ RSpec.describe 'API v1 auth sessions' do
         nickname: 'API Login Passkey'
       )
 
+      post api_v1_auth_login_path,
+           params: {
+             email: user.email_address,
+             password: 'wrong-password'
+           },
+           as: :json
+      invalid_credentials_response = [response.status, response.parsed_body]
+
       expect do
         post api_v1_auth_login_path,
              params: {
@@ -183,8 +198,7 @@ RSpec.describe 'API v1 auth sessions' do
              as: :json
       end.not_to change(ApiSession, :count)
 
-      expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body.dig('error', 'code')).to eq('mfa_required')
+      expect([response.status, response.parsed_body]).to eq(invalid_credentials_response)
     end
   end
 

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -6,8 +6,14 @@ RSpec.describe 'API v1 auth sessions' do
   fixtures :accounts, :people, :users, :locations, :location_memberships
 
   let(:user) { users(:jane) }
+  let(:account) { user.person.account }
 
   describe 'POST /api/v1/auth/login' do
+    before do
+      clear_2fa_for_account(account)
+      AccountLockout.where(account_id: account.id).delete_all if defined?(AccountLockout)
+    end
+
     def create_api_household_for(user)
       household = Household.create!(name: "API Auth #{SecureRandom.hex(4)}", slug: "api-auth-#{SecureRandom.hex(4)}")
       user.person.update!(household: household)
@@ -124,9 +130,70 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
     end
+
+    it 'rejects a locked account without creating an API session' do
+      create_api_household_for(user)
+      lock_account!(account)
+
+      expect do
+        post api_v1_auth_login_path,
+             params: {
+               email: user.email_address,
+               password: 'password'
+             },
+             as: :json
+      end.not_to change(ApiSession, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
+    end
+
+    it 'requires an app token instead of password-only login when TOTP is configured' do
+      create_api_household_for(user)
+      AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+
+      expect do
+        post api_v1_auth_login_path,
+             params: {
+               email: user.email_address,
+               password: 'password'
+             },
+             as: :json
+      end.not_to change(ApiSession, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('mfa_required')
+    end
+
+    it 'requires an app token instead of password-only login when WebAuthn is configured' do
+      create_api_household_for(user)
+      account.account_webauthn_keys.create!(
+        webauthn_id: 'api-login-passkey',
+        public_key: 'api-login-public-key',
+        sign_count: 0,
+        nickname: 'API Login Passkey'
+      )
+
+      expect do
+        post api_v1_auth_login_path,
+             params: {
+               email: user.email_address,
+               password: 'password'
+             },
+             as: :json
+      end.not_to change(ApiSession, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('mfa_required')
+    end
   end
 
   describe 'POST /api/v1/auth/refresh' do
+    before do
+      clear_2fa_for_account(account)
+      AccountLockout.where(account_id: account.id).delete_all if defined?(AccountLockout)
+    end
+
     it 'rotates refresh tokens and invalidates the old refresh token' do
       login_data = api_login(user)
 
@@ -181,9 +248,26 @@ RSpec.describe 'API v1 auth sessions' do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it 'rejects refresh tokens while the account is locked' do
+      login_data = api_login(user)
+      lock_account!(account)
+
+      post api_v1_auth_refresh_path,
+           params: { refresh_token: login_data.fetch('refresh_token') },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_refresh_token')
+    end
   end
 
   describe 'DELETE /api/v1/auth/logout' do
+    before do
+      clear_2fa_for_account(account)
+      AccountLockout.where(account_id: account.id).delete_all if defined?(AccountLockout)
+    end
+
     it 'revokes the current access token' do
       login_data = api_login(user)
       headers = api_auth_headers(login_data.fetch('access_token'))
@@ -210,5 +294,13 @@ RSpec.describe 'API v1 auth sessions' do
                                   event: 'auth_token/api_session/revoked').count
       }.by(1)
     end
+  end
+
+  def lock_account!(account)
+    AccountLockout.create!(
+      account_id: account.id,
+      key: SecureRandom.hex(16),
+      deadline: 30.minutes.from_now
+    )
   end
 end

--- a/spec/requests/api/v1/resources_spec.rb
+++ b/spec/requests/api/v1/resources_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe 'API v1 resources' do
     expect(response.parsed_body.dig('data', 'account', 'status')).to eq('verified')
   end
 
+  it 'rejects an existing API session bearer token while the account is locked' do
+    login_data = api_login(user)
+    household_id = login_data.dig('household', 'id')
+    AccountLockout.create!(
+      account_id: user.person.account.id,
+      key: SecureRandom.hex(16),
+      deadline: 30.minutes.from_now
+    )
+
+    get api_v1_household_me_path(household_id), headers: api_auth_headers(login_data.fetch('access_token')), as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
   it 'returns the core read-only collections' do
     login_data = api_login(user)
     household_id = login_data.dig('household', 'id')

--- a/spec/requests/medications_create_scope_spec.rb
+++ b/spec/requests/medications_create_scope_spec.rb
@@ -235,6 +235,50 @@ RSpec.describe 'Medication creation scope' do
   end
 
   describe 'POST /medications' do
+    it 'does not create a direct plan for a person the actor cannot manage' do
+      target_person = household_person(people(:child_patient))
+      limited_user = create_member_with_access(target_person, access_level: :view)
+      sign_in(limited_user)
+
+      expect do
+        post medications_path, params: onboarding_medication_params(
+          target_person: target_person,
+          schedule_type: 'prn',
+          medication_name: 'Scoped PRN Plan'
+        )
+      end.not_to change(PersonMedication, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'creates a direct plan for a person the actor can manage' do
+      target_person = household_person(people(:child_patient))
+
+      expect do
+        post medications_path, params: onboarding_medication_params(
+          target_person: target_person,
+          schedule_type: 'prn',
+          medication_name: 'Managed PRN Plan'
+        )
+      end.to change(PersonMedication, :count).by(1)
+
+      expect(PersonMedication.last.person).to eq(target_person)
+    end
+
+    it 'creates a scheduled plan for a person the actor can manage' do
+      target_person = household_person(people(:child_patient))
+
+      expect do
+        post medications_path, params: onboarding_medication_params(
+          target_person: target_person,
+          schedule_type: 'multiple_daily',
+          medication_name: 'Managed Scheduled Plan'
+        )
+      end.to change(Schedule, :count).by(1)
+
+      expect(Schedule.last.person).to eq(target_person)
+    end
+
     it 'creates a medication in an authorized location' do
       expect do
         post medications_path, params: {
@@ -578,5 +622,99 @@ RSpec.describe 'Medication creation scope' do
         'Check AI suggestions against the packet, leaflet, or linked guidance before saving.'
       )
     end
+  end
+
+  def onboarding_medication_params(target_person:, schedule_type:, medication_name:)
+    {
+      wizard: 'true',
+      medication: onboarding_medication_payload(medication_name),
+      onboarding_schedule: onboarding_schedule_payload(target_person, schedule_type)
+    }
+  end
+
+  def onboarding_medication_payload(medication_name)
+    {
+      name: medication_name,
+      category: 'Analgesic',
+      dosage_amount: 5,
+      dosage_unit: 'ml',
+      current_supply: 10,
+      reorder_threshold: 1,
+      location_id: home_location.id,
+      dosage_records_attributes: { '0' => onboarding_dosage_payload }
+    }
+  end
+
+  def onboarding_dosage_payload
+    {
+      amount: '5',
+      unit: 'ml',
+      frequency: 'As needed',
+      default_for_adults: '1',
+      default_for_children: '1',
+      default_max_daily_doses: '4',
+      default_min_hours_between_doses: '4',
+      default_dose_cycle: 'daily'
+    }
+  end
+
+  def onboarding_schedule_payload(target_person, schedule_type)
+    {
+      person_id: target_person.id,
+      schedule_type: schedule_type,
+      frequency: 'As needed',
+      start_date: Time.zone.today,
+      end_date: 1.month.from_now.to_date,
+      max_daily_doses: '4',
+      min_hours_between_doses: '4',
+      dose_cycle: 'daily'
+    }
+  end
+
+  def create_member_with_access(target_person, access_level:)
+    account = create_limited_account
+    person = create_limited_person(account)
+    membership = create_limited_membership(account, person)
+    grant_person_access(membership, person, :manage, :self)
+    grant_person_access(membership, target_person, access_level, :family_member)
+
+    User.create!(person: person, email_address: account.email, password: 'password')
+  end
+
+  def create_limited_account
+    Account.create!(
+      email: "limited-member-#{SecureRandom.hex(4)}@example.test",
+      password_hash: RodauthApp.rodauth.allocate.password_hash('password'),
+      status: :verified
+    )
+  end
+
+  def create_limited_person(account)
+    active_spec_household.people.create!(
+      name: 'Limited Member',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true,
+      account: account
+    )
+  end
+
+  def create_limited_membership(account, person)
+    active_spec_household.household_memberships.create!(
+      account: account,
+      person: person,
+      role: :member,
+      status: :active
+    )
+  end
+
+  def grant_person_access(membership, person, access_level, relationship_type)
+    active_spec_household.person_access_grants.create!(
+      household_membership: membership,
+      person: person,
+      access_level: access_level,
+      relationship_type: relationship_type,
+      granted_by_membership: membership
+    )
   end
 end

--- a/spec/requests/person_avatars_spec.rb
+++ b/spec/requests/person_avatars_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Person avatars' do
+  before do
+    grant_owner_avatar_access
+    avatar_person.avatar.attach(io: StringIO.new('avatar'), filename: 'avatar.png', content_type: 'image/png')
+  end
+
+  it 'serves an uploaded avatar to an authorized household member' do
+    sign_in(owner_user)
+
+    get person_avatar_path(person_id: avatar_person.id)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('image/png')
+    expect(response.body).to eq('avatar')
+  end
+
+  it 'does not serve an uploaded avatar to a member without access to the person' do
+    create_avatar_member_membership
+    sign_in(member_user)
+
+    get person_avatar_path(person_id: avatar_person.id)
+
+    expect(response).to have_http_status(:not_found).or have_http_status(:forbidden).or have_http_status(:found)
+  end
+
+  it 'does not serve an uploaded avatar through a foreign household route' do
+    sign_in(owner_user)
+    foreign_household = Household.create!(name: 'Foreign Avatar Household', slug: 'foreign-avatar-household')
+
+    get "/households/#{foreign_household.slug}/people/#{avatar_person.id}/avatar"
+
+    expect(response).to have_http_status(:found)
+  end
+
+  def owner_account
+    @owner_account ||= Account.create!(
+      email: 'avatar-owner@example.test',
+      password_hash: RodauthApp.rodauth.allocate.password_hash('password'),
+      status: :verified
+    )
+  end
+
+  def household
+    @household ||= Household.create_with_owner!(
+      name: 'Avatar Household',
+      owner_account: owner_account,
+      owner_person_attributes: avatar_person_attributes('Avatar Owner')
+    )
+  end
+
+  def owner_membership
+    @owner_membership ||= household.household_memberships.find_by!(account: owner_account)
+  end
+
+  def owner_user
+    @owner_user ||= User.create!(
+      person: owner_membership.person,
+      email_address: owner_account.email,
+      password: 'password'
+    )
+  end
+
+  def avatar_person
+    @avatar_person ||= household.people.create!(avatar_person_attributes('Avatar Patient'))
+  end
+
+  def member_account
+    @member_account ||= Account.create!(
+      email: 'avatar-member@example.test',
+      password_hash: RodauthApp.rodauth.allocate.password_hash('password'),
+      status: :verified
+    )
+  end
+
+  def member_person
+    @member_person ||= household.people.create!(
+      avatar_person_attributes('Avatar Member').merge(account: member_account)
+    )
+  end
+
+  def member_user
+    @member_user ||= User.create!(person: member_person, email_address: member_account.email, password: 'password')
+  end
+
+  def grant_owner_avatar_access
+    household.person_access_grants.create!(
+      household_membership: owner_membership,
+      person: avatar_person,
+      access_level: :manage,
+      relationship_type: :family_member,
+      granted_by_membership: owner_membership
+    )
+  end
+
+  def create_avatar_member_membership
+    household.household_memberships.create!(
+      account: member_account,
+      person: member_person,
+      role: :member,
+      status: :active
+    )
+  end
+
+  def avatar_person_attributes(name)
+    {
+      name: name,
+      date_of_birth: 25.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    }
+  end
+end

--- a/spec/requests/profile_api_tokens_spec.rb
+++ b/spec/requests/profile_api_tokens_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Profile API tokens' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships
+
+  let(:user) { users(:damacus) }
+  let(:account) { user.person.account }
+
+  before do
+    sign_in(user)
+  end
+
+  it 'creates a hashed app token from an MFA-satisfied web session and shows it only once' do
+    configure_totp_for(account)
+    allow(ApiAuthState).to receive(:web_session_mfa_satisfied?).and_return(true)
+    membership = account.household_memberships.active.sole
+
+    expect do
+      post profile_api_tokens_path,
+           params: { api_app_token: { name: 'CI deploy', household_membership_id: membership.id } }
+    end.to change(ApiAppToken, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    raw_token = response.body.match(/mt_app_[A-Za-z0-9_-]+/).to_s
+    app_token = ApiAppToken.order(:id).last
+
+    expect(raw_token).to be_present
+    expect(app_token).to have_attributes(
+      account: account,
+      household_membership: membership,
+      name: 'CI deploy',
+      revoked_at: nil
+    )
+    expect(app_token.token_digest).to eq(ApiAppToken.digest(raw_token))
+    expect(response.body).to include('CI deploy')
+
+    get profile_path
+
+    expect(response.body).to include('CI deploy')
+    expect(response.body).not_to include(raw_token)
+  end
+
+  it 'uses an app token as a bearer token for protected API resources' do
+    configure_totp_for(account)
+    allow(ApiAuthState).to receive(:web_session_mfa_satisfied?).and_return(true)
+    membership = account.household_memberships.active.sole
+    raw_token = create_app_token_from_profile(membership: membership)
+
+    get api_v1_household_me_path(membership.household_id), headers: api_auth_headers(raw_token), as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'email_address')).to eq(user.email_address)
+    expect(ApiAppToken.order(:id).last.reload.last_used_at).to be_within(5.seconds).of(Time.current)
+  end
+
+  it 'rejects app token creation when an MFA-configured account has not satisfied MFA in the web session' do
+    configure_totp_for(account)
+    membership = account.household_memberships.active.sole
+
+    expect do
+      post profile_api_tokens_path,
+           params: { api_app_token: { name: 'CI deploy', household_membership_id: membership.id } }
+    end.not_to change(ApiAppToken, :count)
+
+    expect(response).to redirect_to(profile_path)
+    expect(flash[:alert]).to include('two-factor authentication')
+  end
+
+  it 'revokes an app token and prevents later bearer use' do
+    configure_totp_for(account)
+    allow(ApiAuthState).to receive(:web_session_mfa_satisfied?).and_return(true)
+    membership = account.household_memberships.active.sole
+    raw_token = create_app_token_from_profile(membership: membership)
+    app_token = ApiAppToken.order(:id).last
+
+    delete profile_api_token_path(app_token)
+
+    expect(response).to redirect_to(profile_path)
+    expect(app_token.reload.revoked_at).to be_present
+
+    get api_v1_household_me_path(membership.household_id), headers: api_auth_headers(raw_token), as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects app tokens while the account is locked' do
+    configure_totp_for(account)
+    allow(ApiAuthState).to receive(:web_session_mfa_satisfied?).and_return(true)
+    membership = account.household_memberships.active.sole
+    raw_token = create_app_token_from_profile(membership: membership)
+    lock_account!(account)
+
+    get api_v1_household_me_path(membership.household_id), headers: api_auth_headers(raw_token), as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects app tokens for inactive memberships' do
+    configure_totp_for(account)
+    allow(ApiAuthState).to receive(:web_session_mfa_satisfied?).and_return(true)
+    membership = account.household_memberships.active.sole
+    raw_token = create_app_token_from_profile(membership: membership)
+    add_backup_owner_for(membership.household)
+    membership.update!(status: :revoked)
+
+    get api_v1_household_me_path(membership.household_id), headers: api_auth_headers(raw_token), as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  def configure_totp_for(account)
+    AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+  end
+
+  def create_app_token_from_profile(membership:)
+    post profile_api_tokens_path,
+         params: { api_app_token: { name: 'CI deploy', household_membership_id: membership.id } }
+
+    response.body.match(/mt_app_[A-Za-z0-9_-]+/).to_s
+  end
+
+  def lock_account!(account)
+    AccountLockout.create!(
+      account_id: account.id,
+      key: SecureRandom.hex(16),
+      deadline: 30.minutes.from_now
+    )
+  end
+
+  def add_backup_owner_for(household)
+    owner_account = Account.create!(
+      email: "backup-owner-#{SecureRandom.hex(8)}@example.test",
+      status: :verified
+    )
+    household.household_memberships.create!(account: owner_account, role: :owner, status: :active)
+  end
+end

--- a/spec/services/api_auth_state_spec.rb
+++ b/spec/services/api_auth_state_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiAuthState do
+  fixtures :accounts
+
+  describe '.web_session_mfa_satisfied?' do
+    let(:account) { accounts(:damacus) }
+
+    before do
+      AccountOtpKey.where(id: account.id).delete_all
+      account.account_webauthn_keys.destroy_all
+    end
+
+    it 'does not require MFA session evidence when no MFA is configured' do
+      expect(described_class.web_session_mfa_satisfied?({}, account)).to be(true)
+    end
+
+    it 'accepts a TOTP-authenticated Rodauth web session for an MFA-configured account' do
+      AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+
+      expect(described_class.web_session_mfa_satisfied?({ authenticated_by: %w[password totp] }, account)).to be(true)
+    end
+
+    it 'accepts an OIDC session when the upstream provider performed MFA' do
+      AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+
+      expect(described_class.web_session_mfa_satisfied?({ oidc_mfa_verified: true }, account)).to be(true)
+    end
+
+    it 'rejects a password-only web session for an MFA-configured account' do
+      AccountOtpKey.create!(id: account.id, key: 'test_otp_key_secret')
+
+      expect(described_class.web_session_mfa_satisfied?({ authenticated_by: ['password'] }, account)).to be(false)
+    end
+  end
+end

--- a/spec/services/medication_onboarding_create_service_spec.rb
+++ b/spec/services/medication_onboarding_create_service_spec.rb
@@ -21,12 +21,19 @@ RSpec.describe MedicationOnboardingCreateService do
     med
   end
 
-  def call_service(medication:, schedule_attributes: nil, people_scope: nil, medication_scope: nil)
+  def call_service(
+    medication:,
+    schedule_attributes: nil,
+    people_scope: nil,
+    medication_scope: nil,
+    plan_authorizer: ->(_record) {}
+  )
     described_class.new(
       medication: medication,
       schedule_attributes: schedule_attributes,
       people_scope: people_scope,
-      medication_scope: medication_scope
+      medication_scope: medication_scope,
+      plan_authorizer: plan_authorizer
     ).call
   end
 
@@ -124,6 +131,24 @@ RSpec.describe MedicationOnboardingCreateService do
         .to change(Schedule, :count).by(1)
     end
 
+    it 'requires a plan authorizer before saving a Schedule record' do
+      medication = medication_with_dosage
+      captured_error = nil
+
+      expect do
+        call_service(
+          medication: medication,
+          schedule_attributes: schedule_attrs,
+          people_scope: people_scope,
+          plan_authorizer: nil
+        )
+      rescue StandardError => e
+        captured_error = e
+      end.not_to change(Schedule, :count)
+
+      expect(captured_error.class.name).to eq('MedicationOnboardingCreateService::MissingPlanAuthorizer')
+    end
+
     it 'returns success: true' do
       medication = medication_with_dosage
       result = call_service(medication: medication, schedule_attributes: schedule_attrs, people_scope: people_scope)
@@ -219,6 +244,24 @@ RSpec.describe MedicationOnboardingCreateService do
             people_scope: people_scope
           )
         end.to change(PersonMedication, :count).by(1)
+      end
+
+      it 'requires a plan authorizer before saving a PersonMedication record' do
+        medication = medication_with_dosage(category: 'Analgesic')
+        captured_error = nil
+
+        expect do
+          call_service(
+            medication: medication,
+            schedule_attributes: schedule_attrs(type: 'prn'),
+            people_scope: people_scope,
+            plan_authorizer: nil
+          )
+        rescue StandardError => e
+          captured_error = e
+        end.not_to change(PersonMedication, :count)
+
+        expect(captured_error.class.name).to eq('MedicationOnboardingCreateService::MissingPlanAuthorizer')
       end
 
       it 'returns nil for schedule in the result (PersonMedication is not a Schedule)' do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -30,6 +30,7 @@ module RequestHelpers
     person_schedules_path person_schedule_path new_person_schedule_path edit_person_schedule_path
     take_medication_person_schedule_path
     profile_path profile_avatar_path push_subscription_path reports_path
+    profile_api_tokens_path profile_api_token_path
     schedules_path schedule_path schedules_workflow_path start_schedules_workflow_path
     schedules_frequency_preview_path schedule_medication_takes_path
     search_path

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -21,6 +21,7 @@ module RequestHelpers
     native_device_tokens_path native_device_token_path
     notification_preference_path offline_path offline_snapshot_path offline_medication_takes_path
     people_path person_path new_person_path edit_person_path add_medication_person_path
+    person_avatar_path
     person_carer_relationships_path person_carer_relationship_path
     person_medication_assignments_path new_person_medication_assignment_path
     person_person_medications_path person_person_medication_path new_person_person_medication_path


### PR DESCRIPTION
## Summary

This PR closes the shared state-mutation attack surface and the API authentication bypass class by moving durable mutations behind app-owned, authorized boundaries.

## Security bugs fixed

- Blocks unauthenticated Active Storage direct uploads from creating `ActiveStorage::Blob` records through Rails' default `/rails/active_storage/direct_uploads` endpoint.
- Replaces direct/public avatar reads with an app-owned household avatar route guarded by normal authentication, tenant scoping, and Pundit authorization.
- Prevents medication onboarding from creating derived `Schedule` records for people the actor cannot manage.
- Prevents medication onboarding from creating derived `PersonMedication` records for people the actor cannot manage.
- Requires service-layer authorization before saving derived medication-plan records, so controller authorization of the parent medication is not enough to create secondary tenant-owned state.
- Adds Pundit omission guards so mutating app controller actions must authorize unless the skip is explicit and allowlisted.
- Adds authorization policies around app-owned push subscriptions, native device tokens, and notification preferences so those tenant/account mutations stay inside the app boundary.
- Blocks locked Rodauth accounts from issuing API sessions, refreshing API sessions, or using existing API/app bearer tokens.
- Prevents password-only `/api/v1/auth/login` from issuing API sessions for accounts that already have OTP or WebAuthn MFA configured.
- Adds scoped, revocable, hashed app tokens that MFA users can create from the authenticated web app after satisfying the normal MFA boundary.
- Updates API bearer authentication to accept app tokens while still enforcing verified account, active user, active membership, permissions-version, revocation, and lockout checks.
- Adds architecture specs to keep Active Storage routes, onboarding derived saves, controller auth, and API auth boundaries from regressing.

## Verification

The supplied API static validator now reports the original local password-token issuance, direct BCrypt-in-controller, and protected bearer acceptance indicators as false.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->