### PR TITLE
test: 🧪 Add tests for Api::V1::LocationsController

### DIFF
--- a/spec/requests/api/v1/locations_spec.rb
+++ b/spec/requests/api/v1/locations_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 locations' do
+  fixtures :accounts, :people, :users, :locations, :households
+
+  let(:user) { users(:jane) }
+
+  describe 'GET /api/v1/households/:household_id/locations' do
+    it 'returns locations in the signed-in user scope' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_locations_path(household_id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+
+      returned_ids = response.parsed_body.fetch('data').map { |location| location.fetch('id') }
+      expect(returned_ids).to include(locations(:home).id, locations(:school).id)
+    end
+  end
+
+  describe 'GET /api/v1/households/:household_id/locations/:id' do
+    it 'returns the location for the given id' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      location = locations(:home)
+
+      get api_v1_household_location_path(household_id, location),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+
+      returned_location = response.parsed_body.fetch('data')
+      expect(returned_location.fetch('id')).to eq(location.id)
+      expect(returned_location.fetch('name')).to eq(location.name)
+      expect(returned_location.fetch('description')).to eq(location.description)
+    end
+
+    it 'returns not_found for a location outside scope' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      other_household = Household.create!(name: 'Other API Household', slug: 'other-api-household')
+      other_location = Location.create!(name: 'Other', household: other_household)
+
+      get api_v1_household_location_path(household_id, other_location),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** This PR introduces a missing RSpec integration test suite for `Api::V1::LocationsController`, ensuring the endpoint correctly returns location resources belonging to the authenticated user's household context.

📊 **Coverage:**
- Tests `GET /api/v1/households/:household_id/locations` endpoint (index action) - verifying correct scoping of results for the household.
- Tests `GET /api/v1/households/:household_id/locations/:id` endpoint (show action) - verifying resource rendering format (id, name, description).
- Tests isolation constraints - validating that requests attempting to access locations across different household bounds correctly return a `not_found` (404) response.

✨ **Result:** Enhanced the API testing suite by eliminating a testing gap on the locations controller, resulting in more robust verification of Pundit policies and data isolation guarantees within multitenant scopes.

---
*PR created automatically by Jules for task [5590127514421077796](https://jules.google.com/task/5590127514421077796) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->