### PR TITLE
refactor(ui): centralize modal rendering contract

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -139,7 +139,10 @@ Never push if either command fails.
 - Use Conventional Commits with scopes when useful, for example `fix(medicines): handle missing reorder threshold`.
 - Keep changes atomic and focused.
 - For PR titles and squash messages, use the same Conventional Commit style.
-- PR descriptions should summarize behavior changes, tests run, and screenshots for visible UI changes.
+- PR summaries should be human-readable first: explain what problem the change solves, why the change exists, and what future bugs or confusion it prevents. Write for someone passing by the PR who does not already know the implementation details.
+- For refactors or infrastructure work, describe the before/after contract in plain language, for example: "this used to be handled differently in several places; now one shared rule handles it consistently."
+- Do not include routine test sections in PR descriptions; CI is the source of truth. Mention verification only when it is manual, unusual, blocked, or not covered by CI.
+- Include screenshots for visible UI changes.
 
 ## Session close (mandatory)
 

--- a/app/controllers/admin/carer_relationships_controller.rb
+++ b/app/controllers/admin/carer_relationships_controller.rb
@@ -17,30 +17,25 @@ module Admin
     def new
       @relationship = CarerRelationship.new(patient_id: params[:patient_id])
       authorize @relationship
-      is_modal = request.headers['Turbo-Frame'] == 'modal'
       options = carer_relationship_options
 
-      respond_to do |format|
-        format.html do
-          render Components::Admin::CarerRelationships::FormView.new(
+      render_modal_or_page(
+        modal: lambda {
+          Components::Admin::CarerRelationships::FormView.new(
             relationship: @relationship,
             carers: options.carers,
             patients: options.patients,
-            modal: is_modal
-          ), layout: !is_modal
-        end
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace(
-            'modal',
-            Components::Admin::CarerRelationships::FormView.new(
-              relationship: @relationship,
-              carers: options.carers,
-              patients: options.patients,
-              modal: true
-            )
+            modal: true
           )
-        end
-      end
+        },
+        page: lambda {
+          Components::Admin::CarerRelationships::FormView.new(
+            relationship: @relationship,
+            carers: options.carers,
+            patients: options.patients
+          )
+        }
+      )
     end
 
     def create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,6 +108,30 @@ class ApplicationController < ActionController::Base
     AuthorizationContext.new(account: Current.account, household: Current.household, membership: nil)
   end
 
+  def modal_frame_request?
+    request.headers['Turbo-Frame'] == 'modal'
+  end
+
+  def render_modal_or_page(modal:, page:, status: :ok)
+    respond_to do |format|
+      format.html do
+        if modal_frame_request?
+          render modal_renderable(modal), layout: false, status: status
+        else
+          render modal_renderable(page), status: status
+        end
+      end
+
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace('modal', modal_renderable(modal)), status: status
+      end
+    end
+  end
+
+  def modal_renderable(renderable)
+    renderable.is_a?(Proc) ? renderable.call : renderable
+  end
+
   def safe_redirect_path(path)
     url_from(path)
   end

--- a/app/controllers/medication_assignments_controller.rb
+++ b/app/controllers/medication_assignments_controller.rb
@@ -93,37 +93,25 @@ class MedicationAssignmentsController < ApplicationController
 
   def render_assignment_form(status: :ok)
     back_path = params[:source] == 'workflow' ? add_medication_path(medication_id: params[:medication_id]) : nil
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
 
-    respond_to do |format|
-      format.html do
-        if is_modal
-          render Components::MedicationAssignments::Modal.new(
-            assignment: @assignment,
-            person: @person,
-            medications: @medications,
-            back_path: back_path
-          ), layout: false, status: status
-        else
-          render Components::MedicationAssignments::FormView.new(
-            assignment: @assignment,
-            person: @person,
-            medications: @medications
-          ), status: status
-        end
-      end
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace(
-          'modal',
-          Components::MedicationAssignments::Modal.new(
-            assignment: @assignment,
-            person: @person,
-            medications: @medications,
-            back_path: back_path
-          )
-        ), status: status
-      end
-    end
+    render_modal_or_page(
+      modal: lambda {
+        Components::MedicationAssignments::Modal.new(
+          assignment: @assignment,
+          person: @person,
+          medications: @medications,
+          back_path: back_path
+        )
+      },
+      page: lambda {
+        Components::MedicationAssignments::FormView.new(
+          assignment: @assignment,
+          person: @person,
+          medications: @medications
+        )
+      },
+      status: status
+    )
   end
 
   def assignment_success_message(result)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -26,27 +26,23 @@ class PeopleController < ApplicationController
   def new
     @person = Person.new
     authorize @person
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
     assigned_location = primary_location
 
-    if is_modal
-      render Components::People::Modal.new(person: @person, assigned_location: assigned_location), layout: false
-    else
-      render Components::People::FormView.new(person: @person, assigned_location: assigned_location)
-    end
+    render_modal_or_page(
+      modal: -> { Components::People::Modal.new(person: @person, assigned_location: assigned_location) },
+      page: -> { Components::People::FormView.new(person: @person, assigned_location: assigned_location) }
+    )
   end
 
   def edit
     @person = policy_scope(Person).find(params.expect(:id))
     authorize @person
     @return_to = url_from(params[:return_to])
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
 
-    if is_modal
-      render Components::People::Modal.new(person: @person, return_to: @return_to), layout: false
-    else
-      render Components::People::FormView.new(person: @person, return_to: @return_to)
-    end
+    render_modal_or_page(
+      modal: -> { Components::People::Modal.new(person: @person, return_to: @return_to) },
+      page: -> { Components::People::FormView.new(person: @person, return_to: @return_to) }
+    )
   end
 
   def create

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -105,25 +105,11 @@ class PersonMedicationsController < ApplicationController
   end
 
   def render_person_medication_form(title:, editing: false, back_path: nil, status: :ok)
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
-
-    respond_to do |format|
-      format.html { render_person_medication_html_form(title:, editing:, back_path:, status:, is_modal:) }
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace(
-          'modal',
-          person_medication_modal(title: title, editing: editing, back_path: back_path)
-        ), status: status
-      end
-    end
-  end
-
-  def render_person_medication_html_form(title:, editing:, back_path:, status:, is_modal:)
-    if is_modal
-      render person_medication_modal(title: title, editing: editing, back_path: back_path), layout: false, status: status
-    else
-      render person_medication_form_view(editing: editing), status: status
-    end
+    render_modal_or_page(
+      modal: -> { person_medication_modal(title: title, editing: editing, back_path: back_path) },
+      page: -> { person_medication_form_view(editing: editing) },
+      status: status
+    )
   end
 
   def person_medication_modal(title:, editing: false, back_path: nil)

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -191,23 +191,12 @@ class SchedulesController < ApplicationController
     editing = options.fetch(:editing, false)
     back_path = options[:back_path]
     status = options.fetch(:status, :ok)
-    is_modal = request.headers['Turbo-Frame'] == 'modal'
 
-    respond_to do |format|
-      format.html do
-        if is_modal
-          render schedule_modal_component(schedule:, medications:, title:, editing:, back_path:), layout: false, status: status
-        else
-          render schedule_form_view(schedule:, medications:, editing:), status: status
-        end
-      end
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace(
-          'modal',
-          schedule_modal_component(schedule:, medications:, title:, editing:, back_path:)
-        ), status: status
-      end
-    end
+    render_modal_or_page(
+      modal: -> { schedule_modal_component(schedule:, medications:, title:, editing:, back_path:) },
+      page: -> { schedule_form_view(schedule:, medications:, editing:) },
+      status: status
+    )
   end
 
   def schedule_modal_component(schedule:, medications:, title:, editing: false, back_path: nil)

--- a/spec/requests/modal_rendering_contract_spec.rb
+++ b/spec/requests/modal_rendering_contract_spec.rb
@@ -122,6 +122,38 @@ RSpec.describe 'Modal rendering contract' do
       expect_modal_stream
       expect(response.body).to include('Edit Person')
     end
+
+    it 'replaces the modal frame for the schedule form' do
+      get new_person_schedule_path(people(:john)), headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('New Schedule for John Doe')
+    end
+
+    it 'replaces the modal frame for the person medication form' do
+      get new_person_person_medication_path(people(:admin)), headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('Add Medication for')
+    end
+
+    it 'replaces the modal frame for the admin carer relationship form' do
+      get new_admin_carer_relationship_path, headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('New Carer Relationship')
+    end
+  end
+
+  describe 'Turbo Stream medication assignment modal requests' do
+    before { sign_in(users(:parent)) }
+
+    it 'replaces the modal frame for the medication assignment form' do
+      get new_person_medication_assignment_path(people(:child_user_person)), headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('Add Medication for')
+    end
   end
 
   def expect_application_layout

--- a/spec/requests/modal_rendering_contract_spec.rb
+++ b/spec/requests/modal_rendering_contract_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Modal rendering contract' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages,
+           :carer_relationships
+
+  describe 'standalone HTML requests' do
+    before { sign_in(users(:admin)) }
+
+    it 'renders the people form with the application layout' do
+      get new_person_path
+
+      expect_application_layout
+      expect(response.body).to include('New Person')
+    end
+
+    it 'renders the people edit form with the application layout' do
+      get edit_person_path(people(:john))
+
+      expect_application_layout
+      expect(response.body).to include('Edit Person')
+    end
+
+    it 'renders the schedule form with the application layout' do
+      get new_person_schedule_path(people(:john))
+
+      expect_application_layout
+      expect(response.body).to include('Add schedule for John Doe')
+    end
+
+    it 'renders the person medication form with the application layout' do
+      get new_person_person_medication_path(people(:admin))
+
+      expect_application_layout
+      expect(response.body).to include('Add Medication for')
+    end
+
+    it 'renders the admin carer relationship form with the application layout' do
+      get new_admin_carer_relationship_path
+
+      expect_application_layout
+      expect(response.body).to include('New Carer Relationship')
+    end
+  end
+
+  describe 'standalone medication assignment HTML requests' do
+    before { sign_in(users(:parent)) }
+
+    it 'renders the medication assignment form with the application layout' do
+      get new_person_medication_assignment_path(people(:child_user_person))
+
+      expect_application_layout
+      expect(response.body).to include('Add Medication for')
+    end
+  end
+
+  describe 'modal frame HTML requests' do
+    before { sign_in(users(:admin)) }
+
+    it 'renders the people form as a layoutless modal fragment' do
+      get new_person_path, headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('New Person')
+    end
+
+    it 'renders the people edit form as a layoutless modal fragment' do
+      get edit_person_path(people(:john)), headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('Edit Person')
+    end
+
+    it 'renders the schedule form as a layoutless modal fragment' do
+      get new_person_schedule_path(people(:john)), headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('New Schedule for John Doe')
+    end
+
+    it 'renders the person medication form as a layoutless modal fragment' do
+      get new_person_person_medication_path(people(:admin)), headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('Add Medication for')
+    end
+
+    it 'renders the admin carer relationship form as a layoutless modal fragment' do
+      get new_admin_carer_relationship_path, headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('New Carer Relationship')
+    end
+  end
+
+  describe 'modal medication assignment frame HTML requests' do
+    before { sign_in(users(:parent)) }
+
+    it 'renders the medication assignment form as a layoutless modal fragment' do
+      get new_person_medication_assignment_path(people(:child_user_person)), headers: modal_frame_headers
+
+      expect_modal_fragment
+      expect(response.body).to include('Add Medication for')
+    end
+  end
+
+  describe 'Turbo Stream modal requests' do
+    before { sign_in(users(:admin)) }
+
+    it 'replaces the modal frame for the people form' do
+      get new_person_path, headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('New Person')
+    end
+
+    it 'replaces the modal frame for the people edit form' do
+      get edit_person_path(people(:john)), headers: turbo_stream_headers
+
+      expect_modal_stream
+      expect(response.body).to include('Edit Person')
+    end
+  end
+
+  def expect_application_layout
+    expect_ok_html_response
+    expect(response.body).to include('<html')
+    expect(response.body).to include('stylesheet')
+    expect(response.body).to include('data-controller="global-search responsive-shell"')
+  end
+
+  def expect_modal_fragment
+    expect_ok_html_response
+    expect(response.body).to include('<turbo-frame id="modal"')
+    expect(response.body).not_to include('<html')
+    expect(response.body).not_to include('stylesheet')
+  end
+
+  def expect_modal_stream
+    expect_ok_turbo_stream_response
+    expect(response.body).to include('action="replace"')
+    expect(response.body).to include('target="modal"')
+  end
+
+  def modal_frame_headers
+    { 'Turbo-Frame' => 'modal' }
+  end
+
+  def turbo_stream_headers
+    { 'Accept' => 'text/vnd.turbo-stream.html' }
+  end
+
+  def expect_ok_html_response
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('text/html')
+  end
+
+  def expect_ok_turbo_stream_response
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+  end
+end


### PR DESCRIPTION
## Summary
This PR makes every "open this form as a modal" path follow one shared rule instead of each controller inventing its own version.

The app uses the same form screens in two ways:

1. Opened as a normal page.
2. Opened inside a modal popup.

Those two cases need different wrapping:

- Normal page: include the full app layout, sidebar/header/assets/etc.
- Modal: only send the modal content, not the whole page shell.
- Turbo Stream modal request: replace the existing modal frame consistently.

Before this PR, several controllers had their own little "is this a modal?" checks. That makes bugs easy: one controller forgets the layout, another sends the wrong wrapper, another handles Turbo Streams differently. Those bugs can look like dark-mode/layout weirdness, broken modals, or standalone pages that appear half-rendered.

The point of centralising it is:

- One place defines the rule.
- Controllers only say: "this is my modal component, this is my full-page component."
- New modal/page routes are less likely to accidentally miss the app layout or return the wrong response type.
- The request spec now locks the behaviour down so regressions fail as tests rather than turning into visual UI bugs later.

This PR is not meant to change how the UI looks. It makes the rendering plumbing boring and predictable.

## Screenshots
Not required; this is a rendering-contract refactor with no intended visual output change.