### PR TITLE
feat(medication-takes): define dose source boundary

### DIFF
--- a/app/models/medication_dose_source.rb
+++ b/app/models/medication_dose_source.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MedicationDoseSource
+  TYPES = {
+    Schedule => 'schedule',
+    PersonMedication => 'person_medication'
+  }.freeze
+
+  attr_reader :record
+
+  delegate :person, :medication, :household, to: :record
+  delegate :id, to: :record, prefix: true
+
+  def self.for(take)
+    record = take.schedule || take.person_medication
+    return unless record
+
+    new(record)
+  end
+
+  def initialize(record)
+    @record = record
+    raise ArgumentError, "Unsupported medication dose source: #{record.class.name}" unless type
+  end
+
+  def type
+    TYPES[record.class]
+  end
+end

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -36,24 +36,28 @@ class MedicationTake < ApplicationRecord
   after_commit :publish_low_stock_threshold_reached, on: :create
 
   # Delegate to get the source (schedule or person_medication)
+  def dose_source
+    MedicationDoseSource.for(self)
+  end
+
   def source
-    schedule || person_medication
+    dose_source&.record
   end
 
   def source_type
-    schedule_id.present? ? 'schedule' : 'person_medication'
+    dose_source&.type
   end
 
   def source_record_id
-    schedule_id || person_medication_id
+    dose_source&.record_id
   end
 
   def person
-    schedule&.person || person_medication&.person
+    dose_source&.person
   end
 
   def medication
-    schedule&.medication || person_medication&.medication
+    dose_source&.medication
   end
 
   def inventory_medication

--- a/db/migrate/20260702154500_add_medication_take_source_check_constraint.rb
+++ b/db/migrate/20260702154500_add_medication_take_source_check_constraint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddMedicationTakeSourceCheckConstraint < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :medication_takes,
+                         'num_nonnulls(schedule_id, person_medication_id) = 1',
+                         name: 'chk_medication_takes_exactly_one_source'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_154500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -359,6 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_120000) do
     t.bigint "taken_from_location_id"
     t.bigint "taken_from_medication_id"
     t.datetime "updated_at", null: false
+    t.check_constraint "num_nonnulls(schedule_id, person_medication_id) = 1", name: "chk_medication_takes_exactly_one_source"
     t.index ["client_uuid"], name: "index_medication_takes_on_client_uuid", unique: true, where: "(client_uuid IS NOT NULL)"
     t.index ["household_id"], name: "index_medication_takes_on_household_id"
     t.index ["id", "household_id"], name: "index_medication_takes_on_id_and_household_id", unique: true

--- a/docs/adrs/0006-medication-take-aggregate-source-boundary.md
+++ b/docs/adrs/0006-medication-take-aggregate-source-boundary.md
@@ -1,0 +1,55 @@
+# ADR 0006: MedicationTake Aggregate Source Boundary
+
+- Status: Accepted
+- Date: 2026-07-02
+
+## Context
+
+`MedicationTake` records a dose administered from either a scheduled plan or an ad hoc person-medication assignment. The table historically represented that with two optional foreign keys, `schedule_id` and `person_medication_id`, plus a Rails validation requiring exactly one of them.
+
+That validation expressed the domain invariant, but it left the database unable to reject invalid rows written outside model validations. It also spread source discriminator logic across helpers, policies, serializers, and reporting code.
+
+## Decision
+
+Keep `MedicationTake` as the single dose administration record and make the source boundary explicit in two places:
+
+- Add a PostgreSQL check constraint requiring exactly one of `schedule_id` or `person_medication_id`.
+- Introduce `MedicationDoseSource` as the value object used by `MedicationTake#dose_source`, `#source`, `#source_type`, `#source_record_id`, `#person`, and `#medication`.
+
+The aggregate ownership remains:
+
+- `Schedule` owns scheduled dose records.
+- `PersonMedication` owns ad hoc dose records.
+
+## Rationale
+
+### Why keep one table
+
+Dose records share auditing, stock mutation, offline sync, reporting, authorization, and notification behavior. Splitting into `ScheduledDose` and `AdHocDose` would duplicate that surface or introduce a new query abstraction across most medication history paths.
+
+### Why not polymorphic `sourceable`
+
+A polymorphic association would make the discriminator explicit, but Rails cannot create normal foreign keys for polymorphic targets. This application relies heavily on household-scoped composite foreign keys, so losing concrete references would weaken tenant integrity.
+
+### Why a value object plus constraint
+
+The check constraint enforces the invariant for every writer. The value object gives application code a single source boundary without changing existing foreign keys, policies, or reporting queries.
+
+## Consequences
+
+### Positive
+
+- Invalid dual-source or missing-source rows are rejected by PostgreSQL.
+- Domain code can depend on one explicit source object.
+- Existing reporting and API queries keep their concrete joins.
+- Household composite foreign keys remain intact.
+
+### Negative
+
+- Callers still need two concrete joins when querying across both source tables.
+- The application still carries two nullable foreign keys, but the nullability is now constrained as a pair.
+
+## Follow-up
+
+- Prefer `MedicationTake#dose_source` for new domain logic.
+- Revisit a table split only if scheduled and ad hoc doses develop materially different lifecycle behavior.

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -80,6 +80,34 @@ RSpec.describe MedicationTake do
     end
   end
 
+  describe '#dose_source' do
+    it 'wraps scheduled doses in an explicit source value object' do
+      source = described_class.new(schedule: schedule).dose_source
+
+      expect(source).to have_attributes(
+        type: 'schedule',
+        record: schedule,
+        record_id: schedule.id,
+        person: schedule.person,
+        medication: schedule.medication,
+        household: schedule.household
+      )
+    end
+
+    it 'wraps ad hoc doses in an explicit source value object' do
+      source = described_class.new(person_medication: person_medication).dose_source
+
+      expect(source).to have_attributes(
+        type: 'person_medication',
+        record: person_medication,
+        record_id: person_medication.id,
+        person: person_medication.person,
+        medication: person_medication.medication,
+        household: person_medication.household
+      )
+    end
+  end
+
   describe 'household assignment' do
     it 'falls back to the person medication household when a present schedule has none' do
       household = Household.create!(name: 'Medication Take Source Household')
@@ -89,6 +117,18 @@ RSpec.describe MedicationTake do
       )
 
       expect(take.send(:source_household)).to eq(household)
+    end
+  end
+
+  describe 'database constraints' do
+    it 'enforces exactly one aggregate source below model validations' do
+      constraint = ActiveRecord::Base.connection.check_constraints(:medication_takes).find do |check|
+        check.name == 'chk_medication_takes_exactly_one_source'
+      end
+
+      expect(constraint&.expression).to include('num_nonnulls')
+      expect(constraint&.expression).to include('schedule_id')
+      expect(constraint&.expression).to include('person_medication_id')
     end
   end
 


### PR DESCRIPTION
## Summary
- Add MedicationDoseSource to centralize the scheduled/ad-hoc source discriminator
- Add a PostgreSQL check constraint requiring exactly one medication take aggregate source
- Document the chosen aggregate boundary in ADR 0006

Closes #1032

## Tests
- ruby -c app/models/medication_take.rb
- ruby -c app/models/medication_dose_source.rb
- ruby -c db/migrate/20260702154500_add_medication_take_source_check_constraint.rb
- ruby -c spec/models/medication_take_spec.rb
- rubocop app/models/medication_take.rb app/models/medication_dose_source.rb db/migrate/20260702154500_add_medication_take_source_check_constraint.rb spec/models/medication_take_spec.rb
- git diff --check

Docker-backed local checks blocked: task test TEST_FILE=spec/models/medication_take_spec.rb and task rubocop both fail because /var/run/docker.sock is unavailable in this session.