### PR TITLE
feat(observability): configure production trace sampling

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -2,14 +2,32 @@
 
 require 'opentelemetry-api'
 require 'otel/allowlisted_span_exporter'
+require 'otel/critical_path_sampler'
 
 OpenTelemetry.logger = Logger.new($stdout, level: Rails.env.test? ? Logger::WARN : Logger::ERROR)
 
 module OpenTelemetryConfig
+  DEFAULT_PRODUCTION_TRACE_SAMPLE_RATE = 0.1
+  DEFAULT_TRACE_SAMPLE_RATE = 1.0
+  DEFAULT_CRITICAL_TRACE_MATCHERS = [
+    '/login',
+    '/logout',
+    '/create-account',
+    '/api/v1/auth/login',
+    '/api/v1/auth/refresh',
+    '/api/v1/auth/logout',
+    '/medication_takes',
+    '/take_medication',
+    '/offline/medication_takes',
+    '/admin/audit_logs',
+    '/platform/support_access_sessions',
+    'medication_take.'
+  ].freeze
+
   module_function
 
   def parse_otlp_headers(headers_string)
-    return {} unless headers_string.present?
+    return {} if headers_string.blank?
 
     headers_string.split(',').each_with_object({}) do |header, hash|
       key, value = header.split('=', 2)
@@ -19,6 +37,70 @@ module OpenTelemetryConfig
         hash[key.strip] = ''
       end
     end
+  end
+
+  def trace_sampler(environment: Rails.env, env: ENV)
+    Otel::CriticalPathSampler.new(
+      delegate: delegate_trace_sampler(environment:, env:),
+      critical_path_matchers: critical_trace_matchers(env:)
+    )
+  end
+
+  def apply_trace_sampler(configurator, sampler)
+    configurator.send(:tracer_provider).sampler = sampler
+  end
+
+  def trace_sample_rate(environment: Rails.env, env: ENV)
+    configured_rate = env['MEDTRACKER_OTEL_TRACE_SAMPLE_RATE'].presence || env['OTEL_TRACES_SAMPLER_ARG'].presence
+
+    parse_trace_sample_rate(configured_rate, fallback: default_trace_sample_rate(environment))
+  end
+
+  def critical_trace_matchers(env: ENV)
+    configured_matchers = env['MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS']
+    return DEFAULT_CRITICAL_TRACE_MATCHERS if configured_matchers.blank?
+    return [] if configured_matchers.strip.casecmp?('none')
+
+    configured_matchers.split(',').map(&:strip).compact_blank
+  end
+
+  def delegate_trace_sampler(environment: Rails.env, env: ENV)
+    sample_rate = trace_sample_rate(environment:, env:)
+
+    named_trace_sampler(env['OTEL_TRACES_SAMPLER'].presence, sample_rate)
+  end
+
+  def named_trace_sampler(sampler_name, sample_rate)
+    case sampler_name
+    when 'always_on'
+      OpenTelemetry::SDK::Trace::Samplers::ALWAYS_ON
+    when 'always_off'
+      OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF
+    when 'traceidratio'
+      OpenTelemetry::SDK::Trace::Samplers.trace_id_ratio_based(sample_rate)
+    when 'parentbased_always_on'
+      parent_based_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_ON)
+    when 'parentbased_always_off'
+      parent_based_sampler(OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF)
+    else
+      parent_based_sampler(OpenTelemetry::SDK::Trace::Samplers.trace_id_ratio_based(sample_rate))
+    end
+  end
+
+  def parent_based_sampler(root_sampler)
+    OpenTelemetry::SDK::Trace::Samplers.parent_based(root: root_sampler)
+  end
+
+  def default_trace_sample_rate(environment)
+    environment.to_s == 'production' ? DEFAULT_PRODUCTION_TRACE_SAMPLE_RATE : DEFAULT_TRACE_SAMPLE_RATE
+  end
+
+  def parse_trace_sample_rate(value, fallback:)
+    return fallback if value.blank?
+
+    Float(value).clamp(0.0, 1.0)
+  rescue ArgumentError, TypeError
+    fallback
   end
 end
 
@@ -71,6 +153,7 @@ elsif Rails.env.production? || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].present?
   OpenTelemetry::SDK.configure do |c|
     c.service_name = 'medtracker'
     c.service_version = ENV.fetch('APP_VERSION', '1.0.0')
+    OpenTelemetryConfig.apply_trace_sampler(c, OpenTelemetryConfig.trace_sampler)
 
     if otlp_endpoint.present?
       span_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(

--- a/docs/observability-sampling.md
+++ b/docs/observability-sampling.md
@@ -1,0 +1,29 @@
+# OpenTelemetry Sampling
+
+Production tracing uses a parent-based trace-id ratio sampler wrapped with a critical-path sampler.
+
+## Defaults
+
+- Production baseline: `MEDTRACKER_OTEL_TRACE_SAMPLE_RATE=0.1`
+- Non-production baseline: `1.0`
+- Critical paths are retained even when the baseline sampler would drop the trace.
+
+Critical defaults cover authentication, support access, audit logs, medication-take writes, offline medication-take sync, and `MedicationTake` model spans.
+
+## Tuning
+
+Set `MEDTRACKER_OTEL_TRACE_SAMPLE_RATE` to a value from `0.0` to `1.0` to adjust non-critical trace volume without changing code.
+
+Set `MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS` to comma-separated path or span-name fragments to replace the default critical matcher list.
+
+Use `MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS=none` to disable critical matcher retention for emergency volume reduction.
+
+Standard OpenTelemetry sampler settings are still accepted through `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`. Critical-path retention wraps those delegate sampler choices unless the critical matcher list is disabled.
+
+## Rollback
+
+For maximum retention during incident review, set `MEDTRACKER_OTEL_TRACE_SAMPLE_RATE=1.0`.
+
+For emergency volume reduction, set `MEDTRACKER_OTEL_TRACE_SAMPLE_RATE=0.0` and `MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS=none`.
+
+After changing sampling settings, restart the Rails process and confirm exporter throughput in the collector before applying the same setting to all production instances.

--- a/lib/otel/critical_path_sampler.rb
+++ b/lib/otel/critical_path_sampler.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'opentelemetry/sdk/trace/samplers'
+
+module Otel
+  class CriticalPathSampler
+    ATTRIBUTE_KEYS = %w[
+      http.route
+      http.target
+      url.path
+    ].freeze
+
+    def initialize(delegate:, critical_path_matchers:)
+      @delegate = delegate
+      @critical_path_matchers = critical_path_matchers
+    end
+
+    def should_sample?(**sampling_options)
+      name = sampling_options[:name]
+      attributes = sampling_options[:attributes]
+
+      return always_on.should_sample?(**sampling_options) if critical_path?(name, attributes || {})
+
+      delegate.should_sample?(**sampling_options)
+    end
+
+    def description
+      "CriticalPathSampler{matchers=#{critical_path_matchers.size}, delegate=#{delegate.description}}"
+    end
+
+    private
+
+    attr_reader :delegate, :critical_path_matchers
+
+    def always_on
+      OpenTelemetry::SDK::Trace::Samplers::ALWAYS_ON
+    end
+
+    def critical_path?(name, attributes)
+      candidates = [name, *ATTRIBUTE_KEYS.filter_map { |key| attributes[key] }]
+      candidates.any? { |candidate| critical_path_matchers.any? { |matcher| matches?(matcher, candidate) } }
+    end
+
+    def matches?(matcher, candidate)
+      matcher.is_a?(Regexp) ? matcher.match?(candidate.to_s) : candidate.to_s.include?(matcher.to_s)
+    end
+  end
+end

--- a/spec/features/observability/trace_sampling_config_spec.rb
+++ b/spec/features/observability/trace_sampling_config_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OTEL-019: trace sampling configuration' do
+  describe '.trace_sample_rate' do
+    it 'uses the production baseline by default' do
+      rate = OpenTelemetryConfig.trace_sample_rate(environment: 'production', env: {})
+
+      expect(rate).to eq(0.1)
+    end
+
+    it 'uses the app-specific override when present' do
+      env = { 'MEDTRACKER_OTEL_TRACE_SAMPLE_RATE' => '0.25' }
+
+      rate = OpenTelemetryConfig.trace_sample_rate(environment: 'production', env: env)
+
+      expect(rate).to eq(0.25)
+    end
+
+    it 'falls back to the environment default for invalid overrides' do
+      env = { 'MEDTRACKER_OTEL_TRACE_SAMPLE_RATE' => 'invalid' }
+
+      rate = OpenTelemetryConfig.trace_sample_rate(environment: 'production', env: env)
+
+      expect(rate).to eq(0.1)
+    end
+  end
+
+  describe '.critical_trace_matchers' do
+    it 'uses safe defaults when no override is configured' do
+      matchers = OpenTelemetryConfig.critical_trace_matchers(env: {})
+
+      expect(matchers).to include('/medication_takes', '/api/v1/auth/login', 'medication_take.')
+    end
+
+    it 'parses operator supplied matchers' do
+      env = { 'MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS' => '/login, /admin/audit_logs' }
+
+      matchers = OpenTelemetryConfig.critical_trace_matchers(env: env)
+
+      expect(matchers).to eq(['/login', '/admin/audit_logs'])
+    end
+
+    it 'allows operators to disable critical matcher overrides' do
+      env = { 'MEDTRACKER_OTEL_CRITICAL_TRACE_MATCHERS' => 'none' }
+
+      matchers = OpenTelemetryConfig.critical_trace_matchers(env: env)
+
+      expect(matchers).to eq([])
+    end
+  end
+
+  describe '.trace_sampler' do
+    it 'builds a critical path sampler around the baseline sampler' do
+      env = { 'MEDTRACKER_OTEL_TRACE_SAMPLE_RATE' => '0.2' }
+
+      sampler = OpenTelemetryConfig.trace_sampler(environment: 'production', env: env)
+
+      expect(sampler).to be_a(Otel::CriticalPathSampler)
+      expect(sampler.description).to include('TraceIdRatioBased{0.200000}')
+    end
+
+    it 'honours the standard always_off sampler while retaining critical paths' do
+      env = { 'OTEL_TRACES_SAMPLER' => 'always_off' }
+
+      sampler = OpenTelemetryConfig.trace_sampler(environment: 'production', env: env)
+      result = sampler.should_sample?(
+        trace_id: '0af7651916cd43dd8448eb211c80319c',
+        parent_context: OpenTelemetry::Context.empty,
+        links: [],
+        name: 'GET /households/:household_slug/dashboard',
+        kind: :server,
+        attributes: { 'http.route' => '/households/:household_slug/schedules/:schedule_id/medication_takes' }
+      )
+
+      expect(result).to be_sampled
+    end
+  end
+
+  describe '.apply_trace_sampler' do
+    it 'sets the sampler on the SDK tracer provider' do
+      provider = Struct.new(:sampler).new
+      configurator_class = Class.new do
+        def initialize(provider)
+          @provider = provider
+        end
+
+        private
+
+        def tracer_provider
+          @provider
+        end
+      end
+      sampler = OpenTelemetry::SDK::Trace::Samplers::ALWAYS_ON
+
+      OpenTelemetryConfig.apply_trace_sampler(configurator_class.new(provider), sampler)
+
+      expect(provider.sampler).to eq(sampler)
+    end
+  end
+end

--- a/spec/lib/otel/critical_path_sampler_spec.rb
+++ b/spec/lib/otel/critical_path_sampler_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'otel/critical_path_sampler'
+
+RSpec.describe Otel::CriticalPathSampler do
+  subject(:sampler) { described_class.new(delegate:, critical_path_matchers:) }
+
+  let(:delegate) { OpenTelemetry::SDK::Trace::Samplers::ALWAYS_OFF }
+  let(:critical_path_matchers) { ['/medication_takes', 'medication_take.'] }
+  let(:trace_id) { '0af7651916cd43dd8448eb211c80319c' }
+  let(:base_arguments) do
+    {
+      trace_id: trace_id,
+      parent_context: OpenTelemetry::Context.empty,
+      links: [],
+      name: 'GET /households/:household_slug/dashboard',
+      kind: :server,
+      attributes: {}
+    }
+  end
+
+  it 'samples spans whose HTTP route matches a critical path' do
+    result = sampler.should_sample?(
+      **base_arguments,
+      attributes: { 'http.route' => '/households/:household_slug/schedules/:schedule_id/medication_takes' }
+    )
+
+    expect(result).to be_sampled
+  end
+
+  it 'samples spans whose name matches a critical model operation' do
+    result = sampler.should_sample?(**base_arguments, name: 'medication_take.create')
+
+    expect(result).to be_sampled
+  end
+
+  it 'delegates non-critical spans to the configured sampler' do
+    result = sampler.should_sample?(**base_arguments)
+
+    expect(result).not_to be_sampled
+  end
+end


### PR DESCRIPTION
Closes #628.\n\n## Summary\n- add production trace sampling defaults with env overrides\n- retain critical auth, audit, support-access, and medication-take traces through a critical-path sampler\n- document tuning and rollback settings\n\n## Verification\n- ruby -c lib/otel/critical_path_sampler.rb\n- ruby -c config/initializers/opentelemetry.rb\n- ruby -c spec/lib/otel/critical_path_sampler_spec.rb\n- ruby -c spec/features/observability/trace_sampling_config_spec.rb\n- git diff --check\n- task test TEST_FILE=spec/lib/otel/critical_path_sampler_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task test TEST_FILE=spec/features/observability/trace_sampling_config_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)