### PR TITLE
fix(notifications): honor low-stock preferences

### DIFF
--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -149,6 +149,7 @@ class MedicationTake < ApplicationRecord
 
   def publish_low_stock_threshold_reached
     return unless @low_stock_threshold_payload
+    return unless low_stock_notifications_enabled?
 
     ActiveSupport::Notifications.instrument(
       'low_stock_threshold_reached.med_tracker',
@@ -156,6 +157,13 @@ class MedicationTake < ApplicationRecord
     )
   ensure
     @low_stock_threshold_payload = nil
+  end
+
+  def low_stock_notifications_enabled?
+    preference = person&.notification_preference
+    return true unless preference
+
+    preference.enabled? && preference.low_stock_enabled?
   end
 
   def low_stock_threshold_crossed?(inventory:, stock_row:)

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -353,6 +353,21 @@ RSpec.describe MedicationTake do
       )
     end
 
+    it 'does not publish when low-stock notifications are disabled for the person' do
+      person.create_notification_preference!(enabled: true, low_stock_enabled: false)
+      medication.update!(current_supply: 11, reorder_threshold: 10)
+
+      payloads = capture_low_stock_payloads do
+        create_taken_from_schedule(
+          schedule: schedule,
+          taken_from_medication: medication,
+          taken_from_location: medication.location
+        )
+      end
+
+      expect(payloads).to be_empty
+    end
+
     it 'does not publish when stock remains above the threshold' do
       medication.update!(current_supply: 12, reorder_threshold: 10)
 


### PR DESCRIPTION
## Summary
- suppress low-stock threshold notification events when a person's notifications are disabled or their low-stock category is disabled
- add model coverage for the disabled low-stock category
- checked the current codebase and found no separate missed-dose notification delivery path yet; dose-due reminders already gate on dose_due_enabled

Closes #1364

## Tests
- ruby -c app/models/medication_take.rb
- ruby -c spec/models/medication_take_spec.rb
- git diff --check
- rubocop app/models/medication_take.rb spec/models/medication_take_spec.rb
- task test TEST_FILE=spec/models/medication_take_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)