### PR TITLE
feat(observability): emit medication take metrics

### DIFF
--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -39,6 +39,7 @@ class TakeMedicationService
   end
 
   def call(source:, amount_override:, taken_from_medication_id:, user:, **options)
+    publish_take_metric('take_attempted.med_tracker', source:, user:, options:)
     prepared_take = prepare_take(
       source: source,
       amount_override: amount_override,
@@ -46,12 +47,12 @@ class TakeMedicationService
       user: user,
       options: options
     )
-    return failure(prepared_take.error) if prepared_take.error
+    return rule_blocked_failure(prepared_take, source:, user:, options:) if prepared_take.error
 
     take = prepared_take.record
-    return failure(:create_failed) unless take.persisted?
+    return persistence_failure(source:, user:, options:) unless take.persisted?
 
-    success(take)
+    success(take, source:, user:, options:)
   end
 
   private
@@ -60,8 +61,19 @@ class TakeMedicationService
     Result.new(success: false, take: nil, error: error)
   end
 
-  def success(take)
+  def rule_blocked_failure(prepared_take, source:, user:, options:)
+    publish_take_metric('take_blocked_by_rules.med_tracker', source:, user:, options:, error: prepared_take.error)
+    failure(prepared_take.error)
+  end
+
+  def persistence_failure(source:, user:, options:)
+    publish_take_metric('take_errors.med_tracker', source:, user:, options:, error: :create_failed)
+    failure(:create_failed)
+  end
+
+  def success(take, source:, user:, options:)
     publish_dose_taken(take)
+    publish_take_metric('take_recorded.med_tracker', source:, user:, options:)
     Result.new(success: true, take: take, error: nil)
   end
 
@@ -139,6 +151,29 @@ class TakeMedicationService
 
   def publish_dose_taken(take)
     ActiveSupport::Notifications.instrument('dose_taken.med_tracker', dose_taken_payload(take))
+  end
+
+  def publish_take_metric(event_name, source:, user:, options:, error: nil)
+    ActiveSupport::Notifications.instrument(event_name, take_metric_payload(source:, user:, options:, error:))
+  end
+
+  def take_metric_payload(source:, user:, options:, error:)
+    {
+      environment: Rails.env.to_s,
+      role: metric_role(user),
+      route: options[:route],
+      medicine_context_class: source.class.name,
+      source_type: source.class.model_name.singular,
+      error: error&.to_s
+    }
+  end
+
+  def metric_role(user)
+    return user.membership&.role if user.is_a?(AuthorizationContext)
+    return unless user.respond_to?(:person)
+
+    account = user.person&.account
+    account&.first_active_household_membership&.role
   end
 
   def dose_taken_payload(take)

--- a/docs/adrs/0004-domain-events-with-active-support-notifications.md
+++ b/docs/adrs/0004-domain-events-with-active-support-notifications.md
@@ -24,6 +24,10 @@ Event names for the initial tranche:
 
 - `dose_taken.med_tracker`
 - `low_stock_threshold_reached.med_tracker`
+- `take_attempted.med_tracker`
+- `take_recorded.med_tracker`
+- `take_blocked_by_rules.med_tracker`
+- `take_errors.med_tracker`
 
 Publishers will emit raw notification payloads directly at the domain/service boundary. We are not introducing a custom event bus, wrapper object, or subscriber framework in this tranche.
 

--- a/docs/operations/medication-take-metrics.md
+++ b/docs/operations/medication-take-metrics.md
@@ -1,0 +1,40 @@
+# Medication Take Metrics
+
+Medication take activity is emitted through `ActiveSupport::Notifications` at the `TakeMedicationService` boundary.
+
+## Event Names
+
+| Event | Meaning |
+| --- | --- |
+| `take_attempted.med_tracker` | A dose-recording request reached the service boundary. |
+| `take_recorded.med_tracker` | A medication take was persisted successfully. |
+| `take_blocked_by_rules.med_tracker` | Business rules blocked the take before persistence. |
+| `take_errors.med_tracker` | The service accepted the request but persistence failed. |
+| `dose_taken.med_tracker` | Domain event with medication-take context for in-process subscribers. |
+
+## Labels
+
+Metric events use coarse labels only:
+
+| Label | Description |
+| --- | --- |
+| `environment` | Rails environment. |
+| `role` | Current household membership role when available. |
+| `route` | Optional caller-supplied route name. |
+| `medicine_context_class` | Source class, such as `Schedule` or `PersonMedication`. |
+| `source_type` | Source model name, such as `schedule` or `person_medication`. |
+| `error` | Error code for blocked/error events, otherwise blank. |
+
+## Dashboard Panels
+
+Operational dashboards should chart:
+
+| Panel | Source |
+| --- | --- |
+| Daily take attempts | Count of `take_attempted.med_tracker` grouped by day and `medicine_context_class`. |
+| Daily recorded takes | Count of `take_recorded.med_tracker` grouped by day and `medicine_context_class`. |
+| Blocked take reasons | Count of `take_blocked_by_rules.med_tracker` grouped by `error`. |
+| Take error trend | Count of `take_errors.med_tracker` grouped by day and `error`. |
+
+Alert on any sustained increase in `take_errors.med_tracker` or a sudden spike in
+`take_blocked_by_rules.med_tracker` for `cooldown`, `out_of_stock`, or `invalid_source`.

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe TakeMedicationService do
   before { FixtureHouseholdSetup.apply! }
 
   # Shared helper to invoke the service
-  def call_service(source:, amount_override: nil, taken_from_medication_id: nil)
+  def call_service(source:, amount_override: nil, taken_from_medication_id: nil, **)
     service.call(
       source: source,
       amount_override: amount_override,
       taken_from_medication_id: taken_from_medication_id,
-      user: user
+      user: user,
+      **
     )
   end
 
@@ -413,7 +414,7 @@ RSpec.describe TakeMedicationService do
     end
   end
 
-  describe 'dose_taken.med_tracker' do
+  describe 'medication take events' do
     def captured_event_payloads(event_name, &)
       payloads = []
       subscriber = lambda do |*args|
@@ -423,6 +424,19 @@ RSpec.describe TakeMedicationService do
       ActiveSupport::Notifications.subscribed(subscriber, event_name, &)
 
       payloads
+    end
+
+    def expect_metric_payload(payloads, source:, error: nil)
+      expect(payloads).to contain_exactly(
+        include(
+          environment: Rails.env.to_s,
+          role: user.person.account.first_active_household_membership.role,
+          route: nil,
+          medicine_context_class: source.class.name,
+          source_type: source.class.model_name.singular,
+          error: error
+        )
+      )
     end
 
     def expect_dose_taken_payload(payloads, result:, source:, dose_amount:, source_type:)
@@ -440,6 +454,56 @@ RSpec.describe TakeMedicationService do
           taken_at: result.take.taken_at
         )
       )
+    end
+
+    it 'publishes attempted and recorded metric events for a successful dose' do
+      schedule = schedules(:john_paracetamol)
+      result = nil
+
+      travel_to Time.current.end_of_day - 1.minute do
+        attempted_payloads = captured_event_payloads('take_attempted.med_tracker') do
+          recorded_payloads = captured_event_payloads('take_recorded.med_tracker') do
+            result = call_service(source: schedule)
+          end
+
+          expect_metric_payload(recorded_payloads, source: schedule)
+        end
+
+        expect(result.success).to be true
+        expect_metric_payload(attempted_payloads, source: schedule)
+      end
+    end
+
+    it 'publishes attempted and blocked metric events when rules prevent a dose' do
+      schedule = schedules(:john_paracetamol)
+      schedule.medication.update!(current_supply: 0)
+      result = nil
+
+      attempted_payloads = captured_event_payloads('take_attempted.med_tracker') do
+        blocked_payloads = captured_event_payloads('take_blocked_by_rules.med_tracker') do
+          result = call_service(source: schedule)
+        end
+
+        expect_metric_payload(blocked_payloads, source: schedule, error: 'out_of_stock')
+      end
+
+      expect(result.error).to eq(:out_of_stock)
+      expect_metric_payload(attempted_payloads, source: schedule)
+    end
+
+    it 'publishes an error metric when take persistence fails' do
+      schedule = schedules(:john_paracetamol)
+      allow(schedule).to receive(:effective_dose_unit).and_return(nil)
+      result = nil
+
+      travel_to Time.current.end_of_day - 1.minute do
+        payloads = captured_event_payloads('take_errors.med_tracker') do
+          result = call_service(source: schedule)
+        end
+
+        expect(result.error).to eq(:create_failed)
+        expect_metric_payload(payloads, source: schedule, error: 'create_failed')
+      end
     end
 
     it 'publishes one event for a successful scheduled dose' do


### PR DESCRIPTION
## Summary
- emit coarse medication take metric events for attempted, recorded, blocked, and persistence-error paths
- keep detailed dose context on the existing dose_taken domain event while metric events use safe labels
- document stable event names, labels, and dashboard panel mappings

## Verification
- ruby -c app/services/take_medication_service.rb
- ruby -c spec/services/take_medication_service_spec.rb
- git diff --check
- task test TEST_FILE=spec/services/take_medication_service_spec.rb (fails locally: Docker socket unavailable at /var/run/docker.sock)
- task rubocop (fails locally: Docker socket unavailable at /var/run/docker.sock)

Closes #700