### PR TITLE
feat(schedules): expose dose availability state

### DIFF
--- a/app/models/concerns/schedule_dose_availability.rb
+++ b/app/models/concerns/schedule_dose_availability.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module ScheduleDoseAvailability
+  extend ActiveSupport::Concern
+
+  def can_take_dose?(at: Time.current) = dose_blocked_reason(at: at).nil?
+
+  def dose_blocked_reason(at: Time.current)
+    at = normalize_time(at)
+    return :inactive if at.blank? || !active_on?(at.to_date)
+    return :stock if medication.out_of_stock?
+    return :timing unless can_take_at?(at)
+
+    nil
+  end
+
+  def next_dose_due_at(at: Time.current)
+    at = normalize_time(at)
+    return if at.blank?
+
+    next_configured_due_at(at) || next_available_time
+  end
+
+  def overdue?(at: Time.current)
+    at = normalize_time(at)
+    return false if at.blank? || !active_on?(at.to_date) || schedule_type_prn?
+
+    due_count = configured_due_times_for(at.to_date).count { |due_at| due_at <= at }
+    due_count.positive? && taken_count_until(at) < due_count
+  end
+
+  private
+
+  def normalize_time(value)
+    return value.in_time_zone if value.respond_to?(:in_time_zone)
+
+    Time.zone.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def next_configured_due_at(at)
+    return if configured_times.empty?
+
+    due_at = configured_due_times_for(at.to_date).find { |configured_time| configured_time >= at }
+    return due_at if due_at
+
+    next_configured_due_on_future_date(at.to_date + 1.day)
+  end
+
+  def next_configured_due_on_future_date(date)
+    return if date > end_date
+    return configured_due_times_for(date).first if applies_on?(date)
+
+    next_configured_due_on_future_date(date + 1.day)
+  end
+
+  def configured_due_times_for(date)
+    return [] unless applies_on?(date)
+
+    configured_times.filter_map { |time| configured_time_on(date, time) }.sort
+  end
+
+  def configured_time_on(date, value)
+    hour, minute = value.to_s.split(':', 3).first(2)
+    return unless hour&.match?(/\A\d+\z/) && minute&.match?(/\A\d+\z/)
+
+    hour = hour.to_i
+    minute = minute.to_i
+    return unless (0..23).cover?(hour) && (0..59).cover?(minute)
+
+    Time.zone.local(date.year, date.month, date.day, hour, minute)
+  end
+
+  def taken_count_until(at)
+    range = at.beginning_of_day..at
+    return medication_takes.count { |take| range.cover?(take.taken_at) } if medication_takes.loaded?
+
+    medication_takes.where(taken_at: range).count
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -3,6 +3,7 @@
 # Schedule model
 class Schedule < ApplicationRecord
   include TimingRestrictions
+  include ScheduleDoseAvailability
   include HouseholdAssignable
   include Pausable
 
@@ -35,8 +36,7 @@ class Schedule < ApplicationRecord
 
   scope :active, -> { where(active: true).where('start_date <= ? AND end_date >= ?', Time.zone.today, Time.zone.today) }
 
-  validates :start_date, presence: true
-  validates :end_date, presence: true
+  validates :start_date, :end_date, presence: true
   validates :dose_amount, presence: true, numericality: { greater_than: 0 }
   validates :dose_unit, presence: true, inclusion: { in: Medication::DOSAGE_UNITS }
   validate :source_dosage_option_matches_medication

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -235,6 +235,62 @@ RSpec.describe Schedule do
     end
   end
 
+  describe 'dose availability' do
+    let(:now) { Time.zone.local(2026, 4, 20, 9, 0, 0) }
+    let(:schedule) do
+      create(
+        :schedule,
+        start_date: now.to_date,
+        end_date: now.to_date + 1.week,
+        max_daily_doses: 1,
+        min_hours_between_doses: 4,
+        schedule_config: { 'times' => %w[08:00 14:00] }
+      )
+    end
+
+    it 'allows a dose when the schedule is active, stocked, and timing permits' do
+      travel_to now do
+        expect(schedule.can_take_dose?(at: now)).to be true
+      end
+    end
+
+    it 'reports inactive schedules as blocked' do
+      schedule.update!(active: false)
+
+      expect(schedule.dose_blocked_reason(at: now)).to eq(:inactive)
+    end
+
+    it 'reports out-of-stock schedules as stock blocked' do
+      schedule.medication.update!(current_supply: 0)
+
+      expect(schedule.dose_blocked_reason(at: now)).to eq(:stock)
+    end
+
+    it 'reports cooldown-blocked schedules as timing blocked' do
+      travel_to now do
+        create(:medication_take, :for_schedule, schedule: schedule, taken_at: now - 1.hour)
+
+        expect(schedule.reload.dose_blocked_reason(at: now)).to eq(:timing)
+      end
+    end
+
+    it 'returns the next configured dose time' do
+      before_first_dose = Time.zone.local(2026, 4, 20, 7, 0, 0)
+
+      expect(schedule.next_dose_due_at(at: before_first_dose)).to eq(Time.zone.local(2026, 4, 20, 8, 0, 0))
+    end
+
+    it 'reports overdue when a configured dose time has passed without a take' do
+      expect(schedule.overdue?(at: now)).to be true
+    end
+
+    it 'does not report overdue when the configured dose has been taken' do
+      create(:medication_take, :for_schedule, schedule: schedule, taken_at: now.change(hour: 8, min: 15))
+
+      expect(schedule.overdue?(at: now)).to be false
+    end
+  end
+
   describe '#active?' do
     let(:schedule) do
       described_class.new(


### PR DESCRIPTION
## Summary
- add Schedule#can_take_dose?, #dose_blocked_reason, #next_dose_due_at, and #overdue?
- detect configured due times from schedule_config times
- route MedicationStockSourceResolver through the schedule domain method while preserving its existing blocked_reason symbols

Closes #1035

## Tests
- ruby -c app/models/schedule.rb
- ruby -c app/services/medication_stock_source_resolver.rb
- ruby -c spec/models/schedule_spec.rb
- git diff --check
- task test TEST_FILE=spec/models/schedule_spec.rb (fails locally: Docker socket /var/run/docker.sock is unavailable)
- task rubocop (fails locally: Docker socket /var/run/docker.sock is unavailable)