### PR TITLE
test: 🧪 Add missing spec file for InvitationsController

### DIFF
--- a/spec/requests/invitations_controller_spec.rb
+++ b/spec/requests/invitations_controller_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe InvitationsController, type: :request do
+RSpec.describe InvitationsController do
   fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
 
   describe 'GET #accept' do
@@ -18,7 +20,9 @@ RSpec.describe InvitationsController, type: :request do
       )
     end
     let(:membership) { household.household_memberships.sole }
-    let(:invitation) { FactoryBot.create(:household_invitation, household: household, invited_by_membership: membership) }
+    let(:invitation) do
+      create(:household_invitation, household: household, invited_by_membership: membership)
+    end
 
     it 'renders the accept invitation view for a valid token' do
       get accept_invitation_path(token: invitation.token)
@@ -34,10 +38,10 @@ RSpec.describe InvitationsController, type: :request do
       expect(response.body).to include('This invitation link is invalid or has expired.')
     end
 
-    it 'raises ActionController::ParameterMissing when token is missing' do
-      expect do
-        get accept_invitation_path
-      end.to raise_error(ActionController::ParameterMissing)
+    it 'returns a 400 Bad Request when token is missing' do
+      get accept_invitation_path
+
+      expect(response).to have_http_status(:bad_request)
     end
   end
 end

--- a/spec/requests/invitations_controller_spec.rb
+++ b/spec/requests/invitations_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe InvitationsController, type: :request do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
+
+  describe 'GET #accept' do
+    let(:account) { Account.create!(email: 'valid-owner@example.test', status: :verified) }
+    let(:household) do
+      Household.create_with_owner!(
+        name: 'Valid Token Household',
+        owner_account: account,
+        owner_person_attributes: {
+          name: 'Valid Owner',
+          date_of_birth: 30.years.ago.to_date,
+          person_type: :adult,
+          has_capacity: true
+        }
+      )
+    end
+    let(:membership) { household.household_memberships.sole }
+    let(:invitation) { FactoryBot.create(:household_invitation, household: household, invited_by_membership: membership) }
+
+    it 'renders the accept invitation view for a valid token' do
+      get accept_invitation_path(token: invitation.token)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Accept Invitation - MedTracker')
+    end
+
+    it 'renders a not found message for an invalid or expired token' do
+      get accept_invitation_path(token: 'invalid_token')
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include('This invitation link is invalid or has expired.')
+    end
+
+    it 'raises ActionController::ParameterMissing when token is missing' do
+      expect do
+        get accept_invitation_path
+      end.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** 
Added a missing RSpec request spec file for the `InvitationsController`. As request specs are the modern standard over deprecated controller specs, the test file `spec/requests/invitations_controller_spec.rb` was created.

📊 **Coverage:** 
The new spec provides comprehensive integration testing coverage for the `GET #accept` endpoint. It verifies:
- The happy path, where a valid token renders the `Accept Invitation` view correctly.
- An error path where a missing token parameter appropriately raises an `ActionController::ParameterMissing` exception.
- An error path where an invalid or expired token correctly renders the plain text 'not found' message with a `404 Not Found` status code.

✨ **Result:** 
The test coverage for `InvitationsController` is significantly improved. These robust integration tests provide a safety net ensuring that any future changes to the controller's logic do not introduce regressions or unexpectedly alter the handling of valid/invalid invitations.

---
*PR created automatically by Jules for task [2824536847620834653](https://jules.google.com/task/2824536847620834653) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->