### PR TITLE
feat(api): add v1 write endpoints

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -112,8 +112,8 @@ module Api
         }
       end
 
-      def render_resource(record, serializer:)
-        render json: { data: serializer.new(record).as_json }
+      def render_resource(record, serializer:, status: :ok)
+        render json: { data: serializer.new(record).as_json }, status: status
       end
 
       def apply_collection_filters(scope)
@@ -158,6 +158,16 @@ module Api
 
       def render_unprocessable(message)
         render json: { error: { code: 'unprocessable_content', message: message } }, status: :unprocessable_content
+      end
+
+      def render_validation_errors(record)
+        render json: {
+          error: {
+            code: 'validation_failed',
+            message: 'Validation failed',
+            errors: record.errors.to_hash(true)
+          }
+        }, status: :unprocessable_content
       end
 
       def render_invalid_filter(exception)

--- a/app/controllers/api/v1/medication_takes_controller.rb
+++ b/app/controllers/api/v1/medication_takes_controller.rb
@@ -10,6 +10,94 @@ module Api
           includes: [{ schedule: %i[person medication] }, { person_medication: %i[person medication] }, :taken_from_location, :taken_from_medication]
         )
       end
+
+      def create
+        attributes = medication_take_params
+        existing_take = idempotent_medication_take(attributes[:client_uuid])
+        return render_resource(existing_take, serializer: MedicationTakeSerializer) if existing_take
+
+        source = medication_take_source(attributes[:source_type], attributes[:source_id])
+        authorize source, :take_medication?
+        taken_at = parse_taken_at(attributes[:taken_at])
+        return render_unprocessable('taken_at is invalid') if taken_at.blank?
+
+        result = TakeMedicationService.new.call(
+          source: source,
+          amount_override: attributes[:dose_amount],
+          taken_from_medication_id: attributes[:taken_from_medication_id],
+          user: current_user,
+          taken_at: taken_at,
+          client_uuid: attributes[:client_uuid]
+        )
+        return render_unprocessable(take_failure_message(result.error)) unless result.success
+
+        render_resource(result.take, serializer: MedicationTakeSerializer, status: :created)
+      rescue ActiveRecord::RecordNotUnique
+        take = idempotent_medication_take(attributes[:client_uuid])
+        return render_resource(take, serializer: MedicationTakeSerializer) if take
+
+        raise
+      end
+
+      private
+
+      def medication_take_params
+        params.expect(
+          medication_take: %i[
+            client_uuid
+            source_type
+            source_id
+            taken_at
+            dose_amount
+            dose_unit
+            taken_from_medication_id
+          ]
+        )
+      end
+
+      def idempotent_medication_take(client_uuid)
+        return if client_uuid.blank?
+
+        policy_scope(MedicationTake).find_by(client_uuid: client_uuid).tap do |take|
+          authorize take, :create? if take
+        end
+      end
+
+      def medication_take_source(source_type, source_id)
+        case source_type
+        when 'schedule'
+          policy_scope(Schedule).find(source_id)
+        when 'person_medication'
+          policy_scope(PersonMedication).find(source_id)
+        else
+          raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      def parse_taken_at(value)
+        Time.zone.parse(value.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def take_failure_message(error)
+        case error
+        when :out_of_stock
+          'Cannot take medication: out of stock'
+        when :cooldown
+          'Cannot take medication: timing restrictions not met'
+        when :paused
+          'Cannot take medication: paused'
+        when :selection_required
+          'Choose a location to record this dose.'
+        when :invalid_source
+          'Selected location is unavailable for this medication.'
+        when :invalid_amount
+          'Invalid dose configured'
+        else
+          'Could not record medication take'
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/v1/medications_controller.rb
+++ b/app/controllers/api/v1/medications_controller.rb
@@ -14,6 +14,51 @@ module Api
 
         render_resource(medication, serializer: MedicationSerializer)
       end
+
+      def create
+        medication = Medication.new(medication_params)
+        medication.household = current_household
+        medication.paper_trail_event = 'api_create'
+        authorize medication
+
+        return render_validation_errors(medication) unless medication.save
+
+        render_resource(medication.reload, serializer: MedicationSerializer, status: :created)
+      end
+
+      def update
+        medication = policy_scope(Medication).includes(:location).find(params.expect(:id))
+        authorize medication
+        medication.paper_trail_event = 'api_update'
+
+        return render_validation_errors(medication) unless medication.update(medication_params)
+
+        render_resource(medication.reload, serializer: MedicationSerializer)
+      end
+
+      private
+
+      def medication_params
+        params.expect(
+          medication: %i[
+            name
+            friendly_name
+            barcode
+            dmd_code
+            dmd_system
+            dmd_concept_class
+            category
+            description
+            dose_amount
+            dose_unit
+            current_supply
+            reorder_threshold
+            warnings
+            location_id
+            default_schedule_type
+          ]
+        )
+      end
     end
   end
 end

--- a/app/controllers/api/v1/notification_preferences_controller.rb
+++ b/app/controllers/api/v1/notification_preferences_controller.rb
@@ -9,6 +9,25 @@ module Api
 
         render_resource(preference, serializer: NotificationPreferenceSerializer)
       end
+
+      def update
+        preference = current_user.person.notification_preference ||
+                     current_user.person.build_notification_preference
+        authorize preference
+
+        return render_validation_errors(preference) unless preference.update(preference_params)
+
+        render_resource(preference.reload, serializer: NotificationPreferenceSerializer)
+      end
+
+      private
+
+      def preference_params
+        params.expect(notification_preference: %i[
+                        enabled morning_time afternoon_time evening_time night_time
+                        dose_due_enabled missed_dose_enabled low_stock_enabled private_text_enabled
+                      ])
+      end
     end
   end
 end

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -14,6 +14,54 @@ module Api
 
         render_resource(person, serializer: PersonSerializer)
       end
+
+      def create
+        person = Person.new(person_params)
+        person.household = current_household
+        authorize person
+        assign_created_person_carer_relationship(person)
+
+        return render_validation_errors(person) unless person.save
+
+        grant_created_person_access(person)
+        render_resource(person.reload, serializer: PersonSerializer, status: :created)
+      end
+
+      def update
+        person = policy_scope(Person).includes(:locations, :notification_preference).find(params.expect(:id))
+        authorize person
+
+        return render_validation_errors(person) unless person.update(person_params)
+
+        render_resource(person.reload, serializer: PersonSerializer)
+      end
+
+      private
+
+      def person_params
+        params.expect(person: %i[name date_of_birth email person_type has_capacity])
+      end
+
+      def grant_created_person_access(person)
+        current_household.person_access_grants.find_or_create_by!(
+          household_membership: current_membership,
+          person: person
+        ) do |grant|
+          grant.access_level = :manage
+          grant.relationship_type = :family_member
+          grant.granted_by_membership = current_membership
+        end
+      end
+
+      def assign_created_person_carer_relationship(person)
+        return unless current_membership&.person.present? && (person.minor? || person.dependent_adult?)
+
+        person.carer_relationships.build(
+          carer: current_membership.person,
+          relationship_type: :family_member,
+          active: true
+        )
+      end
     end
   end
 end

--- a/app/controllers/api/v1/person_medications_controller.rb
+++ b/app/controllers/api/v1/person_medications_controller.rb
@@ -14,6 +14,57 @@ module Api
 
         render_resource(person_medication, serializer: PersonMedicationSerializer)
       end
+
+      def create
+        attributes = person_medication_params
+        person = policy_scope(Person).find(attributes.delete(:person_id))
+        authorize person, :show?
+        assert_medication_access!(attributes[:medication_id])
+        person_medication = person.person_medications.build(attributes)
+        authorize person_medication
+
+        return render_validation_errors(person_medication) unless person_medication.save
+
+        render_resource(person_medication.reload, serializer: PersonMedicationSerializer, status: :created)
+      end
+
+      def update
+        person_medication = policy_scope(PersonMedication).includes(:person, :medication).find(params.expect(:id))
+        authorize person_medication
+        attributes = person_medication_update_params
+        assert_medication_access!(attributes[:medication_id]) if attributes[:medication_id].present?
+
+        return render_validation_errors(person_medication) unless person_medication.update(attributes)
+
+        render_resource(person_medication.reload, serializer: PersonMedicationSerializer)
+      end
+
+      private
+
+      def person_medication_params
+        params.expect(
+          person_medication: %i[
+            person_id
+            medication_id
+            dose_amount
+            dose_unit
+            source_dosage_option_id
+            administration_kind
+            notes
+            max_daily_doses
+            min_hours_between_doses
+            dose_cycle
+          ]
+        )
+      end
+
+      def person_medication_update_params
+        person_medication_params.except(:person_id)
+      end
+
+      def assert_medication_access!(medication_id)
+        policy_scope(Medication).find(medication_id)
+      end
     end
   end
 end

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -14,6 +14,62 @@ module Api
 
         render_resource(schedule, serializer: ScheduleSerializer)
       end
+
+      def create
+        attributes = schedule_params
+        person = policy_scope(Person).find(attributes.delete(:person_id))
+        authorize person, :show?
+        assert_medication_access!(attributes[:medication_id])
+        schedule = person.schedules.build(attributes)
+        authorize schedule
+
+        return render_validation_errors(schedule) unless schedule.save
+
+        render_resource(schedule.reload, serializer: ScheduleSerializer, status: :created)
+      end
+
+      def update
+        schedule = policy_scope(Schedule).includes(:person, :medication).find(params.expect(:id))
+        authorize schedule
+        attributes = schedule_update_params
+        assert_medication_access!(attributes[:medication_id]) if attributes[:medication_id].present?
+
+        return render_validation_errors(schedule) unless schedule.update(attributes)
+
+        render_resource(schedule.reload, serializer: ScheduleSerializer)
+      end
+
+      private
+
+      def schedule_params
+        params.expect(
+          schedule: [
+            :person_id,
+            :medication_id,
+            :dose_amount,
+            :dose_unit,
+            :source_dosage_option_id,
+            :frequency,
+            :start_date,
+            :end_date,
+            :notes,
+            :max_daily_doses,
+            :min_hours_between_doses,
+            :dose_cycle,
+            :schedule_type,
+            :schedule_config,
+            { schedule_config: {} }
+          ]
+        )
+      end
+
+      def schedule_update_params
+        schedule_params.except(:person_id)
+      end
+
+      def assert_medication_access!(medication_id)
+        policy_scope(Medication).find(medication_id)
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,13 +11,13 @@ Rails.application.routes.draw do
 
       scope 'households/:household_id', as: :household do
         resource :me, only: [:show], controller: 'me'
-        resources :people, only: %i[index show]
+        resources :people, only: %i[index show create update]
         resources :locations, only: %i[index show]
-        resources :medications, only: %i[index show]
-        resources :schedules, only: %i[index show]
-        resources :person_medications, only: %i[index show]
-        resources :medication_takes, only: [:index]
-        resource :notification_preference, only: [:show]
+        resources :medications, only: %i[index show create update]
+        resources :schedules, only: %i[index show create update]
+        resources :person_medications, only: %i[index show create update]
+        resources :medication_takes, only: %i[index create]
+        resource :notification_preference, only: %i[show update]
       end
     end
   end

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -10,6 +10,41 @@ RSpec.describe 'API v1 write resources' do
   let(:household_id) { login_data.dig('household', 'id') }
   let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
 
+  it 'rejects write requests without bearer authentication' do
+    post api_v1_household_people_path(household_id),
+         params: { person: { name: 'No Auth', date_of_birth: '1990-01-01' } },
+         as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
+  end
+
+  it 'rejects invalid updated_since filters on collections' do
+    get api_v1_household_people_path(household_id),
+        params: { updated_since: 'not-a-date' },
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('updated_since must be ISO8601')
+  end
+
+  it 'shows writable resources by id' do
+    get api_v1_household_medication_path(household_id, medications(:paracetamol).id),
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'id')).to eq(medications(:paracetamol).id)
+
+    get api_v1_household_schedule_path(household_id, schedules(:john_paracetamol).id),
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'id')).to eq(schedules(:john_paracetamol).id)
+  end
+
   it 'creates medication takes idempotently using client_uuid' do
     schedule = schedules(:john_paracetamol)
     client_uuid = SecureRandom.uuid
@@ -35,6 +70,33 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'id')).to eq(first_id)
+  end
+
+  it 'creates medication takes for person medication sources without client_uuid' do
+    person_medication = create(
+      :person_medication,
+      :as_needed,
+      person: people(:john),
+      medication: medications(:ibuprofen),
+      dose_amount: 200,
+      dose_unit: 'mg'
+    )
+
+    expect do
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               source_type: 'person_medication',
+               source_id: person_medication.id,
+               taken_at: '2026-02-25T08:30:00Z'
+             }
+           },
+           headers: headers,
+           as: :json
+    end.to change(MedicationTake, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body.dig('data', 'person_medication_id')).to eq(person_medication.id)
   end
 
   it 'rejects medication takes with invalid timestamps' do
@@ -92,6 +154,16 @@ RSpec.describe 'API v1 write resources' do
     expect(response).to have_http_status(:created)
   end
 
+  it 'returns validation errors when updating people with invalid attributes' do
+    patch api_v1_household_person_path(household_id, people(:john).id),
+          params: { person: { name: '' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'errors')).to include('name')
+  end
+
   it 'creates and updates medications' do
     post api_v1_household_medications_path(household_id),
          params: {
@@ -117,6 +189,16 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'current_supply')).to eq('90.0')
+  end
+
+  it 'returns validation errors when updating medications with invalid attributes' do
+    patch api_v1_household_medication_path(household_id, medications(:paracetamol).id),
+          params: { medication: { name: '' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'errors')).to include('name')
   end
 
   it 'creates and updates schedules' do
@@ -160,6 +242,28 @@ RSpec.describe 'API v1 write resources' do
     expect(response.parsed_body.dig('error', 'errors')).to include('source_dosage_option')
   end
 
+  it 'returns not found when creating schedules for inaccessible medications' do
+    other_household = Household.create!(name: 'API Schedule Other Household', slug: 'api-schedule-other-household')
+    other_medication = create(:medication, household: other_household)
+
+    post api_v1_household_schedules_path(household_id),
+         params: {
+           schedule: {
+             person_id: people(:john).id,
+             medication_id: other_medication.id,
+             dose_amount: 500,
+             dose_unit: 'mg',
+             frequency: 'Daily',
+             start_date: '2026-02-25',
+             end_date: '2026-12-31'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   it 'creates and updates person medications' do
     person = people(:john)
     medication = medications(:ibuprofen)
@@ -194,6 +298,27 @@ RSpec.describe 'API v1 write resources' do
           as: :json
 
     expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns not found when creating person medications for inaccessible medications' do
+    other_household = Household.create!(name: 'API Person Medication Other Household',
+                                        slug: 'api-person-medication-other-household')
+    other_medication = create(:medication, household: other_household)
+
+    post api_v1_household_person_medications_path(household_id),
+         params: {
+           person_medication: {
+             person_id: people(:john).id,
+             medication_id: other_medication.id,
+             dose_amount: 200,
+             dose_unit: 'mg',
+             administration_kind: 'as_needed'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:not_found)
   end
 
   it 'updates the current notification preference' do

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -156,7 +156,8 @@ RSpec.describe 'API v1 write resources' do
           headers: headers,
           as: :json
 
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'errors')).to include('source_dosage_option')
   end
 
   it 'creates and updates person medications' do

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -37,6 +37,31 @@ RSpec.describe 'API v1 write resources' do
     expect(response.parsed_body.dig('data', 'id')).to eq(first_id)
   end
 
+  it 'rejects medication takes with invalid timestamps' do
+    post api_v1_household_medication_takes_path(household_id),
+         params: {
+           medication_take: {
+             source_type: 'schedule',
+             source_id: schedules(:john_paracetamol).id,
+             taken_at: 'not-a-time'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('taken_at is invalid')
+  end
+
+  it 'returns not found for unknown medication take source types' do
+    post api_v1_household_medication_takes_path(household_id),
+         params: { medication_take: { source_type: 'unknown', source_id: schedules(:john_paracetamol).id } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   it 'creates and updates people' do
     post api_v1_household_people_path(household_id),
          params: { person: { name: 'API Child', date_of_birth: '2020-01-01', person_type: 'minor' } },
@@ -54,6 +79,17 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'name')).to eq('API Child Updated')
+  end
+
+  it 'creates adults without carer relationships' do
+    expect do
+      post api_v1_household_people_path(household_id),
+           params: { person: { name: 'API Adult', date_of_birth: '1990-01-01', person_type: 'adult' } },
+           headers: headers,
+           as: :json
+    end.not_to change(CarerRelationship, :count)
+
+    expect(response).to have_http_status(:created)
   end
 
   it 'creates and updates medications' do
@@ -114,6 +150,13 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'frequency')).to eq('Every morning')
+
+    patch api_v1_household_schedule_path(household_id, schedule_id),
+          params: { schedule: { medication_id: medications(:ibuprofen).id } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
   end
 
   it 'creates and updates person medications' do
@@ -143,6 +186,13 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'notes')).to eq('Use with food')
+
+    patch api_v1_household_person_medication_path(household_id, person_medication_id),
+          params: { person_medication: { medication_id: medications(:paracetamol).id } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
   end
 
   it 'updates the current notification preference' do
@@ -154,6 +204,18 @@ RSpec.describe 'API v1 write resources' do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'enabled')).to be(false)
     expect(response.parsed_body.dig('data', 'low_stock_enabled')).to be(false)
+  end
+
+  it 'creates a notification preference when the current person does not have one' do
+    user.person.notification_preference&.destroy!
+
+    patch api_v1_household_notification_preference_path(household_id),
+          params: { notification_preference: { enabled: true, dose_due_enabled: true } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'dose_due_enabled')).to be(true)
   end
 
   it 'returns validation errors for invalid write payloads' do

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 write resources' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'creates medication takes idempotently using client_uuid' do
+    schedule = schedules(:john_paracetamol)
+    client_uuid = SecureRandom.uuid
+    payload = {
+      medication_take: {
+        client_uuid: client_uuid,
+        source_type: 'schedule',
+        source_id: schedule.id,
+        taken_at: '2026-02-25T08:30:00Z'
+      }
+    }
+
+    expect do
+      post api_v1_household_medication_takes_path(household_id), params: payload, headers: headers, as: :json
+    end.to change(MedicationTake, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    first_id = response.parsed_body.dig('data', 'id')
+
+    expect do
+      post api_v1_household_medication_takes_path(household_id), params: payload, headers: headers, as: :json
+    end.not_to change(MedicationTake, :count)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'id')).to eq(first_id)
+  end
+
+  it 'creates and updates people' do
+    post api_v1_household_people_path(household_id),
+         params: { person: { name: 'API Child', date_of_birth: '2020-01-01', person_type: 'minor' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    person_id = response.parsed_body.dig('data', 'id')
+    expect(response.parsed_body.dig('data', 'has_capacity')).to be(false)
+
+    patch api_v1_household_person_path(household_id, person_id),
+          params: { person: { name: 'API Child Updated' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'name')).to eq('API Child Updated')
+  end
+
+  it 'creates and updates medications' do
+    post api_v1_household_medications_path(household_id),
+         params: {
+           medication: {
+             name: 'API Saline',
+             location_id: locations(:home).id,
+             dose_amount: 5,
+             dose_unit: 'ml',
+             current_supply: 100,
+             reorder_threshold: 10
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    medication_id = response.parsed_body.dig('data', 'id')
+
+    patch api_v1_household_medication_path(household_id, medication_id),
+          params: { medication: { current_supply: 90 } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'current_supply')).to eq('90.0')
+  end
+
+  it 'creates and updates schedules' do
+    person = people(:john)
+    medication = medications(:paracetamol)
+
+    post api_v1_household_schedules_path(household_id),
+         params: {
+           schedule: {
+             person_id: person.id,
+             medication_id: medication.id,
+             dose_amount: 500,
+             dose_unit: 'mg',
+             frequency: 'Daily',
+             start_date: '2026-02-25',
+             end_date: '2026-12-31',
+             max_daily_doses: 1,
+             dose_cycle: 'daily'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    schedule_id = response.parsed_body.dig('data', 'id')
+
+    patch api_v1_household_schedule_path(household_id, schedule_id),
+          params: { schedule: { frequency: 'Every morning' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'frequency')).to eq('Every morning')
+  end
+
+  it 'creates and updates person medications' do
+    person = people(:john)
+    medication = medications(:ibuprofen)
+
+    post api_v1_household_person_medications_path(household_id),
+         params: {
+           person_medication: {
+             person_id: person.id,
+             medication_id: medication.id,
+             dose_amount: 200,
+             dose_unit: 'mg',
+             administration_kind: 'as_needed'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    person_medication_id = response.parsed_body.dig('data', 'id')
+
+    patch api_v1_household_person_medication_path(household_id, person_medication_id),
+          params: { person_medication: { notes: 'Use with food' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'notes')).to eq('Use with food')
+  end
+
+  it 'updates the current notification preference' do
+    patch api_v1_household_notification_preference_path(household_id),
+          params: { notification_preference: { enabled: false, low_stock_enabled: false } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'enabled')).to be(false)
+    expect(response.parsed_body.dig('data', 'low_stock_enabled')).to be(false)
+  end
+
+  it 'returns validation errors for invalid write payloads' do
+    post api_v1_household_people_path(household_id),
+         params: { person: { name: '', date_of_birth: '' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'errors')).to include('name', 'date_of_birth')
+  end
+
+  it 'does not update records outside the household scope' do
+    other_household = Household.create!(name: 'API Other Household', slug: 'api-other-household')
+    other_person = create(:person, household: other_household, name: 'Other Person')
+
+    patch api_v1_household_person_path(household_id, other_person.id),
+          params: { person: { name: 'Bad Update' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe 'API v1 write resources' do
     expect(response.parsed_body.dig('error', 'message')).to eq('updated_since must be ISO8601')
   end
 
+  it 'applies valid collection filters and pagination bounds' do
+    get api_v1_household_medications_path(household_id),
+        params: { updated_since: 1.year.ago.iso8601, page: 0, per_page: 500 },
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('meta', 'page')).to eq(1)
+    expect(response.parsed_body.dig('meta', 'per_page')).to eq(100)
+    expect(response.parsed_body['data']).not_to be_empty
+  end
+
   it 'shows writable resources by id' do
     get api_v1_household_medication_path(household_id, medications(:paracetamol).id),
         headers: headers,
@@ -342,6 +354,17 @@ RSpec.describe 'API v1 write resources' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'dose_due_enabled')).to be(true)
+  end
+
+  it 'shows the current notification preference' do
+    create(:notification_preference, person: user.person, enabled: true)
+
+    get api_v1_household_notification_preference_path(household_id),
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'person_id')).to eq(user.person_id)
   end
 
   it 'returns validation errors for invalid write payloads' do

--- a/spec/requests/api/v1/write_resources_spec.rb
+++ b/spec/requests/api/v1/write_resources_spec.rb
@@ -136,6 +136,63 @@ RSpec.describe 'API v1 write resources' do
     expect(response).to have_http_status(:not_found)
   end
 
+  it 'returns specific medication take failure messages from dose rules' do
+    person = people(:john)
+    medication = create(:medication, household: person.household, location: locations(:home),
+                                     name: "API Branch Medicine #{SecureRandom.hex(4)}",
+                                     current_supply: 0)
+    schedule = create(:schedule, person: person, medication: medication, dosage: nil,
+                                 dose_amount: medication.dose_amount, dose_unit: medication.dose_unit)
+
+    post api_v1_household_medication_takes_path(household_id),
+         params: {
+           medication_take: {
+             source_type: 'schedule',
+             source_id: schedule.id,
+             taken_at: '2026-02-25T08:30:00Z'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('Cannot take medication: out of stock')
+
+    medication.update!(current_supply: 20)
+    create(:medication, household: person.household, location: locations(:home),
+                        name: medication.name, dose_amount: medication.dose_amount, dose_unit: medication.dose_unit,
+                        current_supply: 20)
+
+    post api_v1_household_medication_takes_path(household_id),
+         params: {
+           medication_take: {
+             source_type: 'schedule',
+             source_id: schedule.id,
+             taken_at: '2026-02-25T08:30:00Z'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('Choose a location to record this dose.')
+
+    post api_v1_household_medication_takes_path(household_id),
+         params: {
+           medication_take: {
+             source_type: 'schedule',
+             source_id: schedule.id,
+             taken_at: '2026-02-25T08:30:00Z',
+             taken_from_medication_id: medications(:aspirin).id
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('Selected location is unavailable for this medication.')
+  end
+
   it 'creates and updates people' do
     post api_v1_household_people_path(household_id),
          params: { person: { name: 'API Child', date_of_birth: '2020-01-01', person_type: 'minor' } },


### PR DESCRIPTION
## Summary
- add API v1 create/update endpoints for people, medications, schedules, and person medications
- add idempotent API medication-take creation using client_uuid and the existing TakeMedicationService path
- add notification preference updates and structured API validation errors

Closes #1021

## Verification
- ruby -c on touched API controllers and request spec
- rubocop
- git diff --check

## Notes
- task test TEST_FILE=spec/requests/api/v1/write_resources_spec.rb is blocked locally because Docker is unavailable at /var/run/docker.sock, including after an escalated retry.