### PR TITLE
fix(medications): aggregate overlapping dose limits

### DIFF
--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -10,7 +10,7 @@ module TakeMedicationGuardable
   # Maps a TakeMedicationService error symbol to the appropriate HTTP response.
   def handle_take_medication_failure(error, scope:)
     case error
-    when :out_of_stock, :cooldown, :paused
+    when :out_of_stock, :cooldown, :paused, :overlapping_prescription_restriction
       default_message = take_medication_default_message(error)
       respond_take_medication_error(message: t("#{scope}.cannot_take_medication", default: default_message))
     when :invalid_amount, :create_failed
@@ -24,6 +24,7 @@ module TakeMedicationGuardable
     case error
     when :out_of_stock then 'Cannot take medication: out of stock'
     when :paused then 'Cannot take medication: paused'
+    when :overlapping_prescription_restriction then t('take_medications.overlapping_prescription_restriction')
     else 'Cannot take medication: timing restrictions not met'
     end
   end

--- a/app/controllers/medication_takes_controller.rb
+++ b/app/controllers/medication_takes_controller.rb
@@ -43,6 +43,7 @@ class MedicationTakesController < ApplicationController
     when :out_of_stock   then t('take_medications.out_of_stock', default: 'Cannot take medication: out of stock')
     when :cooldown       then t('take_medications.cooldown', default: 'Cannot take medication: timing restrictions not met')
     when :paused         then t('take_medications.paused', default: 'Cannot take medication: paused')
+    when :overlapping_prescription_restriction then t('take_medications.overlapping_prescription_restriction')
     when :selection_required then t('take_medications.location_required', default: 'Choose a location to record this dose.')
     when :invalid_source then t('take_medications.invalid_location', default: 'Selected location is unavailable for this medication.')
     else                      t('take_medications.failure')

--- a/app/controllers/offline_controller.rb
+++ b/app/controllers/offline_controller.rb
@@ -119,8 +119,8 @@ class OfflineController < ApplicationController
     case error
     when :out_of_stock
       t('take_medications.out_of_stock', default: 'Cannot take medication: out of stock')
-    when :cooldown
-      t('take_medications.cooldown', default: 'Cannot take medication: timing restrictions not met')
+    when :cooldown, :overlapping_prescription_restriction
+      timing_failure_message(error)
     when :paused
       t('take_medications.paused', default: 'Cannot take medication: paused')
     when :selection_required
@@ -132,6 +132,12 @@ class OfflineController < ApplicationController
     else
       t('take_medications.failure')
     end
+  end
+
+  def timing_failure_message(error)
+    return t('take_medications.overlapping_prescription_restriction') if error == :overlapping_prescription_restriction
+
+    t('take_medications.cooldown', default: 'Cannot take medication: timing restrictions not met')
   end
 
   def render_unprocessable(message)

--- a/app/services/medication_dose_decision_context.rb
+++ b/app/services/medication_dose_decision_context.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class MedicationDoseDecisionContext
+  Decision = Data.define(:blocking_source, :source_count)
+
+  def initialize(source:, taken_at:)
+    @source = source
+    @taken_at = taken_at
+  end
+
+  def blocked?
+    decision.blocking_source.present?
+  end
+
+  def blocked_reason
+    :overlapping_prescription_restriction if blocked?
+  end
+
+  def audit_payload
+    {
+      decision_source_count: decision.source_count,
+      decision_blocking_source_type: source_type(decision.blocking_source),
+      decision_blocking_source_id: decision.blocking_source&.id
+    }.compact
+  end
+
+  private
+
+  attr_reader :source, :taken_at
+
+  def decision
+    @decision ||= Decision.new(
+      blocking_source: related_sources.find { |candidate| blocks_take?(candidate) },
+      source_count: related_sources.size
+    )
+  end
+
+  def blocks_take?(candidate)
+    return false unless candidate.restrictions?
+
+    !DoseTimingPolicy.new(
+      takes: related_takes,
+      dose_constraints: candidate.dose_constraints,
+      dose_cycle: candidate.respond_to?(:dose_cycle) ? candidate.dose_cycle : 'daily'
+    ).can_take_at?(taken_at)
+  end
+
+  def related_sources
+    @related_sources ||= (related_schedules + related_person_medications).sort_by do |candidate|
+      [source_sort_order(candidate), candidate.id]
+    end
+  end
+
+  def related_schedules
+    Schedule.where(person_id: person_id, medication_id: medication_id, active: true)
+            .where('start_date <= ? AND end_date >= ?', effective_date, effective_date)
+            .to_a
+  end
+
+  def related_person_medications
+    PersonMedication.where(person_id: person_id, medication_id: medication_id, active: true).to_a
+  end
+
+  def related_takes
+    @related_takes ||=
+      MedicationTake
+      .where(schedule_id: schedule_ids)
+      .or(MedicationTake.where(person_medication_id: person_medication_ids))
+      .where(taken_at: 31.days.ago.beginning_of_day..Time.current.end_of_day)
+      .to_a
+  end
+
+  def schedule_ids
+    related_sources.grep(Schedule).map(&:id)
+  end
+
+  def person_medication_ids
+    related_sources.grep(PersonMedication).map(&:id)
+  end
+
+  def source_sort_order(candidate)
+    return 0 if candidate.is_a?(Schedule)
+    return 1 if candidate.is_a?(PersonMedication)
+
+    2
+  end
+
+  def source_type(candidate)
+    return unless candidate
+
+    candidate.class.model_name.singular
+  end
+
+  def person_id
+    source.person_id
+  end
+
+  def medication_id
+    source.medication_id
+  end
+
+  def effective_date
+    return taken_at.to_date if taken_at.respond_to?(:to_date)
+
+    Time.zone.today
+  end
+end

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -19,7 +19,9 @@
 #                   #    :selection_required | :invalid_source | :create_failed
 class TakeMedicationService
   Result = Data.define(:success, :take, :error)
-  PreparedTake = Data.define(:source, :amount, :unit, :medication, :taken_at, :client_uuid, :error) do
+  PreparedTake = Data.define(
+    :source, :amount, :unit, :medication, :taken_at, :client_uuid, :error, :decision_context
+  ) do
     def record
       source.medication_takes.create(medication_take_attributes)
     end
@@ -62,7 +64,7 @@ class TakeMedicationService
   end
 
   def rule_blocked_failure(prepared_take, source:, user:, options:)
-    publish_take_metric('take_blocked_by_rules.med_tracker', source:, user:, options:, error: prepared_take.error)
+    publish_rule_blocked_metric(prepared_take, source:, user:, options:)
     failure(prepared_take.error)
   end
 
@@ -88,13 +90,23 @@ class TakeMedicationService
     error, medication = resolve_stock_source(resolver, taken_from_medication_id)
     return prepared_error(error) if error
 
+    decision_error = overlapping_decision_error(source, taken_at)
+    return decision_error if decision_error
+
     prepared_success(source:, amount:, medication:, taken_at:, options:)
   end
 
-  def prepared_error(error)
+  def overlapping_decision_error(source, taken_at)
+    decision_context = MedicationDoseDecisionContext.new(source: source, taken_at: taken_at)
+    return unless decision_context.blocked?
+
+    prepared_error(decision_context.blocked_reason, decision_context: decision_context.audit_payload)
+  end
+
+  def prepared_error(error, decision_context: nil)
     PreparedTake.new(
       source: nil, amount: nil, unit: nil, medication: nil,
-      taken_at: nil, client_uuid: nil, error: error
+      taken_at: nil, client_uuid: nil, error: error, decision_context: decision_context
     )
   end
 
@@ -106,7 +118,8 @@ class TakeMedicationService
       medication: medication,
       taken_at: taken_at,
       client_uuid: options[:client_uuid],
-      error: nil
+      error: nil,
+      decision_context: nil
     )
   end
 
@@ -154,10 +167,26 @@ class TakeMedicationService
   end
 
   def publish_take_metric(event_name, source:, user:, options:, error: nil)
-    ActiveSupport::Notifications.instrument(event_name, take_metric_payload(source:, user:, options:, error:))
+    ActiveSupport::Notifications.instrument(
+      event_name,
+      take_metric_payload(source:, user:, options:, error:, decision_context: nil)
+    )
   end
 
-  def take_metric_payload(source:, user:, options:, error:)
+  def publish_rule_blocked_metric(prepared_take, source:, user:, options:)
+    ActiveSupport::Notifications.instrument(
+      'take_blocked_by_rules.med_tracker',
+      take_metric_payload(
+        source: source,
+        user: user,
+        options: options,
+        error: prepared_take.error,
+        decision_context: prepared_take.decision_context
+      )
+    )
+  end
+
+  def take_metric_payload(source:, user:, options:, error:, decision_context:)
     {
       environment: Rails.env.to_s,
       role: metric_role(user),
@@ -165,7 +194,7 @@ class TakeMedicationService
       medicine_context_class: source.class.name,
       source_type: source.class.model_name.singular,
       error: error&.to_s
-    }
+    }.merge(decision_context || {})
   end
 
   def metric_role(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1292,6 +1292,7 @@ en:
     invalid_taken_at: Choose a valid dose time.
     future_taken_at: Dose time cannot be more than an hour in the future.
     paused: 'Cannot take medication: paused'
+    overlapping_prescription_restriction: 'Cannot take medication: another active prescription for this medication sets a stricter timing limit.'
   barcode_scanner:
     title: Scan Barcode
     start: Start Scanner

--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -146,6 +146,41 @@ RSpec.describe 'Medication Timing Restrictions' do
       end
     end
 
+    context 'when another active prescription for the same medication sets a stricter limit' do
+      let!(:other_schedule) do
+        Schedule.create!(
+          person: person,
+          medication: medication,
+          dose_amount: 1000,
+          dose_unit: 'mg',
+          start_date: Time.zone.today - 1.day,
+          end_date: Time.zone.today + 30.days,
+          max_daily_doses: 1,
+          min_hours_between_doses: nil
+        )
+      end
+
+      before do
+        MedicationTake.create!(
+          schedule: other_schedule,
+          taken_at: 1.hour.ago,
+          dose_amount: 1000,
+          dose_unit: 'mg',
+          taken_from_medication: medication,
+          taken_from_location: medication.location
+        )
+      end
+
+      it 'does not create a medication take and explains the overlapping prescription limit' do
+        expect do
+          post take_medication_person_schedule_path(person, schedule)
+        end.not_to change(MedicationTake, :count)
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:alert]).to include('another active prescription')
+      end
+    end
+
     context 'when schedule dose is invalid' do
       it 'does not create a medication take and shows a friendly alert' do
         expect do

--- a/spec/services/medication_dose_decision_context_spec.rb
+++ b/spec/services/medication_dose_decision_context_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedicationDoseDecisionContext do
+  fixtures :accounts, :people, :users, :locations, :location_memberships,
+           :medications, :dosages, :schedules, :person_medications
+
+  subject(:context) { described_class.new(source: source, taken_at: taken_at) }
+
+  let(:person) { people(:john) }
+  let(:taken_at) { Time.zone.local(2026, 7, 2, 9, 0, 0) }
+  let(:medication) do
+    create(:medication, household: person.household, location: locations(:home), name: 'Decision Context Medicine')
+  end
+  let(:source) do
+    create(
+      :schedule,
+      person: person,
+      medication: medication,
+      dosage: nil,
+      dose_amount: 500,
+      dose_unit: 'mg',
+      max_daily_doses: 4,
+      min_hours_between_doses: nil
+    )
+  end
+
+  before do
+    FixtureHouseholdSetup.apply!
+    MedicationTake.delete_all
+  end
+
+  def record_take_for(source)
+    source.medication_takes.create!(
+      taken_at: taken_at - 1.hour,
+      dose_amount: 500,
+      dose_unit: 'mg',
+      taken_from_medication: medication,
+      taken_from_location: medication.location
+    )
+  end
+
+  it 'does not block when related sources have no reached restrictions' do
+    create(
+      :person_medication,
+      person: person,
+      medication: medication,
+      dosage: nil,
+      dose_amount: 500,
+      dose_unit: 'mg',
+      max_daily_doses: 3,
+      min_hours_between_doses: nil
+    )
+
+    expect(context.blocked?).to be(false)
+    expect(context.blocked_reason).to be_nil
+    expect(context.audit_payload).to eq(decision_source_count: 2)
+  end
+
+  context 'when a related person medication blocks the dose' do
+    let!(:related_person_medication) do
+      create(
+        :person_medication,
+        person: person,
+        medication: medication,
+        dosage: nil,
+        dose_amount: 500,
+        dose_unit: 'mg',
+        max_daily_doses: 1,
+        min_hours_between_doses: nil
+      )
+    end
+
+    before { record_take_for(related_person_medication) }
+
+    it 'reports the related person medication' do
+      expect(context.blocked?).to be(true)
+      expect(context.blocked_reason).to eq(:overlapping_prescription_restriction)
+      expect(context.audit_payload).to eq(
+        decision_source_count: 2,
+        decision_blocking_source_type: 'person_medication',
+        decision_blocking_source_id: related_person_medication.id
+      )
+    end
+  end
+
+  context 'when only inactive or expired schedules have reached restrictions' do
+    before do
+      expired_schedule = create(
+        :schedule,
+        :expired,
+        person: person,
+        medication: medication,
+        dosage: nil,
+        dose_amount: 500,
+        dose_unit: 'mg',
+        max_daily_doses: 1,
+        min_hours_between_doses: nil
+      )
+      inactive_schedule = create(
+        :schedule,
+        person: person,
+        medication: medication,
+        dosage: nil,
+        dose_amount: 500,
+        dose_unit: 'mg',
+        max_daily_doses: 1,
+        min_hours_between_doses: nil,
+        active: false
+      )
+
+      record_take_for(expired_schedule)
+      record_take_for(inactive_schedule)
+    end
+
+    it 'does not block the dose' do
+      expect(context.blocked?).to be(false)
+      expect(context.audit_payload).to eq(decision_source_count: 1)
+    end
+  end
+end

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe TakeMedicationService do
 
   let(:user) { users(:john) }
 
-  before { FixtureHouseholdSetup.apply! }
+  before do
+    FixtureHouseholdSetup.apply!
+    MedicationTake.delete_all
+  end
 
   # Shared helper to invoke the service
   def call_service(source:, amount_override: nil, taken_from_medication_id: nil, **)

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe TakeMedicationService do
     )
   end
 
+  def captured_event_payloads(event_name, &)
+    payloads = []
+    subscriber = lambda do |*args|
+      payloads << ActiveSupport::Notifications::Event.new(*args).payload
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, event_name, &)
+
+    payloads
+  end
+
   shared_examples 'a successful dose' do |expected_amount|
     it 'returns success' do
       expect(result.success).to be true
@@ -125,6 +136,70 @@ RSpec.describe TakeMedicationService do
 
       it 'does not create a MedicationTake' do
         expect { call_service(source: schedule) }.not_to change(MedicationTake, :count)
+      end
+    end
+
+    context 'when another active prescription for the same medication reaches its limit' do
+      let(:person) { user.person }
+      let(:medication) do
+        create(:medication, household: person.household, location: locations(:home), name: 'Overlap Test Medicine')
+      end
+      let(:schedule) do
+        create(
+          :schedule,
+          person: person,
+          medication: medication,
+          dosage: nil,
+          dose_amount: 500,
+          dose_unit: 'mg',
+          max_daily_doses: 4,
+          min_hours_between_doses: nil
+        )
+      end
+      let(:other_schedule) do
+        create(
+          :schedule,
+          person: person,
+          medication: medication,
+          dosage: nil,
+          dose_amount: 500,
+          dose_unit: 'mg',
+          max_daily_doses: 1,
+          min_hours_between_doses: nil
+        )
+      end
+
+      before do
+        other_schedule.medication_takes.create!(
+          taken_at: 1.hour.ago,
+          dose_amount: 500,
+          dose_unit: 'mg',
+          taken_from_medication: medication,
+          taken_from_location: medication.location
+        )
+      end
+
+      it 'does not create a MedicationTake' do
+        expect { call_service(source: schedule) }.not_to change(MedicationTake, :count)
+      end
+
+      it 'returns an overlapping prescription restriction error' do
+        expect(call_service(source: schedule).error).to eq(:overlapping_prescription_restriction)
+      end
+
+      it 'publishes the related prescription context with the blocked metric' do
+        payloads = captured_event_payloads('take_blocked_by_rules.med_tracker') do
+          call_service(source: schedule)
+        end
+
+        expect(payloads).to contain_exactly(
+          include(
+            error: 'overlapping_prescription_restriction',
+            decision_source_count: 2,
+            decision_blocking_source_type: 'schedule',
+            decision_blocking_source_id: other_schedule.id
+          )
+        )
       end
     end
 
@@ -415,17 +490,6 @@ RSpec.describe TakeMedicationService do
   end
 
   describe 'medication take events' do
-    def captured_event_payloads(event_name, &)
-      payloads = []
-      subscriber = lambda do |*args|
-        payloads << ActiveSupport::Notifications::Event.new(*args).payload
-      end
-
-      ActiveSupport::Notifications.subscribed(subscriber, event_name, &)
-
-      payloads
-    end
-
     def expect_metric_payload(payloads, source:, error: nil)
       expect(payloads).to contain_exactly(
         include(


### PR DESCRIPTION
Closes #672\n\n## Summary\n- add aggregate dose decision context across active prescriptions for the same person and medication\n- block dose recording when a related active prescription has the stricter timing limit\n- expose the overlap decision context in blocked-dose instrumentation and user-facing failure messages\n\n## Tests\n- ruby -c app/services/medication_dose_decision_context.rb app/services/take_medication_service.rb app/controllers/concerns/take_medication_guardable.rb app/controllers/medication_takes_controller.rb app/controllers/offline_controller.rb spec/services/take_medication_service_spec.rb spec/requests/medication_timing_spec.rb\n- ruby -e "require \"yaml\"; YAML.load_file(\"config/locales/en.yml\"); puts \"YAML OK\""\n- env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop app/services/medication_dose_decision_context.rb app/services/take_medication_service.rb app/controllers/concerns/take_medication_guardable.rb app/controllers/medication_takes_controller.rb app/controllers/offline_controller.rb spec/services/take_medication_service_spec.rb spec/requests/medication_timing_spec.rb\n- git diff --check\n- task test TEST_FILE=spec/services/take_medication_service_spec.rb (blocked locally: Docker socket unavailable)