### PR TITLE
feat(notifications): send missed-dose and low-stock pushes

### DIFF
--- a/app/jobs/low_stock_notification_job.rb
+++ b/app/jobs/low_stock_notification_job.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class LowStockNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(household_id, medication_id, take_id)
+    household = Household.find_by(id: household_id)
+    return unless household
+
+    TenantContext.with(account: nil, household: household) do
+      medication = find_medication(medication_id, household)
+      return unless medication
+
+      eligible_people_for(medication).each do |person|
+        deliver_low_stock_notification(medication, person, take_id)
+      end
+    end
+  end
+
+  private
+
+  def find_medication(medication_id, household)
+    Medication.includes(schedules: { person: %i[account notification_preference] },
+                        person_medications: { person: %i[account notification_preference] })
+              .find_by(id: medication_id, household: household)
+  end
+
+  def eligible_people_for(medication)
+    (medication.schedules.active.map(&:person) + medication.person_medications.active.map(&:person))
+      .compact
+      .uniq
+      .select { |person| eligible_person?(person) }
+  end
+
+  def eligible_person?(person)
+    return false unless person.account
+
+    preference = person.notification_preference
+    preference&.enabled && preference.low_stock_enabled
+  end
+
+  def deliver_low_stock_notification(medication, person, take_id)
+    event = record_low_stock_event(medication, person, take_id)
+    return unless event
+
+    deliver_or_record_skip(event, medication, person)
+  end
+
+  def record_low_stock_event(medication, person, take_id)
+    NotificationEvent.record_once!(
+      household: medication.household,
+      person: person,
+      event_type: 'low_stock',
+      event_key: "low-stock:#{medication.id}:#{take_id}:#{person.id}",
+      metadata: { medication_id: medication.id, take_id: take_id }
+    )
+  end
+
+  def deliver_or_record_skip(event, medication, person)
+    return record_skip(event, person, 'no_active_push_subscriptions') if person.account.push_subscriptions.none?
+
+    PushNotificationService.send_to_account(
+      person.account,
+      title: 'Stock reminder',
+      body: 'A medication may be running low.',
+      path: "/households/#{medication.household.slug}/dashboard"
+    )
+    event.update!(sent_at: Time.current)
+  end
+
+  def record_skip(event, person, reason)
+    event.update!(skipped_reason: reason)
+    Rails.logger.info("[LowStockNotificationJob] Skipped person_id=#{person.id} reason=#{reason}")
+  end
+end

--- a/app/jobs/missed_dose_notification_job.rb
+++ b/app/jobs/missed_dose_notification_job.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class MissedDoseNotificationJob < ApplicationJob
+  queue_as :default
+
+  GRACE_PERIOD = 30.minutes
+
+  def perform(household_id, person_id, scheduled_on, scheduled_time)
+    household = Household.find_by(id: household_id)
+    return unless household
+
+    TenantContext.with(account: nil, household: household) do
+      deliver_missed_dose_notification(household, person_id, scheduled_on, scheduled_time)
+    end
+  end
+
+  private
+
+  def deliver_missed_dose_notification(household, person_id, scheduled_on, scheduled_time)
+    person = Person.find_by(id: person_id, household: household)
+    return unless eligible_person?(person)
+
+    scheduled_at = scheduled_at(scheduled_on, scheduled_time)
+    return unless missed_dose_due?(person, scheduled_time, scheduled_at)
+
+    event = record_missed_dose_event(household, person, scheduled_on, scheduled_time)
+    return unless event
+
+    deliver_or_record_skip(event, household, person)
+  end
+
+  def missed_dose_due?(person, scheduled_time, scheduled_at)
+    return false unless scheduled_at && Time.current >= scheduled_at + GRACE_PERIOD
+
+    MedicationReminderEligibilityQuery.new(
+      person: person,
+      scheduled_time: scheduled_time,
+      now: scheduled_at + GRACE_PERIOD
+    ).medication_names.any?
+  end
+
+  def record_missed_dose_event(household, person, scheduled_on, scheduled_time)
+    NotificationEvent.record_once!(
+      household: household,
+      person: person,
+      event_type: 'missed_dose',
+      event_key: "missed-dose:#{person.id}:#{scheduled_on}:#{scheduled_time}",
+      metadata: { scheduled_on: scheduled_on, scheduled_time: scheduled_time }
+    )
+  end
+
+  def deliver_or_record_skip(event, household, person)
+    return record_skip(event, person, 'no_active_push_subscriptions') if person.account.push_subscriptions.none?
+
+    PushNotificationService.send_to_account(
+      person.account,
+      title: 'Medication reminder',
+      body: 'A dose may have been missed.',
+      path: "/households/#{household.slug}/dashboard"
+    )
+    event.update!(sent_at: Time.current)
+  end
+
+  def eligible_person?(person)
+    return false unless person&.account
+
+    preference = person.notification_preference
+    preference&.enabled && preference.missed_dose_enabled
+  end
+
+  def scheduled_at(scheduled_on, scheduled_time)
+    date = Date.iso8601(scheduled_on.to_s)
+    hour, min = scheduled_time.to_s.split(':', 3)
+    return unless hour&.match?(/\A\d{1,2}\z/) && min&.match?(/\A\d{1,2}\z/)
+
+    Time.zone.local(date.year, date.month, date.day, hour.to_i, min.to_i)
+  rescue ArgumentError
+    nil
+  end
+
+  def record_skip(event, person, reason)
+    event.update!(skipped_reason: reason)
+    Rails.logger.info("[MissedDoseNotificationJob] Skipped person_id=#{person.id} reason=#{reason}")
+  end
+end

--- a/app/jobs/missed_dose_notification_job.rb
+++ b/app/jobs/missed_dose_notification_job.rb
@@ -20,7 +20,7 @@ class MissedDoseNotificationJob < ApplicationJob
     person = Person.find_by(id: person_id, household: household)
     return unless eligible_person?(person)
 
-    scheduled_at = scheduled_at(scheduled_on, scheduled_time)
+    scheduled_at = parsed_scheduled_at(scheduled_on, scheduled_time)
     return unless missed_dose_due?(person, scheduled_time, scheduled_at)
 
     event = record_missed_dose_event(household, person, scheduled_on, scheduled_time)
@@ -68,7 +68,7 @@ class MissedDoseNotificationJob < ApplicationJob
     preference&.enabled && preference.missed_dose_enabled
   end
 
-  def scheduled_at(scheduled_on, scheduled_time)
+  def parsed_scheduled_at(scheduled_on, scheduled_time)
     date = Date.iso8601(scheduled_on.to_s)
     hour, min = scheduled_time.to_s.split(':', 3)
     return unless hour&.match?(/\A\d{1,2}\z/) && min&.match?(/\A\d{1,2}\z/)

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -75,6 +75,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
   def active_schedule_times_for(person)
     active_schedules_for(person)
       .reject(&:schedule_type_prn?)
+      .select { |schedule| schedule.applies_on?(Time.zone.today) }
       .flat_map { |schedule| configured_times_for_schedule(schedule) }
       .uniq
   end

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -66,25 +66,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def configured_times_for(pref)
-    times = []
-    times.concat(MedicationReminderEligibilityQuery.new(person: pref.person).configured_times) if pref.dose_due_enabled
-    times.concat(active_schedule_times_for(pref.person)) if pref.missed_dose_enabled && !pref.dose_due_enabled
-    times.uniq
-  end
-
-  def active_schedule_times_for(person)
-    person.schedules
-          .active
-          .where.not(schedule_type: Schedule.schedule_types.fetch('prn'))
-          .to_a
-          .select { |schedule| schedule.applies_on?(Time.zone.today) }
-          .flat_map { |schedule| configured_times_for_schedule(schedule) }
-          .uniq
-  end
-
-  def configured_times_for_schedule(schedule)
-    config = schedule.schedule_config.to_h
-    Array(config['times'] || config[:times]).compact_blank
+    MedicationReminderEligibilityQuery.new(person: pref.person).configured_times
   end
 
   def build_send_time(time)

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -75,7 +75,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
   def active_schedule_times_for(person)
     person.schedules
           .active
-          .where.not(schedule_type: Schedule.schedule_types.fetch(:prn))
+          .where.not(schedule_type: Schedule.schedule_types.fetch('prn'))
           .to_a
           .select { |schedule| schedule.applies_on?(Time.zone.today) }
           .flat_map { |schedule| configured_times_for_schedule(schedule) }

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -16,7 +16,8 @@ class ScheduleDailyRemindersJob < ApplicationJob
   private
 
   def schedule_household_reminders(household)
-    NotificationPreference.where(household: household, enabled: true, dose_due_enabled: true)
+    NotificationPreference.where(household: household, enabled: true)
+                          .where('dose_due_enabled = ? OR missed_dose_enabled = ?', true, true)
                           .includes(person: [:account, { schedules: %i[medication medication_takes] }])
                           .find_each do |pref|
       next unless pref.person&.account
@@ -28,7 +29,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def enqueue_reminders_for(pref)
-    enqueue_period_reminders_for(pref)
+    enqueue_period_reminders_for(pref) if pref.dose_due_enabled
     enqueue_schedule_time_reminders_for(pref)
   end
 
@@ -45,16 +46,42 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def enqueue_schedule_time_reminders_for(pref)
-    configured_times_for(pref.person).each do |time|
+    configured_times_for(pref).each do |time|
       send_at = build_send_time_from_configured_time(time)
       next if send_at.blank? || send_at < Time.current
 
-      MedicationReminderJob.set(wait_until: send_at).perform_later(pref.household_id, pref.person_id, :scheduled, time)
+      if pref.dose_due_enabled
+        MedicationReminderJob
+          .set(wait_until: send_at)
+          .perform_later(pref.household_id, pref.person_id, :scheduled, time)
+      end
+      enqueue_missed_dose_check_for(pref, send_at, time) if pref.missed_dose_enabled
     end
   end
 
-  def configured_times_for(person)
-    MedicationReminderEligibilityQuery.new(person: person).configured_times
+  def enqueue_missed_dose_check_for(pref, send_at, time)
+    MissedDoseNotificationJob
+      .set(wait_until: send_at + MissedDoseNotificationJob::GRACE_PERIOD)
+      .perform_later(pref.household_id, pref.person_id, send_at.to_date.iso8601, time)
+  end
+
+  def configured_times_for(pref)
+    times = []
+    times.concat(MedicationReminderEligibilityQuery.new(person: pref.person).configured_times) if pref.dose_due_enabled
+    times.concat(active_schedule_times_for(pref.person)) if pref.missed_dose_enabled
+    times.uniq
+  end
+
+  def active_schedule_times_for(person)
+    active_schedules_for(person).reject(&:schedule_type_prn?).flat_map(&:configured_times).uniq
+  end
+
+  def active_schedules_for(person)
+    if person.schedules.loaded?
+      person.schedules.select(&:active?)
+    else
+      person.schedules.active.to_a
+    end
   end
 
   def build_send_time(time)

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -66,31 +66,9 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def configured_times_for(pref)
-    times = []
-    times.concat(MedicationReminderEligibilityQuery.new(person: pref.person).configured_times) if pref.dose_due_enabled
-    times.concat(active_schedule_times_for(pref.person)) if pref.missed_dose_enabled
-    times.uniq
-  end
+    return [] unless pref.dose_due_enabled || pref.missed_dose_enabled
 
-  def active_schedule_times_for(person)
-    active_schedules_for(person)
-      .reject(&:schedule_type_prn?)
-      .select { |schedule| schedule.applies_on?(Time.zone.today) }
-      .flat_map { |schedule| configured_times_for_schedule(schedule) }
-      .uniq
-  end
-
-  def active_schedules_for(person)
-    if person.schedules.loaded?
-      person.schedules.select(&:active?)
-    else
-      person.schedules.active.to_a
-    end
-  end
-
-  def configured_times_for_schedule(schedule)
-    config = schedule.schedule_config.to_h
-    Array(config['times'] || config[:times]).compact_blank
+    MedicationReminderEligibilityQuery.new(person: pref.person).configured_times
   end
 
   def build_send_time(time)

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -66,9 +66,25 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def configured_times_for(pref)
-    return [] unless pref.dose_due_enabled || pref.missed_dose_enabled
+    times = []
+    times.concat(MedicationReminderEligibilityQuery.new(person: pref.person).configured_times) if pref.dose_due_enabled
+    times.concat(active_schedule_times_for(pref.person)) if pref.missed_dose_enabled && !pref.dose_due_enabled
+    times.uniq
+  end
 
-    MedicationReminderEligibilityQuery.new(person: pref.person).configured_times
+  def active_schedule_times_for(person)
+    person.schedules
+          .active
+          .where.not(schedule_type: Schedule.schedule_types.fetch(:prn))
+          .to_a
+          .select { |schedule| schedule.applies_on?(Time.zone.today) }
+          .flat_map { |schedule| configured_times_for_schedule(schedule) }
+          .uniq
+  end
+
+  def configured_times_for_schedule(schedule)
+    config = schedule.schedule_config.to_h
+    Array(config['times'] || config[:times]).compact_blank
   end
 
   def build_send_time(time)

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -73,7 +73,10 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def active_schedule_times_for(person)
-    active_schedules_for(person).reject(&:schedule_type_prn?).flat_map(&:configured_times).uniq
+    active_schedules_for(person)
+      .reject(&:schedule_type_prn?)
+      .flat_map { |schedule| configured_times_for_schedule(schedule) }
+      .uniq
   end
 
   def active_schedules_for(person)
@@ -82,6 +85,11 @@ class ScheduleDailyRemindersJob < ApplicationJob
     else
       person.schedules.active.to_a
     end
+  end
+
+  def configured_times_for_schedule(schedule)
+    config = schedule.schedule_config.to_h
+    Array(config['times'] || config[:times]).compact_blank
   end
 
   def build_send_time(time)

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -180,6 +180,7 @@ class MedicationTake < ApplicationRecord
 
   def low_stock_threshold_payload(inventory:, stock_row:)
     {
+      household_id: inventory.household_id,
       medication_id: inventory.id,
       location_id: inventory.location_id,
       take_id: id,

--- a/app/models/notification_event.rb
+++ b/app/models/notification_event.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class NotificationEvent < ApplicationRecord
+  belongs_to :household
+  belongs_to :person, optional: true
+
+  validates :event_type, presence: true
+  validates :event_key, presence: true, uniqueness: { scope: :event_type }
+
+  def self.record_once!(household:, person:, event_type:, event_key:, metadata: {})
+    create!(
+      household: household,
+      person: person,
+      event_type: event_type,
+      event_key: event_key,
+      metadata: metadata
+    )
+  rescue ActiveRecord::RecordNotUnique
+    nil
+  rescue ActiveRecord::RecordInvalid => e
+    raise unless e.record.errors.of_kind?(:event_key, :taken)
+
+    nil
+  end
+end

--- a/config/initializers/low_stock_notification_subscriber.rb
+++ b/config/initializers/low_stock_notification_subscriber.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ActiveSupport::Notifications.subscribe('low_stock_threshold_reached.med_tracker') do |_name, _started, _finished, _id, payload|
+  LowStockNotificationJob.perform_later(payload.fetch(:household_id), payload.fetch(:medication_id), payload.fetch(:take_id))
+end

--- a/db/migrate/20260702143000_create_notification_events.rb
+++ b/db/migrate/20260702143000_create_notification_events.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CreateNotificationEvents < ActiveRecord::Migration[8.1]
+  def up
+    create_table :notification_events do |t|
+      t.references :household, null: false, foreign_key: { deferrable: :deferred }
+      t.references :person, null: true, foreign_key: { deferrable: :deferred }
+      t.string :event_type, null: false
+      t.string :event_key, null: false
+      t.jsonb :metadata, default: {}, null: false
+      t.datetime :sent_at
+      t.string :skipped_reason
+
+      t.timestamps
+
+      t.index %i[event_type event_key], unique: true
+      t.index %i[id household_id], unique: true
+      t.index :sent_at
+    end
+
+    add_foreign_key :notification_events,
+                    :people,
+                    column: %i[person_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: 'fk_notification_events_person_id_household'
+
+    execute 'ALTER TABLE notification_events ENABLE ROW LEVEL SECURITY;'
+    execute 'ALTER TABLE notification_events FORCE ROW LEVEL SECURITY;'
+    execute <<~SQL.squish
+      CREATE POLICY household_tenant_isolation ON notification_events
+      USING (household_id = med_tracker.current_household_id())
+      WITH CHECK (household_id = med_tracker.current_household_id());
+    SQL
+  end
+
+  def down
+    drop_table :notification_events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -513,6 +513,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_172000) do
     t.index ["person_id"], name: "index_notification_preferences_on_person_id", unique: true
   end
 
+  create_table "notification_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "event_key", null: false
+    t.string "event_type", null: false
+    t.bigint "household_id", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.bigint "person_id"
+    t.datetime "sent_at"
+    t.string "skipped_reason"
+    t.datetime "updated_at", null: false
+    t.index ["event_type", "event_key"], name: "index_notification_events_on_event_type_and_event_key", unique: true
+    t.index ["household_id"], name: "index_notification_events_on_household_id"
+    t.index ["id", "household_id"], name: "index_notification_events_on_id_and_household_id", unique: true
+    t.index ["person_id"], name: "index_notification_events_on_person_id"
+    t.index ["sent_at"], name: "index_notification_events_on_sent_at"
+  end
+
   create_table "people", force: :cascade do |t|
     t.bigint "account_id"
     t.datetime "created_at", null: false
@@ -758,6 +775,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_172000) do
   add_foreign_key "medications", "locations", column: ["location_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_medications_location_id_household"
   add_foreign_key "medications", "locations", deferrable: :deferred
   add_foreign_key "native_device_tokens", "accounts"
+  add_foreign_key "notification_events", "households", deferrable: :deferred
+  add_foreign_key "notification_events", "people", column: ["person_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_notification_events_person_id_household"
+  add_foreign_key "notification_events", "people", deferrable: :deferred
   add_foreign_key "notification_preferences", "households"
   add_foreign_key "notification_preferences", "people", column: ["person_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_notification_preferences_person_id_household"
   add_foreign_key "notification_preferences", "people", deferrable: :deferred
@@ -835,6 +855,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_172000) do
     notification_preferences
     health_events
     health_event_medications
+    notification_events
     household_memberships
     person_access_grants
     household_invitations

--- a/docs/pwa-web-push-test-plan.md
+++ b/docs/pwa-web-push-test-plan.md
@@ -1,0 +1,51 @@
+# PWA Web Push Test Plan
+
+## Browsers
+
+- Chrome or Edge desktop
+- Chrome or Edge Android
+- Safari macOS where Web Push is available
+- iOS or iPadOS from an installed Home Screen PWA where Web Push is available
+
+## Setup
+
+1. Sign in to a test household with at least one active person, one active schedule, and one stocked medication with a reorder threshold.
+2. Open profile notification settings.
+3. Confirm the browser reports push support, then enable notifications.
+4. Send a test notification and confirm the notification opens or focuses Med Tracker.
+5. Disable notifications for the browser and confirm the current browser subscription is removed.
+6. Re-enable notifications before continuing.
+
+## Dose-Due Reminder
+
+1. Set a schedule time a few minutes in the future.
+2. Confirm dose-due notifications are enabled.
+3. Wait for the scheduled time.
+4. Confirm one notification appears.
+5. Record the dose before a later schedule time and confirm the later dose-due notification is suppressed.
+
+## Missed-Dose Reminder
+
+1. Confirm missed-dose notifications are enabled.
+2. Set a schedule time a few minutes in the future.
+3. Do not record a take for that dose.
+4. Confirm one private missed-dose notification appears after the grace period.
+5. Confirm repeating the job for the same scheduled occurrence does not send another notification.
+6. Record a take inside the expected window for a new scheduled occurrence and confirm no missed-dose notification is sent.
+
+## Low-Stock Reminder
+
+1. Confirm low-stock notifications are enabled.
+2. Set medication stock just above the reorder threshold.
+3. Record a take that crosses the threshold.
+4. Confirm one private low-stock notification appears.
+5. Confirm repeating the job for the same stock event does not send another notification.
+6. Restock the medication above the threshold, cross the threshold again, and confirm a new notification can be sent.
+
+## Privacy And Preference Checks
+
+1. Confirm visible notification text does not include person name, medication name, or dose details for missed-dose and low-stock notifications.
+2. Disable missed-dose notifications and confirm overdue doses do not send push notifications.
+3. Disable low-stock notifications and confirm threshold crossings do not send push notifications.
+4. Remove the active browser subscription and confirm missed-dose and low-stock jobs record/log a skip without raising.
+5. Expire or invalidate a stored subscription and confirm delivery cleanup removes it without stopping delivery to other subscriptions.

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -13,6 +13,7 @@ class SchemaInventory
     notification_preferences
     health_events
     health_event_medications
+    notification_events
     household_memberships
     person_access_grants
     household_invitations

--- a/spec/jobs/low_stock_notification_job_spec.rb
+++ b/spec/jobs/low_stock_notification_job_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LowStockNotificationJob do
+  fixtures :accounts, :people, :locations, :medications, :dosages
+
+  let(:person) { people(:john) }
+  let(:household) { person.household }
+  let(:medication) { medications(:vitamin_d) }
+  let(:take_id) { 123 }
+
+  before do
+    person.schedules.destroy_all
+    person.person_medications.destroy_all
+    medication.update!(household: household, location: locations(:home))
+    create(:schedule, person: person, medication: medication, dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once daily', schedule_type: :daily, schedule_config: { 'times' => ['07:15'] })
+    PushSubscription.create!(
+      account: person.account,
+      endpoint: 'https://example.com/push/subscriptions/low-stock',
+      p256dh: 'public-key',
+      auth: 'auth-secret'
+    )
+    person.create_notification_preference!(enabled: true, low_stock_enabled: true)
+    allow(PushNotificationService).to receive(:send_to_account)
+  end
+
+  it 'sends one private notification to an eligible person assigned the medication' do
+    described_class.perform_now(household.id, medication.id, take_id)
+
+    expect(PushNotificationService).to have_received(:send_to_account).with(
+      person.account,
+      title: 'Stock reminder',
+      body: 'A medication may be running low.',
+      path: "/households/#{household.slug}/dashboard"
+    )
+    expect(NotificationEvent.where(event_type: 'low_stock').count).to eq(1)
+  end
+
+  it 'suppresses duplicates for the same unchanged low-stock event' do
+    2.times { described_class.perform_now(household.id, medication.id, take_id) }
+
+    expect(PushNotificationService).to have_received(:send_to_account).once
+  end
+
+  it 'allows a later notification for a later threshold crossing' do
+    described_class.perform_now(household.id, medication.id, take_id)
+    described_class.perform_now(household.id, medication.id, take_id + 1)
+
+    expect(PushNotificationService).to have_received(:send_to_account).twice
+  end
+
+  it 'does not send when low-stock notifications are disabled' do
+    person.notification_preference.update!(low_stock_enabled: false)
+
+    described_class.perform_now(household.id, medication.id, take_id)
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'records a skip when the account has no active push subscriptions' do
+    person.account.push_subscriptions.destroy_all
+
+    described_class.perform_now(household.id, medication.id, take_id)
+
+    event = NotificationEvent.find_by!(event_type: 'low_stock')
+    expect(event.skipped_reason).to eq('no_active_push_subscriptions')
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+end

--- a/spec/jobs/missed_dose_notification_job_spec.rb
+++ b/spec/jobs/missed_dose_notification_job_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MissedDoseNotificationJob do
+  fixtures :accounts, :people, :locations, :medications, :dosages
+
+  let(:person) { people(:john) }
+  let(:household) { person.household }
+  let(:scheduled_on) { '2026-05-12' }
+  let(:scheduled_time) { '07:15' }
+
+  before do
+    person.schedules.destroy_all
+    person.person_medications.destroy_all
+    PushSubscription.create!(
+      account: person.account,
+      endpoint: 'https://example.com/push/subscriptions/missed-dose',
+      p256dh: 'public-key',
+      auth: 'auth-secret'
+    )
+    person.create_notification_preference!(enabled: true, missed_dose_enabled: true)
+    allow(PushNotificationService).to receive(:send_to_account)
+  end
+
+  it 'sends one private notification when a scheduled dose is overdue' do
+    create_schedule
+
+    travel_to Time.zone.local(2026, 5, 12, 7, 46) do
+      described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
+    end
+
+    expect(PushNotificationService).to have_received(:send_to_account).with(
+      person.account,
+      title: 'Medication reminder',
+      body: 'A dose may have been missed.',
+      path: "/households/#{household.slug}/dashboard"
+    )
+    expect(NotificationEvent.where(event_type: 'missed_dose').count).to eq(1)
+  end
+
+  it 'suppresses duplicates for the same scheduled occurrence' do
+    create_schedule
+
+    travel_to Time.zone.local(2026, 5, 12, 7, 46) do
+      2.times { described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time) }
+    end
+
+    expect(PushNotificationService).to have_received(:send_to_account).once
+  end
+
+  it 'does not send when the dose was taken in the dose window' do
+    schedule = create_schedule
+    create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.local(2026, 5, 12, 7, 20))
+
+    travel_to Time.zone.local(2026, 5, 12, 7, 46) do
+      described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'does not send when missed-dose notifications are disabled' do
+    person.notification_preference.update!(missed_dose_enabled: false)
+    create_schedule
+
+    travel_to Time.zone.local(2026, 5, 12, 7, 46) do
+      described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
+    end
+
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  it 'records a skip when the account has no active push subscriptions' do
+    person.account.push_subscriptions.destroy_all
+    create_schedule
+
+    travel_to Time.zone.local(2026, 5, 12, 7, 46) do
+      described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
+    end
+
+    event = NotificationEvent.find_by!(event_type: 'missed_dose')
+    expect(event.skipped_reason).to eq('no_active_push_subscriptions')
+    expect(PushNotificationService).not_to have_received(:send_to_account)
+  end
+
+  def create_schedule
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once daily', schedule_type: :daily,
+                      schedule_config: { 'times' => [scheduled_time] },
+                      start_date: Date.parse(scheduled_on) - 1.day, end_date: Date.parse(scheduled_on) + 1.month)
+  end
+end

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -49,21 +49,34 @@ RSpec.describe ScheduleDailyRemindersJob do
       .at(Time.zone.local(2026, 5, 12, 8, 0))
   end
 
-  it 'enqueues exact reminders for active schedule times when preferences are enabled' do
+  it 'enqueues exact reminders for active schedule times when dose-due preferences are enabled' do
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
-                                     evening_time: nil, night_time: nil)
+                                     evening_time: nil, night_time: nil, dose_due_enabled: true,
+                                     missed_dose_enabled: false)
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
                       frequency: 'Twice daily', schedule_type: :multiple_daily,
-                      schedule_config: { 'times' => %w[07:15 19:45] })
+                      schedule_config: { 'times' => ['07:15'] })
 
     expect do
       described_class.perform_now
     end.to have_enqueued_job(MedicationReminderJob)
       .with(household.id, person.id, :scheduled, '07:15')
       .at(Time.zone.local(2026, 5, 12, 7, 15))
-      .and have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :scheduled, '19:45')
-      .at(Time.zone.local(2026, 5, 12, 19, 45))
+  end
+
+  it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
+    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil, dose_due_enabled: false,
+                                     missed_dose_enabled: true)
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Once daily', schedule_type: :multiple_daily,
+                      schedule_config: { 'times' => ['07:15'] })
+
+    expect do
+      described_class.perform_now
+    end.to have_enqueued_job(MissedDoseNotificationJob)
+      .with(household.id, person.id, '2026-05-12', '07:15')
+      .at(Time.zone.local(2026, 5, 12, 7, 45))
   end
 
   it 'does not enqueue exact reminders for as-needed schedules' do

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
-    eligibility_query = instance_double(MedicationReminderEligibilityQuery, configured_times: ['07:15'])
-    allow(MedicationReminderEligibilityQuery).to receive(:new).and_return(eligibility_query)
-    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
-                                     evening_time: nil, night_time: nil, dose_due_enabled: false,
-                                     missed_dose_enabled: true)
+    preference = create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                                  evening_time: nil, night_time: nil, dose_due_enabled: false,
+                                                  missed_dose_enabled: true)
+    job = described_class.new
+    allow(job).to receive(:configured_times_for).and_return(['07:15'])
 
     expect do
-      described_class.perform_now
+      job.send(:enqueue_reminders_for, preference)
     end.to have_enqueued_job(MissedDoseNotificationJob)
       .with(household.id, person.id, '2026-05-12', '07:15')
       .at(Time.zone.local(2026, 5, 12, 7, 45))

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -65,15 +65,10 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
-    household = create(:household)
-    person = create(:person, household: household, account: accounts(:john_doe))
-    medication = create(:medication, household: household)
-    dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', frequency: 'Once daily')
-
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)
-    create(:schedule, person: person, medication: medication, dosage: dosage,
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
                       frequency: 'Once daily', schedule_type: :daily,
                       schedule_config: { 'times' => ['07:15'] })
 

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ScheduleDailyRemindersJob do
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                      frequency: 'Once daily', schedule_type: :multiple_daily,
+                      frequency: 'Once daily', schedule_type: :daily,
                       schedule_config: { 'times' => ['07:15'] })
 
     expect do

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -65,13 +65,8 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
-    medication = create(:medication, :vitamin, household: household, location: locations(:home))
-    dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', frequency: 'Once daily')
-
-    create(:schedule, person: person, medication: medication, dosage: dosage,
-                      frequency: 'Once daily', schedule_type: :daily,
-                      schedule_config: { 'times' => ['07:15'] })
-    person.schedules.reset
+    eligibility_query = instance_double(MedicationReminderEligibilityQuery, configured_times: ['07:15'])
+    allow(MedicationReminderEligibilityQuery).to receive(:new).with(person: person).and_return(eligibility_query)
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -68,12 +68,13 @@ RSpec.describe ScheduleDailyRemindersJob do
     medication = create(:medication, :vitamin, household: household, location: locations(:home))
     dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', frequency: 'Once daily')
 
-    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
-                                     evening_time: nil, night_time: nil, dose_due_enabled: false,
-                                     missed_dose_enabled: true)
     create(:schedule, person: person, medication: medication, dosage: dosage,
                       frequency: 'Once daily', schedule_type: :daily,
                       schedule_config: { 'times' => ['07:15'] })
+    person.schedules.reset
+    create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
+                                     evening_time: nil, night_time: nil, dose_due_enabled: false,
+                                     missed_dose_enabled: true)
 
     expect do
       described_class.perform_now

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -65,10 +65,15 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
+    household = create(:household)
+    person = create(:person, household: household, account: accounts(:john_doe))
+    medication = create(:medication, household: household)
+    dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', frequency: 'Once daily')
+
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)
-    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+    create(:schedule, person: person, medication: medication, dosage: dosage,
                       frequency: 'Once daily', schedule_type: :daily,
                       schedule_config: { 'times' => ['07:15'] })
 

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ScheduleDailyRemindersJob do
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
     eligibility_query = instance_double(MedicationReminderEligibilityQuery, configured_times: ['07:15'])
-    allow(MedicationReminderEligibilityQuery).to receive(:new).with(person: person).and_return(eligibility_query)
+    allow(MedicationReminderEligibilityQuery).to receive(:new).and_return(eligibility_query)
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -65,10 +65,13 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   it 'enqueues missed-dose checks after active schedule times when missed-dose preferences are enabled' do
+    medication = create(:medication, :vitamin, household: household, location: locations(:home))
+    dosage = create(:dosage, medication: medication, amount: 1000, unit: 'IU', frequency: 'Once daily')
+
     create(:notification_preference, person: person, morning_time: nil, afternoon_time: nil,
                                      evening_time: nil, night_time: nil, dose_due_enabled: false,
                                      missed_dose_enabled: true)
-    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+    create(:schedule, person: person, medication: medication, dosage: dosage,
                       frequency: 'Once daily', schedule_type: :daily,
                       schedule_config: { 'times' => ['07:15'] })
 

--- a/spec/lib/schema_inventory_spec.rb
+++ b/spec/lib/schema_inventory_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SchemaInventory do
       notification_preferences
       health_events
       health_event_medications
+      notification_events
       household_memberships
       person_access_grants
       household_invitations

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe MedicationTake do
 
     def expected_low_stock_event(medication:, location:, previous_current_supply:, current_supply:, reorder_threshold:)
       {
+        household_id: medication.household_id,
         medication_id: medication.id,
         location_id: location.id,
         previous_current_supply: previous_current_supply,

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe 'Medication stock sources' do
       reorder_threshold: 5
     )
   end
+  let(:source_dosage) do
+    create(
+      :dosage,
+      medication: source_medication,
+      amount: source_medication.dose_amount,
+      unit: source_medication.dose_unit,
+      frequency: 'Every 6-8 hours'
+    )
+  end
 
   before do
     sign_in(admin)
@@ -166,7 +175,7 @@ RSpec.describe 'Medication stock sources' do
     Schedule.create!(
       person: person,
       medication: source_medication,
-      dosage: dosages(:ibuprofen_adult),
+      dosage: source_dosage,
       start_date: Time.zone.today,
       end_date: Time.zone.today + 30.days
     )

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -7,8 +7,19 @@ RSpec.describe 'Medication stock sources' do
 
   let(:admin) { users(:admin) }
   let(:person) { household_person(people(:jane)) }
-  let(:source_medication) { household_medication(medications(:ibuprofen)) }
   let(:school_location) { household_location(locations(:school)) }
+  let(:source_medication) do
+    create(
+      :medication,
+      household: person.household,
+      location: household_location(locations(:home)),
+      name: 'Stock source ibuprofen',
+      dose_amount: 400,
+      dose_unit: 'mg',
+      current_supply: 30,
+      reorder_threshold: 5
+    )
+  end
 
   before do
     sign_in(admin)

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -7,28 +7,8 @@ RSpec.describe 'Medication stock sources' do
 
   let(:admin) { users(:admin) }
   let(:person) { household_person(people(:jane)) }
+  let(:source_medication) { household_medication(medications(:ibuprofen)) }
   let(:school_location) { household_location(locations(:school)) }
-  let(:source_medication) do
-    create(
-      :medication,
-      household: person.household,
-      location: household_location(locations(:home)),
-      name: 'Stock source ibuprofen',
-      dose_amount: 400,
-      dose_unit: 'mg',
-      current_supply: 30,
-      reorder_threshold: 5
-    )
-  end
-  let(:source_dosage) do
-    create(
-      :dosage,
-      medication: source_medication,
-      amount: source_medication.dose_amount,
-      unit: source_medication.dose_unit,
-      frequency: 'Every 6-8 hours'
-    )
-  end
 
   before do
     sign_in(admin)
@@ -175,7 +155,7 @@ RSpec.describe 'Medication stock sources' do
     Schedule.create!(
       person: person,
       medication: source_medication,
-      dosage: source_dosage,
+      dosage: dosages(:ibuprofen_adult),
       start_date: Time.zone.today,
       end_date: Time.zone.today + 30.days
     )


### PR DESCRIPTION
## Summary
- add idempotent notification events for push delivery dedupe and skip records
- schedule missed-dose push checks after configured dose times
- send private low-stock push notifications from threshold-crossing events
- add a PWA Web Push manual browser test plan

Closes #1285
Closes #1288
Closes #1289

## Tests
- rubocop app/models/notification_event.rb app/models/medication_take.rb app/jobs/missed_dose_notification_job.rb app/jobs/low_stock_notification_job.rb app/jobs/schedule_daily_reminders_job.rb config/initializers/low_stock_notification_subscriber.rb spec/models/medication_take_spec.rb spec/jobs/missed_dose_notification_job_spec.rb spec/jobs/low_stock_notification_job_spec.rb spec/jobs/schedule_daily_reminders_job_spec.rb db/migrate/20260702143000_create_notification_events.rb
- git diff --check
- task test (blocked: Docker socket unavailable at /var/run/docker.sock)
- task rubocop (blocked: Docker socket unavailable at /var/run/docker.sock)