### PR TITLE
feat(lookup): show SPC links in finder results

### DIFF
--- a/app/components/medications/finder_view.rb
+++ b/app/components/medications/finder_view.rb
@@ -24,6 +24,7 @@ module Components
               barcode: t('medications.finder.barcode'),
               dmdCode: t('medications.finder.dmd_code'),
               pilLink: t('medications.finder.pil_link'),
+              spcLink: t('medications.finder.spc_link'),
               formFilterLabel: t('medications.finder.form_filter_label'),
               allForms: t('medications.finder.all_forms'),
               medicineDetailsButton: t('medications.finder.medicine_details_button'),

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -143,6 +143,7 @@ export default class extends Controller {
 
     const identifier = this.renderIdentifier(result)
     const pilLink = this.renderPilLink(result)
+    const spcLink = this.renderSpcLink(result)
     const medicineDetails = this.renderMedicineDetails(result)
     const interactions = this.renderInteractions(result)
     const title = result.name || result.display
@@ -158,6 +159,7 @@ export default class extends Controller {
             ${packageSize}
             ${identifier}
             ${pilLink}
+            ${spcLink}
             ${medicineDetails}
             ${interactions}
           </div>
@@ -460,6 +462,21 @@ export default class extends Controller {
         class="mt-2 inline-flex text-xs font-medium text-primary underline-offset-2 hover:underline"
         data-testid="pil-link"
       >${this.escapeHtml(this.t("pilLink"))}</a>
+    `
+  }
+
+  renderSpcLink(result) {
+    const url = this.safeExternalUrl(result.spc_url)
+    if (!url) return ''
+
+    return `
+      <a
+        href="${this.hrefAttribute(url)}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="ml-3 mt-2 inline-flex text-xs font-medium text-primary underline-offset-2 hover:underline"
+        data-testid="spc-link"
+      >${this.escapeHtml(this.t("spcLink"))}</a>
     `
   }
 

--- a/app/services/nhs_dmd/client.rb
+++ b/app/services/nhs_dmd/client.rb
@@ -24,9 +24,21 @@ module NhsDmd
       patient_information_leaflet_url
       patientInformationLeafletUrl
     ].freeze
-    PIL_VALUE_KEYS = %w[valueUrl valueUri valueString valueCanonical].freeze
+    GUIDANCE_VALUE_KEYS = %w[valueUrl valueUri valueString valueCanonical].freeze
     PIL_EXTENSION_MATCHER = /(?:\bpil\b|patient[-_\s]?information[-_\s]?leaflet)/i
     PIL_URL_VALUE_MATCHER = %r{(?:/pil(?:[/?#]|$)|patient[-_\s]?information[-_\s]?leaflet)}i
+    SPC_URL_KEYS = %w[
+      spc_url
+      spcUrl
+      summary_of_product_characteristics
+      summaryOfProductCharacteristics
+      summary_of_product_characteristics_url
+      summaryOfProductCharacteristicsUrl
+    ].freeze
+    SPC_EXTENSION_MATCHER = /(?:\bspc\b|\bsmpc\b|summary[-_\s]?of[-_\s]?product[-_\s]?characteristics)/i
+    SPC_URL_VALUE_MATCHER = %r{
+      (?:/smpc(?:[/?#]|$)|/spc(?:[/?#]|$)|summary[-_\s]?of[-_\s]?product[-_\s]?characteristics)
+    }ix
 
     VMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/VMP'
     AMP_VALUE_SET = 'https://dmd.nhs.uk/ValueSet/AMP'
@@ -107,7 +119,8 @@ module NhsDmd
         display: item['display'],
         system: item['system'],
         concept_class: extract_concept_class(item),
-        pil_url: extract_pil_url(item)
+        pil_url: extract_pil_url(item),
+        spc_url: extract_spc_url(item)
       }
     end
 
@@ -120,37 +133,45 @@ module NhsDmd
     end
 
     def extract_pil_url(item)
-      direct_pil_url(item) || extension_pil_url(item)
+      direct_guidance_url(item, PIL_URL_KEYS) ||
+        extension_guidance_url(item, PIL_EXTENSION_MATCHER, PIL_URL_VALUE_MATCHER)
     end
 
-    def direct_pil_url(item)
-      PIL_URL_KEYS.filter_map { |key| item[key].presence }.first
+    def extract_spc_url(item)
+      direct_guidance_url(item, SPC_URL_KEYS) ||
+        extension_guidance_url(item, SPC_EXTENSION_MATCHER, SPC_URL_VALUE_MATCHER)
     end
 
-    def extension_pil_url(item)
-      extension_pil_urls(Array(item['extension'])).first
+    def direct_guidance_url(item, keys)
+      keys.filter_map { |key| item[key].presence }.first
     end
 
-    def extension_pil_urls(extensions)
+    def extension_guidance_url(item, extension_matcher, url_value_matcher)
+      extension_guidance_urls(Array(item['extension']), extension_matcher, url_value_matcher).first
+    end
+
+    def extension_guidance_urls(extensions, extension_matcher, url_value_matcher)
       extensions.flat_map do |extension|
         values = []
         value = extension_url_value(extension)
-        values << value if pil_extension?(extension) || pil_url_value?(value)
-        values.concat(extension_pil_urls(Array(extension['extension'])))
+        matched_guidance = guidance_extension?(extension, extension_matcher) ||
+                           guidance_url_value?(value, url_value_matcher)
+        values << value if matched_guidance
+        values.concat(extension_guidance_urls(Array(extension['extension']), extension_matcher, url_value_matcher))
         values
       end.compact
     end
 
     def extension_url_value(extension)
-      PIL_VALUE_KEYS.filter_map { |key| extension[key].presence }.first
+      GUIDANCE_VALUE_KEYS.filter_map { |key| extension[key].presence }.first
     end
 
-    def pil_extension?(extension)
-      extension['url'].to_s.match?(PIL_EXTENSION_MATCHER)
+    def guidance_extension?(extension, matcher)
+      extension['url'].to_s.match?(matcher)
     end
 
-    def pil_url_value?(value)
-      value.to_s.match?(PIL_URL_VALUE_MATCHER)
+    def guidance_url_value?(value, matcher)
+      value.to_s.match?(matcher)
     end
 
     def authenticated?

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -150,6 +150,7 @@ module NhsDmd
         directions: item[:directions],
         warnings: item[:warnings],
         pil_url: item[:pil_url],
+        spc_url: item[:spc_url],
         match_reason: item[:match_reason]
       }
     end

--- a/app/services/nhs_dmd/search_result.rb
+++ b/app/services/nhs_dmd/search_result.rb
@@ -5,7 +5,7 @@ require 'uri'
 module NhsDmd
   class SearchResult
     attr_reader :barcode, :code, :display, :system, :concept_class, :match_reason, :name, :category, :package_size,
-                :package_quantity, :package_unit, :description, :directions, :warnings, :pil_url
+                :package_quantity, :package_unit, :description, :directions, :warnings, :pil_url, :spc_url
 
     def initialize(code:, display:, system:, **attributes)
       @code = code
@@ -41,6 +41,7 @@ module NhsDmd
       @directions = attributes[:directions]
       @warnings = attributes[:warnings]
       @pil_url = safe_https_url(attributes[:pil_url])
+      @spc_url = safe_https_url(attributes[:spc_url])
     end
 
     private :assign_source_attributes, :assign_package_attributes, :assign_guidance_attributes
@@ -104,7 +105,8 @@ module NhsDmd
       {
         directions: directions,
         warnings: warnings,
-        pil_url: pil_url
+        pil_url: pil_url,
+        spc_url: spc_url
       }
     end
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -724,6 +724,7 @@ cy:
       barcode: Cod bar
       dmd_code: Cod dm+d
       pil_link: Taflen wybodaeth i gleifion
+      spc_link: Crynodeb o Nodweddion y Cynnyrch
       form_filter_label: Ffurf dos
       all_forms: Pob ffurf
       forms:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -754,6 +754,7 @@ en:
       barcode: Barcode
       dmd_code: dm+d code
       pil_link: Patient information leaflet
+      spc_link: Summary of Product Characteristics
       form_filter_label: Dosage form
       all_forms: All forms
       forms:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -732,6 +732,7 @@ es:
       barcode: Código de barras
       dmd_code: código dm+d
       pil_link: Prospecto para el paciente
+      spc_link: Resumen de las Características del Producto
       form_filter_label: Forma farmacéutica
       all_forms: Todas las formas
       forms:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -727,6 +727,7 @@ ga:
       barcode: Barrachód
       dmd_code: cód dm+d
       pil_link: Bileog eolais don othar
+      spc_link: Achoimre ar Shaintréithe an Táirge
       form_filter_label: Foirm dáileoige
       all_forms: Gach foirm
       forms:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -730,6 +730,7 @@ pt:
       barcode: Código de barras
       dmd_code: Código dm+d
       pil_link: Folheto informativo do doente
+      spc_link: Resumo das Características do Medicamento
       form_filter_label: Forma farmacêutica
       all_forms: Todas as formas
       forms:

--- a/spec/components/medications/finder_view_spec.rb
+++ b/spec/components/medications/finder_view_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Components::Medications::FinderView, type: :component do
       'resultsTitle' => I18n.t('medications.finder.results_title'),
       'dmdCode' => I18n.t('medications.finder.dmd_code'),
       'updateStock' => 'Update stock',
-      'pilLink' => I18n.t('medications.finder.pil_link')
+      'pilLink' => I18n.t('medications.finder.pil_link'),
+      'spcLink' => I18n.t('medications.finder.spc_link')
     )
     expect(payload.fetch('resultCount')).to include(
       'one' => I18n.t('medications.finder.result_count.one'),

--- a/spec/features/medication_lookup_spec.rb
+++ b/spec/features/medication_lookup_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Medication Lookup', type: :system do
         display: 'Aspirin 300mg tablets',
         system: 'https://dmd.nhs.uk',
         concept_class: 'VMP',
-        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil'
+        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil',
+        spc_url: 'https://www.medicines.org.uk/emc/product/13866/smpc'
       },
       {
         code: '39720411000001102',
@@ -89,12 +90,14 @@ RSpec.describe 'Medication Lookup', type: :system do
     expect(page).to have_text('Aspirin 300mg tablets')
     expect(page).to have_text('Aspirin 75mg tablets')
     expect(page).to have_text('VMP')
-    expect(page).to have_link('Patient information leaflet', href: 'https://www.medicines.org.uk/emc/product/13866/pil')
-
-    pil_link = find_link('Patient information leaflet')
-    expect(pil_link[:target]).to eq('_blank')
-    expect(pil_link[:rel]).to include('noopener')
-    expect(pil_link[:rel]).to include('noreferrer')
+    expect_external_guidance_link(
+      'pil-link',
+      'https://www.medicines.org.uk/emc/product/13866/pil'
+    )
+    expect_external_guidance_link(
+      'spc-link',
+      'https://www.medicines.org.uk/emc/product/13866/smpc'
+    )
   end
 
   it 'Search returns no results' do
@@ -274,5 +277,11 @@ RSpec.describe 'Medication Lookup', type: :system do
     expect(page).to have_text('High')
     expect(page).to have_text('Ibuprofen')
     expect(page).to have_text('bleeding')
+  end
+
+  def expect_external_guidance_link(test_id, href)
+    expect(page).to have_css(
+      "a[data-testid=\"#{test_id}\"][href=\"#{href}\"][target=\"_blank\"][rel~=\"noopener\"][rel~=\"noreferrer\"]"
+    )
   end
 end

--- a/spec/services/medication_dose_decision_context_spec.rb
+++ b/spec/services/medication_dose_decision_context_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe MedicationDoseDecisionContext do
       dose_amount: 500,
       dose_unit: 'mg',
       max_daily_doses: 4,
-      min_hours_between_doses: nil
+      min_hours_between_doses: nil,
+      start_date: taken_at.to_date - 1.day,
+      end_date: taken_at.to_date + 30.days
     )
   end
 
@@ -96,7 +98,9 @@ RSpec.describe MedicationDoseDecisionContext do
         dose_amount: 500,
         dose_unit: 'mg',
         max_daily_doses: 1,
-        min_hours_between_doses: nil
+        min_hours_between_doses: nil,
+        start_date: taken_at.to_date - 30.days,
+        end_date: taken_at.to_date - 1.day
       )
       inactive_schedule = create(
         :schedule,
@@ -107,7 +111,9 @@ RSpec.describe MedicationDoseDecisionContext do
         dose_unit: 'mg',
         max_daily_doses: 1,
         min_hours_between_doses: nil,
-        active: false
+        active: false,
+        start_date: taken_at.to_date - 1.day,
+        end_date: taken_at.to_date + 30.days
       )
 
       record_take_for(expired_schedule)

--- a/spec/services/nhs_dmd/client_spec.rb
+++ b/spec/services/nhs_dmd/client_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe NhsDmd::Client do
                     'valueString' => 'VMP'
                   }
                 ],
-                'patientInformationLeafletUrl' => 'https://www.medicines.org.uk/emc/product/13866/pil'
+                'patientInformationLeafletUrl' => 'https://www.medicines.org.uk/emc/product/13866/pil',
+                'summaryOfProductCharacteristicsUrl' => 'https://www.medicines.org.uk/emc/product/13866/smpc'
               },
               {
                 'system' => 'https://dmd.nhs.uk',
@@ -53,6 +54,10 @@ RSpec.describe NhsDmd::Client do
                   {
                     'url' => 'https://medtracker.test/fhir/StructureDefinition/patient-information-leaflet',
                     'valueUrl' => 'https://www.medicines.org.uk/emc/product/397205/pil'
+                  },
+                  {
+                    'url' => 'https://medtracker.test/fhir/StructureDefinition/summary-of-product-characteristics',
+                    'valueUrl' => 'https://www.medicines.org.uk/emc/product/397205/smpc'
                   }
                 ]
               },
@@ -111,6 +116,24 @@ RSpec.describe NhsDmd::Client do
         results = client.search('aspirin')
 
         expect(results.last[:pil_url]).to be_nil
+      end
+
+      it 'maps an SPC URL from direct provider payload fields' do
+        results = client.search('aspirin')
+
+        expect(results.first[:spc_url]).to eq('https://www.medicines.org.uk/emc/product/13866/smpc')
+      end
+
+      it 'maps an SPC URL from provider payload extensions' do
+        results = client.search('aspirin')
+
+        expect(results.second[:spc_url]).to eq('https://www.medicines.org.uk/emc/product/397205/smpc')
+      end
+
+      it 'sets the SPC URL to nil when provider payload has no SPC data' do
+        results = client.search('aspirin')
+
+        expect(results.last[:spc_url]).to be_nil
       end
     end
 

--- a/spec/services/nhs_dmd/search_result_spec.rb
+++ b/spec/services/nhs_dmd/search_result_spec.rb
@@ -20,29 +20,22 @@ RSpec.describe NhsDmd::SearchResult do
         code: '39720311000001101',
         display: 'Aspirin 300mg tablets',
         system: 'https://dmd.nhs.uk',
-        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil'
+        pil_url: 'https://www.medicines.org.uk/emc/product/13866/pil',
+        spc_url: 'https://www.medicines.org.uk/emc/product/13866/smpc'
       )
 
       expect(result.to_h[:pil_url]).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
+      expect(result.to_h[:spc_url]).to eq('https://www.medicines.org.uk/emc/product/13866/smpc')
     end
 
-    it 'filters unsafe and malformed PIL URLs' do
+    it 'filters unsafe and malformed guidance URLs' do
       urls = [
         'javascript:alert(1)',
         'http://www.medicines.org.uk/emc/product/13866/pil',
         'not a url'
       ]
 
-      expect(
-        urls.map do |url|
-          described_class.new(
-            code: '39720311000001101',
-            display: 'Aspirin 300mg tablets',
-            system: 'https://dmd.nhs.uk',
-            pil_url: url
-          ).to_h[:pil_url]
-        end
-      ).to all(be_nil)
+      expect(urls.flat_map { |url| guidance_url_values(url) }).to all(be_nil)
     end
   end
 
@@ -55,5 +48,15 @@ RSpec.describe NhsDmd::SearchResult do
       category: 'Analgesic',
       package_size: '32 tablets'
     }
+  end
+
+  def guidance_url_values(url)
+    described_class.new(
+      code: '39720311000001101',
+      display: 'Aspirin 300mg tablets',
+      system: 'https://dmd.nhs.uk',
+      pil_url: url,
+      spc_url: url
+    ).to_h.slice(:pil_url, :spc_url).values
   end
 end

--- a/spec/support/nhs_dmd_stubs.rb
+++ b/spec/support/nhs_dmd_stubs.rb
@@ -60,14 +60,19 @@ module NhsDmdStubs
       }
     ]
 
-    if result[:pil_url].present?
-      extension << {
-        url: 'https://medtracker.test/fhir/StructureDefinition/patient-information-leaflet',
-        valueUrl: result[:pil_url]
-      }
-    end
+    append_guidance_extension(extension, result[:pil_url], 'patient-information-leaflet')
+    append_guidance_extension(extension, result[:spc_url], 'summary-of-product-characteristics')
 
     extension
+  end
+
+  def append_guidance_extension(extension, value_url, slug)
+    return if value_url.blank?
+
+    extension << {
+      url: "https://medtracker.test/fhir/StructureDefinition/#{slug}",
+      valueUrl: value_url
+    }
   end
 end
 


### PR DESCRIPTION
## Summary
- expose sanitized SPC URLs from lookup results
- render SPC links beside existing PIL links in finder results
- add locale strings and coverage for URL filtering/rendering

## Tests
- ruby -c app/services/nhs_dmd/search_result.rb app/components/medications/finder_view.rb spec/services/nhs_dmd/search_result_spec.rb spec/components/medications/finder_view_spec.rb spec/features/medication_lookup_spec.rb
- git diff --check
- task test TEST_FILE=spec/services/nhs_dmd/search_result_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/medications/finder_view_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)

Closes #622