### PR TITLE
test(medications): verify daily dose reset

### DIFF
--- a/spec/requests/medication_timing_spec.rb
+++ b/spec/requests/medication_timing_spec.rb
@@ -125,6 +125,26 @@ RSpec.describe 'Medication Timing Restrictions' do
         expect(response).to redirect_to(person_path(person))
         expect(flash[:alert]).to include('Cannot take medication')
       end
+
+      it 'allows another dose after the local midnight reset' do
+        travel_to Time.zone.local(2026, 4, 29, 0, 5) do
+          schedule.update!(min_hours_between_doses: nil)
+          2.times do |index|
+            MedicationTake.create!(
+              schedule: schedule,
+              taken_at: Time.zone.local(2026, 4, 28, 23, 30) + index.minutes,
+              dose_amount: 10
+            )
+          end
+
+          expect do
+            post take_medication_person_schedule_path(person, schedule)
+          end.to change(MedicationTake, :count).by(1)
+        end
+
+        expect(response).to redirect_to(person_path(person))
+        expect(flash[:notice]).to include('Medication taken')
+      end
     end
 
     context 'when minimum hours between doses not met' do

--- a/spec/services/family_dashboard/schedule_query_spec.rb
+++ b/spec/services/family_dashboard/schedule_query_spec.rb
@@ -92,6 +92,22 @@ RSpec.describe FamilyDashboard::ScheduleQuery do
       end
     end
 
+    it 'resets routine direct medication progress at the local day boundary' do
+      travel_to Time.zone.parse('2026-05-06 00:00:00') do
+        routine_medication = create_routine_person_medication
+        MedicationTake.create!(
+          person_medication: routine_medication,
+          taken_at: Time.zone.parse('2026-05-05 23:59:00'),
+          dose_amount: 500,
+          dose_unit: 'mg'
+        )
+
+        rows = described_class.new([people(:john)]).call.select { |row| row[:source] == routine_medication }
+
+        expect(rows).to contain_exactly(include(status: :upcoming, daily_dose_count: 0, daily_dose_limit: 1))
+      end
+    end
+
     it 'keeps a completed routine direct medication out of the actionable schedule' do
       travel_to Time.zone.parse('2026-05-05 20:00:00') do
         routine_medication = create_routine_person_medication


### PR DESCRIPTION
Closes #653

## Summary
- add request coverage proving a dose is allowed after the local midnight reset when the prior day hit the daily limit
- add dashboard query coverage proving routine medication progress resets at the local day boundary

## Tests
- ruby -c spec/requests/medication_timing_spec.rb spec/services/family_dashboard/schedule_query_spec.rb
- env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop spec/requests/medication_timing_spec.rb spec/services/family_dashboard/schedule_query_spec.rb
- git diff --check
- task test TEST_FILE=spec/requests/medication_timing_spec.rb (blocked locally: Docker socket unavailable)
- task test TEST_FILE=spec/services/family_dashboard/schedule_query_spec.rb (blocked locally: Docker socket unavailable)