### PR TITLE
feat(lookup): filter finder results by form

### DIFF
--- a/app/components/medications/finder_view.rb
+++ b/app/components/medications/finder_view.rb
@@ -24,6 +24,8 @@ module Components
               barcode: t('medications.finder.barcode'),
               dmdCode: t('medications.finder.dmd_code'),
               pilLink: t('medications.finder.pil_link'),
+              formFilterLabel: t('medications.finder.form_filter_label'),
+              allForms: t('medications.finder.all_forms'),
               interactionSummary: t('medications.finder.interaction_summary'),
               interactionDetailsButton: t('medications.finder.interaction_details_button'),
               interactionDetails: t('medications.finder.interaction_details'),
@@ -95,6 +97,27 @@ module Components
                 class: 'h-full rounded-shape-xl px-8 font-bold text-sm shadow-lg shadow-primary/20',
                 data: { medication_search_target: 'submitButton' }
               ) { t('medications.finder.search_button') }
+            end
+          end
+          render_form_filter
+        end
+      end
+
+      def render_form_filter
+        div(class: 'mt-4 max-w-xs') do
+          label(
+            for: 'medication-form-filter',
+            class: 'mb-2 block text-sm font-medium text-on-surface-variant'
+          ) { t('medications.finder.form_filter_label') }
+          select(
+            id: 'medication-form-filter',
+            name: 'form',
+            data: { medication_search_target: 'formFilter' },
+            class: 'block w-full rounded-shape-sm border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/5'
+          ) do
+            option(value: '') { t('medications.finder.all_forms') }
+            NhsDmd::DosageFormFilter.options.each_key do |value|
+              option(value: value) { t("medications.finder.forms.#{value}") }
             end
           end
         end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -160,7 +160,11 @@ class MedicationsController < ApplicationController
 
   def search
     authorize Medication, :finder?
-    response = medication_finder_search_responder.call(query: params[:q], permissions: medication_finder_permissions)
+    response = medication_finder_search_responder.call(
+      query: params[:q],
+      form: params[:form],
+      permissions: medication_finder_permissions
+    )
 
     render json: response.body, status: response.status
   end

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "results", "idle", "submitButton"]
+  static targets = ["input", "formFilter", "results", "idle", "submitButton"]
   static values = { translations: Object, searchUrl: String, newMedicationUrl: String }
 
   barcodeDecoded(event) {
@@ -27,6 +27,7 @@ export default class extends Controller {
     try {
       const url = new URL(this.searchUrl, window.location.origin)
       url.searchParams.set("q", query)
+      if (this.selectedForm) url.searchParams.set("form", this.selectedForm)
 
       const response = await fetch(url.toString(), {
         headers: { "Accept": "application/json" }
@@ -52,6 +53,10 @@ export default class extends Controller {
 
   get newMedicationUrl() {
     return this.hasNewMedicationUrlValue ? this.newMedicationUrlValue : "/medications/new"
+  }
+
+  get selectedForm() {
+    return this.hasFormFilterTarget ? this.formFilterTarget.value : ""
   }
 
   showLoading() {

--- a/app/services/medication_finder_search_responder.rb
+++ b/app/services/medication_finder_search_responder.rb
@@ -10,14 +10,14 @@ class MedicationFinderSearchResponder
     @interaction_lookup = interaction_lookup || MedicationInteractionLookup.new(medication_scope: medication_scope)
   end
 
-  def call(query:, permissions: {})
+  def call(query:, form: nil, permissions: {})
     normalized_query = query.to_s.strip
     return Result.new(body: { results: [], permissions: permissions }, status: :ok) if normalized_query.blank?
 
     result = @search.call(normalized_query)
     return unavailable_response unless result&.success?
 
-    successful_response(query: normalized_query, result: result, permissions: permissions)
+    successful_response(query: normalized_query, result: result, form: form, permissions: permissions)
   rescue StandardError => e
     Rails.logger.error("Medication finder search failed: #{e.class}: #{e.message}")
     unavailable_response
@@ -25,12 +25,16 @@ class MedicationFinderSearchResponder
 
   private
 
-  def successful_response(query:, result:, permissions:)
+  def successful_response(query:, result:, form:, permissions:)
+    normalized_form = NhsDmd::DosageFormFilter.normalize(form)
+    results = NhsDmd::DosageFormFilter.filter(result.results, form)
+
     Result.new(
       body: {
-        results: result.results.map { |search_result| result_payload(search_result, result.barcode) },
+        results: results.map { |search_result| result_payload(search_result, result.barcode) },
         query: result.resolved_query.presence || query,
         barcode: result.barcode,
+        form: normalized_form,
         permissions: permissions
       },
       status: :ok

--- a/app/services/nhs_dmd/dosage_form_filter.rb
+++ b/app/services/nhs_dmd/dosage_form_filter.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module NhsDmd
+  class DosageFormFilter
+    def self.normalize_text(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, '_').gsub(/\A_+|_+\z/, '')
+    end
+    private_class_method :normalize_text
+
+    OPTIONS = {
+      'tablet' => 'Tablets',
+      'capsule' => 'Capsules',
+      'liquid' => 'Liquids',
+      'cream' => 'Creams and ointments',
+      'inhaler' => 'Inhalers',
+      'injection' => 'Injections',
+      'patch' => 'Patches',
+      'drops' => 'Drops',
+      'spray' => 'Sprays',
+      'powder' => 'Powders and sachets'
+    }.freeze
+
+    TERMS = {
+      'tablet' => %w[tablet tablets caplet caplets],
+      'capsule' => %w[capsule capsules],
+      'liquid' => %w[liquid solution suspension syrup oral_solution oral_suspension ml],
+      'cream' => %w[cream ointment gel],
+      'inhaler' => %w[inhaler inhalation inhalation_powder nebuliser nebulizer],
+      'injection' => %w[injection injectable syringe ampoule vial],
+      'patch' => %w[patch patches],
+      'drops' => %w[drops eye_drops ear_drops],
+      'spray' => %w[spray sprays],
+      'powder' => %w[powder powders sachet sachets granules]
+    }.freeze
+
+    ALIASES = TERMS.each_with_object({}) do |(form, terms), aliases|
+      aliases[form] = form
+      terms.each { |term| aliases[normalize_text(term)] = form }
+    end.freeze
+
+    def self.options
+      OPTIONS
+    end
+
+    def self.normalize(value)
+      ALIASES[normalize_text(value)]
+    end
+
+    def self.filter(results, form)
+      normalized_form = normalize(form)
+      return results if normalized_form.blank?
+
+      results.select { |result| matches?(result, normalized_form) }
+    end
+
+    def self.matches?(result, form)
+      searchable_text = normalize_text(searchable_values(result).join(' '))
+      TERMS.fetch(form, []).any? { |term| searchable_text.include?(normalize_text(term)) }
+    end
+
+    def self.searchable_values(result)
+      payload = result.respond_to?(:to_h) ? result.to_h : {}
+      [
+        payload[:package_unit],
+        payload[:display],
+        payload[:name],
+        payload[:description],
+        result.respond_to?(:package_unit) ? result.package_unit : nil,
+        result.respond_to?(:display) ? result.display : nil,
+        result.respond_to?(:name) ? result.name : nil
+      ].compact
+    end
+
+    private_class_method :matches?, :searchable_values
+  end
+end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -724,6 +724,19 @@ cy:
       barcode: Cod bar
       dmd_code: Cod dm+d
       pil_link: Taflen wybodaeth i gleifion
+      form_filter_label: Ffurf dos
+      all_forms: Pob ffurf
+      forms:
+        tablet: Tabledi
+        capsule: Capsiwlau
+        liquid: Hylifau
+        cream: Hufenau ac eli
+        inhaler: Anadlyddion
+        injection: Pigiadau
+        patch: Clytiau
+        drops: Diferion
+        spray: Chwistrellau
+        powder: Powdrau a sachau
       update_stock: Diweddaru stoc
       confirm_restock: Cadarnhewch eich bod am ychwanegu %{quantity} uned at %{medication}.
       confirm_restock_without_quantity: Cadarnhewch faint o unedau rydych am eu hychwanegu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -754,6 +754,19 @@ en:
       barcode: Barcode
       dmd_code: dm+d code
       pil_link: Patient information leaflet
+      form_filter_label: Dosage form
+      all_forms: All forms
+      forms:
+        tablet: Tablets
+        capsule: Capsules
+        liquid: Liquids
+        cream: Creams and ointments
+        inhaler: Inhalers
+        injection: Injections
+        patch: Patches
+        drops: Drops
+        spray: Sprays
+        powder: Powders and sachets
       interaction_summary: "%{count} interaction warning (%{severity})"
       interaction_details_button: View Interaction Details
       interaction_details: Interaction Details

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -732,6 +732,19 @@ es:
       barcode: Código de barras
       dmd_code: código dm+d
       pil_link: Prospecto para el paciente
+      form_filter_label: Forma farmacéutica
+      all_forms: Todas las formas
+      forms:
+        tablet: Comprimidos
+        capsule: Cápsulas
+        liquid: Líquidos
+        cream: Cremas y pomadas
+        inhaler: Inhaladores
+        injection: Inyecciones
+        patch: Parches
+        drops: Gotas
+        spray: Sprays
+        powder: Polvos y sobres
       update_stock: Actualizar stock
       confirm_restock: Confirme que desea añadir %{quantity} unidades a %{medication}.
       confirm_restock_without_quantity: Confirme cuántas unidades desea añadir a

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -727,6 +727,19 @@ ga:
       barcode: Barrachód
       dmd_code: cód dm+d
       pil_link: Bileog eolais don othar
+      form_filter_label: Foirm dáileoige
+      all_forms: Gach foirm
+      forms:
+        tablet: Táibléid
+        capsule: Capsúil
+        liquid: Leachtanna
+        cream: Uachtair agus ointments
+        inhaler: Análóirí
+        injection: Instealltaí
+        patch: Paistí
+        drops: Braonta
+        spray: Spraeanna
+        powder: Púdair agus saicíní
       update_stock: Nuashonraigh stoc
       confirm_restock: Deimhnigh gur mian leat %{quantity} aonad a chur le %{medication}.
       confirm_restock_without_quantity: Deimhnigh cé mhéad aonad is mian leat a chur

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -730,6 +730,19 @@ pt:
       barcode: Código de barras
       dmd_code: Código dm+d
       pil_link: Folheto informativo do doente
+      form_filter_label: Forma farmacêutica
+      all_forms: Todas as formas
+      forms:
+        tablet: Comprimidos
+        capsule: Cápsulas
+        liquid: Líquidos
+        cream: Cremes e pomadas
+        inhaler: Inaladores
+        injection: Injeções
+        patch: Adesivos
+        drops: Gotas
+        spray: Sprays
+        powder: Pós e saquetas
       update_stock: Atualizar stock
       confirm_restock: Confirme que pretende adicionar %{quantity} unidades a %{medication}.
       confirm_restock_without_quantity: Confirme quantas unidades pretende adicionar

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe 'GET /medication-finder/search' do
         )
       end
 
+      it 'passes the selected dosage form filter to the responder' do
+        get medication_finder_search_path(format: :json), params: { q: 'aspirin', form: 'tablet' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['form']).to eq('tablet')
+      end
+
       it 'includes interaction warnings for matching accessible medication stock' do
         search = instance_double(
           NhsDmd::Search,

--- a/spec/services/medication_finder_search_responder_spec.rb
+++ b/spec/services/medication_finder_search_responder_spec.rb
@@ -127,6 +127,19 @@ RSpec.describe MedicationFinderSearchResponder do
         result = responder.call(query: 'paracetamol', permissions: { admin: true })
         expect(result.body[:permissions]).to eq({ admin: true })
       end
+
+      it 'filters results by dosage form when requested' do
+        tablet = make_search_result(display: 'Paracetamol 500mg tablets', package_unit: 'tablet')
+        liquid = make_search_result(display: 'Paracetamol 250mg/5ml oral suspension', package_unit: 'ml')
+        allow(search).to receive(:call).and_return(successful_nhs_result(results: [tablet, liquid]))
+
+        result = responder.call(query: 'paracetamol', form: 'liquid')
+
+        expect(result.body[:results]).to contain_exactly(
+          a_hash_including(display: 'Paracetamol 250mg/5ml oral suspension')
+        )
+        expect(result.body[:form]).to eq('liquid')
+      end
     end
 
     context 'when search raises an error' do

--- a/spec/services/nhs_dmd/dosage_form_filter_spec.rb
+++ b/spec/services/nhs_dmd/dosage_form_filter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NhsDmd::DosageFormFilter do
+  describe '.normalize' do
+    it 'normalizes common form aliases' do
+      expect(described_class.normalize('Tablets')).to eq('tablet')
+      expect(described_class.normalize('oral solution')).to eq('liquid')
+      expect(described_class.normalize('inhalation powder')).to eq('inhaler')
+    end
+
+    it 'returns nil for unsupported forms' do
+      expect(described_class.normalize('unknown')).to be_nil
+    end
+  end
+
+  describe '.filter' do
+    let(:tablet) do
+      NhsDmd::SearchResult.new(
+        code: '1',
+        display: 'Aspirin 300mg tablets',
+        system: 'https://dmd.nhs.uk',
+        package_unit: 'tablet'
+      )
+    end
+    let(:liquid) do
+      NhsDmd::SearchResult.new(
+        code: '2',
+        display: 'Amoxicillin 250mg/5ml oral suspension',
+        system: 'https://dmd.nhs.uk',
+        package_unit: 'ml'
+      )
+    end
+
+    it 'returns all results when no form is selected' do
+      expect(described_class.filter([tablet, liquid], nil)).to eq([tablet, liquid])
+    end
+
+    it 'returns only results matching the normalized form' do
+      expect(described_class.filter([tablet, liquid], 'liquid')).to eq([liquid])
+    end
+  end
+end

--- a/spec/system/medication_finder_spec.rb
+++ b/spec/system/medication_finder_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'MedicationFinder' do
       aggregate_failures 'medication finder content' do
         expect(page).to have_text('Medication Finder')
         expect(page).to have_field('medication-search-input')
+        expect(page).to have_select('medication-form-filter')
         expect(page).to have_button('Search')
         expected_text = 'Search NHS dm+d and supported product sources to add medication or restock existing inventory.'
         expect(page).to have_text(expected_text)


### PR DESCRIPTION
Closes #627.\n\n## Summary\n- add dosage-form normalization and filtering for medicine finder results\n- pass the selected form filter through the finder JSON endpoint\n- add a form filter select to the finder UI and include localized labels\n\n## Verification\n- ruby -c app/services/nhs_dmd/dosage_form_filter.rb\n- ruby -c app/services/medication_finder_search_responder.rb\n- ruby -c app/controllers/medications_controller.rb\n- ruby -c app/components/medications/finder_view.rb\n- ruby -c spec/services/nhs_dmd/dosage_form_filter_spec.rb\n- ruby -c spec/services/medication_finder_search_responder_spec.rb\n- ruby -c spec/requests/medications_search_spec.rb\n- ruby -c spec/system/medication_finder_spec.rb\n- YAML.load_file for config/locales/en.yml, pt.yml, es.yml, ga.yml, cy.yml\n- git diff --check\n- task test TEST_FILE=spec/services/nhs_dmd/dosage_form_filter_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task test TEST_FILE=spec/services/medication_finder_search_responder_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task test TEST_FILE=spec/requests/medications_search_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task test TEST_FILE=spec/system/medication_finder_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)\n- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)