### PR TITLE
fix(tenancy): harden scoped pickers and mfa

### DIFF
--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -3,11 +3,12 @@
 module Components
   module Locations
     class ShowView < Components::Base
-      attr_reader :location, :notice
+      attr_reader :location, :notice, :available_people
 
-      def initialize(location:, notice: nil)
+      def initialize(location:, notice: nil, available_people: [])
         @location = location
         @notice = notice
+        @available_people = available_people
         super()
       end
 
@@ -230,8 +231,6 @@ module Components
       end
 
       def render_add_member_dialog
-        available_people = Person.where.not(id: location.member_ids).order(:name)
-
         Dialog do
           DialogTrigger do
             m3_button(
@@ -252,7 +251,7 @@ module Components
             end
 
             DialogMiddle do
-              if available_people.to_a.any?
+              if available_people.any?
                 form_with(url: location_location_memberships_path(location), method: :post, class: 'space-y-4') do
                   div(class: 'space-y-2') do
                     label(for: 'location_membership_person_id', class: 'text-sm font-medium') do

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -9,7 +9,14 @@ module Admin
     private
 
     def household_admin_mfa_gate_applies?
-      current_membership&.owner? || current_membership&.administrator?
+      current_membership&.owner? ||
+        current_membership&.administrator? ||
+        support_access_session_mfa_gate_applies?
+    end
+
+    def support_access_session_mfa_gate_applies?
+      Current.support_access_session&.active? &&
+        Current.support_access_session.household_id == Current.household&.id
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -148,7 +148,7 @@ module Admin
 
     def load_dependents
       @load_dependents ||=
-        Person.where(person_type: %i[minor dependent_adult], has_capacity: false).order(:name).to_a
+        dependent_assignment_scope.where(person_type: %i[minor dependent_adult], has_capacity: false).order(:name).to_a
     end
 
     def account_already_exists?

--- a/app/controllers/concerns/hosted_privileged_action_mfa.rb
+++ b/app/controllers/concerns/hosted_privileged_action_mfa.rb
@@ -3,6 +3,8 @@
 module HostedPrivilegedActionMfa
   extend ActiveSupport::Concern
 
+  PRIVILEGED_ACTION_MFA_TTL = 15.minutes
+
   private
 
   def require_hosted_privileged_action_mfa
@@ -31,9 +33,21 @@ module HostedPrivilegedActionMfa
 
   def privileged_action_mfa_satisfied?
     return true if ApiAuthState.web_session_oidc_mfa_verified?(session)
+    return false if privileged_action_mfa_stale?
     return false unless ApiAuthState.mfa_configured?(current_account)
+    return false unless privileged_action_mfa_verified_at
 
     ApiAuthState.web_session_mfa_method_present?(session)
+  end
+
+  def privileged_action_mfa_stale?
+    verified_at = privileged_action_mfa_verified_at
+    return false unless verified_at
+    return false if verified_at >= PRIVILEGED_ACTION_MFA_TTL.ago
+
+    session.delete(:privileged_action_mfa_verified_at)
+    session.delete('privileged_action_mfa_verified_at')
+    true
   end
 
   def redirect_to_privileged_action_mfa
@@ -49,7 +63,7 @@ module HostedPrivilegedActionMfa
   end
 
   def record_privileged_action_mfa_verified_at
-    session[:privileged_action_mfa_verified_at] ||= Time.current.to_i
+    session[:privileged_action_mfa_verified_at] = Time.current.to_i
   end
 
   def privileged_action_mfa_setup_path

--- a/app/controllers/location_memberships_controller.rb
+++ b/app/controllers/location_memberships_controller.rb
@@ -58,10 +58,21 @@ class LocationMembershipsController < ApplicationController
   end
 
   def location_show_streams
+    location = @location.reload
+
     [
-      turbo_stream.replace(tenant_dom_target("location_show_#{@location.id}"),
-                           Components::Locations::ShowView.new(location: @location.reload)),
+      turbo_stream.replace(
+        tenant_dom_target("location_show_#{location.id}"),
+        Components::Locations::ShowView.new(
+          location: location,
+          available_people: available_people_for_location(location)
+        )
+      ),
       turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
     ]
+  end
+
+  def available_people_for_location(location)
+    policy_scope(Person).where.not(id: location.member_ids).order(:name)
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -9,7 +9,11 @@ class LocationsController < ApplicationController
 
   def show
     authorize @location
-    render Components::Locations::ShowView.new(location: @location, notice: flash[:notice])
+    render Components::Locations::ShowView.new(
+      location: @location,
+      notice: flash[:notice],
+      available_people: available_people_for_location(@location)
+    )
   end
 
   def new
@@ -131,8 +135,18 @@ class LocationsController < ApplicationController
 
   def location_main_content_streams(location)
     [
-      turbo_stream.replace('main-content', Components::Locations::ShowView.new(location: location)),
+      turbo_stream.replace(
+        'main-content',
+        Components::Locations::ShowView.new(
+          location: location,
+          available_people: available_people_for_location(location)
+        )
+      ),
       turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
     ]
+  end
+
+  def available_people_for_location(location)
+    policy_scope(Person).where.not(id: location.member_ids).order(:name)
   end
 end

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -360,6 +360,9 @@ class RodauthMain < Rodauth::Rails::Auth
     # because they don't have any 2FA method yet
     two_factor_auth_required_redirect { two_factor_auth_path }
     two_factor_auth_return_to_requested_location? true
+    after_two_factor_authentication do
+      set_session_value(:privileged_action_mfa_verified_at, Time.current.to_i)
+    end
     before_otp_setup_route do
       # Allow OTP setup if user has no 2FA methods configured yet
       # Only require 2FA auth if they already have a method set up

--- a/spec/architecture/tenant_safety_spec.rb
+++ b/spec/architecture/tenant_safety_spec.rb
@@ -87,6 +87,17 @@ RSpec.describe 'tenant safety architecture' do
     expect(offenders).to be_empty
   end
 
+  it 'keeps tenant people lookups out of view components' do
+    offenders = Rails.root.glob('app/components/**/*.rb').filter_map do |path|
+      matches = File.readlines(path).each_with_index.filter_map do |line, index|
+        "#{path.relative_path_from(Rails.root)}:#{index + 1}" if line.match?(/\bPerson\.(?:all|find|find_by|where)\b/)
+      end
+      matches.presence
+    end.flatten
+
+    expect(offenders).to be_empty
+  end
+
   it 'keeps default Active Storage routes disabled for tenant-owned attachments' do
     expect(Rails.application.config.active_storage.draw_routes).to be(false)
     expect(route_paths).not_to include('/rails/active_storage/direct_uploads(.:format)')

--- a/spec/components/locations/show_view_spec.rb
+++ b/spec/components/locations/show_view_spec.rb
@@ -31,11 +31,21 @@ RSpec.describe Components::Locations::ShowView, type: :component do
     expect(rendered.at_css('[data-testid="person-avatar"]')).to be_present
   end
 
-  def render_location
+  it 'uses controller-supplied people for add-member choices' do
+    allowed_person = create(:person, name: 'Allowed Location Candidate')
+    create(:person, name: 'Foreign Location Candidate')
+
+    rendered = render_location(available_people: [allowed_person], update_allowed: true)
+
+    expect(rendered.text).to include('Allowed Location Candidate')
+    expect(rendered.text).not_to include('Foreign Location Candidate')
+  end
+
+  def render_location(available_people: [], update_allowed: false)
     vc = view_context
-    policy_stub = Struct.new(:update?, :refill?).new(false, false)
+    policy_stub = Struct.new(:update?, :refill?).new(update_allowed, false)
     vc.singleton_class.define_method(:policy) { |_record| policy_stub }
-    html = vc.render(described_class.new(location: location))
+    html = vc.render(described_class.new(location: location, available_people: available_people))
     Nokogiri::HTML::DocumentFragment.parse(html)
   end
 end

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -161,12 +161,24 @@ RSpec.describe 'Admin create and update turbo flows' do
 
   describe 'POST /admin/users' do
     it 'renders role-aware dependent assignment controls on the user form' do
+      foreign_household = Household.create!(name: 'Foreign User Form Household', slug: 'foreign-user-form-household')
+      foreign_dependent = Person.new(
+        name: 'Foreign Dependent Picker Leak',
+        date_of_birth: 12.years.ago.to_date,
+        person_type: :minor,
+        has_capacity: false,
+        household: foreign_household
+      )
+      foreign_dependent.save!(validate: false)
+
       get new_admin_user_path
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('data-controller="dependent-assignment"')
       expect(response.body).to include('data-dependent-assignment-target="field"')
       expect(response.body).to include('name="user[dependent_ids][]"')
+      expect(response.body).not_to include("user_dependent_#{foreign_dependent.id}")
+      expect(response.body).not_to include('Foreign Dependent Picker Leak')
     end
 
     it 'returns turbo_stream and replaces users index and flash on success' do

--- a/spec/requests/admin_mfa_gate_spec.rb
+++ b/spec/requests/admin_mfa_gate_spec.rb
@@ -92,4 +92,21 @@ RSpec.describe 'Hosted admin MFA gate' do
 
     expect(response).to have_http_status(:ok)
   end
+
+  it 'keeps upstream OIDC MFA proof valid after the local privileged action timestamp expires' do
+    ENV['HOSTED_ADMIN_MFA_REQUIRED'] = 'true'
+    sign_in(admin)
+    allow(ApiAuthState).to receive(:web_session_oidc_mfa_verified?).and_return(true)
+    baseline = Time.current
+
+    travel_to baseline do
+      get admin_root_path
+    end
+
+    travel_to baseline + 16.minutes do
+      get admin_root_path
+    end
+
+    expect(response).to have_http_status(:ok)
+  end
 end

--- a/spec/requests/platform/support_access_sessions_spec.rb
+++ b/spec/requests/platform/support_access_sessions_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe 'Platform support access sessions' do
     sign_in(platform_user)
   end
 
+  around do |example|
+    previous_value = ENV.fetch('HOSTED_ADMIN_MFA_REQUIRED', nil)
+    ENV.delete('HOSTED_ADMIN_MFA_REQUIRED')
+    example.run
+  ensure
+    if previous_value.nil?
+      ENV.delete('HOSTED_ADMIN_MFA_REQUIRED')
+    else
+      ENV['HOSTED_ADMIN_MFA_REQUIRED'] = previous_value
+    end
+  end
+
   it 'requires privileged MFA proof before opening support access' do
     post platform_support_access_sessions_path,
          params: {
@@ -23,6 +35,21 @@ RSpec.describe 'Platform support access sessions' do
 
     expect(response).to redirect_to(profile_path)
     expect(flash[:alert]).to include('Set up MFA or a passkey')
+  end
+
+  it 'rejects stale privileged MFA proof before opening support access' do
+    travel_to 16.minutes.ago do
+      authenticate_with_totp
+    end
+
+    expect do
+      post platform_support_access_sessions_path,
+           params: {
+             support_access_session: { household_id: target_household.id, reason: 'Investigate invitation issue' }
+           }
+    end.not_to change(SupportAccessSession, :count)
+
+    expect(response).to redirect_to('/multifactor-auth')
   end
 
   it 'requires a reason before opening support access' do
@@ -80,6 +107,21 @@ RSpec.describe 'Platform support access sessions' do
     get admin_root_path(household_slug: target_household.slug)
 
     expect(response).to have_http_status(:ok)
+  end
+
+  it 'requires hosted privileged MFA before support-mode admin access' do
+    ENV['HOSTED_ADMIN_MFA_REQUIRED'] = 'true'
+    SupportAccessSession.create!(
+      platform_admin: platform_admin,
+      household: target_household,
+      reason: 'Investigate invitation delivery failure',
+      mfa_verified_at: Time.current
+    )
+
+    get admin_root_path(household_slug: target_household.slug)
+
+    expect(response).to redirect_to(profile_path(household_slug: target_household.slug))
+    expect(flash[:alert]).to include('Set up MFA or a passkey')
   end
 
   it 'ends support access and records an audit event' do


### PR DESCRIPTION
## Summary
- scope household admin dependent picker through the household-bound assignment scope
- move location add-member choices out of the component and into authorized controller scopes
- require fresh privileged MFA proof for hosted support sessions using Rodauth second-factor timestamps

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->