### PR TITLE
feat(lookup): rate limit finder searches

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,6 +3,7 @@
 module Rack
   class Attack
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    MEDICATION_LOOKUP_PATH = %r{\A/households/[^/]+/medication-finder/search(?:\.[a-z]+)?\z}
 
     throttle('req/ip', limit: 300, period: 5.minutes, &:ip)
 
@@ -49,6 +50,17 @@ module Rack
       end
     end
 
+    throttle('medication_lookup/ip', limit: 60, period: 1.minute) do |req|
+      req.ip if req.get? && req.path.match?(MEDICATION_LOOKUP_PATH)
+    end
+
+    throttle('medication_lookup/user', limit: 120, period: 1.hour) do |req|
+      if req.get? && req.path.match?(MEDICATION_LOOKUP_PATH)
+        session = req.env['rack.session']
+        session && session['account_id']
+      end
+    end
+
     throttle('ai_medication_suggestions/ip', limit: 10, period: 1.minute) do |req|
       req.ip if req.path == '/ai-medication-suggestions' && req.post?
     end
@@ -66,6 +78,7 @@ module Rack
       retry_after = match_data[:period] - (now % match_data[:period])
 
       throttle_type = request.env['rack.attack.matched']
+      ActiveSupport::Notifications.instrument('rack_attack.throttled', throttle: throttle_type, ip: request.ip)
       Rails.logger.warn("Rate limit exceeded: #{throttle_type} from IP #{request.ip}")
 
       [

--- a/spec/requests/medication_lookup_rate_limiting_spec.rb
+++ b/spec/requests/medication_lookup_rate_limiting_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Medication lookup rate limiting' do
+  include ActiveSupport::Testing::TimeHelpers
+
+  fixtures :accounts, :people, :users
+
+  let(:admin) { users(:admin) }
+
+  around do |example|
+    original_cache_store = Rack::Attack.cache.store
+    original_enabled = Rack::Attack.enabled
+
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+
+    example.run
+  ensure
+    Rack::Attack.cache.store = original_cache_store
+    Rack::Attack.enabled = original_enabled
+  end
+
+  before do
+    freeze_time
+    sign_in(admin)
+    stub_successful_lookup
+  end
+
+  it 'allows ordinary lookup traffic below the threshold' do
+    3.times { get medication_finder_search_path(format: :json), params: { q: 'aspirin' } }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'throttles excessive lookup traffic and emits retry metadata' do
+    notifications = []
+    subscriber = lambda do |_name, _started, _finished, _id, payload|
+      notifications << payload
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'rack_attack.throttled') do
+      60.times { get medication_finder_search_path(format: :json), params: { q: 'aspirin' } }
+      expect(response).to have_http_status(:ok)
+
+      get medication_finder_search_path(format: :json), params: { q: 'aspirin' }
+    end
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.body).to include('Rate limit exceeded')
+    expect(response.headers['Retry-After'].to_i).to be > 0
+    expect(notifications).to include(hash_including(throttle: 'medication_lookup/ip'))
+  end
+
+  def stub_successful_lookup
+    search = instance_double(
+      NhsDmd::Search,
+      call: NhsDmd::Search::Result.new(results: [], error: nil)
+    )
+    allow(NhsDmd::Search).to receive(:new).and_return(search)
+  end
+end


### PR DESCRIPTION
## Summary
- add Rack::Attack IP and user throttles for medication finder search requests
- emit rack_attack.throttled notifications from the shared throttled responder
- cover normal lookup traffic, 429 responses, Retry-After metadata, and throttle telemetry

## Tests
- ruby -c config/initializers/rack_attack.rb spec/requests/medication_lookup_rate_limiting_spec.rb
- git diff --check
- task test TEST_FILE=spec/requests/medication_lookup_rate_limiting_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)

Closes #625