### PR TITLE
fix(dashboard): block as-needed cooldown refresh

### DIFF
--- a/app/components/dashboard/timeline_item.rb
+++ b/app/components/dashboard/timeline_item.rb
@@ -134,7 +134,9 @@ module Components
         }
         m3_variant = variant_map[dose[:status]] || :destructive
 
-        label = if dose[:status] == :cooldown && dose[:source].respond_to?(:countdown_display)
+        label = if dose[:status] == :cooldown && dose[:scheduled_at]
+                  t('dashboard.statuses.available_at', time: dose[:scheduled_at].strftime('%H:%M'))
+                elsif dose[:status] == :cooldown && dose[:source].respond_to?(:countdown_display)
                   "#{t('dashboard.statuses.cooldown')} (#{dose[:source].countdown_display})"
                 else
                   t("dashboard.statuses.#{dose[:status]}")

--- a/app/controllers/concerns/timeline_refreshable.rb
+++ b/app/controllers/concerns/timeline_refreshable.rb
@@ -17,6 +17,11 @@ module TimelineRefreshable
   end
 
   def update_timeline_item_stream(source, take)
+    if as_needed_source?(source)
+      cooldown_stream = replace_timeline_item(source)
+      return cooldown_stream if cooldown_stream
+    end
+
     turbo_stream.replace(
       timeline_dom_id(source),
       Components::Dashboard::TimelineItem.new(dose: {
@@ -82,6 +87,15 @@ module TimelineRefreshable
                                                 status: status
                                               }, current_user: current_user)
     )
+  end
+
+  def as_needed_source?(source)
+    return source.as_needed? if source.respond_to?(:as_needed?)
+    return false unless source.is_a?(Schedule)
+
+    source.schedule_type_prn? ||
+      source.schedule_config.to_h['as_needed'] == true ||
+      source.frequency.to_s.casecmp('as needed').zero?
   end
 
   def timeline_dom_id(source)

--- a/app/models/dose_constraints.rb
+++ b/app/models/dose_constraints.rb
@@ -32,7 +32,7 @@ class DoseConstraints
   def would_violate_interval?(takes:, check_time:)
     return false unless interval_limit?
 
-    last_take = takes.select { |take| take.taken_at < check_time }.max_by(&:taken_at)
+    last_take = takes.select { |take| take.taken_at <= check_time }.max_by(&:taken_at)
     return false unless last_take
 
     hours_since_last = (check_time - last_take.taken_at) / 1.hour

--- a/spec/components/dashboard/timeline_item_spec.rb
+++ b/spec/components/dashboard/timeline_item_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
       end
     end
 
-    it 'renders the cooldown badge with countdown text' do
+    it 'renders the cooldown badge with availability time' do
       cooldown_dose = {
         person: person,
         source: source_with_cooldown,
@@ -69,8 +69,7 @@ RSpec.describe Components::Dashboard::TimelineItem, type: :component do
 
       rendered = render_inline(described_class.new(dose: cooldown_dose))
 
-      expect(rendered.to_html).to include('Wait')
-      expect(rendered.to_html).to include('3h 30m')
+      expect(rendered.to_html).to include('Available at')
     end
 
     it 'does not render an action button for cooldown doses' do

--- a/spec/models/dose_constraints_spec.rb
+++ b/spec/models/dose_constraints_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe DoseConstraints do
       expect(constraints(min_hours_between_doses: 4).would_violate_interval?(takes: [take], check_time: now)).to be true
     end
 
+    it 'returns true when a take was recorded at the check time' do
+      take = fake_take(taken_at: now)
+
+      expect(constraints(min_hours_between_doses: 4).would_violate_interval?(takes: [take], check_time: now)).to be true
+    end
+
     it 'returns false when the latest prior take is outside the interval window' do
       take = fake_take(taken_at: 5.hours.ago)
 

--- a/spec/requests/timeline_refresh_spec.rb
+++ b/spec/requests/timeline_refresh_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Timeline refresh after taking medication' do
       PersonMedication.create!(
         person: person,
         medication: medication,
+        administration_kind: :routine,
         max_daily_doses: 4,
         min_hours_between_doses: 1
       )
@@ -106,6 +107,23 @@ RSpec.describe 'Timeline refresh after taking medication' do
            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
       expect(response.body).to include('Taken')
+    end
+
+    it 'refreshes an as-needed item into cooldown after a take' do
+      travel_to Time.zone.local(2026, 6, 30, 16, 45) do
+        person_medication.update!(
+          administration_kind: :as_needed,
+          min_hours_between_doses: 4
+        )
+
+        post take_medication_person_person_medication_path(person, person_medication),
+             headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end
+
+      expected_id = "timeline_person_medication_#{person_medication.id}"
+      expect(response.body).to include(expected_id)
+      expect(response.body).to include('Available at 20:45')
+      expect(response.body).not_to include("take-dose-personmedication_#{person_medication.id}")
     end
   end
 end


### PR DESCRIPTION
## Summary
- include just-recorded doses in minimum-interval checks so immediate refreshes cannot miss the new take
- refresh as-needed timeline rows back through the dashboard query after taking a dose, so cooldown state replaces the action button
- show the concrete next availability time for cooldown badges when the timeline has it

## Verification
- task test TEST_FILE=spec/requests/timeline_refresh_spec.rb
- task test TEST_FILE=spec/models/dose_constraints_spec.rb
- task test TEST_FILE=spec/components/dashboard/timeline_item_spec.rb
- task test TEST_FILE=spec/requests/medication_timing_spec.rb
- task rubocop
- task test