### PR TITLE
test: 🧪 Add request specs for API v1 medication takes index

### DIFF
--- a/spec/requests/api/v1/medication_takes_spec.rb
+++ b/spec/requests/api/v1/medication_takes_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 medication takes' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules,
+           :person_medications, :medication_takes, :carer_relationships
+
+  let(:user) { users(:jane) }
+
+  describe 'GET /api/v1/households/:household_id/medication_takes collection' do
+    it 'returns only medication takes in the signed-in user scope' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_medication_takes_path(household_id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+
+      returned_ids = response.parsed_body.fetch('data').map { |take| take.fetch('id') }
+      expect(returned_ids).to include(medication_takes(:jane_morning_ibuprofen).id)
+      expect(returned_ids).not_to include(medication_takes(:john_morning_paracetamol).id)
+    end
+
+    it 'applies valid collection filters and pagination bounds' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_medication_takes_path(household_id),
+          params: { updated_since: 1.year.ago.iso8601, page: 0, per_page: 500 },
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('meta', 'page')).to eq(1)
+      expect(response.parsed_body.dig('meta', 'per_page')).to eq(100)
+    end
+
+    it 'returns a structured error for an invalid updated_since filter' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_medication_takes_path(household_id),
+          params: { updated_since: 'not-a-timestamp' },
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body.dig('error', 'code')).to eq('unprocessable_content')
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** The `Api::V1::MedicationTakesController` was missing spec coverage for its `index` action, representing a testing gap for an important API endpoint.

📊 **Coverage:** This PR adds `spec/requests/api/v1/medication_takes_spec.rb` to cover the collection endpoint. It asserts that:
- It returns only medication takes within the signed-in user's scope.
- It applies valid collection filters and correct pagination bounds.
- It returns a structured error for invalid `updated_since` filters.

✨ **Result:** Enhanced test reliability and coverage for the medication takes API collection, preventing regressions on policy scoping and parameter parsing.

---
*PR created automatically by Jules for task [9031736859287874925](https://jules.google.com/task/9031736859287874925) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->