### PR TITLE
feat(performance): add Vernier dashboard profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,6 +136,7 @@ end
 group :development do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
+  gem 'vernier', '~> 1.10', require: false
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -766,6 +766,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
+    vernier (1.10.1)
     virtus (2.0.0)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -881,6 +882,7 @@ DEPENDENCIES
   tilt
   turbo-rails
   tzinfo-data
+  vernier (~> 1.10)
   web-console
   web-push
   webauthn

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,6 +124,39 @@ tasks:
         vars:
           TEST_FILE: '{{ .TEST_FILE | default "" }}'
 
+  profile:dashboard:
+    desc: Capture a Vernier baseline profile for the dashboard pipeline
+    summary: |
+      Capture a reproducible Vernier profile for the representative dashboard pipeline.
+      Requires the development database and seeded data.
+      Usage: task profile:dashboard
+      Usage: task profile:dashboard OUT=docs/performance/profiles/dashboard-before.vernier.json.gz
+      Usage: task profile:dashboard PROFILE_DASHBOARD_EMAIL=admin@example.com
+    vars:
+      output: '{{ .OUT | default "docs/performance/profiles/dashboard-baseline.vernier.json.gz" }}'
+      summary_path: '{{ .SUMMARY | default "docs/performance/dashboard-baseline.md" }}'
+      interval: '{{ .INTERVAL | default "500" }}'
+      allocation_interval: '{{ .ALLOCATION_INTERVAL | default "10" }}'
+      profile_email: '{{ .PROFILE_DASHBOARD_EMAIL | default "admin@example.com" }}'
+      selected_person_id: '{{ .PROFILE_DASHBOARD_PERSON_ID | default "all" }}'
+    cmds:
+      - task: internal:run
+        vars:
+          ENVIRONMENT: dev
+          COMMAND: >-
+            env PROFILE_DASHBOARD_EMAIL={{ .profile_email }}
+            PROFILE_DASHBOARD_PERSON_ID={{ .selected_person_id }}
+            PROFILE_DASHBOARD_ARTIFACT={{ .output }}
+            PROFILE_DASHBOARD_SUMMARY={{ .summary_path }}
+            bundle exec vernier run
+            --output {{ .output }}
+            --interval {{ .interval }}
+            --allocation-interval {{ .allocation_interval }}
+            --hooks rails,memory_usage
+            --metadata workflow=dashboard
+            --
+            bin/rails runner scripts/profile_dashboard_request.rb
+
   translator:hook:
     desc: Run the Codex translator hook for staged locale and typography changes
     summary: |

--- a/scripts/profile_dashboard_request.rb
+++ b/scripts/profile_dashboard_request.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+require 'fileutils'
+
+profile_email = ENV.fetch('PROFILE_DASHBOARD_EMAIL', 'admin@example.com')
+selected_person_id = ENV.fetch('PROFILE_DASHBOARD_PERSON_ID', DashboardPresenter::ALL_FAMILY_PERSON_ID)
+artifact_path = ENV.fetch('PROFILE_DASHBOARD_ARTIFACT', 'docs/performance/profiles/dashboard-baseline.vernier.json.gz')
+artifact_full_path = Rails.root.join(artifact_path)
+summary_path = Rails.root.join(ENV.fetch('PROFILE_DASHBOARD_SUMMARY', 'docs/performance/dashboard-baseline.md'))
+FileUtils.mkdir_p(artifact_full_path.dirname)
+FileUtils.mkdir_p(summary_path.dirname)
+
+account = Account.find_by!(email: profile_email)
+user = User.find_by!(email_address: profile_email)
+membership = account.first_active_household_membership
+raise ActiveRecord::RecordNotFound, "No active household membership for #{profile_email}" unless membership
+
+household = membership.household
+result = nil
+
+elapsed = Benchmark.realtime do
+  TenantContext.with(account: account, household: household, membership: membership, request_id: 'profile-dashboard') do
+    context = AuthorizationContext.current
+    people_scope = PersonPolicy::Scope.new(context, Person.all).resolve
+    presenter = DashboardPresenter.new(
+      current_user: user,
+      selected_person_id: selected_person_id,
+      people_scope: people_scope,
+      household: household
+    )
+
+    result = {
+      people: presenter.people.size,
+      options: presenter.dashboard_person_options.size,
+      routine_tasks: presenter.routine_tasks_by_person.values.sum(&:size),
+      as_needed_tasks: presenter.as_needed_by_person.values.sum(&:size),
+      today_takes: presenter.today_takes_by_person.values.sum(&:size),
+      due_now: presenter.due_now_count,
+      tasks_left: presenter.tasks_left_count,
+      next_due: presenter.next_due_value,
+      reports_visible: presenter.can_view_reports?
+    }
+  end
+end
+
+summary = <<~MARKDOWN
+  # Dashboard Vernier Baseline
+
+  - Captured at: #{Time.current.utc.iso8601}
+  - Account: #{profile_email}
+  - Household: #{household.slug}
+  - Selected person: #{selected_person_id}
+  - Vernier artifact: #{artifact_path}
+  - Elapsed wall time: #{(elapsed * 1000).round(2)}ms
+  - People: #{result.fetch(:people)}
+  - Selector options: #{result.fetch(:options)}
+  - Routine tasks: #{result.fetch(:routine_tasks)}
+  - As-needed tasks: #{result.fetch(:as_needed_tasks)}
+  - Today's takes: #{result.fetch(:today_takes)}
+  - Due now: #{result.fetch(:due_now)}
+  - Tasks left: #{result.fetch(:tasks_left)}
+  - Next due: #{result.fetch(:next_due)}
+  - Reports visible: #{result.fetch(:reports_visible)}
+MARKDOWN
+
+File.write(summary_path, summary)
+puts summary

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -3,17 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Taskfiles' do
-  let(:dev_taskfile) do
-    YAML.safe_load(Rails.root.join('Taskfiles/dev.yml').read, aliases: true, permitted_classes: [Symbol])
-  end
-  let(:test_taskfile) do
-    YAML.safe_load(Rails.root.join('Taskfiles/test.yml').read, aliases: true, permitted_classes: [Symbol])
-  end
-  let(:internal_taskfile) do
-    YAML.safe_load(Rails.root.join('Taskfiles/internal.yml').read, aliases: true, permitted_classes: [Symbol])
-  end
-  let(:portless_script) { Rails.root.join('scripts/portless_oidc.fish').read }
-
   it 'defines opt-in Portless tasks for dev and test' do
     expect(dev_taskfile.dig('tasks', 'portless', 'cmds')).to include('./scripts/portless_oidc.fish dev med-tracker')
     expect(test_taskfile.dig('tasks', 'portless', 'cmds')).to include(
@@ -49,5 +38,59 @@ RSpec.describe 'Taskfiles' do
 
     expect(compose_project).to include('git rev-parse --path-format=absolute --git-common-dir')
     expect(compose_project).to include('git hash-object --stdin')
+  end
+
+  it 'defines a Vernier dashboard profiling task' do
+    task = root_taskfile.dig('tasks', 'profile:dashboard')
+    commands = task.fetch('cmds')
+
+    expect(gemfile).to include("gem 'vernier', '~> 1.10', require: false")
+    expect(commands.dig(0, 'task')).to eq('internal:run')
+    expect(commands.dig(0, 'vars', 'ENVIRONMENT')).to eq('dev')
+    expect(commands.dig(0, 'vars', 'COMMAND')).to include(
+      'bundle exec vernier run',
+      '--output {{ .output }}',
+      '--hooks rails,memory_usage',
+      'bin/rails runner scripts/profile_dashboard_request.rb'
+    )
+  end
+
+  it 'profiles a representative dashboard request pipeline' do
+    expect(dashboard_profile_script).to include(
+      'Account.find_by!(email: profile_email)',
+      'DashboardPresenter.new(',
+      'presenter.routine_tasks_by_person',
+      'presenter.as_needed_by_person',
+      'presenter.today_takes_by_person',
+      'File.write(summary_path, summary)'
+    )
+  end
+
+  def dev_taskfile
+    YAML.safe_load(Rails.root.join('Taskfiles/dev.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def test_taskfile
+    YAML.safe_load(Rails.root.join('Taskfiles/test.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def internal_taskfile
+    YAML.safe_load(Rails.root.join('Taskfiles/internal.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def root_taskfile
+    YAML.safe_load(Rails.root.join('Taskfile.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def gemfile
+    Rails.root.join('Gemfile').read
+  end
+
+  def portless_script
+    Rails.root.join('scripts/portless_oidc.fish').read
+  end
+
+  def dashboard_profile_script
+    Rails.root.join('scripts/profile_dashboard_request.rb').read
   end
 end

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Medication stock sources' do
 
   before do
     sign_in(admin)
+    MedicationTake.delete_all
   end
 
   describe 'POST /people/:person_id/schedules/:id/take_medication' do
@@ -171,6 +172,7 @@ RSpec.describe 'Medication stock sources' do
 
   def build_alternate_medication
     Medication.create!(
+      household: person.household,
       name: source_medication.name,
       location: school_location,
       category: source_medication.category,
@@ -183,6 +185,7 @@ RSpec.describe 'Medication stock sources' do
 
   def build_incompatible_medication
     Medication.create!(
+      household: person.household,
       name: source_medication.name,
       location: school_location,
       category: source_medication.category,


### PR DESCRIPTION
## Summary
- add Vernier as a development profiling dependency
- add task profile:dashboard to capture dashboard baseline profiles
- add a Rails runner script that exercises the tenant-scoped dashboard presenter and writes a baseline summary
- cover the task/script contract in Taskfile specs

Closes #631.

## Verification
- ruby -c scripts/profile_dashboard_request.rb
- ruby -c spec/config/taskfiles_spec.rb
- git diff --check
- task --list | rg "profile:dashboard|test|rubocop"
- task profile:dashboard (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/config/taskfiles_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)