### PR TITLE
fix(ui): align workflow controls with M3 links

### DIFF
--- a/app/components/dashboard/index_view.rb
+++ b/app/components/dashboard/index_view.rb
@@ -112,9 +112,11 @@ module Components
                        'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface'
                      end
 
-        a(
+        m3_link(
           href: dashboard_path(dashboard_person_id: option.fetch(:id)),
-          class: "inline-flex min-h-12 items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold #{link_class}",
+          variant: selected ? :filled : :text,
+          size: :md,
+          class: "min-h-12 gap-2 rounded-xl px-3 py-2 text-sm font-bold #{link_class}",
           aria: selected ? { current: 'true' } : {},
           data: { testid: 'dashboard-person-option' }
         ) do
@@ -178,12 +180,13 @@ module Components
           data: { testid: testid }
         ) do
           render RubyUI::DropdownMenuTrigger.new(class: 'w-full') do
-            button(
+            m3_button(
               type: 'button',
-              class: 'inline-flex min-h-12 w-full items-center justify-between gap-2 rounded-xl border ' \
-                     'border-outline-variant bg-surface-container-low px-3 py-2 text-sm font-bold ' \
-                     'text-on-surface-variant shadow-sm hover:bg-surface-container-high ' \
-                     'focus:outline-none focus:ring-2 focus:ring-primary/20',
+              variant: :outlined,
+              size: :md,
+              class: 'min-h-12 w-full justify-between gap-2 rounded-xl border-outline-variant ' \
+                     'bg-surface-container-low px-3 py-2 text-sm font-bold text-on-surface-variant ' \
+                     'shadow-sm hover:bg-surface-container-high',
               aria: { label: t('dashboard.person_selector.more_people') }
             ) do
               span(class: 'truncate') { overflow_selector_label }

--- a/app/components/medication_assignments/modal.rb
+++ b/app/components/medication_assignments/modal.rb
@@ -42,11 +42,12 @@ module Components
       private
 
       def render_back_link
-        a(
+        m3_link(
           href: back_path,
+          variant: :text,
+          size: :sm,
           data: { turbo_frame: 'modal' },
-          class: 'inline-flex items-center text-sm text-on-surface-variant hover:text-foreground ' \
-                 'transition-colors mb-2 no-underline'
+          class: 'mb-2 h-auto min-h-0 justify-start p-0 text-sm text-on-surface-variant hover:text-foreground'
         ) do
           plain t('medication_workflow.back')
         end

--- a/app/components/medication_workflow/person_selection.rb
+++ b/app/components/medication_workflow/person_selection.rb
@@ -40,12 +40,13 @@ module Components
       def render_person_buttons
         div(class: 'grid grid-cols-1 gap-3 py-2') do
           people.each do |person|
-            a(
+            m3_link(
               href: new_person_medication_assignment_path(person, source: :workflow, medication_id: medication_id),
+              variant: :outlined,
+              size: :lg,
               data: { turbo_frame: 'modal' },
-              class: 'flex items-center gap-4 w-full rounded-2xl border-2 border-outline p-4 ' \
-                     'hover:border-primary hover:bg-primary/5 active:bg-primary/10 ' \
-                     'transition-all cursor-pointer no-underline'
+              class: 'w-full justify-start gap-4 rounded-2xl border-2 border-outline p-4 ' \
+                     'hover:border-primary hover:bg-primary/5 active:bg-primary/10'
             ) do
               render Components::Shared::PersonAvatar.new(person: person, size: :md)
               div do

--- a/app/components/people/add_medication_landing.rb
+++ b/app/components/people/add_medication_landing.rb
@@ -24,11 +24,12 @@ module Components
             DialogContent(size: :md) do
               DialogHeader do
                 if back_path
-                  a(
+                  m3_link(
                     href: back_path,
+                    variant: :text,
+                    size: :sm,
                     data: { turbo_frame: 'modal' },
-                    class: 'inline-flex items-center text-sm text-on-surface-variant hover:text-foreground ' \
-                           'transition-colors mb-2 no-underline'
+                    class: 'mb-2 h-auto min-h-0 justify-start p-0 text-sm text-on-surface-variant hover:text-foreground'
                   ) do
                     plain t('medication_workflow.back')
                   end
@@ -64,12 +65,13 @@ module Components
       private
 
       def render_option(href:, title:, description:, icon:)
-        a(
+        m3_link(
           href: href,
+          variant: :outlined,
+          size: :lg,
           data: { turbo_frame: 'modal' },
-          class: 'flex items-start gap-4 w-full rounded-2xl border-2 border-outline p-6 ' \
-                 'hover:border-primary hover:bg-primary/5 active:bg-primary/10 ' \
-                 'transition-all cursor-pointer no-underline'
+          class: 'w-full items-start justify-start gap-4 rounded-2xl border-2 border-outline p-6 ' \
+                 'hover:border-primary hover:bg-primary/5 active:bg-primary/10'
         ) do
           div(class: 'w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center ' \
                      'text-primary flex-none mt-0.5') do

--- a/app/components/person_medications/modal.rb
+++ b/app/components/person_medications/modal.rb
@@ -28,11 +28,12 @@ module Components
             DialogContent(size: dialog_size) do
               DialogHeader do
                 if back_path
-                  a(
+                  m3_link(
                     href: back_path,
+                    variant: :text,
+                    size: :sm,
                     data: { turbo_frame: 'modal' },
-                    class: 'inline-flex items-center text-sm text-on-surface-variant hover:text-foreground ' \
-                           'transition-colors mb-2 no-underline'
+                    class: 'mb-2 h-auto min-h-0 justify-start p-0 text-sm text-on-surface-variant hover:text-foreground'
                   ) do
                     plain t('medication_workflow.back')
                   end

--- a/spec/components/dashboard/index_view_spec.rb
+++ b/spec/components/dashboard/index_view_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(selected.at_css('[data-testid="person-avatar"]')).to be_present
     end
 
+    it 'renders selected person options with the shared M3 link contract' do
+      presenter = parent_dashboard_presenter
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+      selected = rendered.at_css('[data-testid="dashboard-person-option"][aria-current="true"]')
+      selected_classes = selected['class'].split
+
+      expect(selected_classes).to include('state-layer', 'rounded-xl')
+      expect(selected_classes).to include_person_pill_size_class
+    end
+
     it 'wraps selector controls instead of requiring horizontal scrolling' do
       presenter = parent_dashboard_presenter
 
@@ -114,6 +125,15 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
       expect(overflow['data-controller']).to include('ruby-ui--dropdown-menu')
       expect(overflow.at_css('select')).not_to be_present
       expect(overflow.text).to include('All Family')
+    end
+
+    it 'renders overflow selector triggers with the shared M3 button contract' do
+      presenter = dashboard_presenter(admin_user, people_scope: Person.all)
+
+      rendered = render_inline(described_class.new(presenter: presenter))
+      overflow = rendered.at_css('[data-testid="dashboard-person-overflow"]')
+
+      expect(overflow.at_css('button')['class'].split).to include('state-layer', 'rounded-xl')
     end
 
     it 'renders only the current selection plus a dropdown for other people on mobile' do
@@ -535,6 +555,13 @@ RSpec.describe Components::Dashboard::IndexView, type: :component do
 
   def include_touch_target_class
     satisfy { |classes| classes.include?('min-h-11') || classes.include?('min-h-[44px]') }
+  end
+
+  def include_person_pill_size_class
+    satisfy do |classes|
+      classes.include?('min-h-10') || classes.include?('min-h-11') || classes.include?('min-h-12') ||
+        classes.include?('min-h-[44px]')
+    end
   end
 
   def dashboard_presenter(user, people_scope:, selected_person_id: nil)

--- a/spec/components/medication_assignments/modal_spec.rb
+++ b/spec/components/medication_assignments/modal_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::MedicationAssignments::Modal, type: :component do
+  it 'renders the back action as a shared text link' do
+    back_link = rendered_back_link
+    classes = back_link['class'].split
+
+    expect(back_link.text).to include('Back')
+    expect(back_link['data-turbo-frame']).to eq('modal')
+    expect(classes).to include('state-layer')
+    expect(classes).not_to include('rounded-xl')
+  end
+
+  def rendered_back_link
+    person = create(:person, name: 'Alex Patient')
+    medication = create(:medication, name: 'Paracetamol')
+    assignment = MedicationAssignment.new(medication_id: medication.id)
+    back_path = route_helpers.add_medication_person_path(person, household_slug: 'test-household')
+    rendered = render_inline(
+      described_class.new(assignment: assignment, person: person, medications: [medication],
+                          back_path: back_path)
+    )
+
+    rendered.at_css("a[href='#{back_path}']")
+  end
+
+  def route_helpers = Rails.application.routes.url_helpers
+end

--- a/spec/components/medication_workflow/person_selection_spec.rb
+++ b/spec/components/medication_workflow/person_selection_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::MedicationWorkflow::PersonSelection, type: :component do
+  it 'renders person choices with the shared M3 link contract' do
+    person = create(:person, name: 'Alex Patient')
+
+    rendered = render_inline(described_class.new(people: [person]))
+    choice = rendered.at_css("a[href='#{person_assignment_path(person)}']")
+    classes = choice['class'].split
+
+    expect(choice['data-turbo-frame']).to eq('modal')
+    expect(classes).to include('state-layer', 'rounded-2xl')
+    expect(classes).to include_touch_target_class
+    expect(choice.text).to include('Alex Patient')
+  end
+
+  def include_touch_target_class
+    satisfy { |classes| classes.include?('min-h-11') || classes.include?('min-h-[44px]') }
+  end
+
+  def person_assignment_path(person)
+    Rails.application.routes.url_helpers.new_person_medication_assignment_path(
+      person,
+      source: :workflow,
+      household_slug: 'test-household'
+    )
+  end
+end

--- a/spec/components/people/add_medication_landing_spec.rb
+++ b/spec/components/people/add_medication_landing_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::People::AddMedicationLanding, type: :component do
+  it 'renders workflow options with the shared M3 link contract' do
+    person = create(:person, name: 'Alex Patient')
+
+    rendered = render_inline(described_class.new(person: person, back_path: add_medication_path))
+    options = rendered.css("a[data-turbo-frame='modal']").select do |link|
+      link.text.match?(/Prescribed|As needed/)
+    end
+
+    expect(options.size).to eq(2)
+    expect(options.map { |option| option['class'].split }).to all(include('state-layer', 'rounded-2xl'))
+    expect(options.map { |option| option['class'].split }).to all(include_touch_target_class)
+  end
+
+  it 'renders the back action as a shared text link' do
+    person = create(:person, name: 'Alex Patient')
+
+    rendered = render_inline(described_class.new(person: person, back_path: add_medication_path))
+    back_link = rendered.at_css("a[href='#{add_medication_path}']")
+    classes = back_link['class'].split
+
+    expect(back_link.text).to include('Back')
+    expect(classes).to include('state-layer')
+    expect(classes).not_to include('rounded-xl')
+  end
+
+  def include_touch_target_class
+    satisfy { |classes| classes.include?('min-h-11') || classes.include?('min-h-[44px]') }
+  end
+
+  def add_medication_path
+    Rails.application.routes.url_helpers.add_medication_path(household_slug: 'test-household')
+  end
+end

--- a/spec/components/person_medications/modal_spec.rb
+++ b/spec/components/person_medications/modal_spec.rb
@@ -50,4 +50,29 @@ RSpec.describe Components::PersonMedications::Modal, type: :component do
       medication.id.to_s => [{ 'amount' => '1' }]
     )
   end
+
+  it 'renders the back action as a shared text link' do
+    back_link = rendered_back_link
+    classes = back_link['class'].split
+
+    expect(back_link.text).to include('Back')
+    expect(back_link['data-turbo-frame']).to eq('modal')
+    expect(classes).to include('state-layer')
+    expect(classes).not_to include('rounded-xl')
+  end
+
+  def rendered_back_link
+    person = create(:person, name: 'Damacus User')
+    medication = create(:medication, name: 'Calpol')
+    person_medication = build(:person_medication, person: person, medication: medication)
+    back_path = route_helpers.add_medication_person_path(person, household_slug: 'test-household')
+    rendered = render_inline(
+      described_class.new(person_medication: person_medication, person: person, medications: [medication],
+                          back_path: back_path)
+    )
+
+    rendered.at_css("a[href='#{back_path}']")
+  end
+
+  def route_helpers = Rails.application.routes.url_helpers
 end


### PR DESCRIPTION
## Summary
- convert dashboard person selector controls to shared M3 link/button primitives
- convert medication workflow chooser cards and modal back actions to M3 links
- add component specs for the changed action patterns

Closes #1408

## Tests
- ruby -c app/components/dashboard/index_view.rb
- ruby -c app/components/medication_assignments/modal.rb
- ruby -c app/components/medication_workflow/person_selection.rb
- ruby -c app/components/people/add_medication_landing.rb
- ruby -c app/components/person_medications/modal.rb
- ruby -c spec/components/dashboard/index_view_spec.rb
- ruby -c spec/components/medication_workflow/person_selection_spec.rb
- ruby -c spec/components/people/add_medication_landing_spec.rb
- ruby -c spec/components/medication_assignments/modal_spec.rb
- ruby -c spec/components/person_medications/modal_spec.rb
- git diff --check
- task test TEST_FILE=spec/components/dashboard/index_view_spec.rb (blocked: local Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/person_medications/modal_spec.rb (blocked: local Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/medication_workflow/person_selection_spec.rb (blocked: local Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/people/add_medication_landing_spec.rb (blocked: local Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/medication_assignments/modal_spec.rb (blocked: local Docker socket /var/run/docker.sock unavailable)