### PR TITLE
fix(a11y): improve icon-only button accessibility

### DIFF
--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -29,7 +29,7 @@ module Components
           DialogTrigger do
             if icon_only
               m3_button(variant: button_variant, size: button_size, class: button_class,
-                        'aria-label': t('medications.refill_modal.refill_inventory')) do
+                        aria_label: t('medications.refill_modal.refill_inventory')) do
                 render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
               end
             else

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -27,14 +27,16 @@ module Components
       def view_template
         Dialog do
           DialogTrigger do
-            m3_button(variant: button_variant, size: button_size, class: button_class) do
-              if icon_only
-                render Icons::RefreshCw.new(size: 16)
-                span(class: 'sr-only') { t('medications.refill_modal.refill_inventory') }
-              else
+            if icon_only
+              m3_button(variant: button_variant, size: button_size, class: button_class,
+                        "aria-label": t('medications.refill_modal.refill_inventory')) do
+                render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
+              end
+            else
+              m3_button(variant: button_variant, size: button_size, class: button_class) do
                 if icon
                   icon_class = button_variant == :outlined ? 'mr-2 text-primary' : 'mr-2'
-                  render icon.new(size: 18, class: icon_class)
+                  render icon.new(size: 18, class: icon_class, aria_hidden: 'true')
                 end
                 span { button_label || t('medications.refill_modal.refill_inventory') }
               end

--- a/app/components/medications/refill_modal.rb
+++ b/app/components/medications/refill_modal.rb
@@ -29,7 +29,7 @@ module Components
           DialogTrigger do
             if icon_only
               m3_button(variant: button_variant, size: button_size, class: button_class,
-                        "aria-label": t('medications.refill_modal.refill_inventory')) do
+                        'aria-label': t('medications.refill_modal.refill_inventory')) do
                 render Icons::RefreshCw.new(size: 16, aria_hidden: 'true')
               end
             else

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -48,7 +48,7 @@ module Components
             class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
                    'hover:text-primary hover:border-primary/50 transition-all',
             data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" },
-            'aria-label': t('schedules.card.edit', default: 'Edit schedule')
+            aria_label: t('schedules.card.edit', default: 'Edit schedule')
           ) do
             render Icons::Pencil.new(size: 20, aria_hidden: 'true')
           end
@@ -68,7 +68,7 @@ module Components
                         class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
                                'hover:text-error hover:bg-error/5 transition-all',
                         data: { testid: "delete-schedule-#{schedule.id}" },
-                        'aria-label': t('schedules.card.delete', default: 'Delete schedule')) do
+                        aria_label: t('schedules.card.delete', default: 'Delete schedule')) do
                 render Icons::Trash.new(size: 20, aria_hidden: 'true')
               end
             end

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -48,7 +48,7 @@ module Components
             class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
                    'hover:text-primary hover:border-primary/50 transition-all',
             data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" },
-            "aria-label": t('schedules.card.edit', default: 'Edit schedule')
+            'aria-label': t('schedules.card.edit', default: 'Edit schedule')
           ) do
             render Icons::Pencil.new(size: 20, aria_hidden: 'true')
           end
@@ -68,7 +68,7 @@ module Components
                         class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
                                'hover:text-error hover:bg-error/5 transition-all',
                         data: { testid: "delete-schedule-#{schedule.id}" },
-                        "aria-label": t('schedules.card.delete', default: 'Delete schedule')) do
+                        'aria-label': t('schedules.card.delete', default: 'Delete schedule')) do
                 render Icons::Trash.new(size: 20, aria_hidden: 'true')
               end
             end

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -47,10 +47,10 @@ module Components
             size: :lg,
             class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
                    'hover:text-primary hover:border-primary/50 transition-all',
-            data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" }
+            data: { turbo_frame: 'modal', testid: "edit-schedule-#{schedule.id}" },
+            "aria-label": t('schedules.card.edit', default: 'Edit schedule')
           ) do
-            span(class: 'sr-only') { t('schedules.card.edit', default: 'Edit schedule') }
-            render Icons::Pencil.new(size: 20)
+            render Icons::Pencil.new(size: 20, aria_hidden: 'true')
           end
           render_delete_dialog
         end
@@ -67,9 +67,9 @@ module Components
               m3_button(variant: :text,
                         class: 'w-12 h-12 p-0 rounded-xl text-on-surface-variant ' \
                                'hover:text-error hover:bg-error/5 transition-all',
-                        data: { testid: "delete-schedule-#{schedule.id}" }) do
-                span(class: 'sr-only') { t('schedules.card.delete', default: 'Delete schedule') }
-                render Icons::Trash.new(size: 20)
+                        data: { testid: "delete-schedule-#{schedule.id}" },
+                        "aria-label": t('schedules.card.delete', default: 'Delete schedule')) do
+                render Icons::Trash.new(size: 20, aria_hidden: 'true')
               end
             end
             AlertDialogContent(class: 'rounded-[2rem] border-none shadow-elevation-5 bg-surface-container-high') do

--- a/spec/components/medications/index_view_spec.rb
+++ b/spec/components/medications/index_view_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Components::Medications::IndexView, type: :component do
       policy_stub: Struct.new(:create?, :update?, :refill?, :destroy?).new(false, false, true, false)
     )
 
-    expect(rendered.css('button').map(&:text).join).to include('Restock')
+    expect(rendered.css("button[aria-label='Restock']")).to be_present
     edit_path = Rails.application.routes.url_helpers.edit_medication_path(
       household_slug: 'test-household',
       id: medication

--- a/spec/system/medications/refill_inventory_spec.rb
+++ b/spec/system/medications/refill_inventory_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Refill medication inventory' do
 
   it 'shows refill actions on inventory pages' do
     visit medications_path
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
 
     visit location_path(medication.location)
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
 
     visit medication_path(medication)
-    expect(page).to have_text('Restock')
+    expect(page).to have_button('Restock')
   end
 
   it 'opens medication details from inventory card view action at the top level' do

--- a/spec/system/medications/refill_inventory_spec.rb
+++ b/spec/system/medications/refill_inventory_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Refill medication inventory' do
 
   it 'shows refill actions on inventory pages' do
     visit medications_path
-    expect(page).to have_button('Restock')
+    expect(page).to have_css("button[aria-label='Restock']")
 
     visit location_path(medication.location)
     expect(page).to have_button('Restock')


### PR DESCRIPTION
**💡 What:** Replaced `sr-only` spans with `aria-label` attributes on icon-only buttons in `Schedules::Card::ActionsComponent` and `Medications::RefillModal`. Added `aria_hidden: 'true'` to the SVG icons.

**🎯 Why:** To adhere to standard accessibility guidelines for icon-only buttons. Using `aria-label` directly on the `<button>` or `<a>` element is more robust and standard than relying on visually hidden text inside the element, and explicitly hiding the icon prevents screen readers from making redundant or confusing announcements.

**📸 Before/After:** Screen readers previously announced visually hidden text; now they read the button's native ARIA label. Visually, there is no change.

**♿ Accessibility:**
- Improved screen reader compatibility by explicitly labeling the interactive element itself.
- Removed redundant announcements by hiding decorative SVG icons from the accessibility tree.

---
*PR created automatically by Jules for task [12505235611119413297](https://jules.google.com/task/12505235611119413297) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->