### PR TITLE
feat(schedules): Add medication pause support across schedules and reminders

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "med-tracker"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- ruby
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -9,7 +9,10 @@ version: "3"
 
 vars:
   COMPOSE_PROJECT:
-    sh: basename $PWD
+    sh: |
+      base=$(basename "$PWD")
+      hash=$(git rev-parse --path-format=absolute --git-common-dir | git hash-object --stdin | cut -c1-8)
+      printf '%s-%s\n' "$base" "$hash"
   GIT_COMMON_DIR:
     sh: git rev-parse --path-format=absolute --git-common-dir
   COMPOSE_CMD: MEDTRACKER_GIT_COMMON_DIR={{ .GIT_COMMON_DIR }} docker compose -p {{ .COMPOSE_PROJECT }}

--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -81,7 +81,7 @@ module Components
 
       def visible_person_medications
         @visible_person_medications ||= person.person_medications.select do |person_medication|
-          view_context.policy(person_medication).show?
+          person_medication.active? && view_context.policy(person_medication).show?
         end
       end
 

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -149,8 +149,6 @@ module Components
       end
 
       def render_medications_section
-        accessible_medications = person_medications.select { |pm| view_context.policy(pm).show? }
-
         div(class: 'space-y-8') do
           div(class: 'flex items-center justify-between px-2') do
             m3_heading(variant: :title_large, level: 2, class: 'font-bold tracking-tight') do
@@ -160,24 +158,36 @@ module Components
           end
 
           div(id: 'medications', class: 'grid grid-cols-1 md:grid-cols-2 gap-6') do
-            schedules.each do |schedule|
-              render Components::Schedules::Card.new(
-                schedule: schedule,
-                person: person,
-                current_user: current_user
-              )
-            end
-
-            accessible_medications.each do |person_medication|
-              render Components::PersonMedications::Card.new(
-                person_medication: person_medication,
-                person: person,
-                current_user: current_user
-              )
-            end
+            medication_sources.each { |source| render_medication_source(source) }
           end
 
-          render_empty_state if schedules.none? && accessible_medications.none?
+          render_empty_state if medication_sources.none?
+        end
+      end
+
+      def medication_sources
+        @medication_sources ||= (schedules.to_a + accessible_person_medications).sort_by do |source|
+          source.paused? ? 1 : 0
+        end
+      end
+
+      def accessible_person_medications
+        @accessible_person_medications ||= person_medications.select { |pm| view_context.policy(pm).show? }
+      end
+
+      def render_medication_source(source)
+        if source.is_a?(Schedule)
+          render Components::Schedules::Card.new(
+            schedule: source,
+            person: person,
+            current_user: current_user
+          )
+        else
+          render Components::PersonMedications::Card.new(
+            person_medication: source,
+            person: person,
+            current_user: current_user
+          )
         end
       end
 

--- a/app/components/person_medications/card.rb
+++ b/app/components/person_medications/card.rb
@@ -19,9 +19,7 @@ module Components
       def view_template
         render M3::Card.new(
           id: tenant_dom_id(person_medication),
-          class: 'h-full flex flex-col border-none border-l-4 border-l-primary ' \
-                 'shadow-[0_8px_30px_rgb(0,0,0,0.06)] bg-card rounded-[2.5rem] transition-all ' \
-                 'duration-300 hover:scale-[1.02] hover:shadow-xl group overflow-hidden'
+          class: card_class
         ) do
           render_card_header
           render_card_content
@@ -31,11 +29,23 @@ module Components
 
       private
 
+      def card_class
+        base = 'h-full flex flex-col border-none border-l-4 border-l-primary ' \
+               'shadow-[0_8px_30px_rgb(0,0,0,0.06)] bg-card rounded-[2.5rem] transition-all ' \
+               'duration-300 group overflow-hidden'
+        return "#{base} opacity-70 grayscale-[0.2]" if person_medication.paused?
+
+        "#{base} hover:scale-[1.02] hover:shadow-xl"
+      end
+
       def render_card_header
         CardHeader(class: 'pb-4 pt-8 px-8') do
           div(class: 'flex justify-between items-start mb-4') do
             render_medication_icon
-            render Components::Shared::StockBadge.new(medication: person_medication.medication)
+            div(class: 'flex flex-col items-end gap-2 shrink-0') do
+              render_paused_badge if person_medication.paused?
+              render Components::Shared::StockBadge.new(medication: person_medication.medication)
+            end
           end
           div(class: 'min-w-0') do
             CardTitle(class: 'text-2xl font-black tracking-tight mb-1 text-foreground break-words leading-tight') do
@@ -45,6 +55,12 @@ module Components
               medication_description
             end
           end
+        end
+      end
+
+      def render_paused_badge
+        m3_badge(variant: :outlined, class: 'rounded-full uppercase text-[10px] font-black tracking-widest') do
+          t('person_medications.card.paused')
         end
       end
 
@@ -126,8 +142,11 @@ module Components
       def render_person_medication_actions
         div(class: 'flex items-center gap-2 w-full') do
           render_reorder_controls if view_context.policy(person_medication).update?
-          render_past_dose_button
-          render_edit_button if view_context.policy(person_medication).update?
+          render_past_dose_button unless person_medication.paused?
+          if view_context.policy(person_medication).update?
+            render_active_state_button
+            render_edit_button
+          end
           render_delete_dialog if view_context.policy(person_medication).destroy?
         end
       end
@@ -145,6 +164,49 @@ module Components
                    'hover:bg-tertiary-container transition-colors'
           }
         )
+      end
+
+      def render_active_state_button
+        form_with(
+          url: active_state_path,
+          method: :patch,
+          class: 'inline'
+        ) do
+          m3_button(
+            variant: :outlined,
+            type: :submit,
+            class: 'w-12 min-w-12 h-12 shrink-0 p-0 rounded-xl border-outline text-on-surface-variant ' \
+                   'hover:text-foreground hover:bg-tertiary-container transition-colors',
+            data: { testid: active_state_testid },
+            aria_label: active_state_label
+          ) do
+            render active_state_icon.new(size: 20)
+          end
+        end
+      end
+
+      def active_state_path
+        if person_medication.paused?
+          resume_person_person_medication_path(person, person_medication)
+        else
+          pause_person_person_medication_path(person, person_medication)
+        end
+      end
+
+      def active_state_label
+        if person_medication.paused?
+          t('person_medications.card.resume')
+        else
+          t('person_medications.card.pause')
+        end
+      end
+
+      def active_state_testid
+        "#{person_medication.paused? ? 'resume' : 'pause'}-person-medication-#{person_medication.id}"
+      end
+
+      def active_state_icon
+        person_medication.paused? ? Icons::RefreshCw : Icons::Clock
       end
 
       def render_edit_button

--- a/app/components/schedules/card.rb
+++ b/app/components/schedules/card.rb
@@ -16,9 +16,7 @@ module Components
       def view_template
         render M3::Card.new(
           id: tenant_dom_id(schedule),
-          class: 'h-full flex flex-col border-none ' \
-                 'shadow-[0_15px_40px_rgba(0,0,0,0.08)] bg-card rounded-[2rem] transition-all ' \
-                 'duration-300 hover:scale-[1.02] hover:shadow-2xl group overflow-hidden'
+          class: card_class
         ) do
           render HeaderComponent.new(schedule: schedule, presenter: presenter)
           render DoseStatusComponent.new(schedule: schedule, presenter: presenter)
@@ -39,6 +37,14 @@ module Components
           current_user: current_user,
           person: person
         )
+      end
+
+      def card_class
+        base = 'h-full flex flex-col border-none shadow-[0_15px_40px_rgba(0,0,0,0.08)] bg-card ' \
+               'rounded-[2rem] transition-all duration-300 group overflow-hidden'
+        return "#{base} opacity-70 grayscale-[0.2]" if schedule.paused?
+
+        "#{base} hover:scale-[1.02] hover:shadow-2xl"
       end
     end
   end

--- a/app/components/schedules/card/actions_component.rb
+++ b/app/components/schedules/card/actions_component.rb
@@ -17,7 +17,7 @@ module Components
         def view_template
           CardFooter(class: 'px-8 pb-8 pt-2') do
             div(class: 'flex items-center gap-2 w-full') do
-              render_past_dose_button
+              render_past_dose_button unless schedule.paused?
               render_admin_actions if administrator?
             end
           end
@@ -41,6 +41,7 @@ module Components
         end
 
         def render_admin_actions
+          render_active_state_action
           m3_link(
             href: edit_person_schedule_path(person, schedule),
             variant: :outlined,
@@ -53,6 +54,50 @@ module Components
             render Icons::Pencil.new(size: 20)
           end
           render_delete_dialog
+        end
+
+        def render_active_state_action
+          form_with(
+            url: active_state_path,
+            method: :patch,
+            class: 'inline'
+          ) do
+            m3_button(
+              variant: :outlined,
+              type: :submit,
+              class: 'w-12 h-12 p-0 rounded-xl border-outline text-on-surface-variant ' \
+                     'hover:text-primary hover:border-primary/50 transition-all',
+              data: { testid: active_state_testid },
+              aria_label: active_state_label
+            ) do
+              span(class: 'sr-only') { active_state_label }
+              render active_state_icon.new(size: 20)
+            end
+          end
+        end
+
+        def active_state_path
+          if schedule.paused?
+            resume_person_schedule_path(person, schedule)
+          else
+            pause_person_schedule_path(person, schedule)
+          end
+        end
+
+        def active_state_label
+          if schedule.paused?
+            t('schedules.card.resume')
+          else
+            t('schedules.card.pause')
+          end
+        end
+
+        def active_state_testid
+          "#{schedule.paused? ? 'resume' : 'pause'}-schedule-#{schedule.id}"
+        end
+
+        def active_state_icon
+          schedule.paused? ? Icons::RefreshCw : Icons::Clock
         end
 
         def administrator?

--- a/app/components/schedules/card/header_component.rb
+++ b/app/components/schedules/card/header_component.rb
@@ -17,6 +17,7 @@ module Components
             div(class: 'flex justify-between items-start mb-4') do
               render_medication_icon
               div(class: 'flex flex-col items-end gap-2 shrink-0') do
+                render_paused_badge if schedule.paused?
                 render Components::Shared::StockBadge.new(medication: schedule.medication)
               end
             end
@@ -44,6 +45,12 @@ module Components
                    'group-hover:text-primary group-hover:bg-primary/5 transition-all'
           ) do
             render Components::Shared::MedicationIcon.new(medication: schedule.medication, size: 24)
+          end
+        end
+
+        def render_paused_badge
+          m3_badge(variant: :outlined, class: 'rounded-full uppercase text-[10px] font-black tracking-widest') do
+            t('schedules.card.paused')
           end
         end
       end

--- a/app/controllers/concerns/medication_administration_options.rb
+++ b/app/controllers/concerns/medication_administration_options.rb
@@ -16,6 +16,7 @@ module MedicationAdministrationOptions
 
   def administration_person_medications
     policy_scope(PersonMedication)
+      .active
       .includes(:person, :medication)
       .where(medication: @medication)
       .select { |person_medication| policy(person_medication).take_medication? }

--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -10,17 +10,21 @@ module TakeMedicationGuardable
   # Maps a TakeMedicationService error symbol to the appropriate HTTP response.
   def handle_take_medication_failure(error, scope:)
     case error
-    when :out_of_stock, :cooldown
-      default_message = if error == :out_of_stock
-                          'Cannot take medication: out of stock'
-                        else
-                          'Cannot take medication: timing restrictions not met'
-                        end
+    when :out_of_stock, :cooldown, :paused
+      default_message = take_medication_default_message(error)
       respond_take_medication_error(message: t("#{scope}.cannot_take_medication", default: default_message))
     when :invalid_amount, :create_failed
       respond_take_medication_invalid_dose(scope:)
     when :selection_required, :invalid_source
       respond_take_medication_stock_source_error(scope:, error:)
+    end
+  end
+
+  def take_medication_default_message(error)
+    case error
+    when :out_of_stock then 'Cannot take medication: out of stock'
+    when :paused then 'Cannot take medication: paused'
+    else 'Cannot take medication: timing restrictions not met'
     end
   end
 

--- a/app/controllers/medication_takes_controller.rb
+++ b/app/controllers/medication_takes_controller.rb
@@ -42,6 +42,7 @@ class MedicationTakesController < ApplicationController
     case error
     when :out_of_stock   then t('take_medications.out_of_stock', default: 'Cannot take medication: out of stock')
     when :cooldown       then t('take_medications.cooldown', default: 'Cannot take medication: timing restrictions not met')
+    when :paused         then t('take_medications.paused', default: 'Cannot take medication: paused')
     when :selection_required then t('take_medications.location_required', default: 'Choose a location to record this dose.')
     when :invalid_source then t('take_medications.invalid_location', default: 'Selected location is unavailable for this medication.')
     else                      t('take_medications.failure')

--- a/app/controllers/offline_controller.rb
+++ b/app/controllers/offline_controller.rb
@@ -121,6 +121,8 @@ class OfflineController < ApplicationController
       t('take_medications.out_of_stock', default: 'Cannot take medication: out of stock')
     when :cooldown
       t('take_medications.cooldown', default: 'Cannot take medication: timing restrictions not met')
+    when :paused
+      t('take_medications.paused', default: 'Cannot take medication: paused')
     when :selection_required
       t('take_medications.location_required', default: 'Choose a location to record this dose.')
     when :invalid_source

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -7,7 +7,7 @@ class PersonMedicationsController < ApplicationController
   include MedicationWorkflowBackPathable
 
   before_action :set_person
-  before_action :set_person_medication, only: %i[edit update destroy take_medication reorder]
+  before_action :set_person_medication, only: %i[edit update destroy pause resume take_medication reorder]
 
   def new
     prepare_new_person_medication
@@ -54,6 +54,18 @@ class PersonMedicationsController < ApplicationController
     authorize @person_medication
     @person_medication.destroy
     render_person_medication_destroy_success
+  end
+
+  def pause
+    authorize @person_medication, :update?
+    @person_medication.pause!
+    render_person_medication_pause_success
+  end
+
+  def resume
+    authorize @person_medication, :update?
+    @person_medication.resume!
+    render_person_medication_resume_success
   end
 
   def reorder
@@ -214,6 +226,27 @@ class PersonMedicationsController < ApplicationController
           tenant_dom_target("person_show_#{@person.id}"),
           person_show_view(@person.reload)
         )
+      end
+    end
+  end
+
+  def render_person_medication_pause_success
+    render_person_medication_active_state_success(t('person_medications.paused'))
+  end
+
+  def render_person_medication_resume_success
+    render_person_medication_active_state_success(t('person_medications.resumed'))
+  end
+
+  def render_person_medication_active_state_success(notice)
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: notice }
+      format.turbo_stream do
+        flash.now[:notice] = notice
+        render turbo_stream: [
+          turbo_stream.replace(tenant_dom_target("person_show_#{@person.id}"), person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
       end
     end
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -10,7 +10,7 @@ class SchedulesController < ApplicationController
 
   before_action :redirect_direct_new_schedule, only: :new
   before_action :set_person, except: %i[index workflow start_workflow frequency_preview]
-  before_action :set_schedule, only: %i[edit update destroy take_medication]
+  before_action :set_schedule, only: %i[edit update destroy pause resume take_medication]
 
   def index
     authorize Schedule.new(person: schedule_index_person), :index?
@@ -75,6 +75,18 @@ class SchedulesController < ApplicationController
     authorize @schedule
     @schedule.destroy
     render_schedule_destroy_success
+  end
+
+  def pause
+    authorize @schedule, :update?
+    @schedule.pause!
+    render_schedule_pause_success
+  end
+
+  def resume
+    authorize @schedule, :update?
+    @schedule.resume!
+    render_schedule_resume_success
   end
 
   def take_medication
@@ -263,6 +275,27 @@ class SchedulesController < ApplicationController
       format.html { redirect_back_or_to person_path(@person), notice: t('schedules.deleted') }
       format.turbo_stream do
         flash.now[:notice] = t('schedules.deleted')
+        render turbo_stream: [
+          turbo_stream.replace(tenant_dom_target("person_show_#{@person.id}"), person_show_view(@person.reload)),
+          turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
+        ]
+      end
+    end
+  end
+
+  def render_schedule_pause_success
+    render_schedule_active_state_success(t('schedules.paused'))
+  end
+
+  def render_schedule_resume_success
+    render_schedule_active_state_success(t('schedules.resumed'))
+  end
+
+  def render_schedule_active_state_success(notice)
+    respond_to do |format|
+      format.html { redirect_to person_path(@person), notice: notice }
+      format.turbo_stream do
+        flash.now[:notice] = notice
         render turbo_stream: [
           turbo_stream.replace(tenant_dom_target("person_show_#{@person.id}"), person_show_view(@person.reload)),
           turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))

--- a/app/models/concerns/pausable.rb
+++ b/app/models/concerns/pausable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pausable
+  def paused? = !active
+
+  def pause! = update!(active: false)
+
+  def resume! = update!(active: true)
+end

--- a/app/models/person_medication.rb
+++ b/app/models/person_medication.rb
@@ -6,6 +6,7 @@
 class PersonMedication < ApplicationRecord
   include TimingRestrictions
   include HouseholdAssignable
+  include Pausable
 
   belongs_to :household, optional: true
   belongs_to :person
@@ -21,6 +22,7 @@ class PersonMedication < ApplicationRecord
   # @see docs/audit-trail.md
   has_paper_trail
 
+  scope :active, -> { where(active: true) }
   scope :ordered, -> { order(:position, :id) }
 
   before_validation :assign_household

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,6 +4,7 @@
 class Schedule < ApplicationRecord
   include TimingRestrictions
   include HouseholdAssignable
+  include Pausable
 
   WEEKDAY_INDEXES = Date::DAYNAMES.each_with_index.with_object({}) do |(name, index), indexes|
     indexes[name.downcase] = index
@@ -32,9 +33,7 @@ class Schedule < ApplicationRecord
 
   has_many :medication_takes, dependent: :destroy
 
-  scope :active, lambda {
-    where('start_date <= ? AND end_date >= ?', Time.zone.today, Time.zone.today)
-  }
+  scope :active, -> { where(active: true).where('start_date <= ? AND end_date >= ?', Time.zone.today, Time.zone.today) }
 
   validates :start_date, presence: true
   validates :end_date, presence: true
@@ -94,7 +93,9 @@ class Schedule < ApplicationRecord
       min_hours_between_doses
   end
 
-  def active? = start_date.present? && end_date.present? && Time.zone.today.between?(start_date, end_date)
+  def active? = active_on?(Time.zone.today)
+
+  def active_on?(date) = active && (date = normalize_date(date)).present? && within_schedule_range?(date)
 
   def cycle_period
     DoseCycle.new(dose_cycle).period

--- a/app/presenters/medications/supply_status_presenter.rb
+++ b/app/presenters/medications/supply_status_presenter.rb
@@ -163,7 +163,9 @@ module Medications
     end
 
     def as_needed_sources
-      @as_needed_sources ||= medication.person_medications.select(&:as_needed?) + as_needed_schedules
+      @as_needed_sources ||= medication.person_medications.select do |person_medication|
+        person_medication.active? && person_medication.as_needed?
+      end + as_needed_schedules
     end
 
     def as_needed_schedules

--- a/app/serializers/api/v1/person_medication_serializer.rb
+++ b/app/serializers/api/v1/person_medication_serializer.rb
@@ -31,6 +31,8 @@ module Api
 
       def schedule_data
         {
+          active: person_medication.active?,
+          paused: person_medication.paused?,
           dose_cycle: person_medication.dose_cycle,
           administration_kind: person_medication.administration_kind,
           notes: person_medication.notes,

--- a/app/serializers/api/v1/schedule_serializer.rb
+++ b/app/serializers/api/v1/schedule_serializer.rb
@@ -36,6 +36,7 @@ module Api
           start_date: schedule.start_date&.iso8601,
           end_date: schedule.end_date&.iso8601,
           active: schedule.active?,
+          paused: schedule.paused?,
           notes: schedule.notes,
           updated_at: schedule.updated_at.iso8601
         }

--- a/app/services/family_dashboard/schedule_query.rb
+++ b/app/services/family_dashboard/schedule_query.rb
@@ -57,7 +57,8 @@ module FamilyDashboard
     end
 
     def fetch_person_medications
-      person_medications_by_person_id = PersonMedication.where(person_id: @person_ids)
+      person_medications_by_person_id = PersonMedication.active
+                                                        .where(person_id: @person_ids)
                                                         .includes(:medication)
                                                         .to_a
                                                         .group_by(&:person_id)

--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -49,7 +49,7 @@ class MedicationReminderEligibilityQuery
   end
 
   def person_medications
-    @person_medications ||= person.person_medications.routine.includes(:medication, :medication_takes).to_a
+    @person_medications ||= person.person_medications.active.routine.includes(:medication, :medication_takes).to_a
   end
 
   def due_schedule?(schedule)

--- a/app/services/medication_stock_source_resolver.rb
+++ b/app/services/medication_stock_source_resolver.rb
@@ -14,6 +14,7 @@ class MedicationStockSourceResolver
   end
 
   def blocked_reason
+    return :paused if source.respond_to?(:paused?) && source.paused?
     return :out_of_stock if available_medications.empty?
     return :cooldown unless source.can_take_at?(taken_at)
 

--- a/app/services/medication_timeline_query.rb
+++ b/app/services/medication_timeline_query.rb
@@ -25,7 +25,7 @@ class MedicationTimelineQuery
   end
 
   def person_medications
-    relation = PersonMedication.where(medication: medication).includes(:person, :medication)
+    relation = PersonMedication.active.where(medication: medication).includes(:person, :medication)
     excluding.is_a?(PersonMedication) ? relation.where.not(id: excluding.id) : relation
   end
 end

--- a/app/services/reports/index_query.rb
+++ b/app/services/reports/index_query.rb
@@ -38,6 +38,7 @@ module Reports
 
     def schedules
       @schedules ||= Schedule.where(person_id: person_ids)
+                             .where(active: true)
                              .where('start_date <= ? AND (end_date IS NULL OR end_date >= ?)', end_date, start_date)
                              .to_a
     end

--- a/app/services/smart_insights/context.rb
+++ b/app/services/smart_insights/context.rb
@@ -14,6 +14,7 @@ module SmartInsights
 
     def schedules
       @schedules ||= Schedule.where(person_id: person_ids)
+                             .where(active: true)
                              .where('start_date <= ? AND end_date >= ?', end_date, start_date)
                              .includes(:person, :medication)
                              .to_a
@@ -24,7 +25,8 @@ module SmartInsights
     end
 
     def person_medications
-      @person_medications ||= PersonMedication.where(person_id: person_ids)
+      @person_medications ||= PersonMedication.active
+                                              .where(person_id: person_ids)
                                               .includes(:person, :medication)
                                               .to_a
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -940,6 +940,8 @@ en:
     created: Medication added successfully.
     updated: Medication updated successfully.
     deleted: Medication removed successfully.
+    paused: Medication paused.
+    resumed: Medication resumed.
     medication_taken: Medication taken successfully.
     invalid_dose_configured: Invalid dose configured. Update the medication dose before
       taking.
@@ -948,6 +950,7 @@ en:
       edit_title: Edit Medication for %{person}
       subtitle: Add a routine or as-needed medication
     card:
+      paused: Paused
       notes: 'Notes:'
       timing_restrictions: 'Timing Restrictions:'
       max_doses_per_day: Maximum %{count} dose(s) per day
@@ -963,6 +966,8 @@ en:
       move_down_aria_label: Move medication down in list
       delete_aria_label: Delete medication
       edit: Edit
+      pause: Pause medication
+      resume: Resume medication
       remove: Remove
       remove_medication: Remove Medication
       remove_confirmation: Are you sure you want to remove %{medication}? This action
@@ -1061,6 +1066,8 @@ en:
     created: Schedule was successfully created.
     updated: Schedule was successfully updated.
     deleted: Schedule was successfully deleted.
+    paused: Schedule paused.
+    resumed: Schedule resumed.
     medication_taken: Medication taken successfully.
     invalid_dose_configured: Invalid dose configured. Update the schedule dose before
       taking.
@@ -1069,6 +1076,7 @@ en:
       edit_title: Edit Schedule for %{person}
       subtitle: Add medication details and schedule
     card:
+      paused: Paused
       started: 'Started:'
       ends: 'Ends:'
       notes: 'Notes:'
@@ -1086,6 +1094,8 @@ en:
       waiting: Waiting
       edit: Edit
       delete: Delete
+      pause: Pause schedule
+      resume: Resume schedule
       delete_dialog:
         title: Delete Schedule
         confirm: Are you sure you want to delete the %{medication} schedule? This
@@ -1226,6 +1236,7 @@ en:
     json_success: Medication taken successfully.
     invalid_taken_at: Choose a valid dose time.
     future_taken_at: Dose time cannot be more than an hour in the future.
+    paused: 'Cannot take medication: paused'
   barcode_scanner:
     title: Scan Barcode
     start: Start Scanner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,12 +165,16 @@ Rails.application.routes.draw do
 
       resources :schedules, except: [:index] do
         member do
+          patch :pause
+          patch :resume
           post :take_medication
         end
       end
 
       resources :person_medications, except: [:index] do
         member do
+          patch :pause
+          patch :resume
           patch :reorder
           post :take_medication
         end

--- a/db/migrate/20260629120000_add_active_to_person_medications.rb
+++ b/db/migrate/20260629120000_add_active_to_person_medications.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddActiveToPersonMedications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :person_medications, :active, :boolean, default: true, null: false
+    add_index :person_medications, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -508,6 +508,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_090000) do
   end
 
   create_table "person_medications", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
     t.integer "administration_kind", default: 1, null: false
     t.datetime "created_at", null: false
     t.decimal "dose_amount", precision: 10, scale: 2
@@ -522,6 +523,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_090000) do
     t.integer "position", null: false
     t.bigint "source_dosage_option_id"
     t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_person_medications_on_active"
     t.index ["administration_kind"], name: "index_person_medications_on_administration_kind"
     t.index ["household_id"], name: "index_person_medications_on_household_id"
     t.index ["id", "household_id"], name: "index_person_medications_on_id_and_household_id", unique: true

--- a/spec/components/people/show_view_spec.rb
+++ b/spec/components/people/show_view_spec.rb
@@ -57,4 +57,15 @@ RSpec.describe Components::People::ShowView, type: :component do
     rendered = render_view
     expect(rendered.text).to include('Medications')
   end
+
+  it 'orders active medications before paused medications' do
+    paused_schedule = Schedule.find_by!(person: person, medication: medications(:ibuprofen))
+    paused_schedule.pause!
+    active_person_medication = PersonMedication.find_by!(person: person, medication: medications(:vitamin_d))
+
+    rendered = render_view
+
+    expect(rendered.to_html.index("person_medication_#{active_person_medication.id}"))
+      .to be < rendered.to_html.index("schedule_#{paused_schedule.id}")
+  end
 end

--- a/spec/components/person_medications/card_spec.rb
+++ b/spec/components/person_medications/card_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Components::PersonMedications::Card, type: :component do
     expect(link['class']).to include('min-w-12')
   end
 
+  it 'renders pause action for manageable active assignments' do
+    rendered = render_person_medication_card(update: true)
+
+    expect(rendered.at_css("button[data-testid='pause-person-medication-#{person_medication.id}']")).to be_present
+  end
+
+  it 'renders paused state without dose actions' do
+    person_medication.update!(active: false)
+
+    rendered = render_person_medication_card(update: true)
+
+    expect(rendered.text).to include('Paused')
+    expect(rendered.at_css("button[data-testid='log-past-dose-person-medication-#{person_medication.id}']")).to be_nil
+    expect(rendered.at_css("button[data-testid='resume-person-medication-#{person_medication.id}']")).to be_present
+  end
+
   def render_person_medication_card(update: false, destroy: false)
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }

--- a/spec/components/schedules/card_spec.rb
+++ b/spec/components/schedules/card_spec.rb
@@ -36,9 +36,27 @@ RSpec.describe Components::Schedules::Card, type: :component do
     expect(button.text).to include('Log a past dose')
   end
 
-  def render_schedule_card
+  it 'renders pause action for manageable active schedules' do
+    rendered = render_schedule_card(manage: true)
+
+    expect(rendered.at_css("button[data-testid='pause-schedule-#{schedule.id}']")).to be_present
+  end
+
+  it 'renders paused state without dose actions' do
+    schedule.update!(active: false)
+
+    rendered = render_schedule_card(manage: true)
+
+    expect(rendered.text).to include('Paused')
+    expect(rendered.at_css("button[data-testid='log-past-dose-schedule-#{schedule.id}']")).to be_nil
+    expect(rendered.at_css("button[data-testid='resume-schedule-#{schedule.id}']")).to be_present
+  end
+
+  def render_schedule_card(manage: false)
     vc = view_context
     vc.singleton_class.define_method(:current_user) { nil }
+    policy_stub = Struct.new(:update?).new(manage)
+    allow(SchedulePolicy).to receive(:new).and_return(policy_stub)
     html = vc.render(described_class.new(schedule: schedule, person: person))
     Nokogiri::HTML::DocumentFragment.parse(html)
   end

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe 'Taskfiles' do
   let(:test_taskfile) do
     YAML.safe_load(Rails.root.join('Taskfiles/test.yml').read, aliases: true, permitted_classes: [Symbol])
   end
+  let(:internal_taskfile) do
+    YAML.safe_load(Rails.root.join('Taskfiles/internal.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
   let(:portless_script) { Rails.root.join('scripts/portless_oidc.fish').read }
 
   it 'defines opt-in Portless tasks for dev and test' do
@@ -39,5 +42,12 @@ RSpec.describe 'Taskfiles' do
     expect(portless_script).to include('set -lx TEST_APP_URL $base_url')
     expect(portless_script).to include('set -lx TEST_OIDC_CLIENT_ID $OIDC_CLIENT_ID')
     expect(portless_script).to include('set -lx TEST_OIDC_REDIRECT_URI $callback_url')
+  end
+
+  it 'uses a worktree-specific Docker Compose project name' do
+    compose_project = internal_taskfile.dig('vars', 'COMPOSE_PROJECT', 'sh')
+
+    expect(compose_project).to include('git rev-parse --path-format=absolute --git-common-dir')
+    expect(compose_project).to include('git hash-object --stdin')
   end
 end

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe MedicationReminderJob do
     expect(PushNotificationService).not_to have_received(:send_to_account)
   end
 
+  it 'does not send scheduled-time reminders for paused schedules' do
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      active: false, frequency: 'Once daily', schedule_type: :daily,
+                      schedule_config: { 'times' => ['07:15'] })
+
+    described_class.perform_now(household.id, person.id, :scheduled, '07:15')
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
   it 'does not send period reminders for schedules without configured times' do
     create(:schedule, person: person, medication: medications(:ibuprofen), dosage: dosages(:ibuprofen_adult),
                       frequency: 'Every 6-8 hours', schedule_type: :daily, schedule_config: {},
@@ -139,6 +149,15 @@ RSpec.describe MedicationReminderJob do
                                  schedule_config: { 'times' => ['07:15'] },
                                  max_daily_doses: 1)
     create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.today.noon)
+
+    described_class.perform_now(household.id, person.id, :morning)
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'does not send period reminders for paused routine medications' do
+    create(:person_medication, :routine, person: person, medication: medications(:vitamin_d),
+                                         dosage: dosages(:vitamin_d_daily), active: false)
 
     described_class.perform_now(household.id, person.id, :morning)
 

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe ScheduleDailyRemindersJob do
       .with(household.id, person.id, :scheduled, '07:15')
   end
 
+  it 'does not enqueue exact reminders for paused schedules' do
+    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil)
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      active: false, frequency: 'Once daily', schedule_type: :daily,
+                      schedule_config: { 'times' => ['07:15'] })
+
+    expect do
+      described_class.perform_now
+    end.not_to have_enqueued_job(MedicationReminderJob)
+      .with(household.id, person.id, :scheduled, '07:15')
+  end
+
   it 'loads schedule times once for enabled notification preferences' do
     create(:notification_preference, person: people(:john), morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil)

--- a/spec/models/person_medication_spec.rb
+++ b/spec/models/person_medication_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe PersonMedication do
     end
   end
 
+  describe 'active state' do
+    it 'is active by default' do
+      person_medication = create(:person_medication)
+
+      expect(person_medication).to be_active
+      expect(person_medication).not_to be_paused
+    end
+
+    it 'excludes paused assignments from the active scope' do
+      active_assignment = create(:person_medication)
+      paused_assignment = create(:person_medication, active: false)
+
+      expect(described_class.active).to include(active_assignment)
+      expect(described_class.active).not_to include(paused_assignment)
+    end
+
+    it 'pauses and resumes an assignment' do
+      person_medication = create(:person_medication)
+
+      expect { person_medication.pause! }.to change { person_medication.reload.active }.from(true).to(false)
+      expect { person_medication.resume! }.to change { person_medication.reload.active }.from(false).to(true)
+    end
+  end
+
   describe 'household assignment' do
     let(:assignment_household) { Household.create!(name: 'Person Medication Assignment Household') }
     let(:assignment_location) do

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -91,6 +91,27 @@ RSpec.describe Schedule do
       schedule.update(active: true)
       expect(schedule.active).to be true
     end
+
+    it 'excludes paused schedules from the active scope' do
+      paused_schedule = create(:schedule, active: false)
+      active_schedule = create(:schedule)
+
+      expect(described_class.active).to include(active_schedule)
+      expect(described_class.active).not_to include(paused_schedule)
+    end
+
+    it 'reports paused schedules as inactive today' do
+      schedule.update!(active: false)
+
+      expect(schedule).to be_paused
+      expect(schedule).not_to be_active
+      expect(schedule).not_to be_active_on(Time.zone.today)
+    end
+
+    it 'pauses and resumes a schedule' do
+      expect { schedule.pause! }.to change { schedule.reload.active }.from(true).to(false)
+      expect { schedule.resume! }.to change { schedule.reload.active }.from(false).to(true)
+    end
   end
 
   describe 'validations' do
@@ -227,6 +248,14 @@ RSpec.describe Schedule do
     context 'when today is between start_date and end_date (inclusive)' do
       it 'returns true' do
         expect(schedule.active?).to be true
+      end
+    end
+
+    context 'when schedule is paused' do
+      before { schedule.active = false }
+
+      it 'returns false' do
+        expect(schedule.active?).to be false
       end
     end
 

--- a/spec/presenters/dashboard_presenter_spec.rb
+++ b/spec/presenters/dashboard_presenter_spec.rb
@@ -174,6 +174,14 @@ RSpec.describe DashboardPresenter do
       presenter = presenter_for(admin_user, people_scope: Person.all)
       expect(presenter.active_schedules).not_to include(future_schedule)
     end
+
+    it 'excludes paused schedules' do
+      paused_schedule = schedules(:john_paracetamol)
+      paused_schedule.pause!
+      presenter = presenter_for(admin_user, people_scope: Person.all)
+
+      expect(presenter.active_schedules).not_to include(paused_schedule)
+    end
   end
 
   describe '#upcoming_schedules' do

--- a/spec/requests/medications_log_administration_spec.rb
+++ b/spec/requests/medications_log_administration_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe 'Medication log administration' do
     expect(response.body).to include('Log administration for Paracetamol')
     expect(response.body).to include(take_medication_person_schedule_path(people(:john), schedules(:john_paracetamol)))
   end
+
+  it 'does not render paused administration options for the medication' do
+    schedules(:john_paracetamol).pause!
+    medication = medications(:paracetamol)
+
+    get administration_medication_path(medication), headers: { 'Turbo-Frame' => 'modal' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include(
+      take_medication_person_schedule_path(people(:john), schedules(:john_paracetamol))
+    )
+  end
 end

--- a/spec/requests/person_medications_edit_spec.rb
+++ b/spec/requests/person_medications_edit_spec.rb
@@ -117,4 +117,61 @@ RSpec.describe 'Person medication edit and update' do
       end
     end
   end
+
+  describe 'PATCH /people/:person_id/person_medications/:id/pause' do
+    let!(:linked_person_medication) do
+      PersonMedication.create!(person: person, medication: medications(:vitamin_c), dose_amount: 500, dose_unit: 'mg')
+    end
+
+    context 'when signed in as parent of linked child' do
+      before { sign_in(users(:parent)) }
+
+      it 'pauses the medication assignment and redirects' do
+        patch pause_person_person_medication_path(person, linked_person_medication)
+
+        expect(response).to redirect_to(person_path(person))
+        expect(linked_person_medication.reload).to be_paused
+      end
+
+      it 'returns a turbo stream refresh for the person show container' do
+        patch pause_person_person_medication_path(person, linked_person_medication),
+              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include("target=\"#{household_dom_target("person_show_#{person.id}")}\"")
+        expect(linked_person_medication.reload).to be_paused
+      end
+    end
+
+    context 'when signed in as carer' do
+      before { sign_in(users(:carer)) }
+
+      it 'does not pause the medication assignment' do
+        carer_medication = PersonMedication.create!(person: assigned_patient, medication: medications(:ibuprofen),
+                                                    dose_amount: 200, dose_unit: 'mg')
+
+        patch pause_person_person_medication_path(assigned_patient, carer_medication)
+
+        expect(response).to redirect_to(root_path)
+        expect(carer_medication.reload).not_to be_paused
+      end
+    end
+  end
+
+  describe 'PATCH /people/:person_id/person_medications/:id/resume' do
+    let!(:linked_person_medication) do
+      PersonMedication.create!(person: person, medication: medications(:vitamin_c), dose_amount: 500, dose_unit: 'mg',
+                               active: false)
+    end
+
+    before { sign_in(users(:parent)) }
+
+    it 'resumes the medication assignment and redirects' do
+      patch resume_person_person_medication_path(person, linked_person_medication)
+
+      expect(response).to redirect_to(person_path(person))
+      expect(linked_person_medication.reload).not_to be_paused
+    end
+  end
 end

--- a/spec/requests/schedules_spec.rb
+++ b/spec/requests/schedules_spec.rb
@@ -67,4 +67,59 @@ RSpec.describe 'Schedules' do
       expect(response).to redirect_to(schedules_workflow_path)
     end
   end
+
+  describe 'PATCH /people/:person_id/schedules/:id/pause' do
+    let(:schedule) { schedules(:child_schedule) }
+    let(:person) { schedule.person }
+
+    context 'when signed in as a parent of the linked child' do
+      before { sign_in(users(:parent)) }
+
+      it 'pauses the schedule and redirects to the person page' do
+        patch pause_person_schedule_path(person, schedule)
+
+        expect(response).to redirect_to(person_path(person))
+        expect(schedule.reload).to be_paused
+      end
+
+      it 'returns a turbo stream refresh for the person show container' do
+        patch pause_person_schedule_path(person, schedule),
+              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include("target=\"#{household_dom_target("person_show_#{person.id}")}\"")
+        expect(schedule.reload).to be_paused
+      end
+    end
+
+    context 'when signed in as a carer without manage access' do
+      before { sign_in(users(:carer)) }
+
+      it 'does not pause the schedule' do
+        carer_schedule = schedules(:patient_schedule)
+
+        patch pause_person_schedule_path(carer_schedule.person, carer_schedule)
+
+        expect(response).to redirect_to(root_path)
+        expect(carer_schedule.reload).not_to be_paused
+      end
+    end
+  end
+
+  describe 'PATCH /people/:person_id/schedules/:id/resume' do
+    let(:schedule) { schedules(:child_schedule) }
+
+    before do
+      sign_in(users(:parent))
+      schedule.pause!
+    end
+
+    it 'resumes the schedule and redirects to the person page' do
+      patch resume_person_schedule_path(schedule.person, schedule)
+
+      expect(response).to redirect_to(person_path(schedule.person))
+      expect(schedule.reload).not_to be_paused
+    end
+  end
 end

--- a/spec/serializers/api/v1/person_medication_serializer_spec.rb
+++ b/spec/serializers/api/v1/person_medication_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::PersonMedicationSerializer do
       id: pm.id, person_id: pm.person_id, medication_id: pm.medication_id,
       dose_unit: pm.dose_unit, dose_cycle: 'daily',
       administration_kind: pm.administration_kind, notes: pm.notes, position: pm.position,
+      active: true, paused: false,
       max_daily_doses: pm.max_daily_doses, min_hours_between_doses: pm.min_hours_between_doses,
       updated_at: pm.updated_at.iso8601
     )
@@ -33,5 +34,13 @@ RSpec.describe Api::V1::PersonMedicationSerializer do
     json = described_class.new(pm).as_json
     expect(json[:max_daily_doses]).to eq(2)
     expect(json[:min_hours_between_doses]).to eq(12)
+  end
+
+  it 'serialises paused assignments with paused true and active false' do
+    pm = create(:person_medication, active: false)
+    json = described_class.new(pm).as_json
+
+    expect(json[:active]).to be false
+    expect(json[:paused]).to be true
   end
 end

--- a/spec/serializers/api/v1/schedule_serializer_spec.rb
+++ b/spec/serializers/api/v1/schedule_serializer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1::ScheduleSerializer do
     json = described_class.new(schedule).as_json
     expect(json).to include(
       id: schedule.id, person_id: schedule.person_id, medication_id: schedule.medication_id,
-      frequency: schedule.frequency, dose_cycle: schedule.dose_cycle, active: schedule.active?,
+      frequency: schedule.frequency, dose_cycle: schedule.dose_cycle, active: schedule.active?, paused: false,
       max_daily_doses: schedule.max_daily_doses, min_hours_between_doses: schedule.min_hours_between_doses
     )
     expect(json[:start_date]).to eq(schedule.start_date&.iso8601)
@@ -37,5 +37,13 @@ RSpec.describe Api::V1::ScheduleSerializer do
     schedule = create(:schedule, :expired)
     json = described_class.new(schedule).as_json
     expect(json[:active]).to be false
+  end
+
+  it 'serialises paused schedules with paused true and active false' do
+    schedule = create(:schedule, active: false)
+    json = described_class.new(schedule).as_json
+
+    expect(json[:active]).to be false
+    expect(json[:paused]).to be true
   end
 end

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -212,6 +212,18 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
     end
 
+    it 'filters out paused schedules and person medications' do
+      paused_schedule = create_daily_scheduled_medication
+      paused_schedule.pause!
+      paused_person_medication = create_routine_person_medication
+      paused_person_medication.update!(active: false)
+
+      results = described_class.new([people(:john)]).call
+
+      expect(results.pluck(:source)).not_to include(paused_schedule)
+      expect(results.pluck(:source)).not_to include(paused_person_medication)
+    end
+
     context 'when a schedule has no timing restrictions' do
       let!(:schedule) do
         Schedule.create!(

--- a/spec/services/medication_reminder_eligibility_query_spec.rb
+++ b/spec/services/medication_reminder_eligibility_query_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe MedicationReminderEligibilityQuery do
       expect(build_query.medication_names).not_to include(med.name)
     end
 
+    it 'does not include medications from paused schedules' do
+      schedule = daily_schedule
+      schedule.pause!
+
+      expect(build_query.medication_names).not_to include(schedule.medication_name)
+    end
+
     it 'deduplicates medication names' do
       # Same medication on two active schedules
       med = create(:medication)
@@ -107,6 +114,14 @@ RSpec.describe MedicationReminderEligibilityQuery do
 
         names = build_query.medication_names
         expect(names).not_to include(medication.display_name)
+      end
+
+      it 'excludes paused routine person_medications' do
+        medication = create(:medication)
+        create(:person_medication, :routine, person: person, medication: medication, active: false,
+                                             max_daily_doses: 1)
+
+        expect(build_query.medication_names).not_to include(medication.display_name)
       end
     end
 
@@ -162,6 +177,13 @@ RSpec.describe MedicationReminderEligibilityQuery do
 
       times = build_query.configured_times
       expect(times).not_to include('08:00')
+    end
+
+    it 'excludes times from paused schedules' do
+      schedule = schedule_with_times(times: %w[08:00])
+      schedule.pause!
+
+      expect(build_query.configured_times).not_to include('08:00')
     end
   end
 end

--- a/spec/services/medication_stock_source_resolver_spec.rb
+++ b/spec/services/medication_stock_source_resolver_spec.rb
@@ -21,12 +21,13 @@ RSpec.describe MedicationStockSourceResolver do
   before { FixtureHouseholdSetup.apply! }
 
   # Build a source double pointing at `medication`
-  def build_source(med, can_take: true)
+  def build_source(med, can_take: true, paused: false)
     instance_double(
       PersonMedication,
       medication_id: med.id,
       medication: med,
-      can_take_at?: can_take
+      can_take_at?: can_take,
+      paused?: paused
     )
   end
 
@@ -58,6 +59,15 @@ RSpec.describe MedicationStockSourceResolver do
         resolver = described_class.new(user: nil, source: source, taken_at: taken_at)
 
         expect(resolver.blocked_reason).to eq(:out_of_stock)
+      end
+    end
+
+    context 'when the source is paused' do
+      it 'returns :paused' do
+        source = build_source(medication, paused: true)
+        resolver = described_class.new(user: nil, source: source, taken_at: taken_at)
+
+        expect(resolver.blocked_reason).to eq(:paused)
       end
     end
 

--- a/spec/services/medication_timeline_query_spec.rb
+++ b/spec/services/medication_timeline_query_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe MedicationTimelineQuery do
       expect(result.schedules).to contain_exactly(timeline_data[:other_schedule])
       expect(result.person_medications).to contain_exactly(timeline_data[:person_medication])
     end
+
+    it 'excludes paused timeline sources' do
+      medication = create(:medication)
+      paused_schedule = create(:schedule, medication: medication, active: false)
+      paused_person_medication = create(:person_medication, medication: medication, active: false)
+
+      result = described_class.new(medication: medication).call
+
+      expect(result.schedules).not_to include(paused_schedule)
+      expect(result.person_medications).not_to include(paused_person_medication)
+    end
   end
 
   def create_timeline_data_for(medication:, other_medication:)

--- a/spec/services/reports/index_query_spec.rb
+++ b/spec/services/reports/index_query_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe Reports::IndexQuery do
       expect(result.daily_data.first).to include(expected: 2, actual: 0, percentage: 0)
     end
 
+    it 'excludes paused schedules from compliance and inventory calculations' do
+      report_date = Time.zone.today
+      person = create(:person)
+      schedule = create_daily_report_schedule(person, report_date)
+      schedule.pause!
+
+      result = described_class.new(
+        people: Person.where(id: person.id),
+        start_date: report_date,
+        end_date: report_date
+      ).call
+
+      expect(result.daily_data.first).to include(expected: 0, percentage: 100)
+      expect(result.inventory_alerts).to be_empty
+    end
+
     it 'limits inventory alerts to the soonest two items under 14 days left' do
       medication_one = create(:medication, current_supply: 3, supply_at_last_restock: 3)
       medication_two = create(:medication, current_supply: 5, supply_at_last_restock: 5)

--- a/spec/services/smart_insights/context_spec.rb
+++ b/spec/services/smart_insights/context_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe SmartInsights::Context do
       expect(context.active_schedules).to include(active)
       expect(context.active_schedules).not_to include(expired)
     end
+
+    it 'excludes paused schedules' do
+      medication = create(:medication)
+      paused = create(:schedule, person: person, medication: medication,
+                                 start_date: 7.days.ago.to_date, end_date: 1.year.from_now.to_date,
+                                 active: false)
+
+      expect(context.active_schedules).not_to include(paused)
+    end
   end
 
   describe '#person_medications' do
@@ -82,6 +91,12 @@ RSpec.describe SmartInsights::Context do
     it 'excludes person medications for other people' do
       other = create(:person)
       pm    = create(:person_medication, person: other)
+      expect(context.person_medications).not_to include(pm)
+    end
+
+    it 'excludes paused person medications' do
+      pm = create(:person_medication, person: person, active: false)
+
       expect(context.person_medications).not_to include(pm)
     end
   end
@@ -98,6 +113,17 @@ RSpec.describe SmartInsights::Context do
     it 'includes as-needed person medications' do
       pm = create(:person_medication, :as_needed, person: person)
       expect(context.prn_sources).to include(pm)
+    end
+
+    it 'excludes paused as-needed sources' do
+      medication = create(:medication)
+      paused_schedule = create(:schedule, person: person, medication: medication,
+                                          start_date: start_date, end_date: end_date,
+                                          schedule_type: :prn, active: false)
+      paused_person_medication = create(:person_medication, :as_needed, person: person, active: false)
+
+      expect(context.prn_sources).not_to include(paused_schedule)
+      expect(context.prn_sources).not_to include(paused_person_medication)
     end
   end
 

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe TakeMedicationService do
       end
     end
 
+    context 'when the schedule is paused' do
+      before { schedule.pause! }
+
+      it 'returns :paused error' do
+        expect(call_service(source: schedule).error).to eq(:paused)
+      end
+
+      it 'does not create a MedicationTake' do
+        expect { call_service(source: schedule) }.not_to change(MedicationTake, :count)
+      end
+    end
+
     context 'when timing restrictions prevent the dose' do
       before do
         # Create a recent take to trigger the cooldown


### PR DESCRIPTION
## Summary
- Add active/pause state to person medications and schedules
- Update reminders, timeline, dashboard, serializers, and stock/supply logic to respect paused items
- Refresh UI components and routing so paused plans are surfaced clearly

## Testing
- Added and updated model, service, serializer, request, and component specs
- Verified behavior with the affected query and reminder coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->