### PR TITLE
feat(lookup): configure medicine sources and endpoints

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -33,7 +33,12 @@ module Admin
     private
 
     def settings_params
-      params.expect(app_settings: [:invite_only])
+      params.expect(app_settings: [
+                      :invite_only,
+                      :medicine_lookup_base_url,
+                      :medicine_lookup_token_url,
+                      { medicine_lookup_source_priority: [] }
+                    ])
     end
   end
 end

--- a/app/controllers/platform/settings_controller.rb
+++ b/app/controllers/platform/settings_controller.rb
@@ -22,7 +22,12 @@ module Platform
     private
 
     def settings_params
-      params.expect(app_settings: [:invite_only])
+      params.expect(app_settings: [
+                      :invite_only,
+                      :medicine_lookup_base_url,
+                      :medicine_lookup_token_url,
+                      { medicine_lookup_source_priority: [] }
+                    ])
     end
   end
 end

--- a/app/models/app_settings.rb
+++ b/app/models/app_settings.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 class AppSettings < ApplicationRecord
   has_paper_trail
+
+  LOOKUP_SOURCE_KEYS = %w[
+    imported_catalog
+    local_nhs_dmd
+    cached_open_products_facts
+    open_products_facts
+    curated_catalog
+    nhs_dmd
+    supplements
+  ].freeze
+  DEFAULT_LOOKUP_SOURCE_PRIORITY = LOOKUP_SOURCE_KEYS.freeze
+
+  before_validation :normalize_medicine_lookup_source_priority
+
+  validates :medicine_lookup_base_url, :medicine_lookup_token_url, presence: true
+  validate :medicine_lookup_urls_are_https
+  validate :medicine_lookup_source_priority_is_known
 
   # Always a single row. Access via AppSettings.instance, never instantiate directly.
   def self.instance
@@ -32,5 +51,48 @@ class AppSettings < ApplicationRecord
   # :database otherwise.  Used by the admin UI to disable the toggle.
   def self.invite_only_source
     ENV.key?('INVITE_ONLY') ? :env : :database
+  end
+
+  def medicine_lookup_base_url
+    self[:medicine_lookup_base_url].presence || NhsDmd::Client::BASE_URL
+  end
+
+  def medicine_lookup_token_url
+    self[:medicine_lookup_token_url].presence || NhsDmd::Client::TOKEN_URL
+  end
+
+  def medicine_lookup_source_priority
+    Array(self[:medicine_lookup_source_priority]).presence || DEFAULT_LOOKUP_SOURCE_PRIORITY
+  end
+
+  def lookup_source_priority_for(source_keys)
+    known_source_keys = Array(source_keys)
+    configured = medicine_lookup_source_priority & known_source_keys
+    configured + (known_source_keys - configured)
+  end
+
+  private
+
+  def normalize_medicine_lookup_source_priority
+    self.medicine_lookup_source_priority = medicine_lookup_source_priority.map(&:to_s)
+  end
+
+  def medicine_lookup_urls_are_https
+    %i[medicine_lookup_base_url medicine_lookup_token_url].each do |attribute|
+      errors.add(attribute, 'must be an HTTPS URL') unless https_url?(public_send(attribute))
+    end
+  end
+
+  def https_url?(value)
+    uri = URI.parse(value.to_s)
+    uri.is_a?(URI::HTTPS) && uri.host.present?
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def medicine_lookup_source_priority_is_known
+    return if (medicine_lookup_source_priority - LOOKUP_SOURCE_KEYS).empty?
+
+    errors.add(:medicine_lookup_source_priority, 'contains unknown sources')
   end
 end

--- a/app/services/barcode_catalog/lookup.rb
+++ b/app/services/barcode_catalog/lookup.rb
@@ -2,26 +2,24 @@
 
 module BarcodeCatalog
   class Lookup
+    SOURCE_LOOKUPS = {
+      'imported_catalog' => :lookup_imported_catalog,
+      'local_nhs_dmd' => :lookup_local,
+      'cached_open_products_facts' => :lookup_cached_open_products_facts,
+      'open_products_facts' => :lookup_open_products_facts,
+      'curated_catalog' => :lookup_curated
+    }.freeze
+
     def initialize(opf_lookup: OpenProductsFacts::BarcodeLookup.new)
       @opf_lookup = opf_lookup
     end
 
     def lookup(barcode)
       barcode_candidates(barcode).each do |candidate|
-        imported = lookup_imported_catalog(candidate)
-        return imported if imported
-
-        local = lookup_local(candidate)
-        return local if local
-
-        cached_opf = lookup_cached_open_products_facts(candidate)
-        return cached_opf if cached_opf
-
-        opf = lookup_open_products_facts(candidate)
-        return opf if opf
-
-        curated = lookup_curated(candidate)
-        return curated if curated
+        configured_source_lookups.each do |lookup_method|
+          result = send(lookup_method, candidate)
+          return result if result
+        end
       end
 
       nil
@@ -31,6 +29,10 @@ module BarcodeCatalog
 
     def barcode_candidates(barcode)
       NhsDmd::BarcodeLookup.candidates_for(barcode)
+    end
+
+    def configured_source_lookups
+      AppSettings.instance.lookup_source_priority_for(SOURCE_LOOKUPS.keys).map { |source| SOURCE_LOOKUPS.fetch(source) }
     end
 
     def lookup_imported_catalog(candidate)

--- a/app/services/nhs_dmd/client.rb
+++ b/app/services/nhs_dmd/client.rb
@@ -67,7 +67,7 @@ module NhsDmd
     end
 
     def build_uri(value_set_url, query, count)
-      uri = URI("#{BASE_URL}/ValueSet/$expand")
+      uri = URI.join("#{base_url.chomp('/')}/", 'ValueSet/$expand')
       uri.query = URI.encode_www_form(
         'url' => value_set_url,
         'count' => count.to_s,
@@ -164,7 +164,7 @@ module NhsDmd
     end
 
     def fetch_access_token
-      uri = URI(TOKEN_URL)
+      uri = URI(token_url)
       response = Net::HTTP.post_form(uri, {
                                        'grant_type' => 'client_credentials',
                                        'client_id' => client_id,
@@ -188,12 +188,21 @@ module NhsDmd
       ENV.fetch('NHS_DMD_CLIENT_SECRET', nil)
     end
 
+    def base_url
+      AppSettings.instance.medicine_lookup_base_url
+    end
+
+    def token_url
+      AppSettings.instance.medicine_lookup_token_url
+    end
+
     def value_set_cache_key(value_set_url, query, count)
-      "#{CACHE_PREFIX}/search/#{Digest::SHA256.hexdigest(value_set_url)}/#{count}/#{query}"
+      endpoint_fingerprint = Digest::SHA256.hexdigest("#{base_url}:#{value_set_url}")
+      "#{CACHE_PREFIX}/search/#{endpoint_fingerprint}/#{count}/#{query}"
     end
 
     def token_cache_key
-      token_fingerprint = Digest::SHA256.hexdigest("#{client_id}:#{client_secret}")
+      token_fingerprint = Digest::SHA256.hexdigest("#{token_url}:#{client_id}:#{client_secret}")
       "#{CACHE_PREFIX}/access_token/#{token_fingerprint}"
     end
   end

--- a/db/migrate/20260702170000_add_medicine_lookup_settings_to_app_settings.rb
+++ b/db/migrate/20260702170000_add_medicine_lookup_settings_to_app_settings.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddMedicineLookupSettingsToAppSettings < ActiveRecord::Migration[8.1]
+  def change
+    change_table :app_settings, bulk: true do |t|
+      t.string :medicine_lookup_base_url, null: false, default: 'https://ontology.nhs.uk/production1/fhir'
+      t.string :medicine_lookup_token_url, null: false,
+                                           default: 'https://ontology.nhs.uk/authorisation/auth/realms/nhs-digital-terminology/protocol/openid-connect/token'
+      t.jsonb :medicine_lookup_source_priority, null: false,
+                                                default: %w[
+                                                  imported_catalog
+                                                  local_nhs_dmd
+                                                  cached_open_products_facts
+                                                  open_products_facts
+                                                  curated_catalog
+                                                  nhs_dmd
+                                                  supplements
+                                                ]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_160600) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -206,6 +206,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_160600) do
   create_table "app_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "invite_only", default: false, null: false
+    t.string "medicine_lookup_base_url", default: "https://ontology.nhs.uk/production1/fhir", null: false
+    t.jsonb "medicine_lookup_source_priority", default: ["imported_catalog", "local_nhs_dmd", "cached_open_products_facts", "open_products_facts", "curated_catalog", "nhs_dmd", "supplements"], null: false
+    t.string "medicine_lookup_token_url", default: "https://ontology.nhs.uk/authorisation/auth/realms/nhs-digital-terminology/protocol/openid-connect/token", null: false
     t.datetime "updated_at", null: false
   end
 

--- a/spec/models/app_settings_spec.rb
+++ b/spec/models/app_settings_spec.rb
@@ -59,4 +59,30 @@ RSpec.describe AppSettings do
       expect(PaperTrail::Version.where(item_type: 'AppSettings', item_id: settings.id).last.event).to eq('update')
     end
   end
+
+  describe 'medicine lookup settings' do
+    it 'defaults to the built-in dm+d endpoints and source priority' do
+      settings = described_class.instance
+
+      expect(settings.medicine_lookup_base_url).to eq(NhsDmd::Client::BASE_URL)
+      expect(settings.medicine_lookup_token_url).to eq(NhsDmd::Client::TOKEN_URL)
+      expect(settings.lookup_source_priority_for(%w[open_products_facts local_nhs_dmd])).to eq(
+        %w[local_nhs_dmd open_products_facts]
+      )
+    end
+
+    it 'accepts only HTTPS lookup endpoint URLs' do
+      settings = described_class.instance
+
+      expect(settings.update(medicine_lookup_base_url: 'http://example.test/fhir')).to be(false)
+      expect(settings.errors[:medicine_lookup_base_url]).to include('must be an HTTPS URL')
+    end
+
+    it 'rejects unknown lookup source priority values' do
+      settings = described_class.instance
+
+      expect(settings.update(medicine_lookup_source_priority: %w[local_nhs_dmd unknown])).to be(false)
+      expect(settings.errors[:medicine_lookup_source_priority]).to include('contains unknown sources')
+    end
+  end
 end

--- a/spec/requests/platform/settings_spec.rb
+++ b/spec/requests/platform/settings_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe 'Platform settings' do
     expect(AppSettings.instance.reload.invite_only).to be(false)
   end
 
+  it 'updates medicine lookup settings for an active platform admin' do
+    PlatformAdmin.create!(account: platform_user.person.account)
+    sign_in(platform_user)
+
+    patch platform_settings_path,
+          params: {
+            app_settings: {
+              medicine_lookup_base_url: 'https://terminology.example.test/fhir',
+              medicine_lookup_token_url: 'https://auth.example.test/token',
+              medicine_lookup_source_priority: %w[open_products_facts local_nhs_dmd curated_catalog]
+            }
+          }
+
+    settings = AppSettings.instance.reload
+    expect(response).to redirect_to(platform_settings_path)
+    expect(settings.medicine_lookup_base_url).to eq('https://terminology.example.test/fhir')
+    expect(settings.lookup_source_priority_for(%w[local_nhs_dmd open_products_facts])).to eq(
+      %w[open_products_facts local_nhs_dmd]
+    )
+  end
+
   it 'renders validation errors when platform settings cannot be updated' do
     PlatformAdmin.create!(account: platform_user.person.account)
     settings = AppSettings.instance

--- a/spec/requests/platform/settings_spec.rb
+++ b/spec/requests/platform/settings_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe 'Platform settings' do
     expect(response).to redirect_to(root_path)
   end
 
+  it 'denies lookup setting updates from household owners without platform admin access' do
+    sign_in(household_owner)
+
+    patch platform_settings_path,
+          params: {
+            app_settings: {
+              medicine_lookup_base_url: 'https://terminology.example.test/fhir',
+              medicine_lookup_source_priority: %w[open_products_facts local_nhs_dmd]
+            }
+          }
+
+    expect(response).to redirect_to(root_path)
+    expect(AppSettings.instance.reload.medicine_lookup_base_url).to eq(NhsDmd::Client::BASE_URL)
+  end
+
   it 'keeps household admin settings denied to household managers without platform admin access' do
     sign_in(household_owner)
 

--- a/spec/services/barcode_catalog/lookup_spec.rb
+++ b/spec/services/barcode_catalog/lookup_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe BarcodeCatalog::Lookup do
       )
     end
 
+    def prioritize_open_products_facts
+      AppSettings.instance.update!(
+        medicine_lookup_source_priority: %w[
+          open_products_facts
+          local_nhs_dmd
+          imported_catalog
+          cached_open_products_facts
+          curated_catalog
+        ]
+      )
+    end
+
+    def stub_open_products_facts_result
+      allow(opf_lookup).to receive(:lookup).with(gtin).and_return(
+        gtin: gtin,
+        display: 'Configured Open Products Facts name',
+        source: 'open_products_facts',
+        system: OpenProductsFacts::Client::BASE_URL,
+        concept_class: 'OTC Medicine'
+      )
+    end
+
     it 'prefers an external catalogue entry over the local dm+d barcode table' do
       create_external_entry
       create_local_entry(code: 'old-code', display: 'Old dm+d mapping')
@@ -115,6 +137,17 @@ RSpec.describe BarcodeCatalog::Lookup do
 
       expect(lookup.lookup(gtin)).to include(source: 'nhs_dmd')
       expect(opf_lookup).not_to have_received(:lookup)
+    end
+
+    it 'uses configured source priority when multiple sources match' do
+      prioritize_open_products_facts
+      create_local_entry(code: 'dmd-code', display: 'dm+d name')
+      stub_open_products_facts_result
+
+      expect(lookup.lookup(gtin)).to include(
+        display: 'Configured Open Products Facts name',
+        source: 'open_products_facts'
+      )
     end
 
     it 'prefers dm+d over a cached Open Products Facts entry' do

--- a/spec/services/nhs_dmd/client_spec.rb
+++ b/spec/services/nhs_dmd/client_spec.rb
@@ -223,6 +223,28 @@ RSpec.describe NhsDmd::Client do
       end
     end
 
+    context 'with custom medicine lookup endpoints' do
+      before do
+        AppSettings.instance.update!(
+          medicine_lookup_base_url: 'https://terminology.example.test/fhir',
+          medicine_lookup_token_url: 'https://auth.example.test/token'
+        )
+        stub_request(:post, 'https://auth.example.test/token')
+          .to_return(status: 200, body: { 'access_token' => 'custom-token' }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+        stub_request(:get, %r{terminology\.example\.test/fhir/ValueSet/\$expand})
+          .to_return(status: 200, body: '{"resourceType":"ValueSet","expansion":{"total":0,"contains":[]}}',
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'uses the configured base and token endpoints' do
+        client.search('aspirin')
+
+        expect(WebMock).to have_requested(:post, 'https://auth.example.test/token').once
+        expect(WebMock).to have_requested(:get, %r{terminology\.example\.test/fhir/ValueSet/\$expand}).twice
+      end
+    end
+
     context 'when the same query is requested repeatedly' do
       before do
         stub_request(:get, /ontology\.nhs\.uk/)


### PR DESCRIPTION
Closes #648\nCloses #667\nCloses #670\n\n## Summary\n- add platform/admin settings for custom medicine lookup base and token endpoints\n- add validated source-priority settings for medicine lookup sources\n- route NHS dm+d client endpoint/cache keys and barcode source order through settings\n- cover platform-admin updates and direct non-admin denial for lookup settings\n\n## Tests\n- ruby -c app/models/app_settings.rb app/services/nhs_dmd/client.rb app/services/barcode_catalog/lookup.rb app/controllers/admin/settings_controller.rb app/controllers/platform/settings_controller.rb db/migrate/20260702170000_add_medicine_lookup_settings_to_app_settings.rb spec/models/app_settings_spec.rb spec/services/nhs_dmd/client_spec.rb spec/services/barcode_catalog/lookup_spec.rb spec/requests/platform/settings_spec.rb\n- env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop app/models/app_settings.rb app/services/nhs_dmd/client.rb app/services/barcode_catalog/lookup.rb app/controllers/admin/settings_controller.rb app/controllers/platform/settings_controller.rb db/migrate/20260702170000_add_medicine_lookup_settings_to_app_settings.rb spec/models/app_settings_spec.rb spec/services/nhs_dmd/client_spec.rb spec/services/barcode_catalog/lookup_spec.rb spec/requests/platform/settings_spec.rb\n- git diff --check\n- task test TEST_FILE=spec/services/nhs_dmd/client_spec.rb (blocked locally: Docker socket unavailable)\n- task test TEST_FILE=spec/services/barcode_catalog/lookup_spec.rb (blocked locally: Docker socket unavailable)\n- task test TEST_FILE=spec/requests/platform/settings_spec.rb (blocked locally: Docker socket unavailable)