### PR TITLE
fix(db): allow login-time person lookup under RLS

### DIFF
--- a/db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb
+++ b/db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AllowAccountLinkedPersonRlsLoginLookup < ActiveRecord::Migration[8.1]
+  def up
+    return unless table_exists?(:people) && column_exists?(:people, :account_id)
+    return unless runtime_role_exists?('med_tracker_app')
+
+    execute 'DROP POLICY IF EXISTS people_account_login_lookup ON people;'
+    execute <<~SQL
+      CREATE POLICY people_account_login_lookup ON people
+      FOR SELECT TO med_tracker_app
+      USING (account_id IS NOT NULL);
+    SQL
+  end
+
+  def down
+    execute 'DROP POLICY IF EXISTS people_account_login_lookup ON people;' if table_exists?(:people)
+  end
+
+  private
+
+  def runtime_role_exists?(role_name)
+    select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_roles
+      WHERE rolname = #{quote(role_name)}
+    SQL
+  end
+end

--- a/spec/migrations/allow_account_linked_person_rls_login_lookup_spec.rb
+++ b/spec/migrations/allow_account_linked_person_rls_login_lookup_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AllowAccountLinkedPersonRlsLoginLookup' do
+  before do
+    unless defined?(AllowAccountLinkedPersonRlsLoginLookup)
+      load Rails.root.join('db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb')
+    end
+  end
+
+  it 'does not create the login lookup policy before the runtime role exists' do
+    migration = AllowAccountLinkedPersonRlsLoginLookup.new
+
+    allow(migration).to receive_messages(table_exists?: true, column_exists?: true, runtime_role_exists?: false)
+    allow(migration).to receive(:execute)
+
+    expect { migration.up }.not_to raise_error
+    expect(migration).not_to have_received(:execute)
+  end
+end

--- a/spec/models/household_row_level_security_spec.rb
+++ b/spec/models/household_row_level_security_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Household do
     person
   end
 
+  def household_person(household_name:, slug:, person_name:)
+    described_class.create!(name: household_name, slug: slug).people.create!(
+      name: person_name,
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+
   it 'configures the runtime role without superuser or bypassrls' do
     role = connection.select_one(<<~SQL.squish)
       SELECT rolsuper, rolbypassrls
@@ -118,6 +127,24 @@ RSpec.describe Household do
 
     with_runtime_role do
       expect(Location.where(id: location.id).count).to eq(0)
+    end
+  end
+
+  it 'allows account-linked person lookup before household context is resolved' do
+    account, _membership = household_membership_for(
+      email: 'rls-login-person@example.test',
+      household_name: 'RLS Login Person Household',
+      person_name: 'RLS Login Person'
+    )
+    other_person = household_person(
+      household_name: 'RLS Other Person Household',
+      slug: 'rls-other-person-household',
+      person_name: 'RLS Other Person'
+    )
+
+    with_runtime_role do
+      expect(Person.where(id: [account.person.id, other_person.id]).pluck(:id))
+        .to contain_exactly(account.person.id)
     end
   end
 

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -8,6 +8,7 @@ module DatabaseRuntimeRoleSetup
     db/migrate/20260622000800_partition_paper_trail_versions_by_household.rb
     db/migrate/20260622000900_partition_active_storage_attachments_by_household.rb
     db/migrate/20260622001000_configure_database_runtime_roles.rb
+    db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb
   ].freeze
 
   def self.call
@@ -27,6 +28,7 @@ module DatabaseRuntimeRoleSetup
       PartitionPaperTrailVersionsByHousehold.new.send(:enable_versions_rls)
       PartitionActiveStorageAttachmentsByHousehold.new.send(:enable_attachment_rls)
       ConfigureDatabaseRuntimeRoles.new.up
+      AllowAccountLinkedPersonRlsLoginLookup.new.up
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a SELECT-only RLS policy so the runtime app role can resolve account-linked people during login before household tenant context exists
- cover the pre-household login lookup path with a regression spec
- keep unlinked/dependent people hidden without tenant context

## Incident context
Production accounts were not actually deactivated. In 0.5.0, login ran before household context was available, and the people RLS policy only allowed rows for the current household. As med_tracker_app, account.person resolved to nil, which made the authentication concern show the misleading deactivated-account message.

A matching live policy has already been applied manually to restore login while this migration ships.

## Verification
- task test TEST_FILE=spec/models/household_row_level_security_spec.rb
- task rubocop
- task test