### PR TITLE
fix(auth): restore household membership bootstrap

### DIFF
--- a/app/controllers/household_redirects_controller.rb
+++ b/app/controllers/household_redirects_controller.rb
@@ -4,7 +4,7 @@ class HouseholdRedirectsController < ApplicationController
   skip_after_action :verify_pundit_authorization
 
   def show
-    membership = current_account&.first_active_household_membership
+    membership = first_active_household_membership
 
     return redirect_to_login_without_household unless membership
 
@@ -12,6 +12,14 @@ class HouseholdRedirectsController < ApplicationController
   end
 
   private
+
+  def first_active_household_membership
+    return unless current_account
+
+    TenantContext.with(account: current_account, household: nil, request_id: request.request_id) do
+      current_account.first_active_household_membership
+    end
+  end
 
   def redirect_to_login_without_household
     reset_session

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -658,7 +658,8 @@ class RodauthMain < Rodauth::Rails::Auth
 
     # Redirect to dashboard after successful login
     login_redirect do
-      household = Account.find_by(id: account_id)&.first_active_household
+      account = Account.find_by(id: account_id)
+      household = TenantContext.with(account: account, household: nil) { account&.first_active_household } if account
       household ? "/households/#{household.slug}/dashboard" : '/'
     end
 

--- a/db/migrate/20260630183000_backfill_missing_household_memberships.rb
+++ b/db/migrate/20260630183000_backfill_missing_household_memberships.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+class BackfillMissingHouseholdMemberships < ActiveRecord::Migration[8.1]
+  def up
+    return unless required_tables?
+
+    create_missing_memberships
+    promote_ownerless_households
+    create_self_access_grants
+    create_relationship_access_grants if table_exists?(:carer_relationships)
+  end
+
+  def down; end
+
+  private
+
+  def required_tables?
+    %i[households household_memberships people person_access_grants].all? { |table_name| table_exists?(table_name) }
+  end
+
+  def create_missing_memberships
+    execute <<~SQL.squish
+      INSERT INTO household_memberships (
+        household_id, account_id, person_id, role, status, permissions_version, joined_at, created_at, updated_at
+      )
+      SELECT people.household_id,
+             people.account_id,
+             people.id,
+             'member',
+             'active',
+             1,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
+      FROM people
+      WHERE people.household_id IS NOT NULL
+        AND people.account_id IS NOT NULL
+      ON CONFLICT (household_id, account_id) DO UPDATE
+      SET person_id = EXCLUDED.person_id,
+          status = 'active',
+          revoked_at = NULL,
+          updated_at = CURRENT_TIMESTAMP;
+    SQL
+  end
+
+  def promote_ownerless_households
+    execute <<~SQL.squish
+      WITH owner_candidates AS (
+        SELECT DISTINCT ON (household_memberships.household_id)
+               household_memberships.id
+        FROM household_memberships
+        LEFT JOIN platform_admins
+          ON platform_admins.account_id = household_memberships.account_id
+         AND platform_admins.status = 'active'
+        WHERE household_memberships.status = 'active'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM household_memberships active_owner
+            WHERE active_owner.household_id = household_memberships.household_id
+              AND active_owner.role = 'owner'
+              AND active_owner.status = 'active'
+          )
+        ORDER BY household_memberships.household_id,
+                 CASE WHEN platform_admins.id IS NULL THEN 1 ELSE 0 END,
+                 household_memberships.account_id
+      )
+      UPDATE household_memberships
+      SET role = 'owner',
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id IN (SELECT id FROM owner_candidates);
+    SQL
+  end
+
+  def create_self_access_grants
+    execute <<~SQL.squish
+      INSERT INTO person_access_grants (
+        household_id, household_membership_id, person_id, access_level, relationship_type,
+        granted_by_membership_id, created_at, updated_at
+      )
+      SELECT household_memberships.household_id,
+             household_memberships.id,
+             household_memberships.person_id,
+             'manage',
+             'self',
+             household_memberships.id,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
+      FROM household_memberships
+      WHERE household_memberships.person_id IS NOT NULL
+        AND household_memberships.status = 'active'
+      ON CONFLICT (household_membership_id, person_id) WHERE revoked_at IS NULL DO UPDATE
+      SET access_level = EXCLUDED.access_level,
+          relationship_type = EXCLUDED.relationship_type,
+          granted_by_membership_id = EXCLUDED.granted_by_membership_id,
+          updated_at = CURRENT_TIMESTAMP;
+    SQL
+  end
+
+  def create_relationship_access_grants
+    execute <<~SQL.squish
+      INSERT INTO person_access_grants (
+        household_id, household_membership_id, person_id, access_level, relationship_type,
+        granted_by_membership_id, created_at, updated_at
+      )
+      SELECT household_memberships.household_id,
+             household_memberships.id,
+             carer_relationships.patient_id,
+             CASE WHEN carer_relationships.relationship_type IN ('self', 'parent') THEN 'manage' ELSE 'record' END,
+             CASE
+               WHEN carer_relationships.relationship_type = 'professional_carer' THEN 'professional'
+               WHEN carer_relationships.relationship_type IN ('parent', 'carer', 'family_member', 'self')
+                 THEN carer_relationships.relationship_type
+               ELSE 'family_member'
+             END,
+             owners.id,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
+      FROM carer_relationships
+      JOIN household_memberships
+        ON household_memberships.person_id = carer_relationships.carer_id
+       AND household_memberships.status = 'active'
+      JOIN household_memberships owners
+        ON owners.household_id = household_memberships.household_id
+       AND owners.role = 'owner'
+       AND owners.status = 'active'
+      WHERE carer_relationships.active = true
+      ON CONFLICT (household_membership_id, person_id) WHERE revoked_at IS NULL DO UPDATE
+      SET access_level = EXCLUDED.access_level,
+          relationship_type = EXCLUDED.relationship_type,
+          granted_by_membership_id = EXCLUDED.granted_by_membership_id,
+          updated_at = CURRENT_TIMESTAMP;
+    SQL
+  end
+end

--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -77,6 +77,23 @@ The preflight checks that both runtime roles exist, are `NOLOGIN`, are not
 superusers, do not have `BYPASSRLS`, and that the app login is a member of both
 roles. If it fails, fix the bootstrap state before running `db:prepare`.
 
+## Account access bootstrap
+
+The 0.5 household cutover replaces legacy `users.role` authorization with
+household memberships and person access grants. Upgrades from pre-0.5 databases
+must preserve three pieces of access state:
+
+- every account-linked person needs an active `household_membership`;
+- every active membership linked to a person needs a self `manage`
+  `person_access_grant`;
+- active `carer_relationships` need matching grants for the patient person.
+
+MedTracker includes an idempotent Rails migration to backfill that state. It
+promotes one active membership to `owner` only when a household has no active
+owner, preferring an active `platform_admin` account when one exists. Do not
+manually deactivate accounts to recover access; missing membership/grant rows
+are the usual failure mode.
+
 ## Kubernetes and CNPG
 
 For CloudNativePG, run the bootstrap against the primary PostgreSQL pod. Example:
@@ -151,6 +168,48 @@ ORDER BY table_name;
 
 Every `null_household_id` count should be `0`.
 
+Verify the account access bootstrap:
+
+```sql
+SET row_security = off;
+
+SELECT COUNT(*) AS account_people_without_membership
+FROM people
+LEFT JOIN household_memberships
+  ON household_memberships.household_id = people.household_id
+ AND household_memberships.account_id = people.account_id
+ AND household_memberships.status = 'active'
+WHERE people.household_id IS NOT NULL
+  AND people.account_id IS NOT NULL
+  AND household_memberships.id IS NULL;
+
+SELECT COUNT(*) AS active_memberships_without_self_grant
+FROM household_memberships
+LEFT JOIN person_access_grants
+  ON person_access_grants.household_membership_id = household_memberships.id
+ AND person_access_grants.person_id = household_memberships.person_id
+ AND person_access_grants.relationship_type = 'self'
+ AND person_access_grants.access_level = 'manage'
+ AND person_access_grants.revoked_at IS NULL
+WHERE household_memberships.status = 'active'
+  AND household_memberships.person_id IS NOT NULL
+  AND person_access_grants.id IS NULL;
+
+SELECT COUNT(*) AS ownerless_households
+FROM households
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM household_memberships
+  WHERE household_memberships.household_id = households.id
+    AND household_memberships.role = 'owner'
+    AND household_memberships.status = 'active'
+);
+```
+
+All three counts should be `0`. If any count is non-zero, deploy a release that
+contains the account access backfill migration and rerun migrations with
+`DATABASE_ROLE=med_tracker_owner`.
+
 ## If an earlier 0.5 attempt failed
 
 If a 0.5 migration already enabled forced row-level security and then failed,
@@ -160,3 +219,9 @@ backfills legacy rows, then restores forced RLS before it completes.
 
 This avoids the emergency-only workaround of granting `BYPASSRLS` to the
 migration role.
+
+If users can sign in but the app redirects to login, reports that their account
+is deactivated, or shows "You are not authorized to perform this action" for
+every account after a failed cutover, check the account access bootstrap queries
+above before changing account statuses. That symptom usually means the deployed
+app cannot see an active household membership for the signing-in account.

--- a/spec/migrations/backfill_missing_household_memberships_spec.rb
+++ b/spec/migrations/backfill_missing_household_memberships_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BackfillMissingHouseholdMemberships' do
+  before do
+    unless defined?(BackfillMissingHouseholdMemberships)
+      load Rails.root.join('db/migrate/20260630183000_backfill_missing_household_memberships.rb')
+    end
+  end
+
+  it 'creates memberships and access grants for account-linked household people' do
+    household = Household.create!(name: 'Membership Backfill', slug: 'membership-backfill')
+    account = Account.create!(email: 'membership-backfill@example.test', status: :verified)
+    person = household.people.create!(
+      account: account,
+      name: 'Membership Backfill Person',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+
+    BackfillMissingHouseholdMemberships.new.up
+
+    membership = household.household_memberships.find_by!(account: account)
+    grant = household.person_access_grants.find_by!(household_membership: membership, person: person)
+
+    expect(membership).to have_attributes(person: person, role: 'owner', status: 'active')
+    expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'self')
+  end
+
+  it 'promotes an active platform admin when a household has no owner' do
+    household = Household.create!(name: 'Owner Backfill', slug: 'owner-backfill')
+    member_account = create_account('owner-backfill-member@example.test')
+    admin_account = create_account('owner-backfill-admin@example.test')
+    create_person(household, member_account, 'Owner Backfill Member')
+    admin_person = create_person(household, admin_account, 'Owner Backfill Admin')
+    PlatformAdmin.create!(account: admin_account, status: :active)
+
+    BackfillMissingHouseholdMemberships.new.up
+
+    expect(household.household_memberships.find_by!(account: admin_account)).to have_attributes(
+      person: admin_person,
+      role: 'owner',
+      status: 'active'
+    )
+    expect(household.household_memberships.find_by!(account: member_account).role).to eq('member')
+  end
+
+  it 'creates access grants from active carer relationships' do
+    household = Household.create!(name: 'Relationship Backfill', slug: 'relationship-backfill')
+    carer_account = create_account('relationship-backfill-carer@example.test')
+    carer = create_person(household, carer_account, 'Relationship Backfill Carer')
+    child = household.people.create!(
+      name: 'Relationship Backfill Child',
+      date_of_birth: 20.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+    CarerRelationship.create!(carer: carer, patient: child, relationship_type: 'parent', active: true)
+
+    BackfillMissingHouseholdMemberships.new.up
+
+    membership = household.household_memberships.find_by!(account: carer_account)
+    grant = household.person_access_grants.find_by!(household_membership: membership, person: child)
+
+    expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'parent')
+    expect(grant.granted_by_membership).to eq(household.household_memberships.owner.active.sole)
+  end
+
+  def create_account(email)
+    Account.create!(email: email, status: :verified)
+  end
+
+  def create_person(household, account, name)
+    household.people.create!(
+      account: account,
+      name: name,
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+end

--- a/spec/requests/dashboard_home_spec.rb
+++ b/spec/requests/dashboard_home_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe 'Dashboard home rendering' do
 
       expect(response).to redirect_to("/households/#{household.slug}/dashboard")
     end
+
+    it 'redirects after login when RLS requires account context for membership lookup' do
+      household, = household_membership_for(users(:jane))
+      account = users(:jane).person.account
+      clear_2fa_for_account(account)
+
+      ActiveRecord::Base.connection.execute('SET LOCAL ROLE med_tracker_app')
+
+      post '/login', params: { email: account.email, password: 'password' }
+
+      expect(response).to redirect_to("/households/#{household.slug}/dashboard")
+    end
   end
 
   describe 'GET /households/:household_slug/dashboard' do
@@ -66,9 +78,12 @@ RSpec.describe 'Dashboard home rendering' do
   end
 
   def grant_person(household, membership, person, access_level: :view)
-    household.person_access_grants.create!(
+    grant = household.person_access_grants.find_or_initialize_by(
       household_membership: membership,
       person: person,
+      revoked_at: nil
+    )
+    grant.update!(
       access_level: access_level,
       relationship_type: :family_member,
       granted_by_membership: membership


### PR DESCRIPTION
## Summary
- backfill missing household memberships and person access grants for pre-0.5 databases
- wrap login/root household lookup in account-only tenant context so RLS can see the signing-in account membership
- document account access bootstrap verification in the pre-0.5 upgrade runbook

## Verification
- task test TEST_FILE=spec/migrations/backfill_missing_household_memberships_spec.rb
- task test TEST_FILE=spec/requests/dashboard_home_spec.rb
- task test TEST_FILE=spec/models/household_row_level_security_spec.rb
- task rubocop
- task docs:build (build succeeded; existing broken-link warnings for docs/index.md families/quick-setup.md and passkey-setup.md oauth-setup.md)
- task test (3404 examples, 0 failures, 2 pending)