### PR TITLE
fix(notifications): harden browser push test flow

### DIFF
--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -44,6 +44,9 @@ class PushSubscriptionsController < ApplicationController
       body: 'Push notifications are working correctly from the server.'
     )
     head :no_content
+  rescue StandardError => e
+    Rails.logger.error("Test push notification failed for account #{current_account.id}: #{e.class}: #{e.message}")
+    render json: { error: 'Unable to send test notification.' }, status: :service_unavailable
   end
 
   private

--- a/app/views/profiles/notifications_card.rb
+++ b/app/views/profiles/notifications_card.rb
@@ -71,6 +71,7 @@ module Views
         div(class: 'flex items-center justify-between') do
           p(
             class: 'text-sm text-on-surface-variant',
+            role: 'status', aria: { live: 'polite', atomic: 'true' },
             data: { push_notification_target: 'status' }
           ) { t('profiles.notifications.checking_status') }
           render_push_action_buttons

--- a/spec/components/views/profiles/notifications_card_spec.rb
+++ b/spec/components/views/profiles/notifications_card_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Views::Profiles::NotificationsCard, type: :component do
     expect(test_button['data-action']).to eq('push-notification#sendTest')
   end
 
+  it 'renders browser notification status as an accessible live region' do
+    rendered = render_inline(described_class.new(person: person))
+    status = rendered.at_css('[data-push-notification-target="status"]')
+
+    expect(status).to be_present
+    expect(status['role']).to eq('status')
+    expect(status['aria-live']).to eq('polite')
+    expect(status['aria-atomic']).to eq('true')
+  end
+
   it 'renders notification category controls in the profile form' do
     rendered = render_inline(described_class.new(person: person))
 

--- a/spec/requests/push_subscriptions_spec.rb
+++ b/spec/requests/push_subscriptions_spec.rb
@@ -130,4 +130,30 @@ RSpec.describe 'Push subscriptions' do
       expect(version.object).not_to include('auth_secret')
     end
   end
+
+  describe 'POST /push_subscription/test' do
+    it 'sends a test notification for the signed-in account' do
+      allow(PushNotificationService).to receive(:send_to_account)
+
+      post test_push_subscription_path, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(PushNotificationService).to have_received(:send_to_account).with(
+        user.person.account,
+        title: 'MedTracker Test',
+        body: 'Push notifications are working correctly from the server.'
+      )
+    end
+
+    it 'returns a JSON error when the test notification cannot be sent' do
+      allow(PushNotificationService).to receive(:send_to_account).and_raise(SocketError, 'lookup failed')
+      allow(Rails.logger).to receive(:error)
+
+      post test_push_subscription_path, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body['error']).to eq('Unable to send test notification.')
+      expect(Rails.logger).to have_received(:error).with(/Test push notification failed/)
+    end
+  end
 end

--- a/spec/services/push_notification_service_spec.rb
+++ b/spec/services/push_notification_service_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe PushNotificationService do
       expect(PushSubscription.exists?(second_subscription.id)).to be(true)
     end
 
+    it 'removes invalid subscriptions and continues with the rest' do
+      calls = 0
+      stub_const('WebPush::InvalidSubscription', Class.new(StandardError))
+
+      allow(WebPush).to receive(:payload_send) do
+        calls += 1
+        raise WebPush::InvalidSubscription if calls == 1
+      end
+
+      expect do
+        described_class.send_to_account(account, title: 'Medication Reminder', body: 'Take aspirin')
+      end.to change(PushSubscription, :count).by(-1)
+
+      expect(WebPush).to have_received(:payload_send).twice
+      expect(PushSubscription.exists?(first_subscription.id)).to be(false)
+      expect(PushSubscription.exists?(second_subscription.id)).to be(true)
+    end
+
     it 'does not write notification title or body content to native push logs' do
       create_native_device_token
       allow(WebPush).to receive(:payload_send)


### PR DESCRIPTION
## Summary
- return a JSON service-unavailable response when the browser push test send fails instead of surfacing a server error
- make the profile notification status text an accessible live region
- cover invalid WebPush subscriptions continuing through the remaining account subscriptions

## Verification
- ruby -c app/controllers/push_subscriptions_controller.rb
- ruby -c app/views/profiles/notifications_card.rb
- ruby -c spec/requests/push_subscriptions_spec.rb
- ruby -c spec/components/views/profiles/notifications_card_spec.rb
- ruby -c spec/services/push_notification_service_spec.rb
- env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache RUBOCOP_SERVER=false rubocop --cache false app/controllers/push_subscriptions_controller.rb app/views/profiles/notifications_card.rb spec/requests/push_subscriptions_spec.rb spec/components/views/profiles/notifications_card_spec.rb spec/services/push_notification_service_spec.rb

Docker-backed task checks are blocked locally because /var/run/docker.sock is unavailable in this environment.