### PR TITLE
feat(profile): add account time zone preference

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,9 +42,15 @@ class ApplicationController < ActionController::Base
     !request.get? && !request.head?
   end
 
-  def with_current_context
+  def with_current_context(&)
     Current.account = current_account
     Current.request_id = request.request_id
+    Time.use_zone(current_account_time_zone) { with_current_tenant_context(&) }
+  ensure
+    Current.reset
+  end
+
+  def with_current_tenant_context
     household_slug = request.path_parameters[:household_slug]
     return yield if household_slug.blank?
 
@@ -65,8 +71,10 @@ class ApplicationController < ActionController::Base
         user_not_authorized
       end
     end
-  ensure
-    Current.reset
+  end
+
+  def current_account_time_zone
+    current_account&.preferred_time_zone || Rails.application.config.time_zone
   end
 
   def active_household_membership

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -156,6 +156,6 @@ class ProfilesController < ApplicationController
   end
 
   def account_params
-    params.expect(account: %i[email gravatar_enabled]) if params[:account]
+    params.expect(account: %i[email gravatar_enabled time_zone]) if params[:account]
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,7 +7,9 @@ class Account < ApplicationRecord
 
   WIZARD_VARIANTS = %w[fullpage modal slideover].freeze
 
-  store_accessor :preferences, :wizard_variant, :gravatar_enabled
+  TIME_ZONE_NAMES = ActiveSupport::TimeZone.all.map(&:name).freeze
+
+  store_accessor :preferences, :wizard_variant, :gravatar_enabled, :time_zone
 
   enum :status, { unverified: 1, verified: 2, closed: 3 }
 
@@ -23,6 +25,7 @@ class Account < ApplicationRecord
   has_one :platform_admin, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
+  validates :time_zone, inclusion: { in: TIME_ZONE_NAMES }, allow_blank: true
 
   def first_active_household_membership
     household_memberships.active.includes(:household).order(:id).first
@@ -45,5 +48,9 @@ class Account < ApplicationRecord
 
   def gravatar_enabled?
     !!ActiveModel::Type::Boolean.new.cast(gravatar_enabled)
+  end
+
+  def preferred_time_zone
+    time_zone.presence || Rails.application.config.time_zone
   end
 end

--- a/app/views/profiles/personal_info_content.rb
+++ b/app/views/profiles/personal_info_content.rb
@@ -3,6 +3,7 @@
 module Views
   module Profiles
     class PersonalInfoContent < Views::Base
+      include Phlex::Rails::Helpers::FormWith
       include Phlex::Rails::Helpers::Routes
 
       attr_reader :person, :account
@@ -18,6 +19,7 @@ module Views
           render_basic_info_rows
           render_age_row if person.age
           render_capacity_info_rows
+          render_time_zone_form
         end
       end
 
@@ -26,6 +28,7 @@ module Views
       def render_basic_info_rows
         render_info_row('Name', person.name)
         render_info_row('Email', account.email)
+        render_info_row('Time Zone', account.preferred_time_zone)
         render_info_row('Date of Birth', formatted_date_of_birth)
       end
 
@@ -49,6 +52,35 @@ module Views
         return 'Not set' unless person.date_of_birth
 
         person.date_of_birth.strftime('%B %d, %Y')
+      end
+
+      def render_time_zone_form
+        div(class: 'rounded-shape-xl border border-outline-variant/70 bg-surface-container p-4') do
+          form_with(url: profile_path, method: :patch, class: 'flex flex-col gap-4 sm:flex-row sm:items-end') do
+            div(class: 'flex-1 space-y-2') do
+              label(class: 'block text-sm font-bold text-foreground', for: 'account_time_zone') { 'Time Zone' }
+              select(
+                id: 'account_time_zone',
+                name: 'account[time_zone]',
+                class: time_zone_select_classes
+              ) do
+                time_zone_options.each do |zone_name|
+                  option(value: zone_name, selected: zone_name == account.preferred_time_zone) { zone_name }
+                end
+              end
+            end
+            m3_button(type: :submit, variant: :tonal, size: :sm) { 'Save time zone' }
+          end
+        end
+      end
+
+      def time_zone_options
+        Account::TIME_ZONE_NAMES
+      end
+
+      def time_zone_select_classes
+        'block w-full rounded-shape-sm border border-border bg-card px-3 py-2 text-sm text-foreground ' \
+          'focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/5'
       end
     end
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe Account do
     end
   end
 
+  describe 'time zone preference' do
+    it 'allows Rails time zone names' do
+      account = described_class.new(email: 'time-zone@example.test', status: :verified, time_zone: 'London')
+
+      account.validate
+
+      expect(account.errors[:time_zone]).to be_empty
+    end
+
+    it 'rejects unknown time zones' do
+      account = described_class.new(email: 'time-zone@example.test', status: :verified, time_zone: 'Atlantis/Nowhere')
+
+      account.validate
+
+      expect(account.errors[:time_zone]).to be_present
+    end
+
+    it 'falls back to the app time zone when no preference is set' do
+      account = accounts(:jane_doe)
+      account.time_zone = nil
+
+      expect(account.preferred_time_zone).to eq(Rails.application.config.time_zone)
+    end
+  end
+
   describe 'versioning' do
     it 'creates a version when account status changes' do
       account = accounts(:jane_doe)

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -22,8 +22,18 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include(user.name)
       expect(response.body).to include(account.email)
       expect(response.body).to include('Account Security')
+      expect(response.body).to include('Time Zone')
       expect(response.body).to include('System Information')
       expect(response.body.scan('data-turbo-frame="modal"').size).to be >= 2
+    end
+
+    it 'uses the account time zone around the request' do
+      account.update!(time_zone: 'Pacific Time (US & Canada)')
+      allow(Time).to receive(:use_zone).and_call_original
+
+      get profile_path
+
+      expect(Time).to have_received(:use_zone).with('Pacific Time (US & Canada)')
     end
 
     it 'renders readable stacked identity details in the profile hero', :aggregate_failures do
@@ -163,6 +173,21 @@ RSpec.describe 'Profiles' do
 
       expect(response).to redirect_to(profile_path)
       expect(account.reload.gravatar_enabled?).to be(false)
+    end
+
+    it 'updates the account time zone preference' do
+      patch profile_path, params: { account: { time_zone: 'London' } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(account.reload.time_zone).to eq('London')
+    end
+
+    it 'rejects an invalid account time zone preference' do
+      patch profile_path, params: { account: { time_zone: 'Atlantis/Nowhere' } }
+
+      expect(response).to redirect_to(profile_path)
+      expect(flash[:alert]).to include('Time zone')
+      expect(account.reload.time_zone).not_to eq('Atlantis/Nowhere')
     end
 
     it 'rejects a blank account email' do


### PR DESCRIPTION
## Summary
- store a validated account time zone preference
- apply the account time zone around authenticated requests
- add profile UI for viewing and updating the preference

Closes #630.

## Verification
- ruby -c app/models/account.rb
- ruby -c app/controllers/application_controller.rb
- ruby -c app/controllers/profiles_controller.rb
- ruby -c app/views/profiles/personal_info_content.rb
- ruby -c spec/models/account_spec.rb
- ruby -c spec/requests/profiles_show_spec.rb
- git diff --check
- task test TEST_FILE=spec/models/account_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/requests/profiles_show_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)