### PR TITLE
perf: Group timing insight take matching

### DIFF
--- a/app/services/smart_insights/detectors/timing_consistency.rb
+++ b/app/services/smart_insights/detectors/timing_consistency.rb
@@ -40,9 +40,10 @@ module SmartInsights
 
       def on_time_count
         @on_time_count ||= begin
-          remaining_takes = takes_with_configured_times.dup
+          remaining_takes_by_schedule_id = takes_with_configured_times.group_by(&:schedule_id)
 
           expected_occurrences.count do |occurrence|
+            remaining_takes = remaining_takes_by_schedule_id.fetch(occurrence[:schedule].id, [])
             matching_take = remaining_takes.find { |take| on_time?(take, occurrence) }
             remaining_takes.delete(matching_take) if matching_take
           end

--- a/spec/services/smart_insights/detectors/timing_consistency_spec.rb
+++ b/spec/services/smart_insights/detectors/timing_consistency_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe SmartInsights::Detectors::TimingConsistency do
     take
   end
 
+  def counted_take_at(schedule:, taken_at:, counter:)
+    take = instance_double(MedicationTake, taken_at: taken_at)
+    allow(take).to receive(:schedule).and_return(schedule)
+    allow(take).to receive(:schedule_id) do
+      counter[:schedule_id_reads] += 1
+      schedule.id
+    end
+    take
+  end
+
+  def counted_takes_for(schedule:, start_date:, end_date:, time_str:, counter:)
+    (start_date..end_date).map do |date|
+      counted_take_at(schedule: schedule, taken_at: expected_time(date, time_str), counter: counter)
+    end
+  end
+
   # Build a context double that satisfies all methods the detector calls.
   def context_with(schedules:, takes:, start_date:, end_date:)
     instance_double(
@@ -199,6 +215,24 @@ RSpec.describe SmartInsights::Detectors::TimingConsistency do
       end
       ctx = context_with(schedules: [ext_sched], takes: takes, start_date: start_date, end_date: extended_end)
       expect(described_class.new(ctx).call.size).to eq(1)
+    end
+
+    it 'matches takes by schedule before scanning timing windows' do
+      other_sched = schedule_double(id: 99, time: time_str, start_date: start_date, end_date: end_date)
+      counter = { schedule_id_reads: 0 }
+      other_takes = counted_takes_for(schedule: other_sched, start_date: start_date, end_date: end_date,
+                                      time_str: time_str, counter: counter)
+      primary_takes = counted_takes_for(schedule: sched, start_date: start_date, end_date: end_date,
+                                        time_str: time_str, counter: counter)
+      ctx = context_with(
+        schedules: [sched, other_sched],
+        takes: other_takes + primary_takes,
+        start_date: start_date,
+        end_date: end_date
+      )
+
+      expect(described_class.new(ctx).call.size).to eq(1)
+      expect(counter[:schedule_id_reads]).to be <= 20
     end
 
     it 'skips days where expected_doses_on returns 0 when counting occurrences' do

--- a/spec/services/smart_insights/detectors/timing_consistency_spec.rb
+++ b/spec/services/smart_insights/detectors/timing_consistency_spec.rb
@@ -24,22 +24,6 @@ RSpec.describe SmartInsights::Detectors::TimingConsistency do
     take
   end
 
-  def counted_take_at(schedule:, taken_at:, counter:)
-    take = instance_double(MedicationTake, taken_at: taken_at)
-    allow(take).to receive(:schedule).and_return(schedule)
-    allow(take).to receive(:schedule_id) do
-      counter[:schedule_id_reads] += 1
-      schedule.id
-    end
-    take
-  end
-
-  def counted_takes_for(schedule:, start_date:, end_date:, time_str:, counter:)
-    (start_date..end_date).map do |date|
-      counted_take_at(schedule: schedule, taken_at: expected_time(date, time_str), counter: counter)
-    end
-  end
-
   # Build a context double that satisfies all methods the detector calls.
   def context_with(schedules:, takes:, start_date:, end_date:)
     instance_double(
@@ -87,6 +71,12 @@ RSpec.describe SmartInsights::Detectors::TimingConsistency do
         base = expected_time(date, time_str)
         offset = on_time ? 0.minutes : (described_class::WINDOW_MINUTES + 1).minutes
         take_at(schedule_id: 42, taken_at: base + offset, schedule: sched)
+      end
+    end
+
+    def on_time_takes_for(schedule)
+      (start_date..end_date).map do |date|
+        take_at(schedule_id: schedule.id, taken_at: expected_time(date, time_str), schedule: schedule)
       end
     end
 
@@ -219,20 +209,17 @@ RSpec.describe SmartInsights::Detectors::TimingConsistency do
 
     it 'matches takes by schedule before scanning timing windows' do
       other_sched = schedule_double(id: 99, time: time_str, start_date: start_date, end_date: end_date)
-      counter = { schedule_id_reads: 0 }
-      other_takes = counted_takes_for(schedule: other_sched, start_date: start_date, end_date: end_date,
-                                      time_str: time_str, counter: counter)
-      primary_takes = counted_takes_for(schedule: sched, start_date: start_date, end_date: end_date,
-                                        time_str: time_str, counter: counter)
       ctx = context_with(
         schedules: [sched, other_sched],
-        takes: other_takes + primary_takes,
+        takes: on_time_takes_for(other_sched) + on_time_takes_for(sched),
         start_date: start_date,
         end_date: end_date
       )
+      insights = described_class.new(ctx).call
 
-      expect(described_class.new(ctx).call.size).to eq(1)
-      expect(counter[:schedule_id_reads]).to be <= 20
+      expect(insights.size).to eq(1)
+      expect(insights.first.metric_value).to eq(I18n.t('smart_insights.detectors.timing_consistency.metric_value',
+                                                       count: 10))
     end
 
     it 'skips days where expected_doses_on returns 0 when counting occurrences' do


### PR DESCRIPTION
What changed
- Grouped timing-consistency candidate takes by schedule before applying the existing on-time window match.
- Kept the spec behavior-focused by covering interleaved two-schedule takes and asserting the resulting insight metric.

Why it was a bottleneck
- The detector previously scanned every remaining take for each expected occurrence, including takes from unrelated schedules. Multi-schedule insight runs could spend avoidable work on schedule-id checks before reaching the relevant timing window.

Measurement used
- During the red/green pass, a temporary comparison-count assertion showed the two-schedule scenario made 35 schedule-id reads before the change and 20 after. The permanent spec now avoids pinning that internal call count and verifies the observable insight output instead.

Expected impact
- Smart Insights timing-consistency detection avoids unrelated schedule comparisons while preserving the existing greedy one-to-one matching behavior inside each schedule.

Tests run
- task test TEST_FILE=spec/services/smart_insights/detectors/timing_consistency_spec.rb
- task rubocop
- task test