### PR TITLE
fix(observability): record request and job exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,9 @@ class ApplicationController < ActionController::Base
     Current.account = current_account
     Current.request_id = request.request_id
     Time.use_zone(current_account_time_zone) { with_current_tenant_context(&) }
+  rescue StandardError => e
+    Otel::ExceptionRecorder.record(e, source: 'request')
+    raise
   ensure
     Current.reset
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,4 +3,11 @@
 class ApplicationJob < ActiveJob::Base
   retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
   discard_on ActiveJob::DeserializationError
+
+  around_perform do |_job, block|
+    block.call
+  rescue StandardError => e
+    Otel::ExceptionRecorder.record(e, source: 'job')
+    raise
+  end
 end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -3,6 +3,7 @@
 require 'opentelemetry-api'
 require 'otel/allowlisted_span_exporter'
 require 'otel/critical_path_sampler'
+require 'otel/exception_recorder'
 
 OpenTelemetry.logger = Logger.new($stdout, level: Rails.env.test? ? Logger::WARN : Logger::ERROR)
 

--- a/lib/otel/allowlisted_span_exporter.rb
+++ b/lib/otel/allowlisted_span_exporter.rb
@@ -6,6 +6,9 @@ module Otel
       %w[
         db.operation
         db.system
+        error.type
+        exception.escaped
+        exception.source
         http.method
         http.request.method
         http.response.status_code

--- a/lib/otel/exception_recorder.rb
+++ b/lib/otel/exception_recorder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Otel
+  class ExceptionRecorder
+    class << self
+      def record(exception, source:)
+        span = OpenTelemetry::Trace.current_span
+        return unless span&.context&.valid?
+
+        span.record_exception(exception, attributes: exception_attributes(exception, source))
+        span.set_attribute('error.type', exception.class.name)
+        span.set_attribute('exception.escaped', true)
+        span.set_attribute('exception.source', source)
+        span.status = OpenTelemetry::Trace::Status.error(exception.class.name)
+      end
+
+      private
+
+      def exception_attributes(exception, source)
+        {
+          'error.type' => exception.class.name,
+          'exception.escaped' => true,
+          'exception.source' => source
+        }
+      end
+    end
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationJob do
+  let(:job_class) do
+    Class.new(described_class) do
+      def perform
+        raise 'job failure'
+      end
+    end
+  end
+
+  it 'records job exceptions on the current trace span before reraising' do
+    allow(Otel::ExceptionRecorder).to receive(:record)
+
+    expect { job_class.perform_now }.to raise_error(RuntimeError, 'job failure')
+    expect(Otel::ExceptionRecorder).to have_received(:record)
+      .with(instance_of(RuntimeError), source: 'job')
+  end
+end

--- a/spec/lib/otel/allowlisted_span_exporter_spec.rb
+++ b/spec/lib/otel/allowlisted_span_exporter_spec.rb
@@ -40,7 +40,11 @@ RSpec.describe Otel::AllowlistedSpanExporter do
         'medication_take.taken_at' => '2026-06-22T10:00:00Z',
         'account.id' => '99',
         'db.system' => 'postgresql',
-        'db.statement' => 'SELECT * FROM people'
+        'db.statement' => 'SELECT * FROM people',
+        'error.type' => 'RuntimeError',
+        'exception.escaped' => true,
+        'exception.source' => 'request',
+        'exception.message' => 'person name leaked'
       }
     )
   end
@@ -54,7 +58,10 @@ RSpec.describe Otel::AllowlistedSpanExporter do
       'model.name' => 'MedicationTake',
       'model.operation' => 'create',
       'model.id_hash' => '169e81c4d785338b1599a3af36a71fd7c21bbfb3ab7c8df5b74d9f678d5355e8',
-      'db.system' => 'postgresql'
+      'db.system' => 'postgresql',
+      'error.type' => 'RuntimeError',
+      'exception.escaped' => true,
+      'exception.source' => 'request'
     )
     expect(span.attributes).to include('model.id' => '123')
   end

--- a/spec/lib/otel/exception_recorder_spec.rb
+++ b/spec/lib/otel/exception_recorder_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Otel::ExceptionRecorder do
+  describe '.record' do
+    it 'records escaped exceptions on the current valid span' do
+      span = instance_double(OpenTelemetry::Trace::Span)
+      context = instance_double(OpenTelemetry::Trace::SpanContext, valid?: true)
+      exception = RuntimeError.new('boom')
+
+      allow(span).to receive(:context).and_return(context)
+      allow(span).to receive(:record_exception)
+      allow(span).to receive(:set_attribute)
+      allow(span).to receive(:status=)
+      allow(OpenTelemetry::Trace).to receive(:current_span).and_return(span)
+
+      described_class.record(exception, source: 'request')
+
+      expect_exception_recorded(span, exception)
+      expect_error_attributes_set(span)
+      expect(span).to have_received(:status=).with(an_instance_of(OpenTelemetry::Trace::Status))
+    end
+
+    it 'does not record when the current span context is invalid' do
+      span = instance_double(OpenTelemetry::Trace::Span)
+      context = instance_double(OpenTelemetry::Trace::SpanContext, valid?: false)
+      exception = RuntimeError.new('boom')
+
+      allow(span).to receive(:context).and_return(context)
+      allow(span).to receive(:record_exception)
+      allow(OpenTelemetry::Trace).to receive(:current_span).and_return(span)
+
+      described_class.record(exception, source: 'job')
+
+      expect(span).not_to have_received(:record_exception)
+    end
+  end
+
+  def expect_exception_recorded(span, exception)
+    expect(span).to have_received(:record_exception).with(
+      exception,
+      attributes: {
+        'error.type' => 'RuntimeError',
+        'exception.escaped' => true,
+        'exception.source' => 'request'
+      }
+    )
+  end
+
+  def expect_error_attributes_set(span)
+    expect(span).to have_received(:set_attribute).with('error.type', 'RuntimeError')
+    expect(span).to have_received(:set_attribute).with('exception.escaped', true)
+    expect(span).to have_received(:set_attribute).with('exception.source', 'request')
+  end
+end

--- a/spec/requests/observability_exception_capture_spec.rb
+++ b/spec/requests/observability_exception_capture_spec.rb
@@ -9,6 +9,8 @@ class ObservabilityFailureController < ApplicationController
 end
 
 RSpec.describe 'Observability exception capture' do
+  fixtures :accounts, :people, :users
+
   around do |example|
     Rails.application.routes.draw do
       get '/observability_failure', to: 'observability_failure#show'
@@ -19,12 +21,12 @@ RSpec.describe 'Observability exception capture' do
     Rails.application.reload_routes!
   end
 
-  it 'records request exceptions on the current trace span before rendering the failure response' do
+  it 'records request exceptions on the current trace span before reraising the failure' do
     allow(Otel::ExceptionRecorder).to receive(:record)
 
-    get '/observability_failure'
+    sign_in users(:admin)
 
-    expect(response).to have_http_status(:internal_server_error)
+    expect { get '/observability_failure' }.to raise_error(RuntimeError, 'request failure')
     expect(Otel::ExceptionRecorder).to have_received(:record)
       .with(instance_of(RuntimeError), source: 'request')
   end

--- a/spec/requests/observability_exception_capture_spec.rb
+++ b/spec/requests/observability_exception_capture_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class ObservabilityFailureController < ApplicationController
+  def show
+    raise 'request failure'
+  end
+end
+
+RSpec.describe 'Observability exception capture' do
+  around do |example|
+    Rails.application.routes.draw do
+      get '/observability_failure', to: 'observability_failure#show'
+    end
+
+    example.run
+  ensure
+    Rails.application.reload_routes!
+  end
+
+  it 'records request exceptions on the current trace span before rendering the failure response' do
+    allow(Otel::ExceptionRecorder).to receive(:record)
+
+    get '/observability_failure'
+
+    expect(response).to have_http_status(:internal_server_error)
+    expect(Otel::ExceptionRecorder).to have_received(:record)
+      .with(instance_of(RuntimeError), source: 'request')
+  end
+end

--- a/spec/services/medication_dose_decision_context_spec.rb
+++ b/spec/services/medication_dose_decision_context_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe MedicationDoseDecisionContext do
       dose_amount: 500,
       dose_unit: 'mg',
       max_daily_doses: 4,
-      min_hours_between_doses: nil
+      min_hours_between_doses: nil,
+      start_date: taken_at.to_date - 1.day,
+      end_date: taken_at.to_date + 30.days
     )
   end
 
@@ -96,7 +98,9 @@ RSpec.describe MedicationDoseDecisionContext do
         dose_amount: 500,
         dose_unit: 'mg',
         max_daily_doses: 1,
-        min_hours_between_doses: nil
+        min_hours_between_doses: nil,
+        start_date: taken_at.to_date - 30.days,
+        end_date: taken_at.to_date - 1.day
       )
       inactive_schedule = create(
         :schedule,
@@ -107,7 +111,9 @@ RSpec.describe MedicationDoseDecisionContext do
         dose_unit: 'mg',
         max_daily_doses: 1,
         min_hours_between_doses: nil,
-        active: false
+        active: false,
+        start_date: taken_at.to_date - 1.day,
+        end_date: taken_at.to_date + 30.days
       )
 
       record_take_for(expired_schedule)


### PR DESCRIPTION
## Summary
- record unhandled request and ActiveJob exceptions on the current OpenTelemetry span before re-raising
- allowlist non-sensitive exception metadata while continuing to filter exception messages
- add focused coverage for the recorder, request capture, job capture, and exporter filtering

Closes #655.

## Tests
- ruby -c lib/otel/exception_recorder.rb
- ruby -c app/controllers/application_controller.rb
- ruby -c app/jobs/application_job.rb
- ruby -c spec/lib/otel/exception_recorder_spec.rb
- ruby -c spec/lib/otel/allowlisted_span_exporter_spec.rb
- ruby -c spec/jobs/application_job_spec.rb
- ruby -c spec/requests/observability_exception_capture_spec.rb
- git diff --check
- task test TEST_FILE=spec/lib/otel/exception_recorder_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/jobs/application_job_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/requests/observability_exception_capture_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/lib/otel/allowlisted_span_exporter_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)