### PR TITLE
docs: define domain glossary terms

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,9 +2,39 @@
 
 This glossary defines MedTracker's core domain language so model names, UI copy, and business rules stay consistent.
 
-UI components and presenters must use these domain terms and consume server-side domain objects rather than inventing parallel terminology.
+UI components and presenters must use these domain terms and consume server-side
+domain objects rather than inventing parallel terminology.
+
+Prefer these names in new code, UI copy, documentation, and tests. Avoid introducing new patient, individual, plan, routine, stock, or dose-record names unless the surrounding bounded context already requires them.
+
+## People and care terms
+
+### Person
+
+The individual receiving medication or being represented in MedTracker.
+
+- `Person` is the canonical model and code term for the tracked individual.
+- User-facing copy may say "person" or a more specific relationship label when context is clearer.
+- Avoid introducing parallel `Patient`, `Individual`, or `Subject` abstractions for this concept.
+
+### Carer
+
+A person with delegated responsibility for another person.
+
+- Carer relationships grant scoped access to the dependent person's medication records.
+- Use `CarerRelationship` for the relationship record.
+- Use "carer", "parent", or another explicit relationship label in UI copy when
+  that is clearer than a generic user role.
 
 ## Medication inventory terms
+
+### Supply
+
+The inventory quantity for a medication.
+
+- Use `Supply` as the umbrella domain term for inventory quantity.
+- Use the more specific terms below when describing current quantity, last restock quantity, or reorder thresholds.
+- Prefer "Remaining Supply" over "Stock" for new patient/carer-facing copy when the meaning is the amount left now.
 
 ### Remaining Supply (`medications.current_supply`)
 
@@ -13,7 +43,8 @@ The number of dispensable units left **right now**.
 - Decrements by 1 each time a dose is recorded.
 - Drives low/out-of-stock logic.
 - Should be shown in patient/carer-facing quantity displays.
-- Prefer **Remaining Supply** or **units remaining** in new UI copy over generic **Stock** where the meaning is "what is left now".
+- Prefer **Remaining Supply** or **units remaining** in new UI copy over generic
+  **Stock** where the meaning is "what is left now".
 
 ### Supply at Last Restock (`medications.supply_at_last_restock`)
 
@@ -58,9 +89,12 @@ The persisted dose record for a single administration event.
 
 - `MedicationTake` remains the canonical persistence term in this pass.
 - UI copy may use "dose" or "administration" where clearer for users, but code should not introduce a second model name.
+- Avoid introducing a separate `DoseRecord` model name unless a future ADR changes the persistence boundary.
 
 ## Usage guidance
 
 - Use **Remaining Supply** in UI copy where users need "what is left now".
 - Use **Reorder Threshold** to indicate the danger zone for re-ordering.
 - Progress bars use `current_supply / supply_at_last_restock` for a proportional drain.
+- Use **Schedule** for time-based medication regimens, not **Plan** or **Routine** in new code.
+- Use **MedicationTake** for persisted administration records, not **DoseRecord** in new code.

--- a/spec/lib/domain_glossary_document_spec.rb
+++ b/spec/lib/domain_glossary_document_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class DomainGlossaryDocument
+  def glossary = Rails.root.join('docs/glossary.md').read
+
+  def readme = Rails.root.join('README.md').read
+end
+
+RSpec.describe DomainGlossaryDocument do
+  subject(:document) { described_class.new }
+
+  it 'defines the canonical ubiquitous language terms' do
+    canonical_terms = [
+      '### Person',
+      '### Schedule',
+      '### PersonMedication',
+      '### MedicationTake',
+      '### Supply',
+      '### Carer'
+    ]
+
+    expect(document.glossary).to include(*canonical_terms)
+  end
+
+  it 'documents naming guidance and is discoverable from the README' do
+    expect(document.glossary).to include('Prefer these names in new code, UI copy, documentation, and tests.')
+    expect(document.glossary).to include(
+      'Avoid introducing new patient, individual, plan, routine, stock, or dose-record'
+    )
+    expect(document.readme).to include('[Glossary](docs/glossary.md)')
+  end
+end


### PR DESCRIPTION
## Summary
- expand the existing glossary with the canonical Person, Carer, Supply, Schedule, PersonMedication, and MedicationTake terms from #1046
- add naming guidance for avoiding new parallel patient/plan/routine/stock/dose-record terminology
- add a focused documentation spec that keeps the glossary discoverable from README and guards the canonical term list

Fixes #1046

## Verification
- git diff --check
- ruby -c spec/lib/domain_glossary_spec.rb

Blocked locally because Docker daemon is unavailable at /var/run/docker.sock:
- task test TEST_FILE=spec/lib/domain_glossary_spec.rb