### PR TITLE
feat(person): add carer assignment commands

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -99,6 +99,31 @@ class Person < ApplicationRecord
     (minor? || dependent_adult?) && carers.empty?
   end
 
+  def assign_carer!(carer, relationship_type: nil)
+    transaction do
+      relationship = carer_relationships.find_or_initialize_by(carer: carer)
+      relationship.relationship_type = relationship_type.presence ||
+                                       relationship.relationship_type.presence ||
+                                       'family_member'
+      relationship.active = true
+      relationship.save!
+
+      relationship
+    end
+  end
+
+  def remove_carer!(carer)
+    transaction do
+      relationship = carer_relationships.find_by!(carer: carer, active: true)
+      relationship.deactivate!
+      carer_relationships.reset
+      active_carer_relationships.reset
+      validate!
+
+      relationship
+    end
+  end
+
   private
 
   def assign_default_location

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -490,6 +490,56 @@ RSpec.describe Person do
       expect(relationship.relationship_type).to eq('parent')
     end
 
+    describe '#assign_carer!' do
+      it 'creates an active carer relationship' do
+        new_patient = described_class.create!(
+          name: 'Adult Patient',
+          date_of_birth: 30.years.ago,
+          person_type: :adult
+        )
+
+        relationship = new_patient.assign_carer!(carer, relationship_type: 'professional_carer')
+
+        expect(relationship).to be_persisted
+        expect(relationship).to have_attributes(carer: carer, relationship_type: 'professional_carer', active: true)
+        expect(new_patient.reload.carers).to include(carer)
+      end
+
+      it 'reactivates an existing inactive relationship' do
+        relationship = patient.carer_relationships.find_by!(carer: carer)
+        relationship.deactivate!
+
+        patient.assign_carer!(carer)
+
+        expect(relationship.reload).to be_active
+      end
+    end
+
+    describe '#remove_carer!' do
+      it 'deactivates the matching active carer relationship' do
+        second_carer = described_class.create!(
+          name: 'Second Carer',
+          date_of_birth: 40.years.ago,
+          person_type: :adult
+        )
+        patient.assign_carer!(second_carer)
+
+        relationship = patient.remove_carer!(second_carer)
+
+        expect(relationship.reload).not_to be_active
+        expect(patient.reload.carers).not_to include(second_carer)
+      end
+
+      it 'rolls back when removing the last active carer would leave a no-capacity person invalid' do
+        relationship = patient.carer_relationships.find_by!(carer: carer)
+
+        expect { patient.remove_carer!(carer) }
+          .to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(relationship.reload).to be_active
+      end
+    end
+
     context 'with active and inactive relationships' do
       let(:active_carer) do
         described_class.create!(


### PR DESCRIPTION
## Summary
- add Person#assign_carer! and Person#remove_carer! domain commands
- reactivate existing carer relationships instead of duplicating them
- roll back removal when the last active carer would leave a no-capacity person invalid

Closes #1036

## Tests
- ruby -c app/models/person.rb
- ruby -c spec/models/person_spec.rb
- git diff --check
- task test TEST_FILE=spec/models/person_spec.rb (fails locally: Docker socket /var/run/docker.sock is unavailable)
- task rubocop (fails locally: Docker socket /var/run/docker.sock is unavailable)