### PR TITLE
feat(reports): add health history export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'pundit'
 gem 'paper_trail'
 # Pagination [https://github.com/ddnexus/pagy]
 gem 'pagy'
+gem 'prawn'
+gem 'prawn-table'
 # Rate limiting and throttling [https://github.com/rack/rack-attack]
 gem 'rack-attack'
 # TOTP for two-factor authentication [https://github.com/mdp/rotp]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,7 @@ GEM
       ast (~> 2.4.1)
       racc
     path_expander (2.0.1)
+    pdf-core (0.9.0)
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
@@ -446,6 +447,11 @@ GEM
       mime-types (>= 3.0)
     pp (0.6.4)
       prettyprint
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
     prettyprint (0.2.0)
     prism (1.9.0)
     propshaft (1.3.2)
@@ -726,6 +732,7 @@ GEM
       openssl (> 2.0)
       openssl-signature_algorithm (~> 1.0)
     tsort (0.2.0)
+    ttfunk (1.7.0)
     tty-which (0.5.0)
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
@@ -820,6 +827,8 @@ DEPENDENCIES
   paper_trail
   pg (>= 1.1)
   phlex-rails
+  prawn
+  prawn-table
   propshaft
   puma (>= 5.0)
   pundit

--- a/app/components/people/show_view.rb
+++ b/app/components/people/show_view.rb
@@ -143,6 +143,12 @@ module Components
                   class: 'w-full font-bold shadow-elevation-1 transition-all'
                 ) { t('people.show.manage_parents') }
               end
+              m3_link(
+                href: person_health_events_path(person),
+                variant: :tonal,
+                size: :lg,
+                class: 'w-full font-bold shadow-elevation-1 transition-all'
+              ) { t('people.show.health_events') }
             end
           end
         end

--- a/app/controllers/health_events_controller.rb
+++ b/app/controllers/health_events_controller.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+class HealthEventsController < ApplicationController
+  before_action :set_person
+  before_action :set_health_event, only: %i[edit update destroy]
+
+  def index
+    authorize HealthEvent.new(person: @person), :index?
+    render Views::HealthEvents::Index.new(person: @person, health_events: scoped_health_events)
+  end
+
+  def new
+    @health_event = @person.health_events.build(event_kind: event_kind_param || :illness)
+    authorize @health_event
+    render_form
+  end
+
+  def edit
+    authorize @health_event
+    render_form
+  end
+
+  def create
+    @health_event = @person.health_events.build(health_event_params)
+    authorize @health_event
+
+    if save_health_event
+      redirect_to person_health_events_path(@person), notice: t('health_events.created')
+    else
+      render_form(status: :unprocessable_content)
+    end
+  end
+
+  def update
+    authorize @health_event
+    @health_event.assign_attributes(health_event_params)
+
+    if save_health_event
+      redirect_to person_health_events_path(@person), notice: t('health_events.updated')
+    else
+      render_form(status: :unprocessable_content)
+    end
+  end
+
+  def destroy
+    authorize @health_event
+    @health_event.destroy
+    redirect_to person_health_events_path(@person), notice: t('health_events.deleted')
+  end
+
+  private
+
+  def set_person
+    @person = policy_scope(Person).find(params.expect(:person_id))
+    authorize @person, :show?
+  end
+
+  def set_health_event
+    @health_event = policy_scope(HealthEvent).where(person: @person).find(params.expect(:id))
+  end
+
+  def scoped_health_events
+    policy_scope(HealthEvent).where(person: @person).includes(:health_event_medications).order(started_on: :desc, id: :desc)
+  end
+
+  def render_form(status: :ok)
+    render Views::HealthEvents::Form.new(
+      person: @person,
+      health_event: @health_event,
+      medication_options: medication_options,
+      selected_medication_ids: selected_medication_ids
+    ), status: status
+  end
+
+  def save_health_event
+    return false unless medication_links_valid?
+
+    ActiveRecord::Base.transaction do
+      @health_event.save!
+      replace_medication_links
+    end
+    true
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  def medication_links_valid?
+    return true if invalid_medication_ids.empty?
+
+    @health_event.errors.add(:base, t('health_events.invalid_medication_link'))
+    false
+  end
+
+  def replace_medication_links
+    @health_event.health_event_medications.destroy_all
+    selected_medications.each do |medication|
+      @health_event.health_event_medications.create!(medication: medication)
+    end
+  end
+
+  def health_event_params
+    permitted = params.expect(
+      health_event: %i[event_kind title started_on ended_on severity notes action_taken medical_help_sought ongoing]
+    )
+    permitted[:ended_on] = nil if permitted.delete(:ongoing) == '1'
+    permitted
+  end
+
+  def event_kind_param
+    params.permit(:event_kind)[:event_kind].presence_in(HealthEvent.event_kinds.keys)
+  end
+
+  def medication_options
+    @medication_options ||= policy_scope(Medication).where(id: assigned_medication_ids).order(:name, :id)
+  end
+
+  def assigned_medication_ids
+    schedule_ids = Schedule.where(person: @person).select(:medication_id)
+    person_medication_ids = PersonMedication.where(person: @person).select(:medication_id)
+    Medication.where(id: schedule_ids).or(Medication.where(id: person_medication_ids)).select(:id)
+  end
+
+  def selected_medication_ids
+    @selected_medication_ids ||= Array(params[:medication_ids] || @health_event.medication_ids)
+                                 .compact_blank
+                                 .map(&:to_i)
+  end
+
+  def selected_medications
+    @selected_medications ||= medication_options.where(id: selected_medication_ids)
+  end
+
+  def invalid_medication_ids
+    selected_medication_ids - selected_medications.pluck(:id)
+  end
+end

--- a/app/controllers/health_history_reports_controller.rb
+++ b/app/controllers/health_history_reports_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class HealthHistoryReportsController < ApplicationController
+  def show
+    authorize :report, :index?
+
+    send_data pdf_body,
+              filename: filename,
+              type: 'application/pdf',
+              disposition: 'attachment'
+  rescue ArgumentError
+    redirect_to reports_path, alert: t('reports.invalid_date')
+  end
+
+  private
+
+  def pdf_body
+    response.headers['Cache-Control'] = 'no-store'
+    Reports::HealthHistoryPdf.new(
+      result: report_result,
+      start_date: start_date,
+      end_date: end_date,
+      generated_at: Time.current
+    ).render
+  end
+
+  def report_result
+    Reports::HealthHistoryQuery.new(people: filtered_people, start_date: start_date, end_date: end_date).call
+  end
+
+  def people
+    @people ||= policy_scope(Person).order(:name, :id)
+  end
+
+  def filtered_people
+    person_id = params.permit(:person_id).fetch(:person_id, nil)
+    return people if person_id.blank?
+    return people.none unless person_id.match?(/\A\d+\z/)
+
+    people.where(id: person_id)
+  end
+
+  def start_date
+    @start_date ||= params[:start_date].present? ? Date.parse(params[:start_date]) : end_date - 6.days
+  end
+
+  def end_date
+    @end_date ||= params[:end_date].present? ? Date.parse(params[:end_date]) : Time.zone.today
+  end
+
+  def filename
+    "medtracker-health-history-#{start_date.iso8601}-to-#{end_date.iso8601}.pdf"
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -29,9 +29,7 @@ class ReportsController < ApplicationController
       selected_person_id: @selected_person_id
     )
   rescue ArgumentError
-    # rubocop:disable Rails/I18nLocaleTexts
-    redirect_to reports_path, alert: 'Invalid date format provided.'
-    # rubocop:enable Rails/I18nLocaleTexts
+    redirect_to reports_path, alert: t('reports.invalid_date')
   end
 
   private

--- a/app/models/health_event.rb
+++ b/app/models/health_event.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class HealthEvent < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :household
+  belongs_to :person
+  has_many :health_event_medications, dependent: :destroy
+  has_many :medications, through: :health_event_medications
+
+  enum :event_kind, { illness: 0, suspected_side_effect: 1 }
+  enum :severity, { mild: 0, moderate: 1, severe: 2 }
+
+  before_validation :assign_household
+
+  validates :event_kind, :title, :started_on, presence: true
+  validate :ended_on_not_before_started_on
+
+  def ongoing? = ended_on.nil?
+
+  private
+
+  def assign_household
+    self.household ||= person&.household
+  end
+
+  def ended_on_not_before_started_on
+    return if ended_on.blank? || started_on.blank? || ended_on >= started_on
+
+    errors.add(:ended_on, :on_or_after_start_date)
+  end
+end

--- a/app/models/health_event_medication.rb
+++ b/app/models/health_event_medication.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class HealthEventMedication < ApplicationRecord
+  belongs_to :household
+  belongs_to :health_event
+  belongs_to :medication, optional: true
+
+  before_validation :assign_household
+  before_validation :snapshot_medication_name
+
+  validates :medication_name, presence: true
+  validates :medication_id, uniqueness: {
+    scope: :health_event_id,
+    message: :linked_to_health_event
+  }, allow_nil: true
+
+  private
+
+  def assign_household
+    self.household ||= health_event&.household
+  end
+
+  def snapshot_medication_name
+    self.medication_name = medication&.name if medication_name.blank? && medication.present?
+  end
+end

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -16,6 +16,7 @@ class Household < ApplicationRecord
   has_many :schedules, dependent: :restrict_with_error
   has_many :person_medications, dependent: :restrict_with_error
   has_many :medication_takes, dependent: :restrict_with_error
+  has_many :health_events, dependent: :restrict_with_error
   has_many :notification_preferences, dependent: :restrict_with_error
   has_many :person_access_grants, dependent: :destroy
   has_many :household_invitations, dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -17,6 +17,7 @@ class Person < ApplicationRecord
   has_one :household_membership, dependent: :nullify
   has_many :person_access_grants, dependent: :destroy
   has_many :schedules, dependent: :destroy
+  has_many :health_events, dependent: :destroy
   has_many :medications, through: :schedules
   has_many :person_medications, dependent: :destroy
   has_many :non_schedule_medications, through: :person_medications, source: :medication

--- a/app/policies/health_event_policy.rb
+++ b/app/policies/health_event_policy.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class HealthEventPolicy < ApplicationPolicy
+  def index?
+    active_membership?
+  end
+
+  def show?
+    health_event_person_grant_allows?(:view)
+  end
+
+  def create?
+    health_event_person_grant_allows?(:record)
+  end
+
+  alias new? create?
+
+  def update?
+    health_event_person_grant_allows?(:manage)
+  end
+
+  alias edit? update?
+
+  def destroy?
+    health_event_person_grant_allows?(:manage)
+  end
+
+  private
+
+  def person_id_for_authorization
+    record.respond_to?(:person) && record.person ? record.person.id : nil
+  end
+
+  def health_event_person_grant_allows?(access_level)
+    return household_manager? if record.is_a?(Class)
+
+    person_grant_allows?(record.person, access_level)
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      household_health_event_scope
+    end
+
+    private
+
+    def household_health_event_scope
+      return scope.none unless active_membership?
+
+      household_scope = scope.where(household: household)
+      return household_scope if household_manager?
+
+      household_scope.where(person_id: granted_person_ids_for(:view))
+    end
+  end
+end

--- a/app/services/health_events/pattern_summary.rb
+++ b/app/services/health_events/pattern_summary.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module HealthEvents
+  class PatternSummary
+    Summary = Data.define(
+      :normalized_title,
+      :display_title,
+      :episode_count,
+      :average_duration_days,
+      :average_interval_days,
+      :first_started_on,
+      :most_recent_started_on
+    )
+
+    attr_reader :events
+
+    def initialize(events:)
+      @events = events
+    end
+
+    def call
+      grouped_events.filter_map do |normalized_title, group|
+        next unless group.size > 1
+
+        sorted_group = group.sort_by(&:started_on)
+        Summary.new(
+          normalized_title: normalized_title,
+          display_title: sorted_group.first.title.to_s.squish,
+          episode_count: group.size,
+          average_duration_days: average_duration_days(sorted_group),
+          average_interval_days: average_interval_days(sorted_group),
+          first_started_on: sorted_group.first.started_on,
+          most_recent_started_on: sorted_group.last.started_on
+        )
+      end
+    end
+
+    private
+
+    def grouped_events
+      events.group_by { |event| normalize_title(event.title) }.reject { |title, _group| title.blank? }
+    end
+
+    def normalize_title(title)
+      title.to_s.squish.downcase
+    end
+
+    def average_duration_days(group)
+      durations = group.filter_map do |event|
+        next if event.ended_on.blank?
+
+        (event.ended_on - event.started_on).to_i + 1
+      end
+      return if durations.empty?
+
+      average_rounded(durations)
+    end
+
+    def average_interval_days(group)
+      intervals = group.each_cons(2).map do |previous_event, next_event|
+        (next_event.started_on - previous_event.started_on).to_i
+      end
+      return if intervals.empty?
+
+      average_rounded(intervals)
+    end
+
+    def average_rounded(values)
+      (values.sum.to_f / values.size).round
+    end
+  end
+end

--- a/app/services/reports/health_history_pdf.rb
+++ b/app/services/reports/health_history_pdf.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'prawn'
+require 'prawn/table'
+
+module Reports
+  class HealthHistoryPdf
+    attr_reader :result, :start_date, :end_date, :generated_at
+
+    def initialize(result:, start_date:, end_date:, generated_at:)
+      @result = result
+      @start_date = start_date
+      @end_date = end_date
+      @generated_at = generated_at
+    end
+
+    delegate :render, to: :pdf
+
+    private
+
+    def pdf
+      @pdf ||= Prawn::Document.new(page_size: 'A4', margin: 36, compress: false, info: document_info).tap do |document|
+        render_document(document)
+      end
+    end
+
+    def render_document(document)
+      @document = document
+      render_header
+      render_medication_takes
+      render_suspected_side_effects
+      render_notable_illnesses
+      render_illness_patterns
+      render_disclaimer
+    end
+
+    def render_header
+      heading(t('title'), size: 22)
+      header_lines.each { |line| text(line) }
+      document.move_down 18
+    end
+
+    def header_lines
+      [
+        t('people', people: people_label),
+        t('date_range', start_date: date(start_date), end_date: date(end_date)),
+        t('generated_at', timestamp: generated_at.in_time_zone.strftime('%Y-%m-%d %H:%M %Z'))
+      ]
+    end
+
+    def render_medication_takes
+      section(t('medication_takes.title')) do
+        table_or_empty(result.medication_takes, medication_take_headings) { |take| medication_take_row(take) }
+      end
+    end
+
+    def medication_take_headings
+      %w[time person medication dose source location].map { |key| t("medication_takes.#{key}") }
+    end
+
+    def medication_take_row(take)
+      [
+        take.taken_at.in_time_zone.strftime('%Y-%m-%d %H:%M'),
+        take.person.name,
+        take.medication_name,
+        take.dose_display,
+        t("sources.#{take.source_type}"),
+        take.location_name.to_s
+      ]
+    end
+
+    def render_suspected_side_effects
+      section(t('suspected_side_effects.title')) do
+        event_table(result.suspected_side_effects, include_medications: true)
+      end
+    end
+
+    def render_notable_illnesses
+      section(t('notable_illnesses.title')) do
+        event_table(result.notable_illnesses, include_medications: false)
+      end
+    end
+
+    def render_illness_patterns
+      section(t('illness_patterns.title')) do
+        render_pattern_summaries
+      end
+    end
+
+    def render_pattern_summaries
+      return text(t('empty_section')) if result.illness_patterns.empty?
+
+      result.illness_patterns.each { |pattern| text(pattern_summary(pattern)) }
+    end
+
+    def pattern_summary(pattern)
+      t(
+        'illness_patterns.summary',
+        count: pattern.episode_count,
+        title: pattern.display_title,
+        first: date(pattern.first_started_on),
+        last: date(pattern.most_recent_started_on),
+        interval: pattern.average_interval_days
+      )
+    end
+
+    def event_table(events, include_medications:)
+      table_or_empty(events, event_headings(include_medications)) do |event|
+        event_row(event, include_medications)
+      end
+    end
+
+    def event_headings(include_medications)
+      headings = %w[title dates severity notes action].map { |key| t("events.#{key}") }
+      headings.insert(3, t('events.medications')) if include_medications
+      headings
+    end
+
+    def event_row(event, include_medications)
+      row = [event.title, event_date_range(event), event.severity.to_s.humanize, event.notes.to_s,
+             event.action_taken.to_s]
+      row.insert(3, event.medication_names.to_sentence) if include_medications
+      row
+    end
+
+    def table_or_empty(records, headings, &)
+      return text(t('empty_section')) if records.empty?
+
+      document.table([headings] + records.map(&), header: true, width: document.bounds.width) do
+        row(0).font_style = :bold
+        cells.size = 9
+        cells.padding = 6
+      end
+    end
+
+    def render_disclaimer
+      section(t('disclaimer.title')) do
+        text(t('disclaimer.entered_information'))
+        text(t('disclaimer.causation'))
+        text(t('disclaimer.medical_advice'))
+      end
+    end
+
+    def section(title)
+      heading(title, size: 15)
+      yield
+      document.move_down 16
+    end
+
+    def heading(value, size:)
+      document.text(value, size: size, style: :bold)
+      document.move_down 8
+    end
+
+    def text(value)
+      document.text(value.to_s, size: 10, leading: 2)
+      document.move_down 4
+    end
+
+    def event_date_range(event)
+      return t('ongoing_from', started_on: date(event.started_on)) if event.ongoing?
+
+      t('event_date_range', started_on: date(event.started_on), ended_on: date(event.ended_on))
+    end
+
+    def people_label
+      result.people.map(&:name).presence&.to_sentence || t('no_people')
+    end
+
+    def date(value)
+      I18n.l(value)
+    end
+
+    def document_info
+      { Title: t('title'), Creator: 'MedTracker' }
+    end
+
+    def t(key, **)
+      I18n.t("reports.health_history.#{key}", **)
+    end
+
+    attr_reader :document
+  end
+end

--- a/app/services/reports/health_history_query.rb
+++ b/app/services/reports/health_history_query.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Reports
+  class HealthHistoryQuery
+    Result = Data.define(:people, :medication_takes, :suspected_side_effects, :notable_illnesses, :illness_patterns)
+    MedicationTakeEntry = Data.define(:person, :taken_at, :medication_name, :dose_amount, :dose_unit, :source_type,
+                                      :location_name) do
+      def dose_display = [dose_amount, dose_unit].compact.join(' ')
+    end
+    HealthEventEntry = Data.define(:event, :medication_names) do
+      delegate :person, :event_kind, :title, :started_on, :ended_on, :severity, :notes, :action_taken,
+               :medical_help_sought, :ongoing?, to: :event
+
+      def title = event.title.to_s.strip
+
+      def duration_days
+        return if ongoing?
+
+        (ended_on - started_on).to_i + 1
+      end
+    end
+
+    attr_reader :people, :start_date, :end_date
+
+    def initialize(people:, start_date:, end_date:)
+      @people = people
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def call
+      Result.new(
+        people: people_records,
+        medication_takes: medication_take_entries,
+        suspected_side_effects: health_event_entries(health_events.suspected_side_effect),
+        notable_illnesses: health_event_entries(health_events.illness),
+        illness_patterns: HealthEvents::PatternSummary.new(events: health_events.illness).call
+      )
+    end
+
+    private
+
+    def people_records
+      @people_records ||= Person.where(id: person_ids).order(:name, :id).to_a
+    end
+
+    def person_ids
+      @person_ids ||= if people.respond_to?(:pluck)
+                        people.pluck(:id)
+                      else
+                        Array(people).map(&:id)
+                      end
+    end
+
+    def medication_take_entries
+      medication_takes.map do |take|
+        source = take.source
+        MedicationTakeEntry.new(
+          person: take.person,
+          taken_at: take.taken_at,
+          medication_name: medication_display_name(source&.medication || take.taken_from_medication),
+          dose_amount: take.dose_amount,
+          dose_unit: take.dose_unit,
+          source_type: source_type(source),
+          location_name: take.inventory_location&.name
+        )
+      end
+    end
+
+    def medication_takes
+      @medication_takes ||= medication_take_scope
+                            .where(schedule_id: schedule_ids)
+                            .or(medication_take_scope.where(person_medication_id: person_medication_ids))
+                            .order(:taken_at, :id)
+    end
+
+    def medication_take_scope
+      MedicationTake.includes(
+        :taken_from_medication,
+        :taken_from_location,
+        schedule: %i[person medication],
+        person_medication: %i[person medication]
+      ).where(taken_at: date_range)
+    end
+
+    def schedule_ids
+      @schedule_ids ||= Schedule.where(person_id: person_ids).select(:id)
+    end
+
+    def person_medication_ids
+      @person_medication_ids ||= PersonMedication.where(person_id: person_ids).select(:id)
+    end
+
+    def date_range
+      start_date.in_time_zone.beginning_of_day..end_date.in_time_zone.end_of_day
+    end
+
+    def source_type(source)
+      return :as_needed if source.is_a?(PersonMedication)
+      return :as_needed if source.respond_to?(:schedule_type_prn?) && source.schedule_type_prn?
+
+      :scheduled
+    end
+
+    def medication_display_name(medication)
+      medication&.friendly_name.presence || medication&.name
+    end
+
+    def health_event_entries(scope)
+      scope.order(:started_on, :id).map do |event|
+        HealthEventEntry.new(
+          event: event,
+          medication_names: event.health_event_medications.map(&:medication_name)
+        )
+      end
+    end
+
+    def health_events
+      @health_events ||= HealthEvent
+                         .includes(:person, :health_event_medications)
+                         .where(person_id: person_ids)
+                         .where(started_on: ..end_date)
+                         .where(ended_on: nil)
+                         .or(
+                           HealthEvent
+                             .includes(:person, :health_event_medications)
+                             .where(person_id: person_ids)
+                             .where(started_on: ..end_date, ended_on: start_date..)
+                         )
+    end
+  end
+end

--- a/app/views/health_events/form.rb
+++ b/app/views/health_events/form.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Views
+  module HealthEvents
+    class Form < Views::Base
+      include Phlex::Rails::Helpers::FormWith
+
+      def initialize(person:, health_event:, medication_options:, selected_medication_ids:)
+        @person = person
+        @health_event = health_event
+        @medication_options = medication_options
+        @selected_medication_ids = selected_medication_ids
+        super()
+      end
+
+      def view_template
+        div(class: 'container mx-auto max-w-3xl space-y-8 px-4 py-12') do
+          render_header
+          render_form
+        end
+      end
+
+      private
+
+      attr_reader :person, :health_event, :medication_options, :selected_medication_ids
+
+      def render_header
+        div(class: 'space-y-2') do
+          m3_heading(level: 1, size: '7', class: 'font-black') { form_title }
+          m3_text(size: '2', class: 'text-on-surface-variant') { t('health_events.form.subtitle') }
+        end
+      end
+
+      def render_form
+        m3_card(class: 'border border-border/70 bg-card p-6') do
+          form_with(model: [person, health_event], class: 'space-y-6') do |form|
+            render_errors
+            render_form_fields(form)
+            render_actions
+          end
+        end
+      end
+
+      def render_form_fields(form)
+        input(type: 'hidden', name: 'health_event[event_kind]', value: health_event.event_kind)
+        render_field(form, :title, t('health_events.form.title'))
+        render_date_fields(form)
+        render_severity_field(form)
+        render_medication_checkboxes if health_event.suspected_side_effect?
+        render_textarea(form, :notes, t('health_events.form.notes'))
+        render_textarea(form, :action_taken, t('health_events.form.action_taken'))
+        render_medical_help_field(form)
+      end
+
+      def render_errors
+        return if health_event.errors.empty?
+
+        div(class: 'rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive') do
+          ul { health_event.errors.full_messages.each { |message| li { message } } }
+        end
+      end
+
+      def render_field(form, field, label)
+        div(class: 'space-y-2') do
+          form.label(field, label, class: 'text-sm font-bold')
+          form.text_field(field, class: input_class)
+        end
+      end
+
+      def render_date_fields(form)
+        div(class: 'grid gap-4 sm:grid-cols-2') do
+          div(class: 'space-y-2') do
+            form.label(:started_on, t('health_events.form.started_on'), class: 'text-sm font-bold')
+            form.date_field(:started_on, class: input_class)
+          end
+          div(class: 'space-y-2') do
+            form.label(:ended_on, t('health_events.form.ended_on'), class: 'text-sm font-bold')
+            form.date_field(:ended_on, class: input_class)
+            label(class: 'flex items-center gap-2 text-sm') do
+              input(type: 'checkbox', name: 'health_event[ongoing]', value: '1', checked: health_event.ongoing?)
+              plain t('health_events.form.ongoing')
+            end
+          end
+        end
+      end
+
+      def render_severity_field(form)
+        div(class: 'space-y-2') do
+          form.label(:severity, t('health_events.form.severity'), class: 'text-sm font-bold')
+          form.select(
+            :severity,
+            [[t('health_events.form.no_severity'), '']] + HealthEvent.severities.keys.map do |severity|
+              [t("health_events.severities.#{severity}"), severity]
+            end,
+            {},
+            class: input_class
+          )
+        end
+      end
+
+      def render_medication_checkboxes
+        div(class: 'space-y-3') do
+          m3_text(size: '2', class: 'font-bold') { t('health_events.form.suspected_medications') }
+          medication_options.each do |medication|
+            label(class: 'flex items-center gap-2 text-sm') do
+              input(type: 'checkbox', name: 'medication_ids[]', value: medication.id,
+                    checked: selected_medication_ids.include?(medication.id))
+              plain medication.name
+            end
+          end
+        end
+      end
+
+      def render_textarea(form, field, label)
+        div(class: 'space-y-2') do
+          form.label(field, label, class: 'text-sm font-bold')
+          form.text_area(field, rows: 4, class: input_class)
+        end
+      end
+
+      def render_medical_help_field(form)
+        label(class: 'flex items-center gap-2 text-sm') do
+          form.check_box(:medical_help_sought)
+          plain t('health_events.form.medical_help_sought')
+        end
+      end
+
+      def render_actions
+        div(class: 'flex items-center justify-end gap-3') do
+          m3_link(href: person_health_events_path(person), variant: :text) { t('health_events.actions.cancel') }
+          m3_button(type: :submit, variant: :filled) { t('health_events.actions.save') }
+        end
+      end
+
+      def form_title
+        key = health_event.persisted? ? 'edit_title' : 'new_title'
+        t("health_events.form.#{key}", kind: t("health_events.kinds.#{health_event.event_kind}").downcase)
+      end
+
+      def input_class
+        'w-full rounded-xl border border-input bg-background px-3 py-2 text-sm'
+      end
+    end
+  end
+end

--- a/app/views/health_events/index.rb
+++ b/app/views/health_events/index.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Views
+  module HealthEvents
+    class Index < Views::Base
+      include Phlex::Rails::Helpers::L
+
+      def initialize(person:, health_events:)
+        @person = person
+        @health_events = health_events
+        super()
+      end
+
+      def view_template
+        div(class: 'container mx-auto max-w-5xl space-y-8 px-4 py-12') do
+          render_header
+          render_events
+        end
+      end
+
+      private
+
+      attr_reader :person, :health_events
+
+      def render_header
+        div(class: 'flex flex-col gap-4 border-b border-outline-variant/30 pb-6 md:flex-row md:items-end md:justify-between') do
+          div(class: 'space-y-2') do
+            m3_heading(level: 1, size: '7', class: 'font-black') { t('health_events.index.title', person: person.name) }
+            m3_text(size: '2', class: 'text-on-surface-variant') { t('health_events.index.subtitle') }
+          end
+          div(class: 'flex flex-col gap-3 sm:flex-row') do
+            new_event_link(:illness, t('health_events.actions.record_illness'))
+            new_event_link(:suspected_side_effect, t('health_events.actions.record_suspected_side_effect'))
+          end
+        end
+      end
+
+      def new_event_link(event_kind, label)
+        m3_link(
+          href: new_person_health_event_path(person, event_kind: event_kind),
+          variant: event_kind == :illness ? :outlined : :filled,
+          size: :lg,
+          class: 'font-bold'
+        ) { label }
+      end
+
+      def render_events
+        if health_events.any?
+          div(class: 'space-y-4') { health_events.each { |event| render_event(event) } }
+        else
+          m3_card(class: 'border border-dashed border-outline-variant p-8 text-center') do
+            m3_text(size: '2', class: 'text-on-surface-variant') { t('health_events.index.empty') }
+          end
+        end
+      end
+
+      def render_event(event)
+        m3_card(class: 'space-y-4 border border-border/70 bg-card p-6') do
+          div(class: 'flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between') do
+            div(class: 'space-y-2') do
+              m3_badge(variant: :outlined, class: 'w-fit') { t("health_events.kinds.#{event.event_kind}") }
+              m3_heading(level: 2, size: '4', class: 'font-bold') { event.title }
+              m3_text(size: '2', class: 'text-on-surface-variant') { event_date_range(event) }
+              render_event_details(event)
+            end
+            render_event_actions(event)
+          end
+        end
+      end
+
+      def render_event_details(event)
+        details = event_details(event)
+        return if details.empty?
+
+        m3_text(size: '2', class: 'text-on-surface') { details.join(' · ') }
+      end
+
+      def event_details(event)
+        [
+          severity_detail(event),
+          medication_detail(event),
+          event.notes.presence,
+          event.action_taken.presence
+        ].compact
+      end
+
+      def severity_detail(event)
+        t("health_events.severities.#{event.severity}") if event.severity.present?
+      end
+
+      def medication_detail(event)
+        return unless event.health_event_medications.any?
+
+        event.health_event_medications.map(&:medication_name).to_sentence
+      end
+
+      def render_event_actions(event)
+        div(class: 'flex gap-2') do
+          m3_link(href: edit_person_health_event_path(person, event), variant: :text, size: :sm) do
+            t('health_events.actions.edit')
+          end
+          form(action: person_health_event_path(person, event), method: 'post') do
+            input(type: 'hidden', name: '_method', value: 'delete')
+            input(type: 'hidden', name: 'authenticity_token', value: view_context.form_authenticity_token)
+            button(type: 'submit', class: 'text-sm font-bold text-destructive') { t('health_events.actions.delete') }
+          end
+        end
+      end
+
+      def event_date_range(event)
+        return t('health_events.index.ongoing_from', started_on: l(event.started_on)) if event.ongoing?
+
+        t('health_events.index.date_range', started_on: l(event.started_on), ended_on: l(event.ended_on))
+      end
+    end
+  end
+end

--- a/app/views/reports/index.rb
+++ b/app/views/reports/index.rb
@@ -48,9 +48,7 @@ module Views
         end
       end
 
-      def render_today_section
-        render Components::Reports::TodaySection.new(today_taken_medications: @today_taken_medications)
-      end
+      def render_today_section = render Components::Reports::TodaySection.new(today_taken_medications: @today_taken_medications)
 
       # rubocop:disable Metrics/AbcSize
       def render_summary_card
@@ -94,14 +92,16 @@ module Views
         div(class: 'space-y-8') do
           div(class: 'flex items-center justify-between px-2') do
             m3_heading(level: 2, size: '5', class: 'font-bold') { t('reports.index.timeline_title') }
-            m3_button(variant: :outlined, size: :sm) { t('reports.index.download_pdf') }
+            m3_link(
+              href: health_history_report_path(start_date: @start_date, end_date: @end_date,
+                                               person_id: @selected_person_id.presence),
+              variant: :outlined, size: :sm
+            ) { t('reports.index.download_pdf') }
           end
 
           m3_card(class: 'border border-border/70 bg-card p-8 shadow-elevation-2 sm:p-10') do
             div(class: 'flex items-end justify-between h-64 gap-4 px-2') do
-              @daily_data.each do |day|
-                render_bar(day)
-              end
+              @daily_data.each { |day| render_bar(day) }
             end
           end
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,21 @@ en:
       previous_month: Go to previous month
       next_month: Go to next month
   activerecord:
+    errors:
+      models:
+        health_event:
+          attributes:
+            ended_on:
+              on_or_after_start_date: must be on or after the start date
+        health_event_medication:
+          attributes:
+            medication_id:
+              linked_to_health_event: has already been linked to this health event
+        medication:
+          attributes:
+            barcode:
+              invalid: must be a 13 or 14 digit GTIN
+              taken: is already linked to another medication in inventory
     attributes:
       invitation:
         roles:
@@ -81,13 +96,10 @@ en:
           carer: Carer
           parent: Parent
           self: Self
-    errors:
-      models:
-        medication:
-          attributes:
-            barcode:
-              invalid: must be a 13 or 14 digit GTIN
-              taken: is already linked to another medication in inventory
+  errors:
+    messages:
+      linked_to_health_event: has already been linked to this health event
+      on_or_after_start_date: must be on or after the start date
   admin:
     invitations:
       created: Invitation sent
@@ -907,6 +919,7 @@ en:
       edit_person: Edit Person
       add_medication: Add Medication
       manage_parents: Manage parents
+      health_events: Health events
       back: Back
       born: 'Born:'
       age: 'Age:'
@@ -1297,7 +1310,47 @@ en:
   notification_preferences:
     updated: Notification settings saved.
     update_failed: Failed to save notification settings.
+  health_events:
+    created: Health event recorded.
+    updated: Health event updated.
+    deleted: Health event deleted.
+    invalid_medication_link: Select only medications assigned to this person.
+    kinds:
+      illness: Notable illness
+      suspected_side_effect: Suspected side effect
+    severities:
+      mild: Mild
+      moderate: Moderate
+      severe: Severe
+    actions:
+      record_illness: Record notable illness
+      record_suspected_side_effect: Record suspected side effect
+      edit: Edit
+      delete: Delete
+      cancel: Cancel
+      save: Save
+    index:
+      title: "%{person}'s health events"
+      subtitle: Record notable illnesses and suspected side effects without making clinical claims.
+      empty: No health events recorded yet.
+      ongoing_from: "Ongoing since %{started_on}"
+      date_range: "%{started_on} to %{ended_on}"
+    form:
+      new_title: "Record %{kind}"
+      edit_title: "Edit %{kind}"
+      subtitle: Capture facts entered by the family or carer.
+      title: Title
+      started_on: Start date
+      ended_on: End date
+      ongoing: Ongoing
+      severity: Severity
+      no_severity: Not specified
+      suspected_medications: Suspected medications
+      notes: Notes
+      action_taken: Action taken
+      medical_help_sought: Medical help was sought
   reports:
+    invalid_date: Invalid date format provided.
     index:
       eyebrow: Wellness Analytics
       title: Health Report
@@ -1334,6 +1387,45 @@ en:
           other: Your %{medication_name} supply will be exhausted in %{count} days.
             We recommend ordering a refill this afternoon.
       actionable_insight: Actionable insight
+    health_history:
+      title: MedTracker health history report
+      people: "People: %{people}"
+      no_people: No authorised people
+      date_range: "Date range: %{start_date} to %{end_date}"
+      generated_at: "Generated: %{timestamp}"
+      empty_section: No records in this section.
+      ongoing_from: "Ongoing since %{started_on}"
+      event_date_range: "%{started_on} to %{ended_on}"
+      sources:
+        scheduled: Scheduled
+        as_needed: As-needed/direct
+      medication_takes:
+        title: Medication administrations
+        time: Time
+        person: Person
+        medication: Medication
+        dose: Dose
+        source: Source
+        location: Location
+      suspected_side_effects:
+        title: Suspected side effects
+      notable_illnesses:
+        title: Notable illnesses
+      events:
+        title: Title
+        dates: Dates
+        severity: Severity
+        medications: Suspected medications
+        notes: Notes
+        action: Action taken
+      illness_patterns:
+        title: Recorded illness patterns
+        summary: "%{count} \"%{title}\" episodes were recorded between %{first} and %{last}. The average interval between episode starts was %{interval} days."
+      disclaimer:
+        title: Disclaimer
+        entered_information: This report reflects information entered into MedTracker.
+        causation: Suspected side-effect links do not establish causation.
+        medical_advice: This report is not a diagnosis or a substitute for professional medical advice.
   smart_insights:
     title: Smart Insights
     evidence_summary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
     delete 'profile/avatar', to: 'profiles#avatar', as: :profile_avatar
 
     resources :reports, only: %i[index]
+    get 'reports/health-history', to: 'health_history_reports#show', as: :health_history_report
 
     get 'offline', to: 'offline#show'
     get 'offline/snapshot', to: 'offline#snapshot'
@@ -187,6 +188,7 @@ Rails.application.routes.draw do
       end
       resources :carer_relationships, only: %i[new create], controller: 'people/carer_relationships'
       resources :medication_assignments, only: %i[new create]
+      resources :health_events, except: [:show]
     end
 
     resource :push_subscription, only: %i[create destroy] do
@@ -231,7 +233,6 @@ Rails.application.routes.draw do
   # Profile
 
   # Reports
-
 
   # Location management
 

--- a/db/migrate/20260702133700_create_health_events.rb
+++ b/db/migrate/20260702133700_create_health_events.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class CreateHealthEvents < ActiveRecord::Migration[8.1]
+  def up
+    create_table :health_events do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :person, null: false, foreign_key: true
+      t.integer :event_kind, null: false
+      t.string :title, null: false
+      t.date :started_on, null: false
+      t.date :ended_on
+      t.integer :severity
+      t.text :notes
+      t.text :action_taken
+      t.boolean :medical_help_sought, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :health_events, %i[person_id started_on ended_on]
+    add_index :health_events, %i[person_id event_kind started_on]
+    add_index :health_events, %i[id household_id], unique: true
+    add_foreign_key :health_events,
+                    :people,
+                    column: %i[person_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: 'fk_health_events_person_id_household'
+
+    create_table :health_event_medications do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :health_event, null: false, foreign_key: true
+      t.references :medication, foreign_key: true
+      t.string :medication_name, null: false
+
+      t.timestamps
+    end
+
+    add_index :health_event_medications, %i[health_event_id medication_id],
+              unique: true,
+              where: 'medication_id IS NOT NULL',
+              name: 'index_health_event_medications_on_health_event_id_and_med_id'
+    add_index :health_event_medications, %i[id household_id], unique: true
+    add_foreign_key :health_event_medications,
+                    :health_events,
+                    column: %i[health_event_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: 'fk_health_event_medications_health_event_id_household'
+    add_foreign_key :health_event_medications,
+                    :medications,
+                    column: %i[medication_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: 'fk_health_event_medications_medication_id_household'
+
+    enable_household_rls(:health_events)
+    enable_household_rls(:health_event_medications)
+  end
+
+  def down
+    drop_table :health_event_medications
+    drop_table :health_events
+  end
+
+  private
+
+  def enable_household_rls(table_name)
+    quoted_table = quote_table_name(table_name)
+
+    execute "ALTER TABLE #{quoted_table} ENABLE ROW LEVEL SECURITY;"
+    execute "ALTER TABLE #{quoted_table} FORCE ROW LEVEL SECURITY;"
+    execute <<~SQL.squish
+      CREATE POLICY household_tenant_isolation ON #{quoted_table}
+      USING (household_id = med_tracker.current_household_id())
+      WITH CHECK (household_id = med_tracker.current_household_id());
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -258,6 +258,40 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_154500) do
     t.index ["medication_id"], name: "index_dosages_one_child_default", unique: true, where: "(default_for_children = true)"
   end
 
+  create_table "health_events", force: :cascade do |t|
+    t.text "action_taken"
+    t.datetime "created_at", null: false
+    t.date "ended_on"
+    t.integer "event_kind", null: false
+    t.bigint "household_id", null: false
+    t.boolean "medical_help_sought", default: false, null: false
+    t.text "notes"
+    t.bigint "person_id", null: false
+    t.integer "severity"
+    t.date "started_on", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["household_id"], name: "index_health_events_on_household_id"
+    t.index ["id", "household_id"], name: "index_health_events_on_id_and_household_id", unique: true
+    t.index ["person_id", "event_kind", "started_on"], name: "index_health_events_on_person_id_and_event_kind_and_started_on"
+    t.index ["person_id", "started_on", "ended_on"], name: "index_health_events_on_person_id_and_started_on_and_ended_on"
+    t.index ["person_id"], name: "index_health_events_on_person_id"
+  end
+
+  create_table "health_event_medications", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "health_event_id", null: false
+    t.bigint "household_id", null: false
+    t.bigint "medication_id"
+    t.string "medication_name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["health_event_id", "medication_id"], name: "index_health_event_medications_on_health_event_id_and_med_id", unique: true, where: "(medication_id IS NOT NULL)"
+    t.index ["health_event_id"], name: "index_health_event_medications_on_health_event_id"
+    t.index ["household_id"], name: "index_health_event_medications_on_household_id"
+    t.index ["id", "household_id"], name: "index_health_event_medications_on_id_and_household_id", unique: true
+    t.index ["medication_id"], name: "index_health_event_medications_on_medication_id"
+  end
+
   create_table "household_invitation_grants", force: :cascade do |t|
     t.string "access_level", null: false
     t.datetime "created_at", null: false
@@ -679,6 +713,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_154500) do
   add_foreign_key "dosages", "households"
   add_foreign_key "dosages", "medications", column: ["medication_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_dosages_medication_id_household"
   add_foreign_key "dosages", "medications", deferrable: :deferred
+  add_foreign_key "health_event_medications", "health_events"
+  add_foreign_key "health_event_medications", "health_events", column: ["health_event_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_health_event_medications_health_event_id_household"
+  add_foreign_key "health_event_medications", "households"
+  add_foreign_key "health_event_medications", "medications"
+  add_foreign_key "health_event_medications", "medications", column: ["medication_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_health_event_medications_medication_id_household"
+  add_foreign_key "health_events", "households"
+  add_foreign_key "health_events", "people"
+  add_foreign_key "health_events", "people", column: ["person_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_health_events_person_id_household"
   add_foreign_key "household_invitation_grants", "household_invitations"
   add_foreign_key "household_invitation_grants", "household_invitations", column: ["household_invitation_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_household_invitation_grants_invitation_household"
   add_foreign_key "household_invitation_grants", "households"
@@ -785,6 +827,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_154500) do
     person_medications
     medication_takes
     notification_preferences
+    health_events
+    health_event_medications
     household_memberships
     person_access_grants
     household_invitations

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -11,6 +11,8 @@ class SchemaInventory
     person_medications
     medication_takes
     notification_preferences
+    health_events
+    health_event_medications
     household_memberships
     person_access_grants
     household_invitations

--- a/spec/lib/schema_inventory_spec.rb
+++ b/spec/lib/schema_inventory_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SchemaInventory do
       person_medications
       medication_takes
       notification_preferences
+      health_events
+      health_event_medications
       household_memberships
       person_access_grants
       household_invitations

--- a/spec/models/health_event_medication_spec.rb
+++ b/spec/models/health_event_medication_spec.rb
@@ -32,4 +32,34 @@ RSpec.describe HealthEventMedication do
     expect(duplicate).not_to be_valid
     expect(duplicate.errors[:medication_id]).to include('has already been linked to this health event')
   end
+
+  it 'allows a manual medication snapshot without a linked medication' do
+    event = create_health_event
+
+    link = described_class.create!(health_event: event, medication_name: 'Historic medication')
+
+    expect(link.medication).to be_nil
+    expect(link.medication_name).to eq('Historic medication')
+  end
+
+  it 'keeps an explicit medication snapshot name when a medication is linked' do
+    event = create_health_event
+
+    link = described_class.create!(
+      health_event: event,
+      medication: medications(:paracetamol),
+      medication_name: 'Paracetamol suspension'
+    )
+
+    expect(link.medication_name).to eq('Paracetamol suspension')
+  end
+
+  def create_health_event
+    HealthEvent.create!(
+      person: people(:john),
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 2, 1)
+    )
+  end
 end

--- a/spec/models/health_event_medication_spec.rb
+++ b/spec/models/health_event_medication_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HealthEventMedication do
+  fixtures :people, :medications
+
+  it 'snapshots the linked medication name' do
+    event = HealthEvent.create!(
+      person: people(:john),
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 2, 1)
+    )
+
+    link = described_class.create!(health_event: event, medication: medications(:paracetamol))
+
+    expect(link.medication_name).to eq('Paracetamol')
+  end
+
+  it 'prevents duplicate live medication links for an event' do
+    event = HealthEvent.create!(
+      person: people(:john),
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 2, 1)
+    )
+    described_class.create!(health_event: event, medication: medications(:paracetamol))
+
+    duplicate = described_class.new(health_event: event, medication: medications(:paracetamol))
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:medication_id]).to include('has already been linked to this health event')
+  end
+end

--- a/spec/models/health_event_spec.rb
+++ b/spec/models/health_event_spec.rb
@@ -29,4 +29,29 @@ RSpec.describe HealthEvent do
     expect(event).not_to be_valid
     expect(event.errors[:ended_on]).to include('must be on or after the start date')
   end
+
+  it 'allows an end date on or after the start date' do
+    event = described_class.new(
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold',
+      started_on: Date.new(2026, 1, 4),
+      ended_on: Date.new(2026, 1, 5)
+    )
+
+    expect(event).to be_valid
+    expect(event).not_to be_ongoing
+  end
+
+  it 'does not add end date ordering errors when the start date is missing' do
+    event = described_class.new(
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold',
+      ended_on: Date.new(2026, 1, 5)
+    )
+
+    expect(event).not_to be_valid
+    expect(event.errors[:ended_on]).to be_empty
+  end
 end

--- a/spec/models/health_event_spec.rb
+++ b/spec/models/health_event_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HealthEvent do
+  fixtures :people
+
+  it 'tracks ongoing notable illnesses' do
+    event = described_class.new(
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Tonsillitis',
+      started_on: Date.new(2026, 1, 4)
+    )
+
+    expect(event).to be_valid
+    expect(event).to be_ongoing
+  end
+
+  it 'rejects an end date before the start date' do
+    event = described_class.new(
+      person: people(:john),
+      event_kind: :suspected_side_effect,
+      title: 'Rash',
+      started_on: Date.new(2026, 1, 4),
+      ended_on: Date.new(2026, 1, 3)
+    )
+
+    expect(event).not_to be_valid
+    expect(event.errors[:ended_on]).to include('must be on or after the start date')
+  end
+end

--- a/spec/policies/health_event_policy_spec.rb
+++ b/spec/policies/health_event_policy_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe HealthEventPolicy, type: :policy do
+  let(:member) { household_policy_member(role: :member) }
+  let(:household) { member.fetch(:household) }
+  let(:person) { household_policy_person(household) }
+  let(:event) { HealthEvent.new(person: person, event_kind: :illness, title: 'Flu', started_on: Time.zone.today) }
+
+  it 'requires record access to create health events' do
+    expect(described_class.new(member.fetch(:context), event)).to forbid_action(:create)
+
+    grant_policy_person_access(member, person, access_level: :view)
+
+    expect(described_class.new(member.fetch(:context), event)).to forbid_action(:create)
+
+    person.person_access_grants.find_by!(household_membership: member.fetch(:membership)).update!(access_level: :record)
+
+    expect(described_class.new(member.fetch(:context), event)).to permit_action(:create)
+    expect(described_class.new(member.fetch(:context), event)).to permit_action(:new)
+  end
+
+  it 'requires manage access to update or destroy health events' do
+    grant_policy_person_access(member, person, access_level: :record)
+
+    expect(described_class.new(member.fetch(:context), event)).to forbid_action(:update)
+    expect(described_class.new(member.fetch(:context), event)).to forbid_action(:destroy)
+
+    person.person_access_grants.find_by!(household_membership: member.fetch(:membership)).update!(access_level: :manage)
+
+    expect(described_class.new(member.fetch(:context), event)).to permit_action(:update)
+    expect(described_class.new(member.fetch(:context), event)).to permit_action(:destroy)
+  end
+
+  it 'scopes events to manager households or granted people' do
+    owner = household_policy_member(role: :owner, household: household)
+    event = HealthEvent.create!(person: person, event_kind: :illness, title: 'Flu', started_on: Time.zone.today)
+    other_event = HealthEvent.create!(
+      person: household_policy_person(household),
+      event_kind: :suspected_side_effect,
+      title: 'Rash',
+      started_on: Time.zone.today
+    )
+    grant_policy_person_access(member, person, access_level: :view)
+
+    manager_scope = described_class::Scope.new(owner.fetch(:context), HealthEvent.all).resolve
+    member_scope = described_class::Scope.new(member.fetch(:context), HealthEvent.all).resolve
+
+    expect(manager_scope).to include(event, other_event)
+    expect(member_scope).to contain_exactly(event)
+  end
+end

--- a/spec/policies/health_event_policy_spec.rb
+++ b/spec/policies/health_event_policy_spec.rb
@@ -51,4 +51,11 @@ RSpec.describe HealthEventPolicy, type: :policy do
     expect(manager_scope).to include(event, other_event)
     expect(member_scope).to contain_exactly(event)
   end
+
+  it 'allows household managers to create from the class record' do
+    owner = household_policy_member(role: :owner, household: household)
+
+    expect(described_class.new(owner.fetch(:context), HealthEvent)).to permit_action(:create)
+    expect(described_class.new(member.fetch(:context), HealthEvent)).to forbid_action(:create)
+  end
 end

--- a/spec/requests/health_events_spec.rb
+++ b/spec/requests/health_events_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Health events' do
+  fixtures :accounts, :people, :users, :locations, :medications, :schedules, :person_medications
+
+  let(:person) { people(:john) }
+
+  before { sign_in(users(:admin)) }
+
+  it 'lists person-scoped health events chronologically' do
+    HealthEvent.create!(person: person, event_kind: :illness, title: 'Cold', started_on: Date.new(2026, 2, 1))
+
+    get person_health_events_path(person)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Cold')
+    expect(response.body).to include('Record notable illness')
+    expect(response.body).to include('Record suspected side effect')
+  end
+
+  it 'creates a notable illness' do
+    expect do
+      post person_health_events_path(person),
+           params: { health_event: illness_params(title: 'Tonsillitis', started_on: '2026-02-01') }
+    end.to change(HealthEvent.illness, :count).by(1)
+
+    expect(response).to redirect_to(person_health_events_path(person))
+  end
+
+  it 'creates a suspected side effect with authorised medication snapshots' do
+    medication = medications(:paracetamol)
+
+    expect do
+      post person_health_events_path(person),
+           params: {
+             health_event: side_effect_params(title: 'Nausea', started_on: '2026-02-10'),
+             medication_ids: [medication.id]
+           }
+    end.to change(HealthEvent.suspected_side_effect, :count).by(1)
+
+    event = HealthEvent.suspected_side_effect.order(:id).last
+    expect(event.health_event_medications.sole.medication_name).to eq('Paracetamol')
+  end
+
+  it 'rejects medication links that are not assigned to the selected person' do
+    unassigned_medication = create(:medication, name: 'Unassigned stock')
+
+    post person_health_events_path(person),
+         params: {
+           health_event: side_effect_params(title: 'Nausea', started_on: '2026-02-10'),
+           medication_ids: [unassigned_medication.id]
+         }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(HealthEvent.suspected_side_effect.where(title: 'Nausea')).to be_empty
+  end
+
+  it 'updates an event and clears the end date when ongoing is selected' do
+    event = HealthEvent.create!(
+      person: person,
+      event_kind: :illness,
+      title: 'Cold',
+      started_on: Date.new(2026, 2, 1),
+      ended_on: Date.new(2026, 2, 4)
+    )
+
+    patch person_health_event_path(person, event),
+          params: { health_event: illness_params(title: 'Cold again', started_on: '2026-02-01', ongoing: '1') }
+
+    expect(response).to redirect_to(person_health_events_path(person))
+    expect(event.reload).to have_attributes(title: 'Cold again', ended_on: nil)
+  end
+
+  it 'deletes an event' do
+    event = HealthEvent.create!(person: person, event_kind: :illness, title: 'Cold', started_on: Date.new(2026, 2, 1))
+
+    expect do
+      delete person_health_event_path(person, event)
+    end.to change(HealthEvent, :count).by(-1)
+  end
+
+  it 'does not expose unrelated people to another user' do
+    post '/logout'
+    sign_in(users(:parent))
+
+    get person_health_events_path(person)
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  def illness_params(**overrides)
+    {
+      event_kind: 'illness',
+      title: 'Cold',
+      started_on: '2026-02-01',
+      ended_on: '',
+      severity: 'mild',
+      notes: 'Fever and sore throat',
+      action_taken: '',
+      medical_help_sought: '0'
+    }.merge(overrides)
+  end
+
+  def side_effect_params(**overrides)
+    illness_params(event_kind: 'suspected_side_effect', severity: 'moderate', notes: 'Started after dose')
+      .merge(overrides)
+  end
+end

--- a/spec/requests/health_events_spec.rb
+++ b/spec/requests/health_events_spec.rb
@@ -20,6 +20,31 @@ RSpec.describe 'Health events' do
     expect(response.body).to include('Record suspected side effect')
   end
 
+  it 'renders the new form with valid and invalid event kind params' do
+    get new_person_health_event_path(person), params: { event_kind: 'suspected_side_effect' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Record suspected side effect')
+
+    get new_person_health_event_path(person), params: { event_kind: 'unknown' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Record notable illness')
+  end
+
+  it 'renders the edit form with selected medication links' do
+    medication = medications(:paracetamol)
+    event = HealthEvent.create!(person: person, event_kind: :suspected_side_effect, title: 'Nausea',
+                                started_on: Date.new(2026, 2, 10))
+    HealthEventMedication.create!(health_event: event, medication: medication)
+
+    get edit_person_health_event_path(person, event)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Nausea')
+    expect(response.body).to include('Paracetamol')
+  end
+
   it 'creates a notable illness' do
     expect do
       post person_health_events_path(person),
@@ -42,6 +67,16 @@ RSpec.describe 'Health events' do
 
     event = HealthEvent.suspected_side_effect.order(:id).last
     expect(event.health_event_medications.sole.medication_name).to eq('Paracetamol')
+  end
+
+  it 're-renders the form when creation fails validation' do
+    expect do
+      post person_health_events_path(person),
+           params: { health_event: illness_params(title: '', started_on: '') }
+    end.not_to change(HealthEvent, :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.body).to include('Capture facts entered by the family or carer.')
   end
 
   it 'rejects medication links that are not assigned to the selected person' do
@@ -71,6 +106,16 @@ RSpec.describe 'Health events' do
 
     expect(response).to redirect_to(person_health_events_path(person))
     expect(event.reload).to have_attributes(title: 'Cold again', ended_on: nil)
+  end
+
+  it 're-renders the form when updates fail validation' do
+    event = HealthEvent.create!(person: person, event_kind: :illness, title: 'Cold', started_on: Date.new(2026, 2, 1))
+
+    patch person_health_event_path(person, event),
+          params: { health_event: illness_params(started_on: '2026-02-10', ended_on: '2026-02-01') }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(event.reload.started_on).to eq(Date.new(2026, 2, 1))
   end
 
   it 'deletes an event' do

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -98,4 +98,30 @@ RSpec.describe 'Reports' do
       end
     end
   end
+
+  describe 'GET /reports/health-history' do
+    before { sign_in(user) }
+
+    it 'downloads a no-store PDF with the active filters' do
+      get health_history_report_path,
+          params: { start_date: '2026-02-01', end_date: '2026-02-28', person_id: people(:john).id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('application/pdf')
+      expect(response.headers['Cache-Control']).to include('no-store')
+      expect(response.headers['Content-Disposition'])
+        .to include('medtracker-health-history-2026-02-01-to-2026-02-28.pdf')
+      expect(response.body).to start_with('%PDF')
+    end
+
+    it 'does not export an inaccessible person filter' do
+      post '/logout'
+      sign_in(users(:parent))
+
+      get health_history_report_path, params: { person_id: people(:john).id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with('%PDF')
+    end
+  end
 end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -123,5 +123,19 @@ RSpec.describe 'Reports' do
       expect(response).to have_http_status(:ok)
       expect(response.body).to start_with('%PDF')
     end
+
+    it 'exports an empty PDF for nonnumeric person filters' do
+      get health_history_report_path, params: { person_id: 'not-a-person' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with('%PDF')
+    end
+
+    it 'redirects with alert when export dates are invalid' do
+      get health_history_report_path, params: { start_date: 'invalid-date' }
+
+      expect(response).to redirect_to(reports_path)
+      expect(flash[:alert]).to eq('Invalid date format provided.')
+    end
   end
 end

--- a/spec/services/health_events/pattern_summary_spec.rb
+++ b/spec/services/health_events/pattern_summary_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HealthEvents::PatternSummary do
+  fixtures :people
+
+  it 'returns no summaries when there are no repeated illness titles' do
+    HealthEvent.create!(person: people(:john), event_kind: :illness, title: 'Cold', started_on: Date.new(2026, 1, 1))
+
+    summaries = described_class.new(events: HealthEvent.illness).call
+
+    expect(summaries).to be_empty
+  end
+
+  it 'ignores repeated illness episodes with blank titles' do
+    events = [
+      HealthEvent.new(event_kind: :illness, title: ' ', started_on: Date.new(2026, 1, 1)),
+      HealthEvent.new(event_kind: :illness, title: nil, started_on: Date.new(2026, 2, 1))
+    ]
+
+    summaries = described_class.new(events: events).call
+
+    expect(summaries).to be_empty
+  end
+
+  it 'returns no average duration when repeated episodes are ongoing' do
+    create_illness_episode(Date.new(2026, 1, 1), nil, 'Migraine')
+    create_illness_episode(Date.new(2026, 1, 10), nil, 'Migraine')
+
+    summary = described_class.new(events: HealthEvent.illness).call.sole
+
+    expect(summary.average_duration_days).to be_nil
+  end
+
+  it 'groups illness episodes by normalized title with factual interval and duration data' do
+    create_illness_episode(Date.new(2026, 1, 1), Date.new(2026, 1, 3), '  Tonsillitis ')
+    create_illness_episode(Date.new(2026, 2, 1), Date.new(2026, 2, 4), 'tonsillitis')
+    create_illness_episode(Date.new(2026, 3, 1), nil, 'TONSILLITIS')
+
+    summary = described_class.new(events: HealthEvent.illness).call.sole
+
+    expect(summary).to have_attributes(
+      normalized_title: 'tonsillitis',
+      episode_count: 3,
+      average_duration_days: 4,
+      average_interval_days: 30,
+      first_started_on: Date.new(2026, 1, 1),
+      most_recent_started_on: Date.new(2026, 3, 1)
+    )
+  end
+
+  def create_illness_episode(started_on, ended_on, title)
+    HealthEvent.create!(
+      person: people(:john),
+      event_kind: :illness,
+      title: title,
+      started_on: started_on,
+      ended_on: ended_on
+    )
+  end
+end

--- a/spec/services/reports/health_history_query_spec.rb
+++ b/spec/services/reports/health_history_query_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Reports::HealthHistoryQuery do
     )
   end
 
+  it 'reports duration days for ended health events and omits them for ongoing events' do
+    create_suspected_side_effect
+    create_illness_episode(Date.new(2026, 2, 1), Date.new(2026, 2, 3), 'Cold')
+
+    result = described_class.new(people: [person], start_date: start_date, end_date: end_date).call
+
+    expect(result.suspected_side_effects.sole.duration_days).to be_nil
+    expect(result.notable_illnesses.sole.duration_days).to eq(3)
+  end
+
   def create_illness_episode(started_on, ended_on, title)
     HealthEvent.create!(
       person: person,

--- a/spec/services/reports/health_history_query_spec.rb
+++ b/spec/services/reports/health_history_query_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reports::HealthHistoryQuery do
+  fixtures :people, :locations, :medications, :dosages
+
+  let(:person) { people(:john) }
+  let(:start_date) { Date.new(2026, 2, 1) }
+  let(:end_date) { Date.new(2026, 2, 28) }
+
+  it 'includes scheduled and direct medication takes in the inclusive date range' do
+    schedule = create(:schedule, person: person, medication: medications(:paracetamol),
+                                 dosage: dosages(:paracetamol_adult))
+    direct = create(:person_medication, person: person, medication: medications(:ibuprofen),
+                                        dosage: dosages(:ibuprofen_light))
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.parse('2026-02-01 08:30'))
+    create(:medication_take, :for_person_medication, person_medication: direct,
+                                                     taken_at: Time.zone.parse('2026-02-28 20:45'))
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.parse('2026-03-01 08:30'))
+
+    result = described_class.new(people: Person.where(id: person.id), start_date: start_date, end_date: end_date).call
+
+    expect(result.medication_takes.map(&:medication_name)).to eq(%w[Paracetamol Ibuprofen])
+    expect(result.medication_takes.map(&:source_type)).to eq(%i[scheduled as_needed])
+    expect(result.medication_takes.map(&:dose_display)).to eq(['1000.0 mg', '200.0 mg'])
+  end
+
+  it 'accepts an array of people and marks PRN schedule takes as as-needed' do
+    schedule = create(:schedule, person: person, medication: medications(:paracetamol),
+                                 dosage: dosages(:paracetamol_adult), schedule_type: :prn)
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.parse('2026-02-10 08:30'))
+
+    result = described_class.new(people: [person], start_date: start_date, end_date: end_date).call
+
+    expect(result.people).to eq([person])
+    expect(result.medication_takes.sole.source_type).to eq(:as_needed)
+  end
+
+  it 'includes suspected side effects, illnesses, linked medication snapshots, and illness patterns' do
+    create_suspected_side_effect
+    create_illness_episode(Date.new(2026, 2, 1), Date.new(2026, 2, 3), 'Cold')
+    create_illness_episode(Date.new(2026, 2, 20), Date.new(2026, 2, 22), ' cold ')
+
+    result = described_class.new(people: Person.where(id: person.id), start_date: start_date, end_date: end_date).call
+
+    expect(result.suspected_side_effects.sole).to have_attributes(
+      title: 'Nausea',
+      medication_names: ['Paracetamol'],
+      medical_help_sought: true
+    )
+    expect(result.notable_illnesses.map(&:title)).to eq(%w[Cold cold])
+    expect(result.illness_patterns.sole).to have_attributes(
+      normalized_title: 'cold',
+      episode_count: 2,
+      average_interval_days: 19
+    )
+  end
+
+  def create_illness_episode(started_on, ended_on, title)
+    HealthEvent.create!(
+      person: person,
+      event_kind: :illness,
+      title: title,
+      started_on: started_on,
+      ended_on: ended_on
+    )
+  end
+
+  def create_suspected_side_effect
+    side_effect = HealthEvent.create!(
+      person: person,
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 2, 10),
+      severity: :moderate,
+      notes: 'Started after evening dose',
+      action_taken: 'Called pharmacy',
+      medical_help_sought: true
+    )
+    HealthEventMedication.create!(health_event: side_effect, medication: medications(:paracetamol))
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -23,6 +23,7 @@ module RequestHelpers
     notification_preference_path offline_path offline_snapshot_path offline_medication_takes_path
     people_path person_path new_person_path edit_person_path add_medication_person_path
     person_avatar_path
+    person_health_events_path person_health_event_path new_person_health_event_path edit_person_health_event_path
     person_carer_relationships_path person_carer_relationship_path
     person_medication_assignments_path new_person_medication_assignment_path
     person_person_medications_path person_person_medication_path new_person_person_medication_path
@@ -30,7 +31,7 @@ module RequestHelpers
     take_medication_person_person_medication_path
     person_schedules_path person_schedule_path new_person_schedule_path edit_person_schedule_path
     take_medication_person_schedule_path
-    profile_path profile_avatar_path push_subscription_path reports_path
+    profile_path profile_avatar_path push_subscription_path reports_path health_history_report_path
     profile_api_tokens_path profile_api_token_path
     schedules_path schedule_path schedules_workflow_path start_schedules_workflow_path
     schedules_frequency_preview_path schedule_medication_takes_path

--- a/spec/views/reports/index_spec.rb
+++ b/spec/views/reports/index_spec.rb
@@ -59,6 +59,9 @@ RSpec.describe Views::Reports::Index do
     # rubocop:disable RSpec/SubjectStub
     helper_view_context = controller.view_context
     allow(helper_view_context).to receive(:reports_path).and_return('/reports')
+    allow(helper_view_context).to receive(:health_history_report_path) do |params|
+      "/reports/health-history?#{params.to_query}"
+    end
     allow(report_view).to receive(:view_context).and_return(helper_view_context)
     # rubocop:enable RSpec/SubjectStub
   end
@@ -97,6 +100,15 @@ RSpec.describe Views::Reports::Index do
     expect(rendered).to include('Mon')
     expect(rendered).to include('Tue')
     expect(rendered).to include('Wed')
+  end
+
+  it 'links the PDF download with the active filters' do
+    rendered = Nokogiri::HTML.fragment(render(report_view))
+    link = rendered.at_css("a[href*='/reports/health-history']")
+
+    expect(link.text).to include('Download PDF')
+    expect(link['href']).to include('start_date=')
+    expect(link['href']).to include('end_date=')
   end
 
   it 'renders compliance bars without inline styles' do


### PR DESCRIPTION
## Summary
- add person-scoped health events for notable illnesses and suspected side effects, including medication snapshots and PaperTrail auditing
- add authorized nested CRUD screens and person-page discoverability for health events
- add a dedicated health-history query and Prawn PDF export covering scheduled/direct takes, suspected side effects, illnesses, factual illness patterns, no-store responses, and report filter preservation

Closes #1377

## Tests
- bundle install
- ruby -e "require 'prawn'; require 'prawn/table'; pdf = Prawn::Document.new(compress: false); pdf.text('MedTracker'); abort unless pdf.render.start_with?('%PDF')"
- rubocop Gemfile app/controllers/health_events_controller.rb app/controllers/health_history_reports_controller.rb app/controllers/reports_controller.rb app/models/health_event.rb app/models/health_event_medication.rb app/models/household.rb app/models/person.rb app/policies/health_event_policy.rb app/services/health_events/pattern_summary.rb app/services/reports/health_history_pdf.rb app/services/reports/health_history_query.rb app/views/health_events/form.rb app/views/health_events/index.rb app/views/reports/index.rb app/components/people/show_view.rb spec/models/health_event_spec.rb spec/models/health_event_medication_spec.rb spec/policies/health_event_policy_spec.rb spec/requests/health_events_spec.rb spec/requests/reports_spec.rb spec/services/health_events/pattern_summary_spec.rb spec/services/reports/health_history_query_spec.rb spec/views/reports/index_spec.rb spec/support/request_helpers.rb config/routes.rb db/migrate/20260702133700_create_health_events.rb
- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)
- task test (blocked: Docker socket /var/run/docker.sock unavailable)