### PR TITLE
fix(workflows): keep modal cancels on origin page

### DIFF
--- a/app/components/medication_assignments/form.rb
+++ b/app/components/medication_assignments/form.rb
@@ -5,14 +5,15 @@ module Components
     class Form < Components::Base
       include Phlex::Rails::Helpers::FormWith
 
-      attr_reader :assignment, :person, :medications, :modal, :back_path
+      attr_reader :assignment, :person, :medications, :modal, :back_path, :return_to
 
-      def initialize(assignment:, person:, medications:, modal: false, back_path: nil)
+      def initialize(assignment:, person:, medications:, modal: false, navigation: {})
         @assignment = assignment
         @person = person
         @medications = medications
         @modal = modal
-        @back_path = back_path
+        @back_path = navigation[:back_path]
+        @return_to = navigation[:return_to]
         super()
       end
 
@@ -24,6 +25,7 @@ module Components
           class: 'space-y-6',
           data: form_data
         ) do
+          input(type: :hidden, name: 'return_to', value: return_to) if return_to.present?
           render_errors if assignment.errors.any?
           render_workflow
           render_actions
@@ -288,7 +290,7 @@ module Components
       def render_cancel_action
         if modal
           m3_link(
-            href: person_path(person),
+            href: cancel_path,
             variant: :text,
             size: :xl,
             class: 'w-full justify-center sm:w-auto',
@@ -302,6 +304,12 @@ module Components
             class: 'w-full justify-center sm:w-auto'
           ) { t('person_medications.form.cancel') }
         end
+      end
+
+      def cancel_path
+        return return_to if return_to.present?
+
+        person_path(person)
       end
 
       def medication_options_payload

--- a/app/components/medication_assignments/modal.rb
+++ b/app/components/medication_assignments/modal.rb
@@ -6,13 +6,14 @@ module Components
       include Phlex::Rails::Helpers::TurboFrameTag
       include RubyUI
 
-      attr_reader :assignment, :person, :medications, :back_path
+      attr_reader :assignment, :person, :medications, :back_path, :return_to
 
-      def initialize(assignment:, person:, medications:, back_path: nil)
+      def initialize(assignment:, person:, medications:, back_path: nil, return_to: nil)
         @assignment = assignment
         @person = person
         @medications = medications
         @back_path = back_path
+        @return_to = return_to
         super()
       end
 
@@ -31,7 +32,7 @@ module Components
                   person: person,
                   medications: medications,
                   modal: true,
-                  back_path: back_path
+                  navigation: { back_path: back_path, return_to: return_to }
                 )
               end
             end

--- a/app/components/medication_workflow/person_selection.rb
+++ b/app/components/medication_workflow/person_selection.rb
@@ -7,11 +7,12 @@ module Components
       include Phlex::Rails::Helpers::TurboFrameTag
       include RubyUI
 
-      attr_reader :people, :medication_id
+      attr_reader :people, :medication_id, :return_to
 
-      def initialize(people:, medication_id: nil)
+      def initialize(people:, medication_id: nil, return_to: nil)
         @people = people
         @medication_id = medication_id
+        @return_to = return_to
         super()
       end
 
@@ -41,7 +42,7 @@ module Components
         div(class: 'grid grid-cols-1 gap-3 py-2') do
           people.each do |person|
             m3_link(
-              href: new_person_medication_assignment_path(person, source: :workflow, medication_id: medication_id),
+              href: person_assignment_path(person),
               variant: :outlined,
               size: :lg,
               data: { turbo_frame: 'modal' },
@@ -80,11 +81,7 @@ module Components
                       data: {
                         text: person.name,
                         action: 'change->medication-workflow#navigateToType',
-                        url: new_person_medication_assignment_path(
-                          person,
-                          source: :workflow,
-                          medication_id: medication_id
-                        )
+                        url: person_assignment_path(person)
                       }
                     )
                     span { person.name }
@@ -94,6 +91,15 @@ module Components
             end
           end
         end
+      end
+
+      def person_assignment_path(person)
+        new_person_medication_assignment_path(
+          person,
+          source: :workflow,
+          medication_id: medication_id,
+          return_to: return_to
+        )
       end
     end
   end

--- a/app/components/medications/index_view.rb
+++ b/app/components/medications/index_view.rb
@@ -66,11 +66,12 @@ module Components
               render Components::Medications::InventoryScanModal.new if can_refill_medication?
               if can_create_medication?
                 m3_link(
-                  href: add_medication_path,
+                  href: add_medication_path(return_to: medications_path),
                   variant: :outlined,
                   size: :lg,
                   class: 'max-w-full justify-center rounded-shape-full font-bold text-sm bg-card shadow-sm ' \
-                         'border-border'
+                         'border-border',
+                  data: { turbo_frame: 'modal' }
                 ) do
                   render Icons::PlusCircle.new(size: 20, class: 'mr-2 text-primary')
                   span { 'Add Schedule' }

--- a/app/components/people/form_view.rb
+++ b/app/components/people/form_view.rb
@@ -268,11 +268,26 @@ module Components
 
       def render_actions(_f)
         div(class: 'flex gap-3 justify-end pt-4') do
-          m3_button(variant: :text, data: { action: 'click->ruby-ui--dialog#dismiss' }) { t('people.form.cancel') }
+          render_cancel_action
           m3_button(type: :submit, variant: :filled) do
             person.new_record? ? t('people.form.create') : t('people.form.update')
           end
         end
+      end
+
+      def render_cancel_action
+        if is_modal
+          m3_button(variant: :text, data: { action: 'click->ruby-ui--dialog#dismiss' }) { t('people.form.cancel') }
+        else
+          m3_link(href: cancel_path, variant: :text) { t('people.form.cancel') }
+        end
+      end
+
+      def cancel_path
+        return return_to if return_to.present?
+        return person_path(person) if person.persisted?
+
+        people_path
       end
 
       def available_person_types

--- a/app/components/people/person_card.rb
+++ b/app/components/people/person_card.rb
@@ -132,7 +132,8 @@ module Components
           href: add_medication_person_path(person),
           variant: :filled,
           size: :lg,
-          class: 'w-full font-black shadow-elevation-2'
+          class: 'w-full font-black shadow-elevation-2',
+          data: { turbo_frame: 'modal' }
         ) { t('people.card.add_medication') }
       end
 

--- a/app/components/schedules/form.rb
+++ b/app/components/schedules/form.rb
@@ -77,10 +77,7 @@ module Components
 
       def render_actions(_f)
         div(class: 'flex gap-3 justify-end pt-4') do
-          m3_button(variant: :text, size: :lg, class: 'font-bold',
-                    data: { action: 'click->ruby-ui--dialog#dismiss' }) do
-            t('schedules.form.cancel')
-          end
+          render_cancel_action
           unless schedule.new_record? && schedule.medication.blank?
             m3_button(
               type: :submit,
@@ -92,6 +89,23 @@ module Components
             ) { schedule.new_record? ? t('schedules.form.add_plan') : t('schedules.form.update_plan') }
           end
         end
+      end
+
+      def render_cancel_action
+        if modal_form?
+          m3_button(variant: :text, size: :lg, class: 'font-bold',
+                    data: { action: 'click->ruby-ui--dialog#dismiss' }) do
+            t('schedules.form.cancel')
+          end
+        else
+          m3_link(href: person_path(person), variant: :text, size: :lg, class: 'font-bold') do
+            t('schedules.form.cancel')
+          end
+        end
+      end
+
+      def modal_form?
+        frame_id == 'modal'
       end
 
       def form_payload

--- a/app/controllers/medication_assignments_controller.rb
+++ b/app/controllers/medication_assignments_controller.rb
@@ -92,7 +92,10 @@ class MedicationAssignmentsController < ApplicationController
   end
 
   def render_assignment_form(status: :ok)
-    back_path = params[:source] == 'workflow' ? add_medication_path(medication_id: params[:medication_id]) : nil
+    return_to = url_from(params[:return_to])
+    back_path = if params[:source] == 'workflow'
+                  add_medication_path(medication_id: params[:medication_id], return_to: return_to)
+                end
 
     render_modal_or_page(
       modal: lambda {
@@ -100,7 +103,8 @@ class MedicationAssignmentsController < ApplicationController
           assignment: @assignment,
           person: @person,
           medications: @medications,
-          back_path: back_path
+          back_path: back_path,
+          return_to: return_to
         )
       },
       page: lambda {

--- a/app/controllers/medication_workflow_controller.rb
+++ b/app/controllers/medication_workflow_controller.rb
@@ -5,7 +5,11 @@ class MedicationWorkflowController < ApplicationController
     authorize Person, :index?
     people = medication_workflow_people_query.call
 
-    render Components::MedicationWorkflow::PersonSelection.new(people: people, medication_id: params[:medication_id])
+    render Components::MedicationWorkflow::PersonSelection.new(
+      people: people,
+      medication_id: params[:medication_id],
+      return_to: url_from(params[:return_to])
+    )
   end
 
   private

--- a/db/migrate/20260630183000_backfill_missing_household_memberships.rb
+++ b/db/migrate/20260630183000_backfill_missing_household_memberships.rb
@@ -98,6 +98,15 @@ class BackfillMissingHouseholdMemberships < ActiveRecord::Migration[8.1]
 
   def create_relationship_access_grants
     execute <<~SQL.squish
+      WITH owner_memberships AS (
+        SELECT DISTINCT ON (household_id)
+               id,
+               household_id
+        FROM household_memberships
+        WHERE role = 'owner'
+          AND status = 'active'
+        ORDER BY household_id, id
+      )
       INSERT INTO person_access_grants (
         household_id, household_membership_id, person_id, access_level, relationship_type,
         granted_by_membership_id, created_at, updated_at
@@ -119,10 +128,8 @@ class BackfillMissingHouseholdMemberships < ActiveRecord::Migration[8.1]
       JOIN household_memberships
         ON household_memberships.person_id = carer_relationships.carer_id
        AND household_memberships.status = 'active'
-      JOIN household_memberships owners
+      JOIN owner_memberships owners
         ON owners.household_id = household_memberships.household_id
-       AND owners.role = 'owner'
-       AND owners.status = 'active'
       WHERE carer_relationships.active = true
       ON CONFLICT (household_membership_id, person_id) WHERE revoked_at IS NULL DO UPDATE
       SET access_level = EXCLUDED.access_level,

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'API v1 auth sessions' do
 
     def create_api_household_for(user)
       household = user.person.household
-      household.household_memberships.create!(
-        account: user.person.account,
+      membership = household.household_memberships.find_or_initialize_by(account: user.person.account)
+      membership.update!(
         person: user.person,
         role: :owner,
         status: :active
@@ -59,14 +59,14 @@ RSpec.describe 'API v1 auth sessions' do
 
       api_session = ApiSession.order(:id).last
       expect(response).to have_http_status(:created)
-      expect(api_session.household_membership).to eq(household.household_memberships.sole)
+      expect(api_session.household_membership).to eq(household.household_memberships.find_by!(account: account))
       expect(response.parsed_body.dig('data', 'household', 'id')).to eq(household.id)
     end
 
     it 'binds sessions to the requested active household membership' do
       household = people(:jane).household
-      membership = household.household_memberships.create!(
-        account: user.person.account,
+      membership = household.household_memberships.find_or_initialize_by(account: user.person.account)
+      membership.update!(
         person: people(:jane),
         role: :owner,
         status: :active

--- a/spec/requests/api/v1/people_spec.rb
+++ b/spec/requests/api/v1/people_spec.rb
@@ -81,6 +81,9 @@ RSpec.describe 'API v1 people' do
         record.role = :owner
         record.status = :active
       end
+      login_data = api_login(user, household_id: household.id)
+
+      household.person_access_grants.where(household_membership: membership).destroy_all
       household.person_access_grants.create!(
         household_membership: membership,
         person: people(:jane),
@@ -95,8 +98,6 @@ RSpec.describe 'API v1 people' do
         relationship_type: :parent,
         granted_by_membership: membership
       )
-
-      login_data = api_login(user, household_id: household.id)
 
       allow(TenantContext).to receive(:with).and_call_original
       allow(TenantContext).to receive(:set_membership!).and_call_original

--- a/spec/requests/api/v1/resources_spec.rb
+++ b/spec/requests/api/v1/resources_spec.rb
@@ -109,21 +109,25 @@ RSpec.describe 'API v1 resources' do
   end
 
   it 'scopes household resource collections to explicitly granted people' do
-    account = user.person.account
-    household = user.person.household
+    scoped_user = users(:jane)
+    account = scoped_user.person.account
+    household = scoped_user.person.household
     other_household = Household.create!(name: 'Other Resource Household', slug: 'other-resource-household')
 
     membership = household.household_memberships.find_or_create_by!(
       account: account,
-      person: people(:admin)
+      person: scoped_user.person
     ) do |record|
       record.role = :member
       record.status = :active
     end
+    membership.update!(person: scoped_user.person, role: :member, status: :active)
     visible_person = create(:person, household: household, name: 'Alex Resource')
     hidden_person = create(:person, household: household, name: 'Alex Hidden Resource')
     other_person = create(:person, household: other_household, name: 'Alex Other Resource')
 
+    login_data = api_login(scoped_user, household_id: household.id)
+    household.person_access_grants.where(household_membership: membership).destroy_all
     household.person_access_grants.create!(
       household_membership: membership,
       person: visible_person,
@@ -180,7 +184,6 @@ RSpec.describe 'API v1 resources' do
     hidden_take = create(:medication_take, :for_schedule, household: household, schedule: hidden_schedule)
     other_take = create(:medication_take, :for_schedule, household: other_household, schedule: other_schedule)
 
-    login_data = api_login(user, household_id: household.id)
     headers = api_auth_headers(login_data.fetch('access_token'))
 
     {

--- a/spec/requests/offline_spec.rb
+++ b/spec/requests/offline_spec.rb
@@ -32,9 +32,8 @@ RSpec.describe 'Offline mode' do
 
   before do
     membership
-    household.person_access_grants.create!(
-      household_membership: membership,
-      person: user.person,
+    grant = household.person_access_grants.find_or_initialize_by(household_membership: membership, person: user.person)
+    grant.update!(
       access_level: :manage,
       relationship_type: :self,
       granted_by_membership: membership

--- a/spec/requests/request_sign_in_spec.rb
+++ b/spec/requests/request_sign_in_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe 'Request sign-in helper' do
   end
 
   it 'redirects authenticated root requests to the active household dashboard' do
-    household = Household.create_with_owner!(
+    account = users(:admin).person.account
+    Household.create_with_owner!(
       name: 'Root Household',
-      owner_account: users(:admin).person.account,
+      owner_account: account,
       owner_person_attributes: {
         name: 'Root Owner',
         date_of_birth: 30.years.ago.to_date,
@@ -36,6 +37,7 @@ RSpec.describe 'Request sign-in helper' do
         has_capacity: true
       }
     )
+    household = account.reload.first_active_household
 
     sign_in(users(:admin))
     get root_path

--- a/spec/serializers/api/v1/me_serializer_spec.rb
+++ b/spec/serializers/api/v1/me_serializer_spec.rb
@@ -11,12 +11,8 @@ RSpec.describe Api::V1::MeSerializer do
 
   before do
     household = user.person.household
-    Current.membership = household.household_memberships.create!(
-      account: user.person.account,
-      person: user.person,
-      role: :owner,
-      status: :active
-    )
+    Current.membership = household.household_memberships.find_or_initialize_by(account: user.person.account)
+    Current.membership.update!(person: user.person, role: :owner, status: :active)
   end
 
   after { Current.reset }

--- a/spec/services/admin/dashboard_metrics_query_spec.rb
+++ b/spec/services/admin/dashboard_metrics_query_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Admin::DashboardMetricsQuery do
     create(
       :household_invitation,
       household: household,
-      invited_by_membership: household.household_memberships.owner.sole,
+      invited_by_membership: metrics_owner_membership,
       expires_at: expires_at
     )
   end
@@ -245,7 +245,11 @@ RSpec.describe Admin::DashboardMetricsQuery do
   def paper_trail_info
     {
       household_id: household.id,
-      actor_membership_id: household.household_memberships.owner.sole.id
+      actor_membership_id: metrics_owner_membership.id
     }
+  end
+
+  def metrics_owner_membership
+    household.household_memberships.owner.active.order(:id).first!
   end
 end

--- a/spec/system/medications/add_schedule_workflow_spec.rb
+++ b/spec/system/medications/add_schedule_workflow_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Inventory add schedule workflow' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages
+
+  before do
+    driven_by(:playwright)
+    login_as(users(:admin))
+  end
+
+  it 'stays on inventory when cancelling before choosing a person' do
+    visit medications_path
+
+    within '[data-testid="medications-list"]' do
+      click_on 'Add Schedule'
+    end
+
+    expect(page).to have_text('Who is this medication for?')
+
+    click_on 'Close'
+
+    expect(page).to have_current_path(medications_path)
+    expect(page).to have_text('Inventory')
+    expect(page).to have_no_text('Who is this medication for?')
+  end
+
+  it 'stays on inventory when cancelling after choosing a person' do
+    visit medications_path
+
+    within '[data-testid="medications-list"]' do
+      click_on 'Add Schedule'
+    end
+
+    click_button 'Search people'
+    find('[role="option"]', text: people(:john).name, wait: 10).click
+    expect(page).to have_text("Add Medication for #{people(:john).name}")
+
+    click_on 'Cancel'
+
+    expect(page).to have_current_path(medications_path)
+    expect(page).to have_text('Inventory')
+    expect(page).to have_no_text("Add Medication for #{people(:john).name}")
+  end
+end

--- a/spec/system/people_spec.rb
+++ b/spec/system/people_spec.rb
@@ -80,6 +80,34 @@ RSpec.describe 'People' do
     end
   end
 
+  describe 'form navigation' do
+    it 'links cancel back to people from the full-page new form' do
+      visit new_person_path
+
+      expect(page).to have_link('Cancel', href: people_path)
+    end
+
+    it 'does not leave a blank page when cancelling add medication from the people list' do
+      driven_by(:playwright)
+      login_as(user)
+      person = people(:john)
+
+      visit people_path
+
+      within "##{tenant_dom_id(person)}" do
+        click_link 'Add Medication'
+      end
+
+      expect(page).to have_text('How is this medication taken?')
+
+      click_button 'Close'
+
+      expect(page).to have_current_path(people_path)
+      expect(page).to have_text('People')
+      expect(page).to have_no_text('How is this medication taken?')
+    end
+  end
+
   describe 'patients without carers' do
     it 'highlights dependent adults who need carer assignment' do
       carer = Person.create!(

--- a/spec/system/schedules/dosage_selection_spec.rb
+++ b/spec/system/schedules/dosage_selection_spec.rb
@@ -53,4 +53,13 @@ RSpec.describe 'Schedule dosage selection' do
 
     expect(page).to have_text('No dose options are available for this medication.')
   end
+
+  it 'returns to the person page when cancelling the full-page form' do
+    login_as(admin)
+    visit new_person_schedule_path(person)
+
+    click_on 'Cancel'
+
+    expect(page).to have_current_path(person_path(person))
+  end
 end

--- a/spec/views/reports/index_spec.rb
+++ b/spec/views/reports/index_spec.rb
@@ -63,6 +63,9 @@ RSpec.describe Views::Reports::Index do
       "/reports/health-history?#{params.to_query}"
     end
     allow(report_view).to receive(:view_context).and_return(helper_view_context)
+    allow(report_view).to receive(:health_history_report_path) do |params|
+      "/reports/health-history?#{params.to_query}"
+    end
     # rubocop:enable RSpec/SubjectStub
   end
 


### PR DESCRIPTION
## Summary
- keep modal and wizard cancel actions anchored to the originating inventory/person page instead of blank Turbo frames or unrelated redirects
- preserve return targets through add-schedule and add-medication selection steps
- fix the household membership backfill duplicate-owner join and update stale specs around fixture-created memberships/grants

## Verification
- task test
- task rubocop