### PR TITLE
perf: ⚡ Bolt: Optimize API pagination count query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,8 @@
 ## 2025-03-09 - Avoid O(N^2) Linear Searches in Nested Loops
 **Learning:** In view components (like `Locations::ShowView`), looping over a collection (e.g. `location.members`) and performing a linear search (`.find { ... }`) on another association inside the loop creates an O(N^2) performance bottleneck, especially if both collections can grow.
 **Action:** Before entering the loop, pre-index the association being searched using `.index_by(&:foreign_key)`. Then, perform O(1) hash lookups inside the loop (e.g. `indexed_hash[item.id]`), effectively reducing the operation to O(N).
+## 2025-03-09 - Avoid Unnecessary LEFT OUTER JOINs in Pagination Count Queries
+
+**Learning:** When using ActiveRecord to paginate a relation that eager loads associations (e.g., `relation = scope.includes(:association)`), calling `relation.count` forces ActiveRecord to execute a complex `SELECT COUNT(DISTINCT base_table.id) FROM base_table LEFT OUTER JOIN ...` query. This overhead is completely unnecessary for a simple pagination count, as the total number of base records does not change based on eager-loaded children.
+
+**Action:** When computing the `total_count` for pagination on an eager-loaded relation, always call `.count` on the original base `scope` instead of the preloaded `relation` (e.g., `total_count = scope.count`). This ensures a clean, fast `SELECT COUNT(*) FROM base_table` query is executed.

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -131,9 +131,6 @@ module Api
 
         relation = includes ? scope.includes(*Array(includes)) : scope
 
-        # ⚡ Bolt Optimization: Use `scope.count` instead of `relation.count`
-        # Calling count on the `scope` avoids triggering unnecessary LEFT OUTER JOINs
-        # that `.includes` would otherwise generate, resulting in a faster, cleaner COUNT query.
         total_count = scope.count
 
         records = relation.limit(per_page).offset((page - 1) * per_page)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -130,7 +130,12 @@ module Api
         per_page = params.fetch(:per_page, 20).to_i.clamp(1, 100)
 
         relation = includes ? scope.includes(*Array(includes)) : scope
-        total_count = relation.count
+
+        # ⚡ Bolt Optimization: Use `scope.count` instead of `relation.count`
+        # Calling count on the `scope` avoids triggering unnecessary LEFT OUTER JOINs
+        # that `.includes` would otherwise generate, resulting in a faster, cleaner COUNT query.
+        total_count = scope.count
+
         records = relation.limit(per_page).offset((page - 1) * per_page)
 
         {


### PR DESCRIPTION
💡 What: Use `scope.count` instead of `relation.count` to calculate the `total_count` during pagination. Added inline documentation explaining the optimization.
🎯 Why: Calling `.count` on an `includes` relation triggers expensive `LEFT OUTER JOIN`s, which is completely unnecessary for pagination as the number of base records dictates the total.
📊 Impact: Results in faster API pagination queries since complex database joins are entirely avoided during counting, saving significant CPU and memory.
🧪 Measurement: `total_count` will now query identically to a standard `SELECT COUNT(*)` while still paginating correctly with associations.

---
*PR created automatically by Jules for task [6707553921733046497](https://jules.google.com/task/6707553921733046497) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->