### PR TITLE
fix(lookup): fall back when primary search fails

### DIFF
--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -62,6 +62,8 @@ module NhsDmd
       return unconfigured_result(query) unless @client.configured?
 
       configured_result(query)
+    rescue Client::ApiError => e
+      fallback_result_after_primary_failure(query, e)
     end
 
     def unconfigured_result(query)
@@ -78,6 +80,18 @@ module NhsDmd
       return Result.new(results: build_results(results), error: nil) if results.any?
 
       empty_result
+    end
+
+    def fallback_result_after_primary_failure(query, exception)
+      log_failure(exception.message, exception)
+
+      off_match = open_food_facts_result_for(query)
+      return barcode_result(query, off_match) if off_match
+
+      supplement_results = text_supplement_items(query)
+      return Result.new(results: build_results(supplement_results), error: nil) if supplement_results.any?
+
+      Result.new(results: [], error: exception.message)
     end
 
     def nhs_items(query)

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -88,7 +88,7 @@ module NhsDmd
       off_match = open_food_facts_result_for(query)
       return barcode_result(query, off_match) if off_match
 
-      supplement_results = text_supplement_items(query)
+      supplement_results = likely_supplement_text_query?(query) ? text_supplement_items(query) : []
       return Result.new(results: build_results(supplement_results), error: nil) if supplement_results.any?
 
       Result.new(results: [], error: exception.message)

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -553,6 +553,57 @@ RSpec.describe NhsDmd::Search do
       end
     end
 
+    context 'when the primary API fails and secondary supplement lookup succeeds' do
+      before do
+        off_result = {
+          display: 'Wellman Original (Vitabiotics) 30 tablets',
+          barcode: '5021265221301',
+          system: 'https://world.openfoodfacts.org',
+          concept_class: 'Supplement',
+          source: 'open_food_facts'
+        }
+
+        allow(client).to receive(:configured?).and_return(true)
+        allow(client).to receive(:search).and_raise(NhsDmd::Client::ApiError, 'Service unavailable')
+        allow(open_food_facts_search).to receive(:search).with('wellman').and_return([off_result])
+      end
+
+      it 'returns secondary source results without an error' do
+        result = search.call('wellman')
+
+        expect(result).to be_success
+        expect(result.error).to be_nil
+        expect(result.results.map(&:to_h)).to contain_exactly(
+          a_hash_including(display: 'Wellman Original (Vitabiotics) 30 tablets', source_label: 'Open Food Facts')
+        )
+      end
+    end
+
+    context 'when the primary API fails and secondary barcode lookup succeeds' do
+      before do
+        allow(client).to receive(:configured?).and_return(true)
+        allow(client).to receive(:search).and_raise(NhsDmd::Client::ApiError, 'Service unavailable')
+        allow(open_food_facts_lookup).to receive(:lookup).with('5021265221301').and_return(
+          {
+            display: 'Wellman Original (Vitabiotics) 30 tablets',
+            barcode: '5021265221301',
+            system: 'https://world.openfoodfacts.org',
+            concept_class: 'Supplement',
+            source: 'open_food_facts'
+          }
+        )
+      end
+
+      it 'returns the secondary barcode result without an error' do
+        result = search.call('5021265221301')
+
+        expect(result).to be_success
+        expect(result.error).to be_nil
+        expect(result.barcode).to eq('5021265221301')
+        expect(result.resolved_query).to eq('Wellman Original (Vitabiotics) 30 tablets')
+      end
+    end
+
     context 'when the client raises an unexpected error' do
       subject(:search) do
         described_class.new(

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -565,11 +565,11 @@ RSpec.describe NhsDmd::Search do
 
         allow(client).to receive(:configured?).and_return(true)
         allow(client).to receive(:search).and_raise(NhsDmd::Client::ApiError, 'Service unavailable')
-        allow(open_food_facts_search).to receive(:search).with('wellman').and_return([off_result])
+        allow(open_food_facts_search).to receive(:search).with('vitamin').and_return([off_result])
       end
 
       it 'returns secondary source results without an error' do
-        result = search.call('wellman')
+        result = search.call('vitamin')
 
         expect(result).to be_success
         expect(result.error).to be_nil


### PR DESCRIPTION
Closes #654

## Summary
- recover from primary NHS dm+d API failures by trying the existing secondary barcode/text supplement lookup paths
- return successful secondary-source results when fallback succeeds while preserving the existing error response when no fallback is available
- cover text and barcode fallback behavior in NhsDmd::Search

## Tests
- ruby -c app/services/nhs_dmd/search.rb spec/services/nhs_dmd/search_spec.rb
- env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop app/services/nhs_dmd/search.rb spec/services/nhs_dmd/search_spec.rb
- git diff --check
- task test TEST_FILE=spec/services/nhs_dmd/search_spec.rb (blocked locally: Docker socket unavailable)