### PR TITLE
feat(inventory): capture medicine order details

### DIFF
--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -165,7 +165,7 @@ module Components
           action: mark_as_ordered_medication_path(medication),
           method: :post,
           class: 'col-span-2 space-y-3 rounded-shape-xl border border-border/60 bg-card p-4',
-          data: { turbo: false }
+          data_turbo: 'false'
         ) do
           input(type: :hidden, name: :_method, value: :patch)
           input(type: :hidden, name: :authenticity_token, value: view_context.form_authenticity_token)

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -200,14 +200,19 @@ module Components
 
       def order_field_value(name)
         attribute = name == :expected_arrival_on ? name : :"order_#{name}"
-        medication.public_send(attribute) if medication.respond_to?(attribute)
+        return unless medication.respond_to?(attribute)
+
+        format_order_value(name, medication.public_send(attribute))
       end
 
       def render_order_details
         div(class: 'col-span-2 space-y-3 rounded-shape-xl border border-border/60 bg-card p-4') do
           m3_heading(variant: :title_small, level: 3) { t('medications.show.order_details') }
           render_order_detail(t('medications.show.order_supplier'), medication.order_supplier)
-          render_order_detail(t('medications.show.order_quantity'), medication.order_quantity)
+          render_order_detail(
+            t('medications.show.order_quantity'),
+            format_order_value(:quantity, medication.order_quantity)
+          )
           render_order_detail(t('medications.show.expected_arrival'), formatted_expected_arrival)
           m3_link(
             href: mark_as_received_medication_path(medication),
@@ -233,6 +238,16 @@ module Components
 
       def formatted_expected_arrival
         I18n.l(medication.expected_arrival_on, format: :long) if medication.expected_arrival_on
+      end
+
+      def format_order_value(name, value)
+        return if value.blank?
+
+        case name
+        when :quantity then MedicationStockQuantityFormatter.format(value)
+        when :expected_arrival_on then value.respond_to?(:iso8601) ? value.iso8601 : value
+        else value
+        end
       end
 
       def render_refill_modal

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -155,26 +155,84 @@ module Components
       end
 
       def render_reorder_actions
-        config = if medication.reorder_status.nil?
-                   { path: mark_as_ordered_medication_path(medication), label: t('medications.show.mark_as_ordered'),
-                     icon: Icons::Clock }
-                 elsif medication.reorder_ordered?
-                   { path: mark_as_received_medication_path(medication), label: t('medications.show.mark_as_received'),
-                     icon: Icons::Check }
-                 end
+        return render_order_form if medication.reorder_status.nil?
 
-        return unless config
+        render_order_details if medication.reorder_ordered?
+      end
 
-        m3_link(
-          href: config[:path],
-          variant: :filled,
-          size: :lg,
-          class: 'w-full justify-center',
-          data: { turbo_method: :patch }
+      def render_order_form
+        form(
+          action: mark_as_ordered_medication_path(medication),
+          method: :post,
+          class: 'col-span-2 space-y-3 rounded-shape-xl border border-border/60 bg-card p-4',
+          data: { turbo: false }
         ) do
-          render config[:icon].new(size: 18, class: 'mr-2')
-          span { config[:label] }
+          input(type: :hidden, name: :_method, value: :patch)
+          input(type: :hidden, name: :authenticity_token, value: view_context.form_authenticity_token)
+          render_order_field(:supplier, t('medications.show.order_supplier'), type: :text)
+          render_order_field(:quantity, t('medications.show.order_quantity'), type: :number, step: '0.01', min: '0')
+          render_order_field(:expected_arrival_on, t('medications.show.expected_arrival'), type: :date)
+          button(
+            type: :submit,
+            class: 'w-full justify-center whitespace-nowrap inline-flex items-center rounded-shape-full ' \
+                   'font-medium transition-all state-layer bg-primary text-on-primary shadow-elevation-1 ' \
+                   'hover:shadow-elevation-2 h-12 px-6 text-base'
+          ) do
+            render Icons::Clock.new(size: 18, class: 'mr-2')
+            span { t('medications.show.mark_as_ordered') }
+          end
         end
+      end
+
+      def render_order_field(name, label, **input_options)
+        field_id = "order_#{name}"
+        div(class: 'space-y-1') do
+          label(for: field_id, class: 'text-sm font-medium text-on-surface') { label }
+          m3_input(
+            id: field_id,
+            name: "order[#{name}]",
+            value: order_field_value(name),
+            class: 'w-full',
+            **input_options
+          )
+        end
+      end
+
+      def order_field_value(name)
+        attribute = name == :expected_arrival_on ? name : :"order_#{name}"
+        medication.public_send(attribute) if medication.respond_to?(attribute)
+      end
+
+      def render_order_details
+        div(class: 'col-span-2 space-y-3 rounded-shape-xl border border-border/60 bg-card p-4') do
+          m3_heading(variant: :title_small, level: 3) { t('medications.show.order_details') }
+          render_order_detail(t('medications.show.order_supplier'), medication.order_supplier)
+          render_order_detail(t('medications.show.order_quantity'), medication.order_quantity)
+          render_order_detail(t('medications.show.expected_arrival'), formatted_expected_arrival)
+          m3_link(
+            href: mark_as_received_medication_path(medication),
+            variant: :filled,
+            size: :lg,
+            class: 'w-full justify-center',
+            data: { turbo_method: :patch }
+          ) do
+            render Icons::Check.new(size: 18, class: 'mr-2')
+            span { t('medications.show.mark_as_received') }
+          end
+        end
+      end
+
+      def render_order_detail(label, value)
+        return if value.blank?
+
+        div(class: 'flex items-center justify-between gap-3 text-sm') do
+          span(class: 'text-on-surface-variant') { label }
+          span(class: 'font-semibold text-on-surface text-right') { value.to_s }
+        end
+      end
+
+      def formatted_expected_arrival
+        I18n.l(medication.expected_arrival_on, format: :long) if medication.expected_arrival_on
       end
 
       def render_refill_modal

--- a/app/components/medications/show_view.rb
+++ b/app/components/medications/show_view.rb
@@ -167,8 +167,8 @@ module Components
           class: 'col-span-2 space-y-3 rounded-shape-xl border border-border/60 bg-card p-4',
           data_turbo: 'false'
         ) do
-          input(type: :hidden, name: :_method, value: :patch)
-          input(type: :hidden, name: :authenticity_token, value: view_context.form_authenticity_token)
+          input(type: :hidden, name: '_method', value: :patch)
+          input(type: :hidden, name: 'authenticity_token', value: view_context.form_authenticity_token)
           render_order_field(:supplier, t('medications.show.order_supplier'), type: :text)
           render_order_field(:quantity, t('medications.show.order_quantity'), type: :number, step: '0.01', min: '0')
           render_order_field(:expected_arrival_on, t('medications.show.expected_arrival'), type: :date)

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -102,7 +102,7 @@ class MedicationsController < ApplicationController
 
   def mark_as_ordered
     authorize @medication
-    update_reorder_status(:ordered, notice: t('medications.ordered'))
+    update_reorder_status(:ordered, notice: t('medications.ordered'), order_details: order_details_params)
   end
 
   def mark_as_received
@@ -247,8 +247,8 @@ class MedicationsController < ApplicationController
     ), status: :unprocessable_content
   end
 
-  def update_reorder_status(status, notice:)
-    MedicationReorderStatusService.new.call(medication: @medication, status: status)
+  def update_reorder_status(status, notice:, order_details: {})
+    MedicationReorderStatusService.new.call(medication: @medication, status: status, order_details: order_details)
     respond_to do |format|
       format.html { redirect_back_or_to @medication, notice: notice }
       format.turbo_stream do
@@ -256,6 +256,14 @@ class MedicationsController < ApplicationController
         render turbo_stream: medication_streams
       end
     end
+  end
+
+  def order_details_params
+    params.fetch(:order, ActionController::Parameters.new).permit(
+      :supplier,
+      :quantity,
+      :expected_arrival_on
+    ).to_h.symbolize_keys
   end
 
   def restock_medication

--- a/app/services/medication_reorder_status_service.rb
+++ b/app/services/medication_reorder_status_service.rb
@@ -7,8 +7,8 @@ class MedicationReorderStatusService
     end
   end
 
-  def call(medication:, status:, at: Time.current)
-    attributes = attributes_for(status, at)
+  def call(medication:, status:, at: Time.current, order_details: {})
+    attributes = attributes_for(status, at, order_details)
     return Result.new(success: false, medication: medication) unless attributes
 
     medication.paper_trail_event = "mark_as_#{status}"
@@ -18,12 +18,20 @@ class MedicationReorderStatusService
 
   private
 
-  def attributes_for(status, at)
+  def attributes_for(status, at, order_details)
     case status.to_sym
     when :ordered
-      { reorder_status: :ordered, ordered_at: at }
+      order_attributes(order_details).merge(reorder_status: :ordered, ordered_at: at)
     when :received
       { reorder_status: :received, reordered_at: at }
     end
+  end
+
+  def order_attributes(order_details)
+    {
+      order_supplier: order_details[:supplier].presence,
+      order_quantity: order_details[:quantity].presence,
+      expected_arrival_on: order_details[:expected_arrival_on].presence
+    }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,6 +888,10 @@ en:
       edit_dosage: Edit
       mark_as_ordered: Order
       mark_as_received: Received
+      order_details: Order details
+      order_supplier: Supplier
+      order_quantity: Quantity
+      expected_arrival: Expected arrival
       refill_inventory: Restock
       complete_refill: Restock
       adjust_inventory: Adjust Inventory

--- a/db/migrate/20260702172000_add_order_details_to_medications.rb
+++ b/db/migrate/20260702172000_add_order_details_to_medications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrderDetailsToMedications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :medications, :order_supplier, :string
+    add_column :medications, :order_quantity, :decimal, precision: 10, scale: 2
+    add_column :medications, :expected_arrival_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_172000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -425,7 +425,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_170000) do
     t.bigint "household_id", null: false
     t.bigint "location_id", null: false
     t.string "name"
+    t.date "expected_arrival_on"
     t.datetime "ordered_at"
+    t.decimal "order_quantity", precision: 10, scale: 2
+    t.string "order_supplier"
     t.integer "reorder_status"
     t.decimal "reorder_threshold", precision: 10, scale: 2, default: "10.0", null: false
     t.datetime "reordered_at"

--- a/spec/components/medications/show_view_spec.rb
+++ b/spec/components/medications/show_view_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Components::Medications::ShowView, type: :component do
   end
 
   it 'renders order workflow fields before a medication is ordered', :aggregate_failures do
+    medication.update!(order_quantity: BigDecimal('2.0'))
     rendered = render_inline(described_class.new(medication: medication))
     order_form = rendered.at_css("form[action$='/mark_as_ordered']")
 
@@ -138,6 +139,7 @@ RSpec.describe Components::Medications::ShowView, type: :component do
     expect(order_form['data-turbo']).to eq('false')
     expect(order_form.at_css("input[name='_method'][value='patch']")).to be_present
     expect(order_form.at_css("input[name='authenticity_token']")).to be_present
+    expect(order_form.at_css("input[name='order[quantity]']")['value']).to eq('2')
     expect(order_form.at_css("button[type='submit']")).to be_present
     expect(rendered.text).to include('Supplier')
     expect(rendered.text).to include('Quantity')
@@ -149,7 +151,7 @@ RSpec.describe Components::Medications::ShowView, type: :component do
       reorder_status: :ordered,
       ordered_at: Time.zone.local(2026, 5, 5, 9, 30),
       order_supplier: 'Boots',
-      order_quantity: 2,
+      order_quantity: BigDecimal('2.0'),
       expected_arrival_on: Date.new(2026, 5, 8)
     )
 
@@ -157,6 +159,7 @@ RSpec.describe Components::Medications::ShowView, type: :component do
 
     expect(rendered.text).to include('Boots')
     expect(rendered.text).to include('2')
+    expect(rendered.text).not_to include('0.2e1')
     expect(rendered.text).to include(I18n.l(Date.new(2026, 5, 8), format: :long))
     expect(rendered.css("a[href$='/mark_as_received']")).to be_present
   end

--- a/spec/components/medications/show_view_spec.rb
+++ b/spec/components/medications/show_view_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe Components::Medications::ShowView, type: :component do
 
     expect(order_form).to be_present
     expect(order_form['data-turbo']).to eq('false')
+    expect(order_form.at_css("input[name='_method'][value='patch']")).to be_present
+    expect(order_form.at_css("input[name='authenticity_token']")).to be_present
     expect(order_form.at_css("button[type='submit']")).to be_present
     expect(rendered.text).to include('Supplier')
     expect(rendered.text).to include('Quantity')

--- a/spec/components/medications/show_view_spec.rb
+++ b/spec/components/medications/show_view_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe Components::Medications::ShowView, type: :component do
     end
 
     it 'uses action button utility tokens for mark as ordered' do
-      mark_as_ordered_link = fetch_action_element(
+      mark_as_ordered_button = fetch_action_element(
         rendered,
-        "a[href$='/mark_as_ordered']",
-        'Mark as Ordered link not found'
+        "form[action$='/mark_as_ordered'] button",
+        'Mark as Ordered button not found'
       )
 
-      expect(mark_as_ordered_link[:class]).to include('rounded-shape-full')
+      expect(mark_as_ordered_button[:class]).to include('rounded-shape-full')
     end
 
     it 'uses action button utility tokens for refill' do
@@ -128,6 +128,35 @@ RSpec.describe Components::Medications::ShowView, type: :component do
     expect(rendered.text).to include('Restock')
     expect(rendered.text).not_to include('Edit Details')
     expect(rendered.text).not_to include('Adjust Inventory')
+  end
+
+  it 'renders order workflow fields before a medication is ordered', :aggregate_failures do
+    rendered = render_inline(described_class.new(medication: medication))
+    order_form = rendered.at_css("form[action$='/mark_as_ordered']")
+
+    expect(order_form).to be_present
+    expect(order_form['data-turbo']).to eq('false')
+    expect(order_form.at_css("button[type='submit']")).to be_present
+    expect(rendered.text).to include('Supplier')
+    expect(rendered.text).to include('Quantity')
+    expect(rendered.text).to include('Expected arrival')
+  end
+
+  it 'renders captured order details while waiting for delivery' do
+    medication.update!(
+      reorder_status: :ordered,
+      ordered_at: Time.zone.local(2026, 5, 5, 9, 30),
+      order_supplier: 'Boots',
+      order_quantity: 2,
+      expected_arrival_on: Date.new(2026, 5, 8)
+    )
+
+    rendered = render_inline(described_class.new(medication: medication))
+
+    expect(rendered.text).to include('Boots')
+    expect(rendered.text).to include('2')
+    expect(rendered.text).to include(I18n.l(Date.new(2026, 5, 8), format: :long))
+    expect(rendered.css("a[href$='/mark_as_received']")).to be_present
   end
 
   it 'renders safety warnings when present' do

--- a/spec/requests/medication_stock_source_spec.rb
+++ b/spec/requests/medication_stock_source_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Medication stock sources' do
 
   before do
     sign_in(admin)
+    MedicationTake.delete_all
   end
 
   describe 'POST /people/:person_id/schedules/:id/take_medication' do
@@ -171,6 +172,7 @@ RSpec.describe 'Medication stock sources' do
 
   def build_alternate_medication
     Medication.create!(
+      household: person.household,
       name: source_medication.name,
       location: school_location,
       category: source_medication.category,
@@ -183,6 +185,7 @@ RSpec.describe 'Medication stock sources' do
 
   def build_incompatible_medication
     Medication.create!(
+      household: person.household,
       name: source_medication.name,
       location: school_location,
       category: source_medication.category,

--- a/spec/services/medication_reorder_status_service_spec.rb
+++ b/spec/services/medication_reorder_status_service_spec.rb
@@ -5,16 +5,36 @@ require 'rails_helper'
 RSpec.describe MedicationReorderStatusService do
   describe '#call' do
     let(:medication) { create(:medication, reorder_status: nil, ordered_at: nil, reordered_at: nil) }
+    let(:order_details) do
+      {
+        supplier: 'Boots',
+        quantity: '2',
+        expected_arrival_on: Date.new(2026, 5, 8)
+      }
+    end
+    let(:expected_order_attributes) do
+      {
+        order_supplier: 'Boots',
+        order_quantity: BigDecimal('2'),
+        expected_arrival_on: Date.new(2026, 5, 8)
+      }
+    end
 
     it 'marks a medication as ordered' do
       timestamp = Time.zone.local(2026, 5, 5, 9, 30)
 
-      result = described_class.new.call(medication: medication, status: :ordered, at: timestamp)
+      result = described_class.new.call(
+        medication: medication,
+        status: :ordered,
+        at: timestamp,
+        order_details: order_details
+      )
 
       expect(result).to be_success
       expect(medication.reload).to have_attributes(
         reorder_status: 'ordered',
-        ordered_at: timestamp
+        ordered_at: timestamp,
+        **expected_order_attributes
       )
     end
 
@@ -29,13 +49,18 @@ RSpec.describe MedicationReorderStatusService do
 
     it 'marks a medication as received' do
       timestamp = Time.zone.local(2026, 5, 5, 10, 30)
+      medication.update!(
+        reorder_status: :ordered,
+        **expected_order_attributes
+      )
 
       result = described_class.new.call(medication: medication, status: :received, at: timestamp)
 
       expect(result).to be_success
       expect(medication.reload).to have_attributes(
         reorder_status: 'received',
-        reordered_at: timestamp
+        reordered_at: timestamp,
+        **expected_order_attributes
       )
     end
 

--- a/spec/system/medications/reorder_workflow_spec.rb
+++ b/spec/system/medications/reorder_workflow_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe 'Medication reorder workflow' do
     expect(page).to have_text('Low Stock Alert')
     expect(page).to have_text('Order')
 
-    click_on 'Order'
+    within "form[action$='/mark_as_ordered']" do
+      fill_in 'Supplier', with: 'Boots'
+      fill_in 'Quantity', with: '2'
+      click_on 'Order'
+    end
+
+    expect(page).to have_text('Refill marked as ordered')
+    expect(page).to have_text('Order details')
 
     # The 'Order' action link should be gone after clicking it
     within "[data-testid='medication-content']" do


### PR DESCRIPTION
## Summary
- add supplier, quantity, and expected-arrival fields for medication orders
- capture order details when marking medicine as ordered and preserve them when marking received
- render an order form/details panel on the medication detail page

Closes #664.

## Tests
- ruby -c app/services/medication_reorder_status_service.rb
- ruby -c app/controllers/medications_controller.rb
- ruby -c app/components/medications/show_view.rb
- ruby -c db/migrate/20260702172000_add_order_details_to_medications.rb
- ruby -c spec/services/medication_reorder_status_service_spec.rb
- ruby -c spec/components/medications/show_view_spec.rb
- git diff --check
- task test TEST_FILE=spec/services/medication_reorder_status_service_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task test TEST_FILE=spec/components/medications/show_view_spec.rb (blocked: Docker socket /var/run/docker.sock unavailable)
- task rubocop (blocked: Docker socket /var/run/docker.sock unavailable)