### PR TITLE
test: 🧪 Add missing spec for Api::V1::MeController

### DIFF
--- a/spec/requests/api/v1/me_spec.rb
+++ b/spec/requests/api/v1/me_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 me' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:jane) }
+
+  describe 'GET /api/v1/households/:household_id/me' do
+    it 'returns the signed-in user profile' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_me_path(household_id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+
+      data = response.parsed_body.fetch('data')
+      expect(data.fetch('id')).to eq(user.id)
+      expect(data.fetch('email_address')).to eq(user.email_address)
+      expect(data.fetch('active')).to eq(user.active)
+      expect(data).to have_key('membership_role')
+
+      person_data = data.fetch('person')
+      expect(person_data.fetch('id')).to eq(user.person.id)
+
+      account_data = data.fetch('account')
+      expect(account_data.fetch('id')).to eq(user.person.account.id)
+      expect(account_data.fetch('email')).to eq(user.person.account.email)
+    end
+
+    it 'returns unauthorized without a valid token' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      get api_v1_household_me_path(household_id),
+          headers: api_auth_headers('invalid_token'),
+          as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
+    end
+  end
+end


### PR DESCRIPTION
🎯 What: Added `spec/requests/api/v1/me_spec.rb` to cover the missing tests for `Api::V1::MeController`.
📊 Coverage: Added integration tests for the show action. Covers the happy path (returning correctly formatted MeSerializer JSON) and unhappy paths like missing tokens. Also implicitly verifies nested routing setup under households.
✨ Result: `Api::V1::MeController` is now covered by request specs.

---
*PR created automatically by Jules for task [9705448840004718895](https://jules.google.com/task/9705448840004718895) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->