### PR TITLE
perf: Bulk load admin user membership roles

### DIFF
--- a/app/components/admin/users/user_row.rb
+++ b/app/components/admin/users/user_row.rb
@@ -9,10 +9,11 @@ module Components
 
         attr_reader :user, :current_user, :household
 
-        def initialize(user:, current_user: nil, household: nil)
+        def initialize(user:, current_user: nil, household: nil, membership_role: nil)
           @user = user
           @current_user = current_user
           @household = household || Current.household
+          @membership_role = membership_role
           super()
         end
 
@@ -41,10 +42,16 @@ module Components
         private
 
         def membership_role
-          account = user.person&.account
-          return no_membership_label unless household && account
+          return @membership_role if @membership_role
 
-          membership = household.household_memberships.active.find_by(account: account)
+          lookup_membership_role
+        end
+
+        def lookup_membership_role
+          account_id = user.person&.account_id
+          return no_membership_label unless household && account_id
+
+          membership = household.household_memberships.active.find_by(account_id: account_id)
           membership&.role&.titleize || no_membership_label
         end
 

--- a/app/components/admin/users/users_table.rb
+++ b/app/components/admin/users/users_table.rb
@@ -134,17 +134,36 @@ module Components
         def render_table_body
           render RubyUI::TableBody.new do
             users.each do |user|
-              render Components::Admin::Users::UserRow.new(user: user, current_user: current_user, household: household)
+              render Components::Admin::Users::UserRow.new(
+                user: user,
+                current_user: current_user,
+                household: household,
+                membership_role: membership_role_for(user)
+              )
             end
           end
         end
 
         def membership_role_for(user)
-          account = user.person&.account
-          return no_membership_label unless household && account
+          account_id = user.person&.account_id
+          return no_membership_label unless household && account_id
 
-          membership = household.household_memberships.active.find_by(account: account)
+          membership = memberships_by_account_id[account_id]
           membership&.role&.titleize || no_membership_label
+        end
+
+        def memberships_by_account_id
+          return @memberships_by_account_id if defined?(@memberships_by_account_id)
+
+          account_ids = users.filter_map { |user| user.person&.account_id }.uniq
+          @memberships_by_account_id = if household && account_ids.any?
+                                         household.household_memberships
+                                                  .active
+                                                  .where(account_id: account_ids)
+                                                  .index_by(&:account_id)
+                                       else
+                                         {}
+                                       end
         end
 
         def no_membership_label

--- a/spec/components/admin/users/users_table_spec.rb
+++ b/spec/components/admin/users/users_table_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
       expect(rendered.text).to include('Administrator')
       expect(User.column_names).not_to include('role')
     end
+
+    it 'bulk loads household membership roles for both table layouts' do
+      users = User.where(id: [current_user.id, target_user.id]).includes(person: :account).to_a
+
+      expect(count_membership_role_queries do
+        render_inline(described_class.new(users: users, current_user: current_user, household: household))
+      end).to eq(1)
+    end
   end
 
   describe 'sortable headers' do
@@ -133,5 +141,18 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
 
       expect(rendered.css('tbody tr').length).to eq(0)
     end
+  end
+
+  def count_membership_role_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      sql = payload[:sql]
+      count += 1 if sql.include?('FROM "household_memberships"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
   end
 end


### PR DESCRIPTION
## What changed
- Bulk-load active household memberships once in `Components::Admin::Users::UsersTable`.
- Reuse the precomputed membership role for both mobile cards and desktop rows.
- Keep `Components::Admin::Users::UserRow` fallback behavior for standalone turbo row renders.

## Why it was a bottleneck
The admin users table renders each user twice, once for mobile cards and once for the desktop table. Each representation previously called `household.household_memberships.active.find_by(...)`, causing duplicate membership queries per user during a single render.

## Measurement used
Focused `ActiveSupport::Notifications` SQL-count spec:
- Red: two users produced 4 `household_memberships` queries.
- Green: the same render now performs 1 `household_memberships` query.

## Expected impact
Admin users index renders avoid repeated per-user membership lookups, reducing membership-role query volume from 2N to 1 for the table component while preserving rendered roles and standalone row behavior.

## Tests run
- `task test TEST_FILE=spec/components/admin/users/users_table_spec.rb`
- `task rubocop`
- `task test` (3372 examples, 0 failures, 2 pending)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->