### PR TITLE
fix: 🛡️ Sentinel: Medium Fix Insecure Randomness for Client UUIDs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** DOM-based Stored XSS in `app/javascript/controllers/schedule_form_controller.js`. User-controlled dosage properties were interpolated directly into a string mapped to an HTML payload which was then directly assigned to `element.innerHTML`, executing malicious inputs.
 **Learning:** Raw Javascript template literals injected into `.innerHTML` are dangerous. Even if the expected value is alphanumeric (like unit amounts), it must be treated as untrusted and safely escaped. When writing custom escape methods, ensure quotes (`"` and `'`) are covered so attribute injection attacks are also prevented.
 **Prevention:** Use a robust `escapeHtml` function that replaces `&, <, >, ", '` with their entity equivalents. Apply escaping strictly to the output context (HTML strings) while using raw values for logical internal state comparisons to avoid breaking app functionality.
+
+**Vulnerability:** Insecure Randomness for Client UUIDs
+**Learning:** `Math.random()` should not be used as a fallback for generating UUIDs, as it is predictable and not cryptographically secure, which could lead to ID collisions or predictability.
+**Prevention:** Always use a Cryptographically Secure Pseudo-Random Number Generator (CSPRNG) like `window.crypto.getRandomValues()` when generating unique identifiers in the client-side fallback if `window.crypto.randomUUID()` is unavailable.

--- a/app/javascript/controllers/offline_store.js
+++ b/app/javascript/controllers/offline_store.js
@@ -99,7 +99,9 @@ export async function refreshSnapshot(snapshotUrl, tenantKey = defaultTenantKey(
 export function buildClientUuid() {
   if (window.crypto?.randomUUID) return window.crypto.randomUUID()
 
-  return `offline-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+    (c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  )
 }
 
 export async function queueTake(attributes, tenantKey = defaultTenantKey()) {


### PR DESCRIPTION
🎯 **What:** 
The fallback UUID generation in `app/javascript/controllers/offline_store.js` previously relied on `Math.random()`, which is a predictable PRNG. This has been replaced with a secure UUIDv4 generation algorithm utilizing `window.crypto.getRandomValues`.

⚠️ **Risk:** 
`Math.random()` is not cryptographically secure. Using it to generate client UUIDs for syncing offline records could lead to predictable IDs and potential ID collisions, theoretically allowing a malicious actor to guess or brute-force queued IDs, compromising data integrity.

🛡️ **Solution:** 
Replaced `Math.random().toString(16).slice(2)` with a cryptographically secure UUIDv4 generation sequence using `window.crypto.getRandomValues(new Uint8Array(1))`. This ensures that even when `window.crypto.randomUUID()` is unsupported, the fallback generates robust, unguessable UUIDs.

🚨 **Severity:** Medium
💡 **Vulnerability:** Insecure Randomness (CWE-338)
🎯 **Impact:** Client ID predictability and collision risk in offline store logic
🔧 **Fix:** Migrate from `Math.random` to `crypto.getRandomValues`
✅ **Verification:** Verified syntax checks on the modified ES module using `node -c` (converted to .mjs and back for syntax validation). Offline sync operations now safely use CSPRNG fallbacks.

---
*PR created automatically by Jules for task [16366310759853724891](https://jules.google.com/task/16366310759853724891) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->