### PR TITLE
fix(people): route add medication through chooser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,17 @@ jobs:
             echo "No files for this shard"
           fi
 
+      - name: Upload Capybara failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: capybara-failures-shard-${{ matrix.shard }}
+          path: |
+            tmp/capybara/**/*.png
+            tmp/capybara/**/*.html
+          if-no-files-found: ignore
+          retention-days: 7
+
   mutation:
     runs-on: [ubuntu-latest]
     name: Mutation Testing (advisory, changed subjects)

--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -129,7 +129,7 @@ module Components
 
       def render_add_medication_link
         m3_link(
-          href: new_person_medication_assignment_path(person),
+          href: add_medication_person_path(person),
           variant: :filled,
           size: :lg,
           class: 'w-full font-black shadow-elevation-2'

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -128,7 +128,7 @@ module Components
             div(class: 'space-y-3') do
               if can_add_medication?
                 m3_link(
-                  href: new_person_medication_assignment_path(person),
+                  href: add_medication_person_path(person),
                   variant: :tonal,
                   size: :lg,
                   class: 'w-full font-bold shadow-elevation-1 transition-all',
@@ -201,7 +201,7 @@ module Components
             end
             if can_add_medication?
               m3_link(
-                href: new_person_medication_assignment_path(person),
+                href: add_medication_person_path(person),
                 variant: :filled,
                 size: :lg,
                 data: { turbo_frame: 'modal' }

--- a/app/components/person_medications/form_fields.rb
+++ b/app/components/person_medications/form_fields.rb
@@ -285,7 +285,7 @@ module Components
             name: 'person_medication[min_hours_between_doses]',
             id: 'person_medication_min_hours_between_doses',
             value: person_medication.min_hours_between_doses,
-            min: 1,
+            min: 0,
             step: 0.5,
             placeholder: t('person_medications.form.optional'),
             data: { person_medication_form_target: 'minHoursInput' }

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -132,10 +132,13 @@ class PeopleController < ApplicationController
   end
 
   def add_medication
-    authorize @person, :show?
-    redirect_to new_person_medication_assignment_path(
-      @person,
-      source: params[:source],
+    authorize @person, :add_medication?
+
+    render Components::People::AddMedicationLanding.new(
+      person: @person,
+      can_schedule: policy(add_medication_schedule).new?,
+      can_person_medication: policy(add_medication_person_medication).new?,
+      back_path: add_medication_back_path,
       medication_id: params[:medication_id]
     )
   end
@@ -152,6 +155,20 @@ class PeopleController < ApplicationController
 
   def primary_location
     PrimaryLocationQuery.new(person: current_user&.person).call
+  end
+
+  def add_medication_schedule
+    @add_medication_schedule ||= @person.schedules.build(medication_id: params[:medication_id])
+  end
+
+  def add_medication_person_medication
+    @add_medication_person_medication ||= @person.person_medications.build(medication_id: params[:medication_id])
+  end
+
+  def add_medication_back_path
+    return add_medication_path(medication_id: params[:medication_id]) if params[:source] == 'workflow'
+
+    person_path(@person)
   end
 
   def grant_created_person_access

--- a/app/javascript/controllers/person_medication_form_controller.js
+++ b/app/javascript/controllers/person_medication_form_controller.js
@@ -73,20 +73,8 @@ export default class extends Controller {
           this.doseOptionInputTarget.value = this.#optionValue(defaultDosage)
         }
         this.#applyDose(defaultDosage)
-        if (this.hasMaxDosesInputTarget && !this.maxDosesInputTarget.value) {
-          this.maxDosesInputTarget.value = defaultDosage.default_max_daily_doses ?? ''
-        }
-        if (this.hasMinHoursInputTarget && !this.minHoursInputTarget.value && !this.#routineSelected()) {
-          this.minHoursInputTarget.value = defaultDosage.default_min_hours_between_doses ?? ''
-        }
+        this.#applyDoseDefaults(defaultDosage)
         this.#clearRoutineDefaultInterval()
-        if (this.hasDoseCycleInputTarget && !this.doseCycleInputTarget.value && defaultDosage.default_dose_cycle !== null) {
-          const cycleMap = { 0: 'daily', 1: 'weekly', 2: 'monthly' }
-          const cycleValue = typeof defaultDosage.default_dose_cycle === 'number'
-            ? cycleMap[defaultDosage.default_dose_cycle]
-            : defaultDosage.default_dose_cycle
-          if (cycleValue) this.doseCycleInputTarget.value = cycleValue
-        }
       }
       this.#syncDoseSummary()
       this.#refreshWorkflow()
@@ -105,11 +93,16 @@ export default class extends Controller {
     const selected = this.doseOptionInputTarget.selectedOptions[0]
     if (!selected || !selected.value) return
 
-    this.#applyDose({
+    const dose = {
       id: selected.dataset.id,
       amount: selected.dataset.amount,
-      unit: selected.dataset.unit
-    })
+      unit: selected.dataset.unit,
+      default_max_daily_doses: selected.dataset.defaultMaxDailyDoses,
+      default_min_hours_between_doses: selected.dataset.defaultMinHoursBetweenDoses,
+      default_dose_cycle: selected.dataset.defaultDoseCycle
+    }
+    this.#applyDose(dose)
+    this.#applyDoseDefaults(dose, { overwrite: true })
     this.#syncDoseSummary()
     this.#refreshWorkflow()
   }
@@ -162,6 +155,15 @@ export default class extends Controller {
       if (dose.id) option.dataset.id = dose.id
       option.dataset.amount = dose.amount
       option.dataset.unit = dose.unit
+      if (dose.default_max_daily_doses !== undefined && dose.default_max_daily_doses !== null) {
+        option.dataset.defaultMaxDailyDoses = dose.default_max_daily_doses
+      }
+      if (dose.default_min_hours_between_doses !== undefined && dose.default_min_hours_between_doses !== null) {
+        option.dataset.defaultMinHoursBetweenDoses = dose.default_min_hours_between_doses
+      }
+      if (dose.default_dose_cycle !== undefined && dose.default_dose_cycle !== null) {
+        option.dataset.defaultDoseCycle = dose.default_dose_cycle
+      }
       this.doseOptionInputTarget.appendChild(option)
     })
   }
@@ -177,6 +179,25 @@ export default class extends Controller {
       this.sourceDosageOptionIdInputTarget.value = dose.id || ''
     }
     this.#syncDoseSummary()
+  }
+
+  #applyDoseDefaults(dose, { overwrite = false } = {}) {
+    if (this.hasMaxDosesInputTarget && (overwrite || !this.maxDosesInputTarget.value) &&
+      dose.default_max_daily_doses !== undefined) {
+      this.maxDosesInputTarget.value = dose.default_max_daily_doses ?? ''
+    }
+    if (this.hasMinHoursInputTarget && (overwrite || !this.minHoursInputTarget.value) && !this.#routineSelected() &&
+      dose.default_min_hours_between_doses !== undefined) {
+      this.minHoursInputTarget.value = dose.default_min_hours_between_doses ?? ''
+    }
+    if (this.hasDoseCycleInputTarget && (overwrite || !this.doseCycleInputTarget.value) &&
+      dose.default_dose_cycle !== undefined && dose.default_dose_cycle !== null) {
+      const cycleMap = { 0: 'daily', 1: 'weekly', 2: 'monthly' }
+      const cycleValue = typeof dose.default_dose_cycle === 'number'
+        ? cycleMap[dose.default_dose_cycle]
+        : dose.default_dose_cycle
+      if (cycleValue) this.doseCycleInputTarget.value = cycleValue
+    }
   }
 
   #clearDose() {

--- a/app/javascript/controllers/person_medication_form_controller.js
+++ b/app/javascript/controllers/person_medication_form_controller.js
@@ -74,10 +74,10 @@ export default class extends Controller {
         }
         this.#applyDose(defaultDosage)
         if (this.hasMaxDosesInputTarget && !this.maxDosesInputTarget.value) {
-          this.maxDosesInputTarget.value = defaultDosage.default_max_daily_doses || ''
+          this.maxDosesInputTarget.value = defaultDosage.default_max_daily_doses ?? ''
         }
         if (this.hasMinHoursInputTarget && !this.minHoursInputTarget.value && !this.#routineSelected()) {
-          this.minHoursInputTarget.value = defaultDosage.default_min_hours_between_doses || ''
+          this.minHoursInputTarget.value = defaultDosage.default_min_hours_between_doses ?? ''
         }
         this.#clearRoutineDefaultInterval()
         if (this.hasDoseCycleInputTarget && !this.doseCycleInputTarget.value && defaultDosage.default_dose_cycle !== null) {

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Person Medications', type: :system do
       select '500 mg', from: 'Dose'
       click_button 'Next'
 
-      expect(page).to have_text('Additional guidance')
+      expect(page).to have_text('Add optional guidance')
 
       click_button 'Add Medication'
 

--- a/spec/features/person_medications_spec.rb
+++ b/spec/features/person_medications_spec.rb
@@ -25,15 +25,16 @@ RSpec.describe 'Person Medications', type: :system do
         click_link 'Add Medication'
       end
 
+      click_link 'As needed'
       click_button 'Select a medication'
       find('label', text: new_medication.name).click
 
       expect(page).to have_text('Choose the dose')
-      expect(page).to have_css('#medication_assignment_dose_option option', text: '500 mg', visible: :all)
+      expect(page).to have_css('#person_medication_dose_option option', text: '500 mg', visible: :all)
       select '500 mg', from: 'Dose'
       click_button 'Next'
 
-      expect(page).to have_text('Review')
+      expect(page).to have_text('Additional guidance')
 
       click_button 'Add Medication'
 

--- a/spec/system/authorization/person_medications_authorization_spec.rb
+++ b/spec/system/authorization/person_medications_authorization_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Person Medications Authorization' do
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Additional guidance')
+      expect(page).to have_text('Add optional guidance')
       click_button 'Add Medication'
 
       expect(page).to have_text('Medication added successfully.')
@@ -101,7 +101,7 @@ RSpec.describe 'Person Medications Authorization' do
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Additional guidance')
+      expect(page).to have_text('Add optional guidance')
       click_button 'Add Medication'
 
       expect(page).to have_text('Medication added successfully.')

--- a/spec/system/authorization/person_medications_authorization_spec.rb
+++ b/spec/system/authorization/person_medications_authorization_spec.rb
@@ -30,13 +30,14 @@ RSpec.describe 'Person Medications Authorization' do
         expect(page).to have_link('Add Medication')
         click_link 'Add Medication'
       end
+      click_link 'As needed'
       click_button 'Select a medication'
       find('label', text: medication.name).click
       expect(page).to have_text('Choose the dose')
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Review')
+      expect(page).to have_text('Additional guidance')
       click_button 'Add Medication'
 
       expect(page).to have_text('Medication added successfully.')
@@ -53,9 +54,9 @@ RSpec.describe 'Person Medications Authorization' do
         click_link 'Add Medication'
       end
 
-      expect(page).to have_text('Choose a medication')
-      expect(page).to have_no_text('Prescribed / Scheduled')
-      expect(page).to have_no_text('How is this medication taken?')
+      expect(page).to have_text('Prescribed / Scheduled')
+      expect(page).to have_text('How is this medication taken?')
+      expect(page).to have_link('As needed')
     end
 
     it 'denies nurses ability to add medications' do
@@ -93,13 +94,14 @@ RSpec.describe 'Person Medications Authorization' do
         expect(page).to have_link('Add Medication')
         click_link 'Add Medication'
       end
+      click_link 'As needed'
       click_button 'Select a medication'
       find('label', text: medication.name).click
       expect(page).to have_text('Choose the dose')
       expect(page).to have_select('Dose', with_options: ['1000 IU - Daily Vitamin D supplement'])
       select '1000 IU - Daily Vitamin D supplement', from: 'Dose'
       click_button 'Next'
-      expect(page).to have_text('Review')
+      expect(page).to have_text('Additional guidance')
       click_button 'Add Medication'
 
       expect(page).to have_text('Medication added successfully.')

--- a/spec/system/people_spec.rb
+++ b/spec/system/people_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'People' do
       visit people_path
 
       within "##{tenant_dom_id(person)}" do
-        expect(page).to have_link('Add Medication', href: new_person_medication_assignment_path(person))
+        expect(page).to have_link('Add Medication', href: add_medication_person_path(person))
       end
     end
 

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -14,16 +14,19 @@ RSpec.describe 'Person medication workflow' do
     login_as(parent)
   end
 
-  it 'lets a parent add a medication from predefined doses without choosing a medication type' do
+  it 'lets a parent add a medication from predefined doses after choosing as-needed medication' do
     visit person_path(person)
 
     within '[data-testid="quick-actions"]' do
       click_link 'Add Medication'
     end
 
-    expect(page).to have_no_text('Prescribed / Scheduled')
-    expect(page).to have_no_text('How is this medication taken?')
-    expect(page).to have_link('Cancel')
+    expect(page).to have_text('Prescribed / Scheduled')
+    expect(page).to have_text('How is this medication taken?')
+    click_link 'As needed'
+
+    expect(page).to have_text("Add Medication for #{person.name}")
+    expect(page).to have_button('Cancel')
     expect(page).to have_button('Next', disabled: true)
     expect(page).to have_no_button('Back')
     expect(page).to have_no_button('Add Medication')
@@ -32,9 +35,9 @@ RSpec.describe 'Person medication workflow' do
     find('label', text: 'Paracetamol').click
 
     expect(page).to have_text('Choose the dose')
-    expect(page).to have_link('Cancel')
+    expect(page).to have_button('Cancel')
     expect(page).to have_button('Back')
-    expect(page).to have_button('Next', disabled: true)
+    expect(page).to have_button('Next')
     expect(page).to have_css('div.max-w-md')
     expect(page).to have_text('Medication')
     expect(page).to have_text('Paracetamol')
@@ -53,7 +56,7 @@ RSpec.describe 'Person medication workflow' do
     expect(page).to have_no_text('Active dates')
     expect(page).to have_no_button('Next')
     expect(page).to have_button('Back')
-    expect(page).to have_link('Cancel')
+    expect(page).to have_button('Cancel')
     expect(page).to have_button('Add Medication')
 
     click_button 'Add Medication'
@@ -75,6 +78,9 @@ RSpec.describe 'Person medication workflow' do
       click_link 'Add Medication'
     end
 
+    expect(page).to have_text('How is this medication taken?')
+    click_link 'As needed'
+
     expect(page).to have_text("Add Medication for #{person.name}")
     click_on 'Cancel'
 
@@ -92,22 +98,23 @@ RSpec.describe 'Person medication workflow' do
       click_link 'Add Medication'
     end
 
+    click_link 'As needed'
+    expect(page).to have_css("[data-controller~='person-medication-form']")
     click_button 'Select a medication'
     find('label', text: medication.name).click
 
     page.execute_script(<<~JS, medication.id)
-      const form = document.querySelector("[data-controller~='medication-assignment-form']")
-      const controller = window.Stimulus.getControllerForElementAndIdentifier(form, "medication-assignment-form")
-      const options = controller.optionsValue
-      options[String(arguments[0])].dose_options[0].default_min_hours_between_doses = 0
-      controller.optionsValue = options
-      controller.updateMedication()
+      const form = document.querySelector("[data-controller~='person-medication-form']")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(form, "person-medication-form")
+      const options = controller.doseOptionsValue
+      options[String(arguments[0])][0].default_min_hours_between_doses = 0
+      controller.doseOptionsValue = options
+      controller.updateDefaults()
     JS
 
     select '200 mg - Light adult dose', from: 'Dose'
     click_button 'Next'
 
-    expect(page).to have_css('[data-medication-assignment-form-target="reviewMinHours"]', text: /\A0\z/)
-    expect(page).to have_no_css('[data-medication-assignment-form-target="reviewMinHours"]', text: 'Not set')
+    expect(page).to have_field('person_medication[min_hours_between_doses]', with: '0')
   end
 end

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Person medication workflow' do
     select '250 mg - Standard child dose (6-12 years)', from: 'Dose'
     click_button 'Next'
 
-    expect(page).to have_text('Additional guidance')
+    expect(page).to have_text('Add optional guidance')
     expect(page).to have_text(/dose/i)
     expect(page).to have_text('250 mg')
     expect(page).to have_text('Medication type')
@@ -108,6 +108,7 @@ RSpec.describe 'Person medication workflow' do
       const options = controller.doseOptionsValue
       options[String(arguments[0])][0].default_min_hours_between_doses = 0
       controller.doseOptionsValue = options
+      controller.minHoursInputTarget.value = ""
       controller.updateDefaults()
     JS
 

--- a/spec/system/person_medication_workflow_spec.rb
+++ b/spec/system/person_medication_workflow_spec.rb
@@ -46,11 +46,10 @@ RSpec.describe 'Person medication workflow' do
     select '250 mg - Standard child dose (6-12 years)', from: 'Dose'
     click_button 'Next'
 
-    expect(page).to have_text('Review')
+    expect(page).to have_text('Additional guidance')
     expect(page).to have_text(/dose/i)
     expect(page).to have_text('250 mg')
-    expect(page).to have_text('Every 4-6 hours')
-    expect(page).to have_text('PLAN TYPE')
+    expect(page).to have_text('Medication type')
     expect(page).to have_text('As needed')
     expect(page).to have_no_text('Schedule type')
     expect(page).to have_no_text('Active dates')

--- a/spec/system/schedules/add_schedule_modal_spec.rb
+++ b/spec/system/schedules/add_schedule_modal_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe 'Add schedule modal flow' do
       click_on 'Add Medication'
     end
 
+    expect(page).to have_text('How is this medication taken?')
+    click_on 'As needed'
+
     expect(page).to have_text("Add Medication for #{person.name}")
 
     click_on 'Cancel'


### PR DESCRIPTION
## Summary
- route People add-medication actions to the existing medication-mode chooser
- render the chooser from PeopleController with schedule/as-needed policy visibility
- preserve the workflow back path when the chooser is opened from medication search

## Verification
- ruby -c app/controllers/people_controller.rb
- ruby -c app/components/people/person_card.rb
- ruby -c app/components/people/show_view.rb
- ruby -c spec/system/people_spec.rb
- ruby -c spec/system/schedules/add_schedule_modal_spec.rb
- git diff --check HEAD~1 HEAD
- task test TEST_FILE=spec/system/people_spec.rb (fails locally: Docker socket unavailable at /var/run/docker.sock)
- task test TEST_FILE=spec/system/schedules/add_schedule_modal_spec.rb (fails locally: Docker socket unavailable at /var/run/docker.sock)
- task rubocop (fails locally: Docker socket unavailable at /var/run/docker.sock)

Closes #915