### PR TITLE
feat(notifications): deliver native push notifications

### DIFF
--- a/app/services/native_push/apns_client.rb
+++ b/app/services/native_push/apns_client.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'jwt'
+
+module NativePush
+  class ApnsClient
+    class << self
+      def configured?
+        bundle_id.present? && team_id.present? && key_id.present? && private_key.present?
+      end
+
+      def bundle_id
+        ENV['APNS_BUNDLE_ID'].presence || Rails.application.credentials.dig(:apns, :bundle_id)
+      end
+
+      def team_id
+        ENV['APNS_TEAM_ID'].presence || Rails.application.credentials.dig(:apns, :team_id)
+      end
+
+      def key_id
+        ENV['APNS_KEY_ID'].presence || Rails.application.credentials.dig(:apns, :key_id)
+      end
+
+      def private_key
+        key = ENV['APNS_PRIVATE_KEY'].presence || Rails.application.credentials.dig(:apns, :private_key)
+        key&.gsub('\n', "\n")
+      end
+    end
+
+    def initialize(connection: nil)
+      @connection = connection || Faraday.new(url: apns_host)
+    end
+
+    def deliver(token, title:, body:, path: '/')
+      response = connection.post(device_path(token), payload(title: title, body: body, path: path).to_json, headers)
+      result_for(response)
+    rescue StandardError => e
+      DeliveryResult.failed(provider_status: nil, provider_error: e.class.name)
+    end
+
+    private
+
+    attr_reader :connection
+
+    def device_path(token)
+      "/3/device/#{token.device_token}"
+    end
+
+    def headers
+      {
+        'authorization' => "bearer #{authentication_token}",
+        'apns-topic' => self.class.bundle_id,
+        'apns-push-type' => 'alert',
+        'apns-priority' => '10',
+        'content-type' => 'application/json'
+      }
+    end
+
+    def apns_host
+      ENV['APNS_HOST'].presence || Rails.application.credentials.dig(:apns, :host) || default_apns_host
+    end
+
+    def default_apns_host
+      sandbox = ActiveModel::Type::Boolean.new.cast(
+        ENV.fetch('APNS_SANDBOX', Rails.application.credentials.dig(:apns, :sandbox))
+      )
+      sandbox ? 'https://api.sandbox.push.apple.com' : 'https://api.push.apple.com'
+    end
+
+    def authentication_token
+      JWT.encode(
+        { iss: self.class.team_id, iat: Time.current.to_i },
+        OpenSSL::PKey::EC.new(self.class.private_key),
+        'ES256',
+        kid: self.class.key_id
+      )
+    end
+
+    def payload(title:, body:, path:)
+      {
+        aps: {
+          alert: {
+            title: title,
+            body: body
+          },
+          sound: 'default'
+        },
+        path: path
+      }
+    end
+
+    def result_for(response)
+      return DeliveryResult.delivered(provider_status: response.status) if response.status == 200
+      return DeliveryResult.unregistered(provider_status: response.status, provider_error: error_reason(response)) if
+        response.status == 410 || error_reason(response) == 'BadDeviceToken'
+
+      DeliveryResult.failed(provider_status: response.status, provider_error: error_reason(response))
+    end
+
+    def error_reason(response)
+      JSON.parse(response.body.to_s).fetch('reason', nil)
+    rescue JSON::ParserError
+      nil
+    end
+  end
+end

--- a/app/services/native_push/delivery_result.rb
+++ b/app/services/native_push/delivery_result.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module NativePush
+  DeliveryResult = Data.define(:status, :provider_status, :provider_error) do
+    def self.delivered(provider_status: 200)
+      new(status: :delivered, provider_status: provider_status, provider_error: nil)
+    end
+
+    def self.skipped(provider_error:)
+      new(status: :skipped, provider_status: nil, provider_error: provider_error)
+    end
+
+    def self.failed(provider_status:, provider_error:)
+      new(status: :failed, provider_status: provider_status, provider_error: provider_error)
+    end
+
+    def self.unregistered(provider_status: nil, provider_error: nil)
+      new(status: :unregistered, provider_status: provider_status, provider_error: provider_error)
+    end
+
+    def unregistered?
+      status == :unregistered
+    end
+  end
+end

--- a/app/services/native_push/fcm_client.rb
+++ b/app/services/native_push/fcm_client.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module NativePush
+  class FcmClient
+    UNREGISTERED_ERROR_CODES = %w[UNREGISTERED INVALID_ARGUMENT].freeze
+
+    class << self
+      def configured?
+        project_id.present? && bearer_token.present?
+      end
+
+      def project_id
+        ENV['FCM_PROJECT_ID'].presence || Rails.application.credentials.dig(:fcm, :project_id)
+      end
+
+      def bearer_token
+        ENV['FCM_BEARER_TOKEN'].presence || Rails.application.credentials.dig(:fcm, :bearer_token)
+      end
+    end
+
+    def initialize(connection: nil)
+      @connection = connection || Faraday.new(url: 'https://fcm.googleapis.com')
+    end
+
+    def deliver(token, title:, body:, path: '/')
+      response = connection.post(messages_path, payload(token: token, title: title, body: body, path: path).to_json,
+                                 headers)
+      result_for(response)
+    rescue StandardError => e
+      DeliveryResult.failed(provider_status: nil, provider_error: e.class.name)
+    end
+
+    private
+
+    attr_reader :connection
+
+    def messages_path
+      "/v1/projects/#{self.class.project_id}/messages:send"
+    end
+
+    def headers
+      {
+        'authorization' => "Bearer #{self.class.bearer_token}",
+        'content-type' => 'application/json'
+      }
+    end
+
+    def payload(token:, title:, body:, path:)
+      {
+        message: {
+          token: token.device_token,
+          notification: {
+            title: title,
+            body: body
+          },
+          data: {
+            path: path
+          }
+        }
+      }
+    end
+
+    def result_for(response)
+      return DeliveryResult.delivered(provider_status: response.status) if response.status == 200
+
+      error_code = fcm_error_code(response)
+      return DeliveryResult.unregistered(provider_status: response.status, provider_error: error_code) if
+        UNREGISTERED_ERROR_CODES.include?(error_code)
+
+      DeliveryResult.failed(provider_status: response.status, provider_error: error_code)
+    end
+
+    def fcm_error_code(response)
+      body = JSON.parse(response.body.to_s)
+      details = Array(body.dig('error', 'details'))
+      fcm_detail = details.find { |detail| detail['@type'].to_s.include?('google.firebase.fcm.v1.FcmError') }
+      fcm_detail&.fetch('errorCode', nil) || body.dig('error', 'status')
+    rescue JSON::ParserError
+      nil
+    end
+  end
+end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -16,18 +16,45 @@ class PushNotificationService
   end
   private_class_method :send_web_push_to_account
 
-  def self.send_native_push_to_account(account, path: '/', **_notification_content)
+  def self.send_native_push_to_account(account, title:, body:, path: '/')
     tokens = account.native_device_tokens
     return if tokens.none?
 
     tokens.each do |token|
-      Rails.logger.info(
-        "[PushNotificationService] Native push queued: platform=#{token.platform} " \
-        "token_id=#{token.id} path=#{path.inspect}"
-      )
+      deliver_native(token, title: title, body: body, path: path)
     end
   end
   private_class_method :send_native_push_to_account
+
+  def self.deliver_native(token, title:, body:, path:)
+    result = native_client_for(token)&.deliver(token, title: title, body: body, path: path)
+    return log_native_skip(token) unless result
+    return token.destroy if result.unregistered?
+    return if result.status == :delivered
+
+    Rails.logger.error(
+      "[PushNotificationService] Native push failed: platform=#{token.platform} " \
+      "token_id=#{token.id} status=#{result.provider_status.inspect} error=#{result.provider_error.inspect}"
+    )
+  end
+  private_class_method :deliver_native
+
+  def self.native_client_for(token)
+    case token.platform
+    when 'ios'
+      NativePush::ApnsClient.new if NativePush::ApnsClient.configured?
+    when 'android'
+      NativePush::FcmClient.new if NativePush::FcmClient.configured?
+    end
+  end
+  private_class_method :native_client_for
+
+  def self.log_native_skip(token)
+    Rails.logger.info(
+      "[PushNotificationService] Native push skipped: platform=#{token.platform} token_id=#{token.id}"
+    )
+  end
+  private_class_method :log_native_skip
 
   def self.build_vapid_config
     subject = ENV.fetch('VAPID_SUBJECT',

--- a/spec/services/push_notification_service_spec.rb
+++ b/spec/services/push_notification_service_spec.rb
@@ -68,18 +68,56 @@ RSpec.describe PushNotificationService do
       described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin at 07:15')
 
       expect(Rails.logger).to have_received(:info) do |message|
-        expect(message).to include('Native push queued')
+        expect(message).to include('Native push skipped')
         expect(message).not_to include('Medication Reminder')
         expect(message).not_to include('Take aspirin')
       end
     end
+
+    it 'delivers native notifications through the platform adapters' do
+      ios = create_native_device_token(platform: 'ios', device_token: 'ios-token')
+      android = create_native_device_token(platform: 'android', device_token: 'android-token')
+      allow(WebPush).to receive(:payload_send)
+      apns_client = stub_native_client(NativePush::ApnsClient)
+      fcm_client = stub_native_client(NativePush::FcmClient)
+
+      described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin', path: '/today')
+
+      expect_native_delivery(apns_client, ios)
+      expect_native_delivery(fcm_client, android)
+    end
+
+    it 'removes native device tokens rejected by providers as unregistered' do
+      token = create_native_device_token(platform: 'ios', device_token: 'stale-ios-token')
+      allow(WebPush).to receive(:payload_send)
+      stub_native_client(NativePush::ApnsClient, result: NativePush::DeliveryResult.unregistered)
+
+      expect do
+        described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin')
+      end.to change { NativeDeviceToken.exists?(token.id) }.from(true).to(false)
+    end
   end
 
-  def create_native_device_token
+  def create_native_device_token(platform: 'ios', device_token: 'native-token-for-privacy-test')
     NativeDeviceToken.create!(
       account: account,
-      platform: 'ios',
-      device_token: 'native-token-for-privacy-test'
+      platform: platform,
+      device_token: device_token
+    )
+  end
+
+  def stub_native_client(client_class, result: NativePush::DeliveryResult.delivered)
+    client = instance_double(client_class, deliver: result)
+    allow(client_class).to receive_messages(configured?: true, new: client)
+    client
+  end
+
+  def expect_native_delivery(client, token)
+    expect(client).to have_received(:deliver).with(
+      token,
+      title: 'Medication Reminder',
+      body: 'Take aspirin',
+      path: '/today'
     )
   end
 end


### PR DESCRIPTION
## Summary
- Add APNs and FCM native push delivery clients behind PushNotificationService
- Route iOS and Android native device tokens through platform adapters
- Remove native device tokens when providers report them unregistered, while keeping logs free of notification content

Closes #1020

## Tests
- ruby -c app/services/push_notification_service.rb
- ruby -c app/services/native_push/delivery_result.rb
- ruby -c app/services/native_push/apns_client.rb
- ruby -c app/services/native_push/fcm_client.rb
- ruby -c spec/services/push_notification_service_spec.rb
- rubocop app/services/push_notification_service.rb app/services/native_push/delivery_result.rb app/services/native_push/apns_client.rb app/services/native_push/fcm_client.rb spec/services/push_notification_service_spec.rb
- git diff --check

Docker-backed local checks blocked: task test TEST_FILE=spec/services/push_notification_service_spec.rb and task rubocop both fail because /var/run/docker.sock is unavailable in this session.

Docs referenced: Apple APNs provider API and Firebase Cloud Messaging HTTP v1 API via Context7.