### PR TITLE
fix(observability): disable test trace exporting

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -107,6 +107,8 @@ module OpenTelemetryConfig
 end
 
 if Rails.env.test?
+  ENV['OTEL_TRACES_EXPORTER'] = 'none'
+
   require 'opentelemetry/sdk'
   require 'opentelemetry/instrumentation/active_record'
   require 'opentelemetry/instrumentation/pg'

--- a/spec/features/observability/otlp_exporter_spec.rb
+++ b/spec/features/observability/otlp_exporter_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe 'OTEL-011: OTLP exporter configuration' do
       propagators = OpenTelemetry.propagation
       expect(propagators).to be_a(OpenTelemetry::Context::Propagation::CompositeTextMapPropagator)
     end
+
+    it 'does not install span processors that export traces in test' do
+      span_processors = OpenTelemetry.tracer_provider.instance_variable_get(:@span_processors)
+
+      expect(span_processors).to be_empty
+    end
   end
 
   context 'when parsing OTLP headers' do


### PR DESCRIPTION
Stops the test environment from installing trace exporters that attempt OTLP delivery during specs. This keeps production OTLP export unchanged while preventing noisy OpenTelemetry export errors in CI/test logs.\n\nVerification:\n- ruby -c config/initializers/opentelemetry.rb\n- ruby -c spec/features/observability/otlp_exporter_spec.rb\n- focused direct RuboCop on touched files\n\nBlocked locally:\n- task test TEST_FILE=spec/features/observability/otlp_exporter_spec.rb (Docker socket unavailable)\n- task rubocop (Docker socket unavailable)