### PR TITLE
perf(admin): preload user list row associations

### DIFF
--- a/app/components/admin/users/users_table.rb
+++ b/app/components/admin/users/users_table.rb
@@ -183,10 +183,28 @@ module Components
         def platform_admin_account_ids
           return @platform_admin_account_ids if defined?(@platform_admin_account_ids)
 
-          @platform_admin_account_ids = PlatformAdmin.active
-                                                     .where(account_id: memberships_by_account_id.keys)
-                                                     .pluck(:account_id)
-                                                     .to_set
+          @platform_admin_account_ids = if platform_admin_accounts_loaded?
+                                          preloaded_platform_admin_account_ids
+                                        else
+                                          PlatformAdmin.active
+                                                       .where(account_id: memberships_by_account_id.keys)
+                                                       .pluck(:account_id)
+                                                       .to_set
+                                        end
+        end
+
+        def platform_admin_accounts_loaded?
+          loaded_accounts.all? { |account| account.association(:platform_admin).loaded? }
+        end
+
+        def preloaded_platform_admin_account_ids
+          loaded_accounts.filter_map do |account|
+            account.id if account.platform_admin&.active?
+          end.to_set
+        end
+
+        def loaded_accounts
+          @loaded_accounts ||= users.filter_map { |user| user.person&.account }
         end
 
         def render_status_badge(user)

--- a/app/services/admin/users_index_query.rb
+++ b/app/services/admin/users_index_query.rb
@@ -30,7 +30,7 @@ module Admin
     end
 
     def filtered_scope
-      relation = scope.includes(:person)
+      relation = scope.includes(person: { account: :platform_admin })
       relation = apply_search(relation) if search.present?
       relation = apply_membership_role_filter(relation) if membership_role.present?
       relation = apply_status_filter(relation) if status.present?

--- a/spec/components/admin/users/users_table_spec.rb
+++ b/spec/components/admin/users/users_table_spec.rb
@@ -90,6 +90,18 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
         render_inline(described_class.new(users: users, current_user: current_user, household: household))
       end).to eq(1)
     end
+
+    it 'does not query row associations for users loaded by the index query' do
+      users = Admin::UsersIndexQuery.new(
+        scope: User.where(id: [current_user.id, target_user.id]),
+        filters: {},
+        household: household
+      ).call.to_a
+
+      expect(count_row_association_queries do
+        render_inline(described_class.new(users: users, current_user: current_user, household: household))
+      end).to eq(0)
+    end
   end
 
   describe 'sortable headers' do
@@ -150,6 +162,19 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
 
       sql = payload[:sql]
       count += 1 if sql.include?('FROM "household_memberships"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
+  end
+
+  def count_row_association_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      sql = payload[:sql]
+      count += 1 if sql.match?(/FROM "(people|accounts|platform_admins)"/)
     end
 
     ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)


### PR DESCRIPTION
## Summary
- preload person/account/platform-admin associations for the admin users index
- add a regression check that query-built users render without per-row association queries

## Tests
- ruby -c app/services/admin/users_index_query.rb spec/components/admin/users/users_table_spec.rb
- git diff --check
- task test TEST_FILE=spec/components/admin/users/users_table_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)

Closes #624