### PR TITLE
fix(db): harden pre-0.5 database upgrades

### DIFF
--- a/db/migrate/20260622000600_enable_household_row_level_security.rb
+++ b/db/migrate/20260622000600_enable_household_row_level_security.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class EnableHouseholdRowLevelSecurity < ActiveRecord::Migration[8.1]
+  ROLE_NAMES = %w[med_tracker_owner med_tracker_app].freeze
+  UPGRADE_RUNBOOK_URL = 'https://damacus.github.io/med-tracker/pre-0-5-database-upgrade/'
+
   TENANT_TABLES = %w[
     people
     locations
@@ -38,6 +41,8 @@ class EnableHouseholdRowLevelSecurity < ActiveRecord::Migration[8.1]
   private
 
   def create_runtime_roles
+    ensure_runtime_roles_bootstrapped!
+
     execute <<~SQL
       DO $$
       BEGIN
@@ -46,10 +51,35 @@ class EnableHouseholdRowLevelSecurity < ActiveRecord::Migration[8.1]
         END IF;
 
         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
-          CREATE ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+          CREATE ROLE med_tracker_app NOLOGIN;
         END IF;
       END
       $$;
+    SQL
+  end
+
+  def ensure_runtime_roles_bootstrapped!
+    missing_roles = ROLE_NAMES.reject { |role_name| runtime_role_exists?(role_name) }
+    return if missing_roles.empty? || can_create_roles?
+
+    raise ActiveRecord::IrreversibleMigration,
+          "Database runtime roles are missing: #{missing_roles.join(', ')}. " \
+          "Run the pre-0.5 database upgrade bootstrap first: #{UPGRADE_RUNBOOK_URL}"
+  end
+
+  def runtime_role_exists?(role_name)
+    select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_roles
+      WHERE rolname = #{quote(role_name)}
+    SQL
+  end
+
+  def can_create_roles?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper OR rolcreaterole, false)
+      FROM pg_roles
+      WHERE rolname = current_user
     SQL
   end
 

--- a/db/migrate/20260622001000_configure_database_runtime_roles.rb
+++ b/db/migrate/20260622001000_configure_database_runtime_roles.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ConfigureDatabaseRuntimeRoles < ActiveRecord::Migration[8.1]
+  ROLE_NAMES = %w[med_tracker_owner med_tracker_app].freeze
+  UPGRADE_RUNBOOK_URL = 'https://damacus.github.io/med-tracker/pre-0-5-database-upgrade/'
+
   def up
     create_roles
     grant_roles_to_login
@@ -16,6 +19,24 @@ class ConfigureDatabaseRuntimeRoles < ActiveRecord::Migration[8.1]
   private
 
   def create_roles
+    ensure_runtime_roles_bootstrapped!
+    create_missing_runtime_roles if can_create_roles?
+    execute 'ALTER ROLE med_tracker_owner NOLOGIN;' if can_create_roles?
+    execute 'ALTER ROLE med_tracker_app NOLOGIN;' if can_create_roles?
+    execute 'ALTER ROLE med_tracker_app NOSUPERUSER NOBYPASSRLS;' if superuser?
+    verify_runtime_roles_safe!
+  end
+
+  def ensure_runtime_roles_bootstrapped!
+    missing_roles = ROLE_NAMES.reject { |role_name| runtime_role_exists?(role_name) }
+    return if missing_roles.empty? || can_create_roles?
+
+    raise ActiveRecord::IrreversibleMigration,
+          "Database runtime roles are missing: #{missing_roles.join(', ')}. " \
+          "Run the pre-0.5 database upgrade bootstrap first: #{UPGRADE_RUNBOOK_URL}"
+  end
+
+  def create_missing_runtime_roles
     execute <<~SQL
       DO $$
       BEGIN
@@ -24,13 +45,50 @@ class ConfigureDatabaseRuntimeRoles < ActiveRecord::Migration[8.1]
         END IF;
 
         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
-          CREATE ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+          CREATE ROLE med_tracker_app NOLOGIN;
         END IF;
       END
       $$;
     SQL
-    execute 'ALTER ROLE med_tracker_owner NOLOGIN;'
-    execute 'ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;'
+  end
+
+  def verify_runtime_roles_safe!
+    unsafe_roles = select_values(<<~SQL.squish)
+      SELECT rolname
+      FROM pg_roles
+      WHERE rolname IN ('med_tracker_owner', 'med_tracker_app')
+        AND (rolsuper OR rolbypassrls)
+      ORDER BY rolname
+    SQL
+    return if unsafe_roles.empty?
+
+    raise ActiveRecord::IrreversibleMigration,
+          "Database runtime roles have unsafe attributes: #{unsafe_roles.join(', ')}. " \
+          "Run the pre-0.5 database upgrade bootstrap repair first: #{UPGRADE_RUNBOOK_URL}"
+  end
+
+  def runtime_role_exists?(role_name)
+    select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_roles
+      WHERE rolname = #{quote(role_name)}
+    SQL
+  end
+
+  def can_create_roles?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper OR rolcreaterole, false)
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
+  end
+
+  def superuser?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper, false)
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
   end
 
   def grant_roles_to_login
@@ -39,8 +97,13 @@ class ConfigureDatabaseRuntimeRoles < ActiveRecord::Migration[8.1]
       DECLARE
         login_role text := session_user;
       BEGIN
-        EXECUTE format('GRANT med_tracker_owner TO %I', login_role);
-        EXECUTE format('GRANT med_tracker_app TO %I', login_role);
+        IF NOT pg_has_role(login_role, 'med_tracker_owner', 'member') THEN
+          EXECUTE format('GRANT med_tracker_owner TO %I', login_role);
+        END IF;
+
+        IF NOT pg_has_role(login_role, 'med_tracker_app', 'member') THEN
+          EXECUTE format('GRANT med_tracker_app TO %I', login_role);
+        END IF;
       END
       $$;
     SQL

--- a/db/migrate/20260624091000_enforce_strict_household_tenant_boundary.rb
+++ b/db/migrate/20260624091000_enforce_strict_household_tenant_boundary.rb
@@ -20,11 +20,16 @@ class EnforceStrictHouseholdTenantBoundary < ActiveRecord::Migration[8.1]
   ].freeze
 
   def up
-    backfill_derived_household_ids
-    assert_no_null_household_ids!
-    enforce_household_id_not_null
-    replace_household_rls_policies
-    disable_global_versions_rls
+    relax_forced_rls_for_backfill
+    begin
+      backfill_derived_household_ids
+      assert_no_null_household_ids!
+      enforce_household_id_not_null
+      replace_household_rls_policies
+      disable_global_versions_rls
+    ensure
+      restore_forced_rls_after_backfill
+    end
   end
 
   def down
@@ -34,6 +39,18 @@ class EnforceStrictHouseholdTenantBoundary < ActiveRecord::Migration[8.1]
   end
 
   private
+
+  def relax_forced_rls_for_backfill
+    TENANT_TABLES.each do |table_name|
+      execute "ALTER TABLE #{quote_table_name(table_name)} NO FORCE ROW LEVEL SECURITY;" if household_table?(table_name)
+    end
+  end
+
+  def restore_forced_rls_after_backfill
+    TENANT_TABLES.each do |table_name|
+      execute "ALTER TABLE #{quote_table_name(table_name)} FORCE ROW LEVEL SECURITY;" if household_table?(table_name)
+    end
+  end
 
   def backfill_derived_household_ids
     backfill_root_household_ids

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,11 @@ docker compose -f docker-compose.yml run --rm web rails db:migrate
 - All environments use PostgreSQL.
 - PostgreSQL version target is `18`.
 - Use Rails credentials and environment variables for secrets; never commit them.
+- Existing databases created before 0.5 need the
+  [pre-0.5 database upgrade](pre-0-5-database-upgrade.md) bootstrap before
+  running 0.5 migrations.
+- Run migrations with `DATABASE_ROLE=med_tracker_owner`; run the web process
+  with `DATABASE_ROLE=med_tracker_app`.
 
 ## External API credentials
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ ensuring medications are given on time and safely.
 - [Testing Guide](testing.md): run the RSpec and Capybara/Playwright test suites.
 - [Design & Architecture](design.md): explore the domain model and safety guardrails.
 - [Audit & Compliance](audit-trail.md): details on versioning and data history.
+- [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.
 
 ---
 

--- a/docs/operations/hosted-private-beta-runbook.md
+++ b/docs/operations/hosted-private-beta-runbook.md
@@ -10,6 +10,8 @@ Before onboarding another household, verify:
 
 - The web process connects with `DATABASE_ROLE=med_tracker_app`.
 - Migration/setup processes connect with the owner-capable migration role.
+- Existing pre-0.5 databases have completed the
+  [pre-0.5 database upgrade](../pre-0-5-database-upgrade.md) bootstrap.
 - Hosted admin MFA enforcement is enabled with `HOSTED_ADMIN_MFA_REQUIRED=true`.
 - `task rubocop`, `task test`, and `task brakeman` pass on the release branch.
 - The hosted hardening audit has no `NO-GO` rows.

--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -1,0 +1,162 @@
+# Pre-0.5 database upgrade
+
+MedTracker 0.5 adds PostgreSQL runtime roles and strict household row-level
+security. Existing databases created before 0.5 need a one-time database-admin
+bootstrap before the application migration runs.
+
+New empty installs that run `compose/init-roles.sql` before Rails starts do not
+need this manual bootstrap.
+
+## Who needs this
+
+Run this bootstrap when all of these are true:
+
+- The database was created by a MedTracker release before 0.5.
+- The deployment uses PostgreSQL roles without app-superuser privileges.
+- The 0.5 release will run migrations with `DATABASE_ROLE=med_tracker_owner`.
+
+Do not run the web process as the migration role. The app runtime should use
+`DATABASE_ROLE=med_tracker_app`.
+
+## One-time bootstrap
+
+Run this SQL as a database administrator, superuser, or a role allowed to create
+and manage PostgreSQL roles. Replace `<database_name>` and `<app_login_role>`
+with the actual database and login role names. Quote names that contain hyphens.
+
+```sql
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_owner') THEN
+    CREATE ROLE med_tracker_owner NOLOGIN;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
+    CREATE ROLE med_tracker_app NOLOGIN;
+  END IF;
+END
+$$;
+
+ALTER ROLE med_tracker_owner NOLOGIN;
+ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+
+GRANT med_tracker_owner TO <app_login_role>;
+GRANT med_tracker_app TO <app_login_role>;
+
+ALTER DATABASE <database_name> OWNER TO med_tracker_owner;
+ALTER SCHEMA public OWNER TO med_tracker_owner;
+
+GRANT CONNECT ON DATABASE <database_name> TO med_tracker_owner, med_tracker_app;
+GRANT USAGE, CREATE ON SCHEMA public TO med_tracker_owner;
+GRANT USAGE ON SCHEMA public TO med_tracker_app;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'med_tracker') THEN
+    GRANT USAGE ON SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;
+  END IF;
+END
+$$;
+```
+
+The app login should remain a normal non-superuser role. Do not grant it
+`CREATEROLE`, `BYPASSRLS`, or admin option on the runtime roles for normal
+upgrades.
+
+## Preflight check
+
+After the bootstrap SQL and before running migrations, run the read-only Rails
+preflight from a Rails container using the same database login the deployment
+uses:
+
+```bash
+rails med_tracker:pre_0_5_database_upgrade_preflight
+```
+
+The preflight checks that both runtime roles exist, are `NOLOGIN`, are not
+superusers, do not have `BYPASSRLS`, and that the app login is a member of both
+roles. If it fails, fix the bootstrap state before running `db:prepare`.
+
+## Kubernetes and CNPG
+
+For CloudNativePG, run the bootstrap against the primary PostgreSQL pod. Example:
+
+```bash
+kubectl exec -n <namespace> <primary-postgres-pod> -c postgres -- \
+  psql -d <database_name> -v ON_ERROR_STOP=1
+```
+
+Paste the bootstrap SQL into that `psql` session, then update the workload
+configuration:
+
+```yaml
+initContainers:
+  migrate:
+    env:
+      DATABASE_ROLE: med_tracker_owner
+
+containers:
+  app:
+    env:
+      DATABASE_ROLE: med_tracker_app
+```
+
+With Flux or another GitOps controller, commit those values to the source repo
+before reconciling the release.
+
+## Verification
+
+After the migration and app startup complete, verify the role state:
+
+```sql
+SELECT rolname, rolcreaterole, rolsuper, rolbypassrls
+FROM pg_roles
+WHERE rolname IN ('med_tracker_owner', 'med_tracker_app', '<app_login_role>')
+ORDER BY rolname;
+
+SELECT m.roleid::regrole AS granted_role,
+       m.member::regrole AS member_role,
+       m.admin_option
+FROM pg_auth_members m
+WHERE m.roleid IN ('med_tracker_owner'::regrole, 'med_tracker_app'::regrole)
+ORDER BY 1::text, 2::text;
+```
+
+Expected result:
+
+- `med_tracker_owner` is `NOLOGIN`, not superuser, and not `BYPASSRLS`.
+- `med_tracker_app` is `NOLOGIN`, not superuser, and not `BYPASSRLS`.
+- The app login is a member of both runtime roles.
+- `admin_option` is `false` for the app login memberships.
+
+Verify household backfill and migration completion:
+
+```sql
+SET row_security = off;
+
+SELECT COUNT(*) AS households
+FROM households;
+
+SELECT 'people' AS table_name, COUNT(*) FILTER (WHERE household_id IS NULL) AS null_household_id FROM people
+UNION ALL SELECT 'locations', COUNT(*) FILTER (WHERE household_id IS NULL) FROM locations
+UNION ALL SELECT 'location_memberships', COUNT(*) FILTER (WHERE household_id IS NULL) FROM location_memberships
+UNION ALL SELECT 'medications', COUNT(*) FILTER (WHERE household_id IS NULL) FROM medications
+UNION ALL SELECT 'dosages', COUNT(*) FILTER (WHERE household_id IS NULL) FROM dosages
+UNION ALL SELECT 'schedules', COUNT(*) FILTER (WHERE household_id IS NULL) FROM schedules
+UNION ALL SELECT 'person_medications', COUNT(*) FILTER (WHERE household_id IS NULL) FROM person_medications
+UNION ALL SELECT 'medication_takes', COUNT(*) FILTER (WHERE household_id IS NULL) FROM medication_takes
+UNION ALL SELECT 'notification_preferences', COUNT(*) FILTER (WHERE household_id IS NULL) FROM notification_preferences
+ORDER BY table_name;
+```
+
+Every `null_household_id` count should be `0`.
+
+## If an earlier 0.5 attempt failed
+
+If a 0.5 migration already enabled forced row-level security and then failed,
+upgrade to a release containing this runbook before retrying. The strict
+household migration temporarily removes `FORCE ROW LEVEL SECURITY` while it
+backfills legacy rows, then restores forced RLS before it completes.
+
+This avoids the emergency-only workaround of granting `BYPASSRLS` to the
+migration role.

--- a/lib/tasks/pre_0_5_database_upgrade.rake
+++ b/lib/tasks/pre_0_5_database_upgrade.rake
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module MedTracker
+  class Pre05DatabaseUpgradePreflight
+    ROLE_NAMES = %w[med_tracker_owner med_tracker_app].freeze
+    UPGRADE_RUNBOOK_URL = 'https://damacus.github.io/med-tracker/pre-0-5-database-upgrade/'
+
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def call
+      role_rows = runtime_role_rows.index_by { |row| row.fetch('rolname') }
+      missing_roles = ROLE_NAMES - role_rows.keys
+
+      missing_role_errors(missing_roles) +
+        unsafe_role_errors(role_rows) +
+        membership_errors(missing_roles)
+    end
+
+    private
+
+    attr_reader :connection
+
+    def runtime_role_rows
+      connection.select_all(<<~SQL.squish).to_a
+        SELECT rolname, rolcanlogin, rolsuper, rolbypassrls
+        FROM pg_roles
+        WHERE rolname IN ('med_tracker_owner', 'med_tracker_app')
+        ORDER BY rolname
+      SQL
+    end
+
+    def missing_role_errors(missing_roles)
+      missing_roles.map { |role_name| "Missing PostgreSQL runtime role: #{role_name}" }
+    end
+
+    def unsafe_role_errors(role_rows)
+      ROLE_NAMES.filter_map do |role_name|
+        role_row = role_rows[role_name]
+        next if role_row.blank?
+
+        unsafe_attributes = unsafe_attributes_for(role_row)
+        next if unsafe_attributes.empty?
+
+        "#{role_name} has unsafe attributes: #{unsafe_attributes.join(', ')}"
+      end
+    end
+
+    def unsafe_attributes_for(role_row)
+      attributes = []
+      attributes << 'LOGIN' if truthy?(role_row.fetch('rolcanlogin'))
+      attributes << 'SUPERUSER' if truthy?(role_row.fetch('rolsuper'))
+      attributes << 'BYPASSRLS' if truthy?(role_row.fetch('rolbypassrls'))
+      attributes
+    end
+
+    def membership_errors(missing_roles)
+      (ROLE_NAMES - missing_roles).filter_map do |role_name|
+        next if truthy?(runtime_role_member?(role_name))
+
+        "Current database login is not a member of #{role_name}"
+      end
+    end
+
+    def runtime_role_member?(role_name)
+      connection.select_value(<<~SQL.squish)
+        SELECT pg_has_role(session_user, #{connection.quote(role_name)}, 'member')
+      SQL
+    end
+
+    def truthy?(value)
+      value == true || %w[1 t true].include?(value.to_s)
+    end
+  end
+end
+
+namespace :med_tracker do
+  desc 'Check pre-0.5 database runtime role bootstrap state'
+  task pre_0_5_database_upgrade_preflight: :environment do
+    errors = MedTracker::Pre05DatabaseUpgradePreflight.new(ActiveRecord::Base.connection).call
+
+    if errors.empty?
+      puts 'Pre-0.5 database upgrade preflight passed.'
+    else
+      abort <<~MESSAGE
+        Pre-0.5 database upgrade preflight failed:
+        #{errors.map { |error| "- #{error}" }.join("\n")}
+
+        Run the pre-0.5 database upgrade bootstrap first:
+        #{MedTracker::Pre05DatabaseUpgradePreflight::UPGRADE_RUNBOOK_URL}
+      MESSAGE
+    end
+  end
+end

--- a/spec/lib/schema_inventory_hosted_multitenant_hardening_documentation_spec.rb
+++ b/spec/lib/schema_inventory_hosted_multitenant_hardening_documentation_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe SchemaInventory do
     expect(runbook_doc).to include('DATABASE_ROLE=med_tracker_app')
   end
 
+  it 'publishes the pre-0.5 database upgrade runbook from the docs home page', :aggregate_failures do
+    docs_home = Rails.root.join('docs/index.md').read
+    upgrade_doc = Rails.root.join('docs/pre-0-5-database-upgrade.md').read
+
+    expect(docs_home).to include('pre-0-5-database-upgrade.md')
+    expect(upgrade_doc).to include('Pre-0.5 database upgrade')
+    expect(upgrade_doc).to include('DATABASE_ROLE=med_tracker_owner')
+    expect(upgrade_doc).to include('med_tracker:pre_0_5_database_upgrade_preflight')
+    expect(upgrade_doc).to include('med_tracker_owner')
+    expect(upgrade_doc).to include('med_tracker_app')
+    expect(upgrade_doc).to include('BYPASSRLS')
+  end
+
   def expected_requirements
     (1..18).map { |number| "FR#{number}" } + (1..4).map { |number| "NFR#{number}" }
   end

--- a/spec/migrations/configure_database_runtime_roles_spec.rb
+++ b/spec/migrations/configure_database_runtime_roles_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
+  it 'raises a pre-0.5 bootstrap error when runtime roles are missing and cannot be created' do
+    migration = ConfigureDatabaseRuntimeRoles.new
+
+    allow(migration).to receive_messages(runtime_role_exists?: false, can_create_roles?: false)
+
+    expect { migration.send(:ensure_runtime_roles_bootstrapped!) }
+      .to raise_error(ActiveRecord::IrreversibleMigration, /pre-0.5 database upgrade/)
+  end
+end

--- a/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
+++ b/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'EnforceStrictHouseholdTenantBoundary' do
+  delegate :connection, to: :'ActiveRecord::Base'
+
+  before do
+    unless defined?(EnforceStrictHouseholdTenantBoundary)
+      load Rails.root.join('db/migrate/20260624091000_enforce_strict_household_tenant_boundary.rb')
+    end
+  end
+
+  around do |example|
+    connection.transaction(requires_new: true) do
+      example.run
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  it 'relaxes forced RLS before legacy household backfill runs' do
+    migration = EnforceStrictHouseholdTenantBoundary.new
+    table_name = 'people'
+
+    connection.execute("ALTER TABLE #{connection.quote_table_name(table_name)} FORCE ROW LEVEL SECURITY")
+
+    expect { migration.send(:relax_forced_rls_for_backfill) }
+      .to change { forced_rls?(table_name) }
+      .from(true)
+      .to(false)
+  end
+
+  def forced_rls?(table_name)
+    connection.select_value(<<~SQL.squish)
+      SELECT relforcerowsecurity
+      FROM pg_class
+      WHERE oid = #{connection.quote(table_name)}::regclass
+    SQL
+  end
+end

--- a/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
+++ b/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe Rake::Task do
+  let(:task_name) { 'med_tracker:pre_0_5_database_upgrade_preflight' }
+  let(:task) { described_class[task_name] }
+  let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) }
+
+  before do
+    Rails.application.load_tasks unless described_class.task_defined?(task_name)
+    task.reenable
+    allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+  end
+
+  it 'passes when runtime roles are bootstrapped for the app login' do
+    allow(connection).to receive(:select_all).and_return(
+      [
+        { 'rolname' => 'med_tracker_app', 'rolcanlogin' => false, 'rolsuper' => false, 'rolbypassrls' => false },
+        { 'rolname' => 'med_tracker_owner', 'rolcanlogin' => false, 'rolsuper' => false, 'rolbypassrls' => false }
+      ]
+    )
+    allow(connection).to receive(:quote) { |value| "'#{value}'" }
+    allow(connection).to receive(:select_value).with(/med_tracker_owner/).and_return(true)
+    allow(connection).to receive(:select_value).with(/med_tracker_app/).and_return(true)
+
+    expect { task.invoke }.to output(/pre-0.5 database upgrade preflight passed/i).to_stdout
+  end
+
+  it 'aborts with the upgrade runbook when runtime roles are not bootstrapped' do
+    allow(connection).to receive_messages(select_all: [], select_value: false)
+
+    expect { task.invoke }
+      .to raise_error(SystemExit)
+      .and output(/pre-0.5 database upgrade/).to_stderr
+  end
+end


### PR DESCRIPTION
## Summary
- add a published pre-0.5 database upgrade runbook for existing hosted databases
- add a read-only Rails preflight task for runtime role/bootstrap checks
- harden the RLS/runtime-role migrations so ordinary hosted installs do not need CREATEROLE, admin option, or BYPASSRLS during Rails migrations
- temporarily relax FORCE RLS during the legacy household backfill and restore it before completion

## Verification
- task test TEST_FILE="spec/migrations/configure_database_runtime_roles_spec.rb spec/migrations/enforce_strict_household_tenant_boundary_spec.rb spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb spec/lib/schema_inventory_hosted_multitenant_hardening_documentation_spec.rb"
- task docs:build (passes; reports pre-existing missing-link warnings for families/quick-setup.md and oauth-setup.md)
- task rubocop
- task test
