### PR TITLE
refactor: 🧹 Resolve commented out code false positive in TakeMedicationService docs

### DIFF
--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -5,18 +5,12 @@
 # Both Schedule and PersonMedication can be the source of a dose. This service
 # handles the shared flow so controllers remain thin.
 #
-# @example
-#   result = TakeMedicationService.new.call(
-#     source: @schedule,
-#     amount_override: params[:dose_amount],
-#     taken_from_medication_id: params[:taken_from_medication_id],
-#     user: current_user,
-#     taken_at: params[:taken_at] || Time.current   # optional, defaults to now
-#   )
-#   result.success  # => true / false
-#   result.take     # => MedicationTake record (when successful)
-#   result.error    # => :out_of_stock | :cooldown | :invalid_amount |
-#                   #    :selection_required | :invalid_source | :create_failed
+# @param source [Schedule, PersonMedication] the source of the dose
+# @param amount_override [String, nil] optional dose amount override
+# @param taken_from_medication_id [Integer, nil] optional specific medication ID
+# @param user [User] the user recording the dose
+# @param options [Hash] additional options, such as :taken_at (defaults to now)
+# @return [TakeMedicationService::Result] object containing success boolean, the take record, and any error symbol (:out_of_stock, :cooldown, :invalid_amount, :selection_required, :invalid_source, :create_failed)
 class TakeMedicationService
   Result = Data.define(:success, :take, :error)
   PreparedTake = Data.define(

--- a/app/services/take_medication_service.rb
+++ b/app/services/take_medication_service.rb
@@ -10,7 +10,9 @@
 # @param taken_from_medication_id [Integer, nil] optional specific medication ID
 # @param user [User] the user recording the dose
 # @param options [Hash] additional options, such as :taken_at (defaults to now)
-# @return [TakeMedicationService::Result] object containing success boolean, the take record, and any error symbol (:out_of_stock, :cooldown, :invalid_amount, :selection_required, :invalid_source, :create_failed)
+# @return [TakeMedicationService::Result] object containing success boolean,
+#   the take record, and any error symbol (:out_of_stock, :cooldown,
+#   :invalid_amount, :selection_required, :invalid_source, :create_failed)
 class TakeMedicationService
   Result = Data.define(:success, :take, :error)
   PreparedTake = Data.define(


### PR DESCRIPTION
🎯 **What:** 
Refactored the `@example` documentation block in `TakeMedicationService` to use standard YARD `@param` and `@return` annotations instead of a Ruby code block.

💡 **Why:** 
The previous documentation style triggered false positives in the static analysis (code health) scanner, which interpreted the Ruby-like syntax in the `@example` block as "Commented Out Code". By translating the context into formal YARD annotations, we retain the valuable documentation for the service's inputs and outputs without confusing the linter.

✅ **Verification:** 
- Validated syntax using `ruby -c app/services/take_medication_service.rb` (Syntax OK).
- The code review tool approved the approach, confirming it removes the commented-out code structure while correctly documenting the method arguments (source, amount_override, taken_from_medication_id, user, options) and the resulting object (`TakeMedicationService::Result`).

✨ **Result:** 
The "Commented Out Code" code health issue is resolved, making the codebase cleaner and reducing noise in static analysis reports without losing the method's intended documentation.

---
*PR created automatically by Jules for task [808354287510355195](https://jules.google.com/task/808354287510355195) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->