### PR TITLE
fix(API): Harden API sync, exports, and session handling

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -17,6 +17,15 @@ SimpleCov.configure do
   add_filter '/vendor/'
   add_filter '/tmp/'
 
+  add_group 'API' do |source_file|
+    filename = source_file.filename
+
+    filename.include?('/app/controllers/api/') ||
+      filename.match?(%r{/app/models/api_.*\.rb\z}) ||
+      filename.include?('/app/serializers/api/') ||
+      filename.include?('/app/serializers/fhir/') ||
+      filename.include?('/app/services/api/')
+  end
   add_group 'Components', 'app/components'
   add_group 'Controllers', 'app/controllers'
   add_group 'Domain', 'app/domain'
@@ -27,4 +36,20 @@ SimpleCov.configure do
   add_group 'Presenters', 'app/presenters'
   add_group 'Serializers', 'app/serializers'
   add_group 'Services', 'app/services'
+
+  at_exit do
+    result = SimpleCov.result
+    result.format!
+    next unless ENV['COVERAGE'] == 'true'
+
+    api_group = result.groups.fetch('API')
+    api_total = api_group.total_branches.to_i
+    api_covered = api_group.covered_branches.to_i
+    api_percent = api_total.zero? ? 100.0 : (api_covered.to_f / api_total * 100)
+    next if api_percent >= 90.0
+
+    warn format('API branch coverage (%.2f%%) is below the configured minimum coverage (90.00%%).',
+                api_percent)
+    Kernel.exit SimpleCov::ExitCodes::MINIMUM_COVERAGE
+  end
 end

--- a/app/controllers/api/fhir/r4/base_controller.rb
+++ b/app/controllers/api/fhir/r4/base_controller.rb
@@ -4,15 +4,130 @@ module Api
   module Fhir
     module R4
       class BaseController < Api::V1::BaseController
+        FHIR_JSON = 'application/fhir+json'
+        SUPPORTED_FORMATS = ['json', FHIR_JSON].freeze
+
+        before_action :ensure_fhir_format
+
         private
 
-        def render_fhir_collection(scope, serializer)
-          records = scope.limit(100).to_a
-          render json: ::Fhir::R4::Serializer.bundle(records, type: serializer)
+        def render_fhir_collection(scope, serializer, search: {})
+          searched = apply_fhir_search(scope, search)
+          paginated = paginate_fhir(searched)
+          render json: ::Fhir::R4::Serializer.bundle(
+            paginated.fetch(:records),
+            type: serializer,
+            total: paginated.fetch(:total),
+            links: bundle_links(paginated)
+          ), content_type: FHIR_JSON
         end
 
         def render_fhir_resource(record, serializer)
-          render json: ::Fhir::R4::Serializer.public_send(serializer, record)
+          render json: ::Fhir::R4::Serializer.public_send(serializer, record), content_type: FHIR_JSON
+        end
+
+        def render_api_error(code:, message:, status:, errors: nil)
+          outcome_code = fhir_issue_code(code)
+          issue = {
+            severity: 'error',
+            code: outcome_code,
+            details: { text: message },
+            diagnostics: request.request_id
+          }
+          if errors.present?
+            issue[:extension] = [{ url: 'https://medtracker.example/fhir/error-details',
+                                   valueString: errors.to_json }]
+          end
+
+          render json: { resourceType: 'OperationOutcome', issue: [issue] }, status: status, content_type: FHIR_JSON
+        end
+
+        def render_not_acceptable(message)
+          render_api_error(code: 'not_supported', message: message, status: :not_acceptable)
+        end
+
+        def apply_fhir_search(scope, search)
+          unsupported = request.query_parameters.keys - supported_query_parameters(search)
+          raise InvalidFilterValue, "Unsupported FHIR search parameter: #{unsupported.first}" if unsupported.any?
+
+          search.reduce(scope) do |filtered, (name, callable)|
+            value = params[name]
+            value.present? ? callable.call(filtered, value) : filtered
+          end
+        end
+
+        def paginate_fhir(scope)
+          page = [params.fetch(:page, 1).to_i, 1].max
+          count = params.fetch(:_count, 100).to_i.clamp(1, 100)
+          total = scope.count
+
+          {
+            page: page,
+            count: count,
+            total: total,
+            records: scope.limit(count).offset((page - 1) * count).to_a
+          }
+        end
+
+        def bundle_links(paginated)
+          links = [{ relation: 'self', url: request.original_url }]
+          return links unless paginated.fetch(:page) * paginated.fetch(:count) < paginated.fetch(:total)
+
+          links << { relation: 'next', url: next_page_url(paginated.fetch(:page) + 1) }
+        end
+
+        def next_page_url(page)
+          query = request.query_parameters.merge('page' => page)
+          "#{request.base_url}#{request.path}?#{query.to_query}"
+        end
+
+        def supported_query_parameters(search)
+          search.keys.map(&:to_s) + %w[_count _format page]
+        end
+
+        def ensure_fhir_format
+          requested_format = params[:_format].presence
+          return if requested_format.blank? || SUPPORTED_FORMATS.include?(requested_format)
+
+          render_not_acceptable("FHIR R4 responses are only available as #{FHIR_JSON}")
+        end
+
+        def fhir_issue_code(code)
+          case code.to_s
+          when 'not_supported'
+            'not-supported'
+          when 'not_found'
+            'not-found'
+          when 'forbidden', 'unauthorized'
+            'security'
+          when 'unprocessable_content'
+            'invalid'
+          else
+            'processing'
+          end
+        end
+
+        def portable_reference_id(value)
+          value.to_s.split('/').last
+        end
+
+        def iso8601_date(value, field:)
+          Date.iso8601(value.to_s)
+        rescue ArgumentError
+          raise InvalidFilterValue, "#{field} must be ISO8601"
+        end
+
+        def search_by_portable_id
+          lambda do |scope, value|
+            scope.where(portable_id: portable_reference_id(value))
+          end
+        end
+
+        def search_by_updated_date
+          lambda do |scope, value|
+            date = iso8601_date(value, field: 'date')
+            scope.where(updated_at: date.all_day)
+          end
         end
       end
     end

--- a/app/controllers/api/fhir/r4/base_controller.rb
+++ b/app/controllers/api/fhir/r4/base_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class BaseController < Api::V1::BaseController
+        private
+
+        def render_fhir_collection(scope, serializer)
+          records = scope.limit(100).to_a
+          render json: ::Fhir::R4::Serializer.bundle(records, type: serializer)
+        end
+
+        def render_fhir_resource(record, serializer)
+          render json: ::Fhir::R4::Serializer.public_send(serializer, record)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/medication_administrations_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_administrations_controller.rb
@@ -9,7 +9,7 @@ module Api
                   .includes({ schedule: %i[person medication] }, { person_medication: %i[person medication] },
                             :taken_from_medication)
                   .order(:id)
-          render_fhir_collection(scope, :medication_administration)
+          render_fhir_collection(scope, :medication_administration, search: search)
         end
 
         def show
@@ -20,6 +20,49 @@ module Api
             params.expect(:id)
           )
           render_fhir_resource(take, :medication_administration)
+        end
+
+        private
+
+        def search
+          {
+            _id: search_by_portable_id,
+            patient: patient_search,
+            subject: patient_search,
+            medication: medication_search,
+            status: status_search,
+            date: lambda { |scope, value|
+              scope.where(taken_at: iso8601_date(value, field: 'date').all_day)
+            }
+          }
+        end
+
+        def patient_search
+          lambda do |scope, value|
+            person = Person.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.left_outer_joins(:schedule, :person_medication)
+                 .where(schedules: { person_id: person.id })
+                 .or(scope.left_outer_joins(:schedule, :person_medication)
+                          .where(person_medications: { person_id: person.id }))
+          end
+        end
+
+        def medication_search
+          lambda do |scope, value|
+            medication = Medication.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.left_outer_joins(:schedule, :person_medication)
+                 .where(schedules: { medication_id: medication.id })
+                 .or(scope.left_outer_joins(:schedule, :person_medication)
+                          .where(person_medications: { medication_id: medication.id }))
+          end
+        end
+
+        def status_search
+          lambda do |scope, value|
+            raise InvalidFilterValue, 'status must be completed' unless value.to_s == 'completed'
+
+            scope
+          end
         end
       end
     end

--- a/app/controllers/api/fhir/r4/medication_administrations_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_administrations_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class MedicationAdministrationsController < BaseController
+        def index
+          scope = policy_scope(MedicationTake)
+                  .includes({ schedule: %i[person medication] }, { person_medication: %i[person medication] },
+                            :taken_from_medication)
+                  .order(:id)
+          render_fhir_collection(scope, :medication_administration)
+        end
+
+        def show
+          take = find_api_record(
+            policy_scope(MedicationTake).includes({ schedule: %i[person medication] },
+                                                  { person_medication: %i[person medication] },
+                                                  :taken_from_medication),
+            params.expect(:id)
+          )
+          render_fhir_resource(take, :medication_administration)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/medication_requests_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_requests_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class MedicationRequestsController < BaseController
+        def index
+          render_fhir_collection(policy_scope(Schedule).includes(:person, :medication).order(:id), :medication_request)
+        end
+
+        def show
+          schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
+          render_fhir_resource(schedule, :medication_request)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/medication_requests_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_requests_controller.rb
@@ -5,12 +5,55 @@ module Api
     module R4
       class MedicationRequestsController < BaseController
         def index
-          render_fhir_collection(policy_scope(Schedule).includes(:person, :medication).order(:id), :medication_request)
+          scope = policy_scope(Schedule).includes(:person, :medication).order(:id)
+          render_fhir_collection(scope, :medication_request, search: search)
         end
 
         def show
           schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
           render_fhir_resource(schedule, :medication_request)
+        end
+
+        private
+
+        def search
+          {
+            _id: search_by_portable_id,
+            patient: patient_search,
+            subject: patient_search,
+            medication: medication_search,
+            status: status_search,
+            date: lambda { |scope, value|
+              scope.where(start_date: iso8601_date(value, field: 'date'))
+            }
+          }
+        end
+
+        def patient_search
+          lambda do |scope, value|
+            person = Person.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.where(person_id: person.id)
+          end
+        end
+
+        def medication_search
+          lambda do |scope, value|
+            medication = Medication.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.where(medication_id: medication.id)
+          end
+        end
+
+        def status_search
+          lambda do |scope, value|
+            case value.to_s
+            when 'active'
+              scope.where(active: true)
+            when 'stopped'
+              scope.where(active: false)
+            else
+              raise InvalidFilterValue, 'status must be active or stopped'
+            end
+          end
         end
       end
     end

--- a/app/controllers/api/fhir/r4/medication_statements_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_statements_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class MedicationStatementsController < BaseController
+        def index
+          scope = policy_scope(PersonMedication).includes(:person, :medication).order(:id)
+          render_fhir_collection(scope, :medication_statement)
+        end
+
+        def show
+          person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
+                                              params.expect(:id))
+          render_fhir_resource(person_medication, :medication_statement)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/medication_statements_controller.rb
+++ b/app/controllers/api/fhir/r4/medication_statements_controller.rb
@@ -6,13 +6,52 @@ module Api
       class MedicationStatementsController < BaseController
         def index
           scope = policy_scope(PersonMedication).includes(:person, :medication).order(:id)
-          render_fhir_collection(scope, :medication_statement)
+          render_fhir_collection(scope, :medication_statement, search: search)
         end
 
         def show
           person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
                                               params.expect(:id))
           render_fhir_resource(person_medication, :medication_statement)
+        end
+
+        private
+
+        def search
+          {
+            _id: search_by_portable_id,
+            patient: patient_search,
+            subject: patient_search,
+            medication: medication_search,
+            status: status_search
+          }
+        end
+
+        def patient_search
+          lambda do |scope, value|
+            person = Person.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.where(person_id: person.id)
+          end
+        end
+
+        def medication_search
+          lambda do |scope, value|
+            medication = Medication.find_by!(portable_id: portable_reference_id(value), household: current_household)
+            scope.where(medication_id: medication.id)
+          end
+        end
+
+        def status_search
+          lambda do |scope, value|
+            case value.to_s
+            when 'active'
+              scope.where(active: true)
+            when 'stopped'
+              scope.where(active: false)
+            else
+              raise InvalidFilterValue, 'status must be active or stopped'
+            end
+          end
         end
       end
     end

--- a/app/controllers/api/fhir/r4/medications_controller.rb
+++ b/app/controllers/api/fhir/r4/medications_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class MedicationsController < BaseController
+        def index
+          render_fhir_collection(policy_scope(Medication).order(:id), :medication)
+        end
+
+        def show
+          render_fhir_resource(find_api_record(policy_scope(Medication), params.expect(:id)), :medication)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/medications_controller.rb
+++ b/app/controllers/api/fhir/r4/medications_controller.rb
@@ -5,11 +5,25 @@ module Api
     module R4
       class MedicationsController < BaseController
         def index
-          render_fhir_collection(policy_scope(Medication).order(:id), :medication)
+          render_fhir_collection(policy_scope(Medication).order(:id), :medication, search: search)
         end
 
         def show
           render_fhir_resource(find_api_record(policy_scope(Medication), params.expect(:id)), :medication)
+        end
+
+        private
+
+        def search
+          {
+            _id: search_by_portable_id,
+            code: lambda { |scope, value|
+              scope.where(dmd_code: value).or(scope.where(barcode: value))
+            },
+            form: lambda { |scope, value|
+              scope.where(category: value)
+            }
+          }
         end
       end
     end

--- a/app/controllers/api/fhir/r4/metadata_controller.rb
+++ b/app/controllers/api/fhir/r4/metadata_controller.rb
@@ -11,16 +11,39 @@ module Api
             date: Time.current.iso8601,
             kind: 'instance',
             fhirVersion: '4.0.1',
-            format: ['json'],
+            format: ['json', FHIR_JSON],
             rest: [{ mode: 'server', resource: resources }]
-          }
+          }, content_type: FHIR_JSON
         end
 
         private
 
         def resources
-          %w[Patient Medication MedicationRequest MedicationStatement MedicationAdministration].map do |type|
-            { type: type, interaction: [{ code: 'read' }, { code: 'search-type' }] }
+          [
+            resource('Patient', %w[_id name birthdate]),
+            resource('Medication', %w[_id code form]),
+            resource('MedicationRequest', %w[_id patient subject medication status date]),
+            resource('MedicationStatement', %w[_id patient subject medication status]),
+            resource('MedicationAdministration', %w[_id patient subject medication status date])
+          ]
+        end
+
+        def resource(type, search_parameters)
+          {
+            type: type,
+            interaction: [{ code: 'read' }, { code: 'search-type' }],
+            searchParam: search_parameters.map { |name| { name: name, type: search_parameter_type(name) } }
+          }
+        end
+
+        def search_parameter_type(name)
+          case name
+          when '_id', 'patient', 'subject', 'medication', 'status', 'code', 'form'
+            'token'
+          when 'date', 'birthdate'
+            'date'
+          else
+            'string'
           end
         end
       end

--- a/app/controllers/api/fhir/r4/metadata_controller.rb
+++ b/app/controllers/api/fhir/r4/metadata_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class MetadataController < BaseController
+        def show
+          render json: {
+            resourceType: 'CapabilityStatement',
+            status: 'active',
+            date: Time.current.iso8601,
+            kind: 'instance',
+            fhirVersion: '4.0.1',
+            format: ['json'],
+            rest: [{ mode: 'server', resource: resources }]
+          }
+        end
+
+        private
+
+        def resources
+          %w[Patient Medication MedicationRequest MedicationStatement MedicationAdministration].map do |type|
+            { type: type, interaction: [{ code: 'read' }, { code: 'search-type' }] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/fhir/r4/patients_controller.rb
+++ b/app/controllers/api/fhir/r4/patients_controller.rb
@@ -5,11 +5,25 @@ module Api
     module R4
       class PatientsController < BaseController
         def index
-          render_fhir_collection(policy_scope(Person).order(:id), :patient)
+          render_fhir_collection(policy_scope(Person).order(:id), :patient, search: search)
         end
 
         def show
           render_fhir_resource(find_api_record(policy_scope(Person), params.expect(:id)), :patient)
+        end
+
+        private
+
+        def search
+          {
+            _id: search_by_portable_id,
+            name: lambda { |scope, value|
+              scope.where(Person.arel_table[:name].matches("%#{Person.sanitize_sql_like(value)}%"))
+            },
+            birthdate: lambda { |scope, value|
+              scope.where(date_of_birth: iso8601_date(value, field: 'birthdate'))
+            }
+          }
         end
       end
     end

--- a/app/controllers/api/fhir/r4/patients_controller.rb
+++ b/app/controllers/api/fhir/r4/patients_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class PatientsController < BaseController
+        def index
+          render_fhir_collection(policy_scope(Person).order(:id), :patient)
+        end
+
+        def show
+          render_fhir_resource(find_api_record(policy_scope(Person), params.expect(:id)), :patient)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/app_tokens_controller.rb
+++ b/app/controllers/api/v1/admin/app_tokens_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class AppTokensController < BaseController
+        before_action :require_fresh_privileged_action, only: %i[create destroy]
+
+        def index
+          tokens = current_account.api_app_tokens
+                                  .where(household_membership: current_household.household_memberships)
+                                  .order(:id)
+          render json: { data: tokens.map { |token| token_payload(token) } }
+        end
+
+        def create
+          app_token, raw_token = ApiAppToken.issue_for(
+            account: current_account,
+            household_membership: current_membership,
+            name: app_token_params[:name],
+            audit_context: audit_context
+          )
+
+          render json: { data: token_payload(app_token).merge(token: raw_token) }, status: :created
+        end
+
+        def destroy
+          token = current_account.api_app_tokens
+                                 .where(household_membership: current_household.household_memberships)
+                                 .find(params.expect(:id))
+          token.revoke!(audit_context: audit_context)
+          head :no_content
+        end
+
+        private
+
+        def app_token_params
+          params.expect(api_app_token: [:name])
+        end
+
+        def token_payload(token)
+          {
+            id: token.id,
+            name: token.name,
+            last_used_at: token.last_used_at&.iso8601,
+            revoked_at: token.revoked_at&.iso8601,
+            permissions_version: token.permissions_version
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/audit_logs_controller.rb
+++ b/app/controllers/api/v1/admin/audit_logs_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class AuditLogsController < BaseController
+        def index
+          events = SecurityAuditEvent.where(household: current_household).order(created_at: :desc).limit(100)
+          render json: { data: events.map { |event| audit_event_payload(event) } }
+        end
+
+        private
+
+        def audit_event_payload(event)
+          {
+            id: event.id,
+            event_type: event.event_type,
+            actor_account_id: event.actor_account_id,
+            actor_membership_id: event.actor_membership_id,
+            request_id: event.request_id,
+            metadata: event.metadata,
+            created_at: event.created_at.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class BaseController < Api::V1::BaseController
+        before_action :require_household_manager
+
+        private
+
+        def require_household_manager
+          return if current_membership&.owner? || current_membership&.administrator?
+
+          render_forbidden
+        end
+
+        def require_fresh_privileged_action
+          return if Api::FreshPrivilegedAction.new(credential: current_api_session).satisfied?
+
+          render_api_error(
+            code: 'fresh_privileged_action_required',
+            message: 'Fresh MFA or OIDC MFA proof is required for this action.',
+            status: :forbidden
+          )
+        end
+
+        def audit_admin_action!(event_type:, target:, outcome:)
+          SecurityAuditEvent.create!(
+            household: current_household,
+            actor_account: current_account,
+            actor_membership: current_membership,
+            event_type: event_type,
+            request_id: request.request_id,
+            ip: request.remote_ip,
+            metadata: {
+              target_type: target.class.name,
+              target_id: target.id,
+              outcome: outcome
+            }
+          )
+        end
+
+        def audit_context
+          {
+            whodunnit: current_user&.id,
+            ip: request.remote_ip,
+            request_id: request.request_id,
+            household_id: current_household.id,
+            actor_membership_id: current_membership.id
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class InvitationsController < BaseController
+        before_action :require_fresh_privileged_action, only: %i[create destroy]
+
+        def index
+          invitations = current_household.household_invitations.order(created_at: :desc).limit(100)
+          render json: { data: invitations.map { |invitation| invitation_payload(invitation) } }
+        end
+
+        def create
+          invitation = current_household.household_invitations.new(invitation_params)
+          invitation.invited_by_membership = current_membership
+
+          return render_validation_errors(invitation) unless invitation.save
+
+          audit_admin_action!(event_type: 'api/admin/invitation/created', target: invitation, outcome: 'success')
+          render json: { data: invitation_payload(invitation) }, status: :created
+        end
+
+        def destroy
+          invitation = current_household.household_invitations.find(params.expect(:id))
+          invitation.update!(revoked_at: Time.current)
+          audit_admin_action!(event_type: 'api/admin/invitation/revoked', target: invitation, outcome: 'success')
+          head :no_content
+        end
+
+        private
+
+        def invitation_params
+          params.expect(household_invitation: %i[email membership_role])
+        end
+
+        def invitation_payload(invitation)
+          {
+            id: invitation.id,
+            email: invitation.email,
+            membership_role: invitation.membership_role,
+            pending: invitation.pending?,
+            accepted_at: invitation.accepted_at&.iso8601,
+            revoked_at: invitation.revoked_at&.iso8601,
+            expires_at: invitation.expires_at.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/memberships_controller.rb
+++ b/app/controllers/api/v1/admin/memberships_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class MembershipsController < BaseController
+        before_action :require_fresh_privileged_action, only: %i[update destroy]
+
+        def index
+          memberships = current_household.household_memberships.includes(:account, :person).order(:id)
+          render json: { data: memberships.map { |membership| membership_payload(membership) } }
+        end
+
+        def update
+          membership = find_membership
+          return render_validation_errors(membership) unless membership.update(membership_params)
+
+          audit_admin_action!(event_type: 'api/admin/membership/updated', target: membership, outcome: 'success')
+          render json: { data: membership_payload(membership.reload) }
+        end
+
+        def destroy
+          membership = find_membership
+          membership.update!(status: :revoked, revoked_at: Time.current,
+                             permissions_version: membership.permissions_version + 1)
+          audit_admin_action!(event_type: 'api/admin/membership/revoked', target: membership, outcome: 'success')
+          head :no_content
+        end
+
+        private
+
+        def find_membership
+          current_household.household_memberships.find(params.expect(:id))
+        end
+
+        def membership_params
+          params.expect(household_membership: %i[role status person_id])
+        end
+
+        def membership_payload(membership)
+          {
+            id: membership.id,
+            account_id: membership.account_id,
+            email: membership.account.email,
+            person_id: membership.person_id,
+            person_name: membership.person&.name,
+            role: membership.role,
+            status: membership.status,
+            permissions_version: membership.permissions_version,
+            joined_at: membership.joined_at&.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/person_access_grants_controller.rb
+++ b/app/controllers/api/v1/admin/person_access_grants_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class PersonAccessGrantsController < BaseController
+        before_action :require_fresh_privileged_action, only: %i[create destroy]
+
+        def index
+          grants = PersonAccessGrant.where(household: current_household).includes(:person, :household_membership)
+                                    .order(:id)
+          render json: { data: grants.map { |grant| grant_payload(grant) } }
+        end
+
+        def create
+          grant = PersonAccessGrant.new(grant_params)
+          grant.household = current_household
+          grant.granted_by_membership = current_membership
+
+          return render_validation_errors(grant) unless grant.save
+
+          audit_admin_action!(event_type: 'api/admin/person_access_grant/created', target: grant, outcome: 'success')
+          render json: { data: grant_payload(grant) }, status: :created
+        end
+
+        def destroy
+          grant = PersonAccessGrant.where(household: current_household).find(params.expect(:id))
+          grant.update!(revoked_at: Time.current)
+          audit_admin_action!(event_type: 'api/admin/person_access_grant/revoked', target: grant, outcome: 'success')
+          head :no_content
+        end
+
+        private
+
+        def grant_params
+          params.expect(
+            person_access_grant: %i[
+              household_membership_id
+              person_id
+              access_level
+              relationship_type
+              expires_at
+            ]
+          )
+        end
+
+        def grant_payload(grant)
+          {
+            id: grant.id,
+            household_membership_id: grant.household_membership_id,
+            person_id: grant.person_id,
+            person_name: grant.person.name,
+            access_level: grant.access_level,
+            relationship_type: grant.relationship_type,
+            expires_at: grant.expires_at&.iso8601,
+            revoked_at: grant.revoked_at&.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/settings_controller.rb
+++ b/app/controllers/api/v1/admin/settings_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class SettingsController < BaseController
+        before_action :require_fresh_privileged_action, only: :update
+
+        def show
+          render json: { data: household_payload(current_household) }
+        end
+
+        def update
+          return render_validation_errors(current_household) unless current_household.update(household_params)
+
+          audit_admin_action!(event_type: 'api/admin/household_settings/updated',
+                              target: current_household,
+                              outcome: 'success')
+          render json: { data: household_payload(current_household) }
+        end
+
+        private
+
+        def household_params
+          params.expect(household: %i[name timezone subscription_plan])
+        end
+
+        def household_payload(household)
+          {
+            id: household.id,
+            name: household.name,
+            slug: household.slug,
+            timezone: household.timezone,
+            subscription_plan: household.subscription_plan,
+            updated_at: household.updated_at.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/ai_medication_suggestions_controller.rb
+++ b/app/controllers/api/v1/ai_medication_suggestions_controller.rb
@@ -18,7 +18,7 @@ module Api
       private
 
       def medication_identity_params
-        return ActionController::Parameters.new if params[:medication].blank?
+        return ActionController::Parameters.new.permit! if params[:medication].blank?
 
         params.expect(medication: %i[name barcode dmd_code dmd_system dmd_concept_class category description])
       end

--- a/app/controllers/api/v1/ai_medication_suggestions_controller.rb
+++ b/app/controllers/api/v1/ai_medication_suggestions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class AiMedicationSuggestionsController < BaseController
+      def create
+        authorize Medication, :finder?
+        return render_not_found unless PaidFeature.enabled?(:ai_medication_help, user: current_user)
+
+        suggestion = AiMedication::SuggestionService.new.call(
+          medication_identity: medication_identity_params.to_h.deep_symbolize_keys,
+          user: current_user
+        )
+
+        render json: { data: suggestion.as_json }
+      end
+
+      private
+
+      def medication_identity_params
+        return ActionController::Parameters.new if params[:medication].blank?
+
+        params.expect(medication: %i[name barcode dmd_code dmd_system dmd_concept_class category description])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -6,6 +6,17 @@ module Api
       class SessionsController < ActionController::API
         include ErrorRendering
 
+        def index
+          api_credential = authenticated_api_credential
+          return render_unauthorized('Authentication required') unless api_credential
+
+          render json: {
+            data: api_credential.account.api_sessions.active.order(created_at: :desc).map do |session|
+              session_payload(session)
+            end
+          }
+        end
+
         def create
           account = Account.find_by(email: params.expect(:email).to_s.strip.downcase)
           household_membership = requested_household_membership(account)
@@ -26,6 +37,33 @@ module Api
 
           render json: { data: login_payload(api_session, access_token, refresh_token, household_membership) },
                  status: :created
+        end
+
+        def oidc_exchange
+          result = Api::OidcSessionExchange.new(params: oidc_exchange_params, request: request).call
+          render json: {
+            data: login_payload(result.api_session, result.access_token, result.refresh_token,
+                                result.household_membership)
+          }, status: :created
+        rescue Api::OidcSessionExchange::Error
+          render_invalid_oidc_exchange
+        end
+
+        def households
+          api_credential = authenticated_api_credential
+          return render_unauthorized('Authentication required') unless api_credential
+
+          render json: { data: household_memberships_payload(api_credential.account) }
+        end
+
+        def revoke
+          api_credential = authenticated_api_credential
+          return render_unauthorized('Authentication required') unless api_credential
+
+          api_session = api_credential.account.api_sessions.active.find(params.expect(:id))
+          api_session.revoke!(audit_context: audit_context(api_credential.account), action: 'revoked')
+
+          head :no_content
         end
 
         def refresh
@@ -56,6 +94,10 @@ module Api
         end
 
         private
+
+        def oidc_exchange_params
+          params.permit(:id_token, :nonce, :code_verifier, :device_name, :household_id, :provider)
+        end
 
         def audit_context(account)
           {
@@ -156,6 +198,27 @@ module Api
           }
         end
 
+        def household_memberships_payload(account)
+          account.household_memberships.active.includes(:household).order(:id).map do |membership|
+            household_payload(membership.household).merge(
+              role: membership.role,
+              membership_id: membership.id
+            )
+          end
+        end
+
+        def session_payload(api_session)
+          {
+            id: api_session.id,
+            device_name: api_session.device_name,
+            household_id: api_session.household_membership&.household_id,
+            last_used_at: api_session.last_used_at.iso8601,
+            access_token_expires_at: api_session.access_expires_at.iso8601,
+            refresh_token_expires_at: api_session.refresh_expires_at.iso8601,
+            created_at: api_session.created_at.iso8601
+          }
+        end
+
         def login_payload(api_session, access_token, refresh_token, household_membership)
           refresh_payload(api_session, access_token, refresh_token).merge(
             me: Api::V1::MeSerializer.new(api_session.account.person.user).as_json,
@@ -187,6 +250,24 @@ module Api
             message: 'Refresh token is invalid or expired',
             status: :unauthorized
           )
+        end
+
+        def render_invalid_oidc_exchange
+          render_api_error(
+            code: 'invalid_oidc_exchange',
+            message: 'OIDC exchange is invalid',
+            status: :unauthorized
+          )
+        end
+
+        def authenticated_api_credential
+          token = request.headers['Authorization'].to_s.split(' ', 2).last
+          credential = ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
+          return unless credential&.active_for_membership?
+          return if ApiAuthState.locked_out?(credential.account)
+
+          credential.touch_last_used!
+          credential
         end
       end
     end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -8,7 +8,7 @@ module Api
 
         def index
           api_credential = authenticated_api_credential
-          return render_unauthorized('Authentication required') unless api_credential
+          return render_authentication_required unless api_credential
 
           render json: {
             data: api_credential.account.api_sessions.active.order(created_at: :desc).map do |session|
@@ -51,14 +51,14 @@ module Api
 
         def households
           api_credential = authenticated_api_credential
-          return render_unauthorized('Authentication required') unless api_credential
+          return render_authentication_required unless api_credential
 
           render json: { data: household_memberships_payload(api_credential.account) }
         end
 
         def revoke
           api_credential = authenticated_api_credential
-          return render_unauthorized('Authentication required') unless api_credential
+          return render_authentication_required unless api_credential
 
           api_session = api_credential.account.api_sessions.active.find(params.expect(:id))
           api_session.revoke!(audit_context: audit_context(api_credential.account), action: 'revoked')
@@ -260,10 +260,19 @@ module Api
           )
         end
 
+        def render_authentication_required
+          render_api_error(
+            code: 'unauthorized',
+            message: 'Authentication required',
+            status: :unauthorized
+          )
+        end
+
         def authenticated_api_credential
           token = request.headers['Authorization'].to_s.split(' ', 2).last
           credential = ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
           return unless credential&.active_for_membership?
+          return if credential.is_a?(ApiSession) && !credential.access_expires_at.future?
           return if ApiAuthState.locked_out?(credential.account)
 
           credential.touch_last_used!

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -7,6 +7,7 @@ module Api
       include Pundit::Authorization
 
       around_action :with_api_request_context
+      around_action :with_api_idempotency
 
       class InvalidFilterValue < StandardError; end
 
@@ -114,7 +115,33 @@ module Api
       end
 
       def render_resource(record, serializer:, status: :ok)
+        response.set_header('ETag', api_etag(record))
         render json: { data: serializer.new(record).as_json }, status: status
+      end
+
+      def find_api_record(scope, identifier)
+        Api::PortableRecordLocator.new(household: current_household).find(scope, identifier)
+      end
+
+      def api_record_id(scope, identifier)
+        find_api_record(scope, identifier).id
+      end
+
+      def fresh_api_record?(record)
+        expected = request.headers['If-Match'].to_s
+        return true if expected.blank? || expected == api_etag(record)
+
+        render_conflict('Record has changed since it was last read')
+        false
+      end
+
+      def record_api_change(record, action:)
+        Api::ChangeRecorder.new(
+          household: current_household,
+          credential: current_api_session,
+          membership: current_membership,
+          request: request
+        ).record(record, action: action)
       end
 
       def apply_collection_filters(scope)
@@ -177,6 +204,36 @@ module Api
 
       def render_invalid_filter(exception)
         render_unprocessable(exception.message)
+      end
+
+      def render_conflict(message, code: 'conflict')
+        render_api_error(code: code, message: message, status: :conflict)
+      end
+
+      def api_etag(record)
+        %("#{Digest::SHA256.hexdigest([record.class.name, record.id, record.updated_at.to_f].join(':'))}")
+      end
+
+      def with_api_idempotency
+        store = Api::IdempotencyStore.new(request: request, credential: current_api_session, household: current_household)
+        unless store.active?
+          yield
+          return
+        end
+
+        result = store.lookup
+        if result.replayed
+          response.set_header('Idempotency-Replayed', 'true')
+          render json: result.record.response_body, status: result.record.response_status
+          return
+        end
+        if result.conflict
+          return render_conflict('Idempotency key has already been used for a different request',
+                                 code: 'idempotency_key_reused')
+        end
+
+        yield
+        store.store!(response) unless performed? && response.status == 409
       end
     end
   end

--- a/app/controllers/api/v1/capabilities_controller.rb
+++ b/app/controllers/api/v1/capabilities_controller.rb
@@ -16,7 +16,10 @@ module Api
           format: 'medtracker.api.capabilities.v1',
           api_version: 'v1',
           authentication: authentication,
+          administration: administration,
           portable_formats: portable_formats,
+          backups: backups,
+          fhir: fhir,
           sync: sync,
           client_tools: client_tools
         }
@@ -26,7 +29,24 @@ module Api
         {
           methods: %w[bearer_session api_app_token],
           hosted_mobile: 'oidc_authorization_code_pkce',
-          password_login: 'development_or_migration'
+          password_login: 'development_or_migration',
+          oidc_exchange: {
+            supported: true,
+            pkce_required: true,
+            session_listing: true,
+            session_revocation: true
+          }
+        }
+      end
+
+      def administration
+        {
+          household: true,
+          fresh_mfa_required: true,
+          app_tokens: true,
+          audit_logs: true,
+          invitations: true,
+          person_access_grants: true
         }
       end
 
@@ -34,7 +54,29 @@ module Api
         %w[
           medtracker.portable.v1
           medtracker.portable.encrypted.v1
+          medtracker.portable.v2
         ]
+      end
+
+      def backups
+        {
+          encrypted_migration_bundle: true,
+          unencrypted_zip: true,
+          health_data_json: true
+        }
+      end
+
+      def fhir
+        {
+          version: 'R4',
+          resources: %w[
+            Patient
+            Medication
+            MedicationRequest
+            MedicationStatement
+            MedicationAdministration
+          ]
+        }
       end
 
       def sync
@@ -42,7 +84,12 @@ module Api
           portable_ids: true,
           numeric_ids: 'backward_compatible',
           mobile_snapshot: true,
-          dry_run_import: true
+          dry_run_import: true,
+          idempotency_keys: true,
+          etag_conflicts: true,
+          change_feed: true,
+          batch_mutations: true,
+          tombstones: true
         }
       end
 

--- a/app/controllers/api/v1/data_exports_controller.rb
+++ b/app/controllers/api/v1/data_exports_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DataExportsController < BaseController
+      def show
+        render json: { data: export_service.call }
+      rescue DataExports::ProfileExportService::Error, PortableData::Encryptor::Error => e
+        render_unprocessable(e.message)
+      end
+
+      private
+
+      def export_service
+        DataExports::ProfileExportService.new(
+          household: current_household,
+          membership: current_membership,
+          mode: params.expect(:mode),
+          passphrase: request.headers['X-MedTracker-Portable-Passphrase'].presence,
+          request: request
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/dosage_options_controller.rb
+++ b/app/controllers/api/v1/dosage_options_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DosageOptionsController < BaseController
+      def index
+        authorize MedicationDosageOption
+        render_collection(policy_scope(MedicationDosageOption), serializer: DosageOptionSerializer, includes: :medication)
+      end
+
+      def show
+        dosage_option = find_api_record(policy_scope(MedicationDosageOption).includes(:medication), params.expect(:id))
+        authorize dosage_option
+
+        render_resource(dosage_option, serializer: DosageOptionSerializer)
+      end
+
+      def create
+        dosage_option = MedicationDosageOption.new(dosage_option_params)
+        dosage_option.household = current_household
+        authorize dosage_option
+
+        return render_validation_errors(dosage_option) unless dosage_option.save
+
+        record_api_change(dosage_option, action: 'create')
+        render_resource(dosage_option.reload, serializer: DosageOptionSerializer, status: :created)
+      end
+
+      def update
+        dosage_option = find_api_record(policy_scope(MedicationDosageOption).includes(:medication), params.expect(:id))
+        authorize dosage_option
+        return unless fresh_api_record?(dosage_option)
+
+        return render_validation_errors(dosage_option) unless dosage_option.update(dosage_option_update_params)
+
+        record_api_change(dosage_option, action: 'update')
+        render_resource(dosage_option.reload, serializer: DosageOptionSerializer)
+      end
+
+      private
+
+      def dosage_option_params
+        params.expect(
+          dosage_option: %i[
+            medication_id
+            amount
+            unit
+            frequency
+            description
+            default_for_adults
+            default_for_children
+            default_max_daily_doses
+            default_min_hours_between_doses
+            default_dose_cycle
+            current_supply
+            reorder_threshold
+          ]
+        ).tap do |attributes|
+          attributes[:medication_id] = api_record_id(policy_scope(Medication), attributes[:medication_id])
+        end
+      end
+
+      def dosage_option_update_params
+        dosage_option_params.except(:medication_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/dosage_options_controller.rb
+++ b/app/controllers/api/v1/dosage_options_controller.rb
@@ -56,7 +56,9 @@ module Api
             reorder_threshold
           ]
         ).tap do |attributes|
-          attributes[:medication_id] = api_record_id(policy_scope(Medication), attributes[:medication_id])
+          if attributes[:medication_id].present?
+            attributes[:medication_id] = api_record_id(policy_scope(Medication), attributes[:medication_id])
+          end
         end
       end
 

--- a/app/controllers/api/v1/health_events_controller.rb
+++ b/app/controllers/api/v1/health_events_controller.rb
@@ -52,7 +52,9 @@ module Api
             { medication_ids: [] }
           ]
         )
-        attributes[:person_id] = api_record_id(policy_scope(Person), attributes[:person_id])
+        if attributes[:person_id].present?
+          attributes[:person_id] = api_record_id(policy_scope(Person), attributes[:person_id])
+        end
         attributes[:medication_ids] = Array(attributes[:medication_ids]).map do |identifier|
           api_record_id(policy_scope(Medication), identifier)
         end

--- a/app/controllers/api/v1/health_events_controller.rb
+++ b/app/controllers/api/v1/health_events_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class HealthEventsController < BaseController
+      def index
+        authorize HealthEvent
+        render_collection(policy_scope(HealthEvent), serializer: HealthEventSerializer, includes: %i[person medications])
+      end
+
+      def show
+        health_event = find_api_record(policy_scope(HealthEvent).includes(:person, :medications), params.expect(:id))
+        authorize health_event
+
+        render_resource(health_event, serializer: HealthEventSerializer)
+      end
+
+      def create
+        health_event = HealthEvent.new(health_event_params)
+        health_event.household = current_household
+        authorize health_event
+
+        return render_validation_errors(health_event) unless health_event.save
+
+        record_api_change(health_event, action: 'create')
+        render_resource(health_event.reload, serializer: HealthEventSerializer, status: :created)
+      end
+
+      def update
+        health_event = find_api_record(policy_scope(HealthEvent).includes(:person, :medications), params.expect(:id))
+        authorize health_event
+        return unless fresh_api_record?(health_event)
+
+        return render_validation_errors(health_event) unless health_event.update(health_event_update_params)
+
+        record_api_change(health_event, action: 'update')
+        render_resource(health_event.reload, serializer: HealthEventSerializer)
+      end
+
+      private
+
+      def health_event_params
+        attributes = params.expect(
+          health_event: [
+            :person_id,
+            :event_kind,
+            :severity,
+            :title,
+            :notes,
+            :started_on,
+            :ended_on,
+            { medication_ids: [] }
+          ]
+        )
+        attributes[:person_id] = api_record_id(policy_scope(Person), attributes[:person_id])
+        attributes[:medication_ids] = Array(attributes[:medication_ids]).map do |identifier|
+          api_record_id(policy_scope(Medication), identifier)
+        end
+        attributes
+      end
+
+      def health_event_update_params
+        health_event_params.except(:person_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -9,7 +9,7 @@ module Api
       end
 
       def show
-        location = policy_scope(Location).find(params.expect(:id))
+        location = find_api_record(policy_scope(Location), params.expect(:id))
         authorize location
 
         render_resource(location, serializer: LocationSerializer)

--- a/app/controllers/api/v1/medication_lookup_controller.rb
+++ b/app/controllers/api/v1/medication_lookup_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MedicationLookupController < BaseController
+      def show
+        authorize Medication, :finder?
+        response = MedicationFinderSearchResponder.new(medication_scope: policy_scope(Medication)).call(
+          query: params[:q],
+          form: params[:form],
+          permissions: {
+            can_create: policy(Medication).create?,
+            can_update: false
+          }
+        )
+
+        render json: response.body, status: response.status
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/medication_takes_controller.rb
+++ b/app/controllers/api/v1/medication_takes_controller.rb
@@ -66,9 +66,9 @@ module Api
       def medication_take_source(source_type, source_id)
         case source_type
         when 'schedule'
-          policy_scope(Schedule).find(source_id)
+          find_api_record(policy_scope(Schedule), source_id)
         when 'person_medication'
-          policy_scope(PersonMedication).find(source_id)
+          find_api_record(policy_scope(PersonMedication), source_id)
         else
           raise ActiveRecord::RecordNotFound
         end

--- a/app/controllers/api/v1/medications_controller.rb
+++ b/app/controllers/api/v1/medications_controller.rb
@@ -9,7 +9,7 @@ module Api
       end
 
       def show
-        medication = policy_scope(Medication).includes(:location).find(params.expect(:id))
+        medication = find_api_record(policy_scope(Medication).includes(:location), params.expect(:id))
         authorize medication
 
         render_resource(medication, serializer: MedicationSerializer)
@@ -24,20 +24,58 @@ module Api
 
         return render_validation_errors(medication) unless medication.save
 
+        record_api_change(medication, action: 'create')
         render_resource(medication.reload, serializer: MedicationSerializer, status: :created)
       end
 
       def update
-        medication = policy_scope(Medication).includes(:location).find(params.expect(:id))
+        medication = find_api_record(policy_scope(Medication).includes(:location), params.expect(:id))
         authorize medication
+        return unless fresh_api_record?(medication)
+
         medication.paper_trail_event = 'api_update'
 
         return render_validation_errors(medication) unless medication.update(medication_params)
 
+        record_api_change(medication, action: 'update')
         render_resource(medication.reload, serializer: MedicationSerializer)
       end
 
+      def adjust_inventory
+        medication = find_api_record(policy_scope(Medication).includes(:location), params.expect(:id))
+        authorize medication, :update?
+        result = AdjustMedicationInventoryService.new.call(
+          medication: medication,
+          new_quantity: params.dig(:adjustment, :new_quantity),
+          reason: params.dig(:adjustment, :reason)
+        )
+        return render_unprocessable(result.error.to_s) unless result.success?
+
+        record_api_change(medication.reload, action: 'update')
+        render_resource(medication, serializer: MedicationSerializer)
+      end
+
+      def mark_as_ordered
+        update_reorder_status(:ordered)
+      end
+
+      def mark_as_received
+        update_reorder_status(:received)
+      end
+
       private
+
+      def update_reorder_status(status)
+        medication = find_api_record(policy_scope(Medication).includes(:location), params.expect(:id))
+        authorize medication
+        MedicationReorderStatusService.new.call(
+          medication: medication,
+          status: status,
+          order_details: order_details_params
+        )
+        record_api_change(medication.reload, action: 'update')
+        render_resource(medication, serializer: MedicationSerializer)
+      end
 
       def medication_params
         params.expect(
@@ -66,6 +104,13 @@ module Api
         return if location_id.blank?
 
         permitted[:location_id] = policy_scope(Location).find(location_id).id
+      end
+
+      def order_details_params
+        params.fetch(:order_details, ActionController::Parameters.new)
+              .permit(:supplier, :quantity, :expected_arrival_on)
+              .to_h
+              .symbolize_keys
       end
     end
   end

--- a/app/controllers/api/v1/native_device_tokens_controller.rb
+++ b/app/controllers/api/v1/native_device_tokens_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NativeDeviceTokensController < BaseController
+      def create
+        token = current_account.native_device_tokens.find_or_initialize_by(device_token: token_params[:device_token])
+        token.assign_attributes(platform: token_params[:platform], user_agent: request.user_agent)
+        authorize token, :create?
+
+        return render_validation_errors(token) unless token.save
+
+        head :created
+      end
+
+      def destroy
+        token = current_account.native_device_tokens.find_by(device_token: params.expect(:id))
+        unless token
+          authorize NativeDeviceToken.new(account: current_account), :destroy?
+          return head :no_content
+        end
+
+        authorize token, :destroy?
+        token.destroy!
+        head :no_content
+      end
+
+      private
+
+      def token_params
+        params.expect(native_device_token: %i[device_token platform])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/person_medications_controller.rb
+++ b/app/controllers/api/v1/person_medications_controller.rb
@@ -9,7 +9,8 @@ module Api
       end
 
       def show
-        person_medication = policy_scope(PersonMedication).includes(:person, :medication).find(params.expect(:id))
+        person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
+                                            params.expect(:id))
         authorize person_medication
 
         render_resource(person_medication, serializer: PersonMedicationSerializer)
@@ -25,24 +26,58 @@ module Api
 
         return render_validation_errors(person_medication) unless person_medication.save
 
+        record_api_change(person_medication, action: 'create')
         render_resource(person_medication.reload, serializer: PersonMedicationSerializer, status: :created)
       end
 
       def update
-        person_medication = policy_scope(PersonMedication).includes(:person, :medication).find(params.expect(:id))
+        person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
+                                            params.expect(:id))
         authorize person_medication
+        return unless fresh_api_record?(person_medication)
+
         attributes = person_medication_update_params
         assert_medication_access!(attributes[:medication_id]) if attributes[:medication_id].present?
 
         return render_validation_errors(person_medication) unless person_medication.update(attributes)
 
+        record_api_change(person_medication, action: 'update')
         render_resource(person_medication.reload, serializer: PersonMedicationSerializer)
+      end
+
+      def pause
+        update_pause_state(:pause!)
+      end
+
+      def resume
+        update_pause_state(:resume!)
+      end
+
+      def reorder
+        person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
+                                            params.expect(:id))
+        authorize person_medication, :update?
+        PersonMedicationReorderService.new.call(
+          person_medication: person_medication,
+          direction: params.expect(:direction)
+        )
+        record_api_change(person_medication.reload, action: 'update')
+        render_resource(person_medication, serializer: PersonMedicationSerializer)
       end
 
       private
 
+      def update_pause_state(method_name)
+        person_medication = find_api_record(policy_scope(PersonMedication).includes(:person, :medication),
+                                            params.expect(:id))
+        authorize person_medication, :update?
+        person_medication.public_send(method_name)
+        record_api_change(person_medication.reload, action: 'update')
+        render_resource(person_medication, serializer: PersonMedicationSerializer)
+      end
+
       def person_medication_params
-        params.expect(
+        attributes = params.expect(
           person_medication: %i[
             person_id
             medication_id
@@ -56,6 +91,19 @@ module Api
             dose_cycle
           ]
         )
+        if attributes[:person_id].present?
+          attributes[:person_id] = api_record_id(policy_scope(Person), attributes[:person_id])
+        end
+        if attributes[:medication_id].present?
+          attributes[:medication_id] = api_record_id(policy_scope(Medication), attributes[:medication_id])
+        end
+        if attributes[:source_dosage_option_id].present?
+          attributes[:source_dosage_option_id] = api_record_id(
+            policy_scope(MedicationDosageOption),
+            attributes[:source_dosage_option_id]
+          )
+        end
+        attributes
       end
 
       def person_medication_update_params

--- a/app/controllers/api/v1/push_subscriptions_controller.rb
+++ b/app/controllers/api/v1/push_subscriptions_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PushSubscriptionsController < BaseController
+      def create
+        subscription = current_account.push_subscriptions.find_or_initialize_by(endpoint: subscription_params[:endpoint])
+        subscription.assign_attributes(
+          p256dh: subscription_params.dig(:keys, :p256dh),
+          auth: subscription_params.dig(:keys, :auth),
+          user_agent: request.user_agent
+        )
+        authorize subscription, :create?
+
+        return render_validation_errors(subscription) unless subscription.save
+
+        head :created
+      end
+
+      def destroy
+        subscription = current_account.push_subscriptions.find_by(endpoint: params.expect(:endpoint))
+        unless subscription
+          authorize PushSubscription.new(account: current_account), :destroy?
+          return head :no_content
+        end
+
+        authorize subscription, :destroy?
+        subscription.destroy!
+        head :no_content
+      end
+
+      def test
+        authorize PushSubscription.new(account: current_account), :test?
+        PushNotificationService.send_to_account(
+          current_account,
+          title: 'MedTracker Test',
+          body: 'Push notifications are working correctly from the server.'
+        )
+        head :no_content
+      rescue StandardError
+        render_api_error(
+          code: 'push_test_failed',
+          message: 'Unable to send test notification.',
+          status: :service_unavailable
+        )
+      end
+
+      private
+
+      def subscription_params
+        params.expect(push_subscription: [:endpoint, { keys: %i[p256dh auth] }])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -9,7 +9,7 @@ module Api
       end
 
       def show
-        schedule = policy_scope(Schedule).includes(:person, :medication).find(params.expect(:id))
+        schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
         authorize schedule
 
         render_resource(schedule, serializer: ScheduleSerializer)
@@ -25,24 +25,44 @@ module Api
 
         return render_validation_errors(schedule) unless schedule.save
 
+        record_api_change(schedule, action: 'create')
         render_resource(schedule.reload, serializer: ScheduleSerializer, status: :created)
       end
 
       def update
-        schedule = policy_scope(Schedule).includes(:person, :medication).find(params.expect(:id))
+        schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
         authorize schedule
+        return unless fresh_api_record?(schedule)
+
         attributes = schedule_update_params
         assert_medication_access!(attributes[:medication_id]) if attributes[:medication_id].present?
 
         return render_validation_errors(schedule) unless schedule.update(attributes)
 
+        record_api_change(schedule, action: 'update')
         render_resource(schedule.reload, serializer: ScheduleSerializer)
+      end
+
+      def pause
+        update_pause_state(:pause!)
+      end
+
+      def resume
+        update_pause_state(:resume!)
       end
 
       private
 
+      def update_pause_state(method_name)
+        schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
+        authorize schedule, :update?
+        schedule.public_send(method_name)
+        record_api_change(schedule.reload, action: 'update')
+        render_resource(schedule, serializer: ScheduleSerializer)
+      end
+
       def schedule_params
-        params.expect(
+        attributes = params.expect(
           schedule: [
             :person_id,
             :medication_id,
@@ -61,6 +81,19 @@ module Api
             { schedule_config: {} }
           ]
         )
+        if attributes[:person_id].present?
+          attributes[:person_id] = api_record_id(policy_scope(Person), attributes[:person_id])
+        end
+        if attributes[:medication_id].present?
+          attributes[:medication_id] = api_record_id(policy_scope(Medication), attributes[:medication_id])
+        end
+        if attributes[:source_dosage_option_id].present?
+          attributes[:source_dosage_option_id] = api_record_id(
+            policy_scope(MedicationDosageOption),
+            attributes[:source_dosage_option_id]
+          )
+        end
+        attributes
       end
 
       def schedule_update_params

--- a/app/controllers/api/v1/sync/batches_controller.rb
+++ b/app/controllers/api/v1/sync/batches_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Sync
+      class BatchesController < Api::V1::BaseController
+        class BatchError < StandardError; end
+
+        def create
+          results = []
+          ActiveRecord::Base.transaction(requires_new: true) do
+            operations.each_with_index do |operation, index|
+              results << apply_operation(operation, index)
+            end
+          end
+
+          render json: { data: { applied: true, results: results } }, status: :created
+        rescue BatchError => e
+          render_unprocessable(e.message)
+        end
+
+        private
+
+        def operations
+          params.expect(batch: [{ operations: [[:action, :resource_type, :id, { attributes: {} }]] }])
+                .fetch(:operations)
+        end
+
+        def apply_operation(operation, index)
+          case operation.fetch(:action)
+          when 'update'
+            update_record(operation, index)
+          when 'delete'
+            delete_record(operation, index)
+          else
+            raise BatchError, "operation #{index} action is unsupported"
+          end
+        end
+
+        def update_record(operation, index)
+          record = find_batch_record(operation)
+          authorize record, :update?
+          attributes = permitted_attributes_for(record, operation.fetch(:attributes, {}))
+          raise BatchError, "operation #{index} attributes are invalid" unless record.update(attributes)
+
+          record_api_change(record, action: 'update')
+          { index: index, action: 'update', record_type: record.class.name, record_portable_id: record.portable_id }
+        end
+
+        def delete_record(operation, index)
+          record = find_batch_record(operation)
+          authorize record, :destroy?
+          portable_id = record.portable_id
+          record_type = record.class.name
+          record.destroy!
+          ApiTombstone.create!(
+            household: current_household,
+            account: current_account,
+            household_membership: current_membership,
+            record_type: record_type,
+            record_portable_id: portable_id,
+            action: 'delete',
+            deleted_at: Time.current,
+            metadata: { record_type: record_type }
+          )
+          { index: index, action: 'delete', record_type: record_type, record_portable_id: portable_id }
+        end
+
+        def find_batch_record(operation)
+          scope = batch_scope(operation.fetch(:resource_type))
+          find_api_record(scope, operation.fetch(:id))
+        rescue KeyError
+          raise BatchError, 'operation resource_type and id are required'
+        end
+
+        def batch_scope(resource_type)
+          case resource_type
+          when 'medication'
+            policy_scope(Medication)
+          when 'health_event'
+            policy_scope(HealthEvent)
+          else
+            raise BatchError, "resource_type #{resource_type} is unsupported"
+          end
+        end
+
+        def permitted_attributes_for(record, attributes)
+          case record
+          when Medication
+            attributes.to_h.slice('name', 'friendly_name', 'current_supply', 'reorder_threshold')
+          when HealthEvent
+            attributes.to_h.slice('title', 'notes', 'severity', 'ended_on')
+          else
+            {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sync/feeds_controller.rb
+++ b/app/controllers/api/v1/sync/feeds_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Sync
+      class FeedsController < Api::V1::BaseController
+        def snapshot
+          payload = exporter.payload.merge(format: 'medtracker.portable.v2', cursor: Time.current.iso8601)
+          render json: { data: payload }
+        end
+
+        def changes
+          since = Time.iso8601(params.expect(:cursor))
+          render json: { data: changes_payload(since) }
+        rescue ArgumentError
+          render_unprocessable('cursor must be ISO8601')
+        end
+
+        private
+
+        def exporter
+          PortableData::Exporter.new(
+            household: current_household,
+            membership: current_membership,
+            passphrase: nil,
+            request: request
+          )
+        end
+
+        def changes_payload(since)
+          {
+            cursor: Time.current.iso8601,
+            changes: change_events_since(since).map { |event| change_payload(event) },
+            tombstones: tombstones_since(since).map { |tombstone| tombstone_payload(tombstone) }
+          }
+        end
+
+        def change_events_since(since)
+          ApiChangeEvent.where(household: current_household).where(occurred_at: since..).order(:occurred_at, :id)
+        end
+
+        def tombstones_since(since)
+          ApiTombstone.where(household: current_household).where(deleted_at: since..).order(:deleted_at, :id)
+        end
+
+        def change_payload(event)
+          {
+            id: event.id,
+            record_type: event.record_type,
+            record_id: event.record_id,
+            record_portable_id: event.record_portable_id,
+            action: event.action,
+            occurred_at: event.occurred_at.iso8601,
+            metadata: event.metadata
+          }
+        end
+
+        def tombstone_payload(tombstone)
+          {
+            id: tombstone.id,
+            record_type: tombstone.record_type,
+            record_portable_id: tombstone.record_portable_id,
+            action: tombstone.action,
+            deleted_at: tombstone.deleted_at.iso8601,
+            metadata: tombstone.metadata
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/profiles/data_exports_controller.rb
+++ b/app/controllers/profiles/data_exports_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Profiles
+  class DataExportsController < ApplicationController
+    before_action :require_authentication
+
+    def show
+      result = export_service.call
+      return send_zip(result) if params.expect(:mode) == 'backup_zip'
+
+      render json: result
+    rescue DataExports::ProfileExportService::Error, PortableData::Encryptor::Error => e
+      redirect_to profile_path, alert: e.message
+    end
+
+    private
+
+    def export_service
+      DataExports::ProfileExportService.new(
+        household: current_household,
+        membership: current_membership,
+        mode: params.expect(:mode),
+        request: request
+      )
+    end
+
+    def send_zip(result)
+      send_data Base64.strict_decode64(result.fetch(:base64)),
+                filename: result.fetch(:filename),
+                type: result.fetch(:content_type)
+    end
+  end
+end

--- a/app/models/api_change_event.rb
+++ b/app/models/api_change_event.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApiChangeEvent < ApplicationRecord
+  belongs_to :household
+  belongs_to :account
+  belongs_to :household_membership
+
+  validates :record_type, :record_id, :action, :occurred_at, presence: true
+end

--- a/app/models/api_idempotency_key.rb
+++ b/app/models/api_idempotency_key.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ApiIdempotencyKey < ApplicationRecord
+  belongs_to :household
+  belongs_to :account
+  belongs_to :api_session, optional: true
+  belongs_to :api_app_token, optional: true
+
+  validates :key, :request_method, :request_path, :request_digest, :response_status, :expires_at, presence: true
+  validates :key, uniqueness: { scope: :household_id }
+end

--- a/app/models/api_oidc_nonce.rb
+++ b/app/models/api_oidc_nonce.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ApiOidcNonce < ApplicationRecord
+  validates :issuer, :subject, :nonce, :used_at, presence: true
+  validates :nonce, uniqueness: { scope: %i[issuer subject] }
+end

--- a/app/models/api_session.rb
+++ b/app/models/api_session.rb
@@ -15,15 +15,14 @@ class ApiSession < ApplicationRecord
   scope :active, -> { where(revoked_at: nil) }
 
   class << self
-    def issue_for(account:, household_membership:, device_name: nil, user_agent: nil, audit_context: nil)
+    def issue_for(account:, household_membership:, audit_context: nil, **)
       access_token = build_token
       refresh_token = build_token
       session = create_session(
         account: account,
         household_membership: household_membership,
-        device_name: device_name,
-        user_agent: user_agent,
-        tokens: { access: access_token, refresh: refresh_token }
+        tokens: { access: access_token, refresh: refresh_token },
+        **
       )
 
       record_audit(session, 'created', audit_context)
@@ -55,15 +54,17 @@ class ApiSession < ApplicationRecord
 
     private
 
-    def create_session(account:, household_membership:, device_name:, user_agent:, tokens:)
+    def create_session(account:, household_membership:, tokens:, **options)
       now = Time.current
 
       create!(
         account: account,
         household_membership: household_membership,
         permissions_version: household_membership.permissions_version,
-        device_name: device_name,
-        user_agent: user_agent,
+        device_name: options[:device_name],
+        user_agent: options[:user_agent],
+        mfa_verified_at: options[:mfa_verified_at],
+        oidc_mfa_verified: options.fetch(:oidc_mfa_verified, false),
         last_used_at: now,
         access_expires_at: now + ACCESS_TOKEN_TTL,
         refresh_expires_at: now + REFRESH_TOKEN_TTL,

--- a/app/models/api_tombstone.rb
+++ b/app/models/api_tombstone.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApiTombstone < ApplicationRecord
+  belongs_to :household
+  belongs_to :account
+  belongs_to :household_membership
+
+  validates :record_type, :record_portable_id, :action, :deleted_at, presence: true
+end

--- a/app/models/health_event.rb
+++ b/app/models/health_event.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HealthEvent < ApplicationRecord
+  include PortableIdentifiable
+
   has_paper_trail
 
   belongs_to :household

--- a/app/policies/medication_dosage_option_policy.rb
+++ b/app/policies/medication_dosage_option_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MedicationDosageOptionPolicy < DosagePolicy
+  def index?
+    active_membership?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none unless active_membership?
+
+      scope.where(household: household)
+    end
+  end
+end

--- a/app/serializers/api/v1/dosage_option_serializer.rb
+++ b/app/serializers/api/v1/dosage_option_serializer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DosageOptionSerializer
+      def initialize(dosage_option)
+        @dosage_option = dosage_option
+      end
+
+      def as_json(*)
+        identity_data.merge(dose_data).merge(default_data).merge(inventory_data)
+      end
+
+      private
+
+      attr_reader :dosage_option
+
+      def identity_data
+        {
+          id: dosage_option.id,
+          portable_id: dosage_option.portable_id,
+          medication_id: dosage_option.medication_id,
+          medication_portable_id: dosage_option.medication&.portable_id
+        }
+      end
+
+      def dose_data
+        {
+          amount: dosage_option.amount,
+          unit: dosage_option.unit,
+          frequency: dosage_option.frequency,
+          description: dosage_option.description
+        }
+      end
+
+      def default_data
+        {
+          default_for_adults: dosage_option.default_for_adults,
+          default_for_children: dosage_option.default_for_children,
+          default_max_daily_doses: dosage_option.default_max_daily_doses,
+          default_min_hours_between_doses: dosage_option.default_min_hours_between_doses,
+          default_dose_cycle: dosage_option.default_dose_cycle
+        }
+      end
+
+      def inventory_data
+        {
+          current_supply: dosage_option.current_supply,
+          reorder_threshold: dosage_option.reorder_threshold,
+          updated_at: dosage_option.updated_at.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/health_event_serializer.rb
+++ b/app/serializers/api/v1/health_event_serializer.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class HealthEventSerializer
+      def initialize(health_event)
+        @health_event = health_event
+      end
+
+      def as_json(*)
+        identity_data.merge(event_data).merge(date_data).merge(medication_data)
+      end
+
+      private
+
+      attr_reader :health_event
+
+      def identity_data
+        {
+          id: health_event.id,
+          portable_id: health_event.portable_id,
+          person_id: health_event.person_id,
+          person_portable_id: health_event.person&.portable_id
+        }
+      end
+
+      def event_data
+        {
+          event_kind: health_event.event_kind,
+          severity: health_event.severity,
+          title: health_event.title,
+          notes: health_event.notes
+        }
+      end
+
+      def date_data
+        {
+          started_on: health_event.started_on&.iso8601,
+          ended_on: health_event.ended_on&.iso8601,
+          updated_at: health_event.updated_at.iso8601
+        }
+      end
+
+      def medication_data
+        {
+          medication_ids: health_event.medication_ids,
+          medication_portable_ids: health_event.medications.map(&:portable_id)
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/fhir/r4/serializer.rb
+++ b/app/serializers/fhir/r4/serializer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Fhir
+  module R4
+    class Serializer
+      class << self
+        def bundle(records, type:)
+          {
+            resourceType: 'Bundle',
+            type: 'searchset',
+            total: records.size,
+            entry: records.map { |record| { resource: public_send(type, record) } }
+          }
+        end
+
+        def patient(person)
+          {
+            resourceType: 'Patient',
+            id: person.portable_id,
+            name: [{ text: person.name }],
+            birthDate: person.date_of_birth&.iso8601
+          }.compact
+        end
+
+        def medication(medication)
+          {
+            resourceType: 'Medication',
+            id: medication.portable_id,
+            code: { text: medication.display_name },
+            form: { text: medication.category }
+          }.compact
+        end
+
+        def medication_request(schedule)
+          {
+            resourceType: 'MedicationRequest',
+            id: schedule.portable_id,
+            status: schedule.active? ? 'active' : 'stopped',
+            intent: 'order',
+            subject: reference('Patient', schedule.person),
+            medicationReference: reference('Medication', schedule.medication),
+            dosageInstruction: [dosage(schedule)]
+          }
+        end
+
+        def medication_statement(person_medication)
+          {
+            resourceType: 'MedicationStatement',
+            id: person_medication.portable_id,
+            status: person_medication.active? ? 'active' : 'stopped',
+            subject: reference('Patient', person_medication.person),
+            medicationReference: reference('Medication', person_medication.medication),
+            dosage: [dosage(person_medication)]
+          }
+        end
+
+        def medication_administration(take)
+          source = take.schedule || take.person_medication
+          medication = take.taken_from_medication || source&.medication
+          {
+            resourceType: 'MedicationAdministration',
+            id: take.portable_id,
+            status: 'completed',
+            subject: reference('Patient', source&.person),
+            medicationReference: reference('Medication', medication),
+            effectiveDateTime: take.taken_at&.iso8601
+          }.compact
+        end
+
+        private
+
+        def reference(resource_type, record)
+          return if record.blank?
+
+          { reference: "#{resource_type}/#{record.portable_id}" }
+        end
+
+        def dosage(record)
+          {
+            text: [record.dose_amount, record.dose_unit, record.try(:frequency)].compact_blank.join(' '),
+            doseAndRate: [
+              {
+                doseQuantity: {
+                  value: record.dose_amount&.to_f,
+                  unit: record.dose_unit
+                }.compact
+              }
+            ]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/fhir/r4/serializer.rb
+++ b/app/serializers/fhir/r4/serializer.rb
@@ -4,12 +4,13 @@ module Fhir
   module R4
     class Serializer
       class << self
-        def bundle(records, type:)
+        def bundle(records, type:, total: records.size, links: [])
           {
             resourceType: 'Bundle',
             type: 'searchset',
-            total: records.size,
-            entry: records.map { |record| { resource: public_send(type, record) } }
+            total: total,
+            link: links,
+            entry: records.map { |record| { resource: public_send(type, record), search: { mode: 'match' } } }
           }
         end
 
@@ -17,6 +18,7 @@ module Fhir
           {
             resourceType: 'Patient',
             id: person.portable_id,
+            meta: meta(person),
             name: [{ text: person.name }],
             birthDate: person.date_of_birth&.iso8601
           }.compact
@@ -26,7 +28,8 @@ module Fhir
           {
             resourceType: 'Medication',
             id: medication.portable_id,
-            code: { text: medication.display_name },
+            meta: meta(medication),
+            code: codeable_concept(medication),
             form: { text: medication.category }
           }.compact
         end
@@ -35,6 +38,7 @@ module Fhir
           {
             resourceType: 'MedicationRequest',
             id: schedule.portable_id,
+            meta: meta(schedule),
             status: schedule.active? ? 'active' : 'stopped',
             intent: 'order',
             subject: reference('Patient', schedule.person),
@@ -47,6 +51,7 @@ module Fhir
           {
             resourceType: 'MedicationStatement',
             id: person_medication.portable_id,
+            meta: meta(person_medication),
             status: person_medication.active? ? 'active' : 'stopped',
             subject: reference('Patient', person_medication.person),
             medicationReference: reference('Medication', person_medication.medication),
@@ -60,6 +65,7 @@ module Fhir
           {
             resourceType: 'MedicationAdministration',
             id: take.portable_id,
+            meta: meta(take),
             status: 'completed',
             subject: reference('Patient', source&.person),
             medicationReference: reference('Medication', medication),
@@ -73,6 +79,31 @@ module Fhir
           return if record.blank?
 
           { reference: "#{resource_type}/#{record.portable_id}" }
+        end
+
+        def meta(record)
+          return unless record.respond_to?(:updated_at)
+          return if record.updated_at.blank?
+
+          { lastUpdated: record.updated_at.iso8601 }
+        end
+
+        def codeable_concept(medication)
+          concept = { text: medication.display_name }
+          coding = medication_coding(medication)
+          concept[:coding] = [coding] if coding.present?
+          concept
+        end
+
+        def medication_coding(medication)
+          return if medication.dmd_code.blank?
+
+          {
+            system: medication.dmd_system,
+            code: medication.dmd_code,
+            display: medication.display_name,
+            userSelected: true
+          }.compact
         end
 
         def dosage(record)

--- a/app/services/api/change_recorder.rb
+++ b/app/services/api/change_recorder.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Api
+  class ChangeRecorder
+    def initialize(household:, credential:, membership:, request:)
+      @household = household
+      @credential = credential
+      @membership = membership
+      @request = request
+    end
+
+    def record(record, action:)
+      return unless recordable?(record)
+
+      ApiChangeEvent.create!(change_attributes(record, action))
+    end
+
+    private
+
+    attr_reader :household, :credential, :membership, :request
+
+    def recordable?(record)
+      household && credential&.account && membership && record&.persisted?
+    end
+
+    def change_attributes(record, action)
+      {
+        household: household,
+        account: credential.account,
+        household_membership: membership,
+        request_id: request.request_id,
+        record_type: record.class.name,
+        record_id: record.id,
+        record_portable_id: portable_id(record),
+        action: action,
+        occurred_at: Time.current,
+        metadata: metadata_for(record)
+      }
+    end
+
+    def metadata_for(record)
+      {
+        record_type: record.class.name,
+        record_id: record.id,
+        portable_id: portable_id(record)
+      }.compact
+    end
+
+    def portable_id(record)
+      record.portable_id if record.respond_to?(:portable_id)
+    end
+  end
+end

--- a/app/services/api/fresh_privileged_action.rb
+++ b/app/services/api/fresh_privileged_action.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  class FreshPrivilegedAction
+    TTL = 15.minutes
+
+    def initialize(credential:)
+      @credential = credential
+    end
+
+    def satisfied?
+      return false unless credential.is_a?(ApiSession)
+      return false unless credential.oidc_mfa_verified?
+      return false if credential.mfa_verified_at.blank?
+
+      credential.mfa_verified_at >= TTL.ago
+    end
+
+    private
+
+    attr_reader :credential
+  end
+end

--- a/app/services/api/idempotency_store.rb
+++ b/app/services/api/idempotency_store.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Api
+  class IdempotencyStore
+    EXPIRY = 24.hours
+
+    Result = Data.define(:record, :replayed, :conflict)
+
+    def initialize(request:, credential:, household:)
+      @request = request
+      @credential = credential
+      @household = household
+    end
+
+    def active?
+      key.present? && mutating_request? && household.present? && credential.present?
+    end
+
+    def lookup
+      record = ApiIdempotencyKey.find_by(household: household, key: key)
+      return Result.new(record: nil, replayed: false, conflict: false) unless record
+
+      Result.new(record: record, replayed: same_request?(record), conflict: !same_request?(record))
+    end
+
+    def store!(response)
+      return unless active? && response.status < 500
+
+      ApiIdempotencyKey.create!(idempotency_attributes(response))
+    rescue ActiveRecord::RecordNotUnique
+      nil
+    end
+
+    private
+
+    attr_reader :request, :credential, :household
+
+    def idempotency_attributes(response)
+      credential_attributes.merge(request_attributes).merge(response_attributes(response)).merge(
+        household: household,
+        account: credential.account,
+        key: key,
+        expires_at: EXPIRY.from_now
+      )
+    end
+
+    def credential_attributes
+      {
+        api_session: credential.is_a?(ApiSession) ? credential : nil,
+        api_app_token: credential.is_a?(ApiAppToken) ? credential : nil
+      }
+    end
+
+    def request_attributes
+      {
+        request_method: request.request_method,
+        request_path: request.path,
+        request_digest: request_digest
+      }
+    end
+
+    def response_attributes(response)
+      {
+        response_status: response.status,
+        response_body: response_body(response)
+      }
+    end
+
+    def key
+      request.headers['Idempotency-Key'].to_s.presence
+    end
+
+    def mutating_request?
+      request.post? || request.patch? || request.put? || request.delete?
+    end
+
+    def same_request?(record)
+      record.request_method == request.request_method &&
+        record.request_path == request.path &&
+        record.request_digest == request_digest
+    end
+
+    def request_digest
+      @request_digest ||= Digest::SHA256.hexdigest(
+        JSON.generate(
+          method: request.request_method,
+          path: request.path,
+          params: request.filtered_parameters.except('controller', 'action')
+        )
+      )
+    end
+
+    def response_body(response)
+      JSON.parse(response.body.presence || '{}')
+    rescue JSON::ParserError
+      {}
+    end
+  end
+end

--- a/app/services/api/idempotency_store.rb
+++ b/app/services/api/idempotency_store.rb
@@ -27,7 +27,7 @@ module Api
       return unless active? && response.status < 500
 
       ApiIdempotencyKey.create!(idempotency_attributes(response))
-    rescue ActiveRecord::RecordNotUnique
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       nil
     end
 

--- a/app/services/api/oidc_session_exchange.rb
+++ b/app/services/api/oidc_session_exchange.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Api
+  class OidcSessionExchange
+    class Error < StandardError; end
+
+    Result = Data.define(:api_session, :access_token, :refresh_token, :household_membership)
+
+    def initialize(params:, request:)
+      @params = params
+      @request = request
+    end
+
+    def call
+      validate_pkce!
+      claims = decode_claims
+      validate_nonce!(claims)
+      reject_replay!(claims)
+      account = account_for(claims)
+      membership = membership_for(account)
+      validate_account!(account)
+      validate_membership!(membership)
+
+      result_for(account, membership, claims)
+    end
+
+    private
+
+    attr_reader :params, :request
+
+    def result_for(account, membership, claims)
+      api_session, access_token, refresh_token = issue_session(account, membership, claims)
+      Result.new(api_session: api_session, access_token: access_token, refresh_token: refresh_token,
+                 household_membership: membership)
+    end
+
+    def issue_session(account, membership, claims)
+      mfa_verified = oidc_mfa_verified?(claims)
+      ApiSession.issue_for(
+        account: account,
+        household_membership: membership,
+        device_name: params[:device_name],
+        user_agent: request.user_agent,
+        mfa_verified_at: mfa_verified ? Time.current : nil,
+        oidc_mfa_verified: mfa_verified,
+        audit_context: audit_context(account, membership)
+      )
+    end
+
+    def validate_pkce!
+      raise Error, 'PKCE verifier is required' if params[:code_verifier].blank?
+      raise Error, 'OIDC token is required' if params[:id_token].blank?
+    end
+
+    def decode_claims
+      payload, = JWT.decode(
+        params[:id_token].to_s,
+        client_secret,
+        true,
+        algorithm: 'HS256',
+        iss: issuer,
+        verify_iss: true,
+        aud: audience,
+        verify_aud: true,
+        verify_expiration: true
+      )
+      payload
+    rescue JWT::DecodeError => e
+      raise Error, e.message
+    end
+
+    def validate_nonce!(claims)
+      raise Error, 'OIDC nonce is invalid' if claims['nonce'].blank? || claims['nonce'] != params[:nonce].to_s
+      raise Error, 'OIDC subject is invalid' if claims['sub'].blank?
+    end
+
+    def reject_replay!(claims)
+      ApiOidcNonce.create!(
+        issuer: claims.fetch('iss'),
+        subject: claims.fetch('sub'),
+        nonce: claims.fetch('nonce'),
+        used_at: Time.current
+      )
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+      raise Error, 'OIDC nonce has already been used'
+    end
+
+    def account_for(claims)
+      AccountIdentity.find_by!(provider: params.fetch(:provider, 'oidc'), uid: claims.fetch('sub')).account
+    rescue ActiveRecord::RecordNotFound
+      raise Error, 'OIDC identity is not linked'
+    end
+
+    def membership_for(account)
+      scope = account.household_memberships.active.includes(:household).order(:id)
+      return scope.find_by(household_id: params[:household_id]) if params[:household_id].present?
+
+      memberships = scope.limit(2).to_a
+      memberships.first if memberships.one?
+    end
+
+    def validate_account!(account)
+      raise Error, 'OIDC account is unavailable' unless account&.verified? && account.person&.user&.active?
+      raise Error, 'OIDC account is unavailable' if ApiAuthState.locked_out?(account)
+    end
+
+    def validate_membership!(membership)
+      raise Error, 'OIDC household membership is unavailable' unless membership&.active?
+    end
+
+    def issuer
+      ENV.fetch('OIDC_ISSUER_URL', nil).presence || Rails.application.credentials.dig(:oidc, :issuer_url).to_s
+    end
+
+    def audience
+      ENV.fetch('OIDC_MOBILE_CLIENT_ID', nil).presence ||
+        ENV.fetch('OIDC_CLIENT_ID', nil).presence ||
+        Rails.application.credentials.dig(:oidc, :client_id).to_s
+    end
+
+    def client_secret
+      ENV.fetch('OIDC_CLIENT_SECRET', nil).presence ||
+        Rails.application.credentials.dig(:oidc, :client_secret).to_s
+    end
+
+    def audit_context(account, membership)
+      {
+        whodunnit: account.person&.user&.id,
+        ip: request.remote_ip,
+        request_id: request.request_id,
+        household_id: membership.household_id,
+        actor_membership_id: membership.id
+      }
+    end
+
+    def oidc_mfa_verified?(claims)
+      Array(claims['amr']).map(&:to_s).intersect?(ApiAuthState::MFA_METHODS) ||
+        claims['acr'].to_s.include?('mfa')
+    end
+  end
+end

--- a/app/services/api/portable_record_locator.rb
+++ b/app/services/api/portable_record_locator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  class PortableRecordLocator
+    UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
+
+    def initialize(household:)
+      @household = household
+    end
+
+    def find(scope, identifier)
+      return scope.find(identifier) unless portable_identifier?(identifier)
+
+      scope.where(household: household).find_by!(portable_id: identifier)
+    end
+
+    private
+
+    attr_reader :household
+
+    def portable_identifier?(identifier)
+      identifier.to_s.match?(UUID_PATTERN)
+    end
+  end
+end

--- a/app/services/api/portable_record_locator.rb
+++ b/app/services/api/portable_record_locator.rb
@@ -2,7 +2,7 @@
 
 module Api
   class PortableRecordLocator
-    UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
+    UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
 
     def initialize(household:)
       @household = household

--- a/app/services/data_exports/profile_export_service.rb
+++ b/app/services/data_exports/profile_export_service.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'stringio'
+require 'zlib'
+
+module DataExports
+  class ProfileExportService
+    class Error < StandardError; end
+
+    def initialize(household:, membership:, mode:, passphrase: nil, request: nil)
+      @household = household
+      @membership = membership
+      @mode = mode.to_s
+      @passphrase = passphrase
+      @request = request
+    end
+
+    def call
+      case mode
+      when 'encrypted_migration_bundle'
+        encrypted_migration_bundle
+      when 'backup_zip'
+        backup_zip
+      when 'health_data_json'
+        health_data_json
+      else
+        raise Error, 'Export mode is unsupported'
+      end
+    end
+
+    private
+
+    attr_reader :household, :membership, :mode, :passphrase, :request
+
+    def encrypted_migration_bundle
+      raise Error, 'Portable passphrase header is required' if passphrase.blank?
+
+      portable_exporter(passphrase: passphrase).call
+    end
+
+    def backup_zip
+      json = JSON.pretty_generate(portable_payload.merge(format: 'medtracker.backup.v1'))
+      {
+        filename: "medtracker-backup-#{Time.current.utc.strftime('%Y%m%d%H%M%S')}.zip",
+        content_type: 'application/zip',
+        base64: Base64.strict_encode64(zip_file('medtracker-backup.json', json))
+      }
+    end
+
+    def health_data_json
+      portable_payload.merge(format: 'medtracker.health_data.v1')
+    end
+
+    def portable_payload
+      @portable_payload ||= portable_exporter(passphrase: nil).payload
+    end
+
+    def portable_exporter(passphrase:)
+      PortableData::Exporter.new(
+        household: household,
+        membership: membership,
+        passphrase: passphrase,
+        request: request
+      )
+    end
+
+    def zip_file(filename, content)
+      io = StringIO.new.binmode
+      crc = Zlib.crc32(content)
+      size = content.bytesize
+      name = filename.b
+
+      local_header_offset = write_local_file(io, name, content, crc, size)
+      central_directory_offset = io.pos
+      write_central_directory(io, name, crc, size, local_header_offset)
+      write_end_of_central_directory(io, central_directory_offset)
+      io.string
+    end
+
+    def write_local_file(io, name, content, crc, size)
+      offset = io.pos
+      io.write([0x04034b50, 20, 0, 0, 0, 0, crc, size, size, name.bytesize, 0].pack('VvvvvvVVVvv'))
+      io.write(name)
+      io.write(content)
+      offset
+    end
+
+    def write_central_directory(io, name, crc, size, local_header_offset)
+      central_directory = [
+        0x02014b50, 20, 20, 0, 0, 0, 0, crc, size, size, name.bytesize, 0, 0, 0, 0, 0, local_header_offset
+      ].pack('VvvvvvvVVVvvvvvVV')
+      io.write(central_directory)
+      io.write(name)
+    end
+
+    def write_end_of_central_directory(io, central_directory_offset)
+      central_directory_size = io.pos - central_directory_offset
+      payload = [0x06054b50, 0, 0, 1, 1, central_directory_size, central_directory_offset, 0]
+      io.write(payload.pack('VvvvvVVv'))
+    end
+  end
+end

--- a/app/views/profiles/data_exports_card.rb
+++ b/app/views/profiles/data_exports_card.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Views
+  module Profiles
+    class DataExportsCard < Views::Base
+      include Phlex::Rails::Helpers::LinkTo
+      include Phlex::Rails::Helpers::Routes
+
+      def view_template
+        m3_card(class: 'border-border/70 shadow-elevation-2', data: { testid: 'profile-data-exports-card' }) do
+          m3_card_header do
+            m3_card_title { 'Data backup' }
+            m3_card_description { 'Download a copy of your medication and health records.' }
+          end
+          m3_card_content(class: 'space-y-4') do
+            p(class: 'rounded-shape-lg border border-warning/40 bg-warning-container px-3 py-2 text-sm text-on-warning-container') do
+              plain 'Unencrypted ZIP exports are not password protected. Store them somewhere private.'
+            end
+            div(class: 'flex flex-wrap gap-2') do
+              m3_link(href: profile_data_export_path('health_data_json'), variant: :button) { 'Health data JSON' }
+              m3_link(href: profile_data_export_path('backup_zip'), variant: :button) { 'Unencrypted ZIP' }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -81,6 +81,7 @@ module Views
         div(class: 'space-y-6') do
           render AccountSecurityCard.new(account: account)
           render_api_tokens_card
+          render DataExportsCard.new
           render NotificationsCard.new(person: person)
           render ExperimentsCard.new(account: account)
           render DangerZoneCard.new

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,5 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   passw passphrase email secret token _key crypt salt certificate otp ssn cvv cvc q query search
+  authorization_code id_token access_token refresh_token device_token bundle payload ciphertext backup
 ]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -41,6 +41,30 @@ module Rack
       req.ip if req.path == '/api/v1/auth/refresh' && req.post?
     end
 
+    throttle('api/auth/oidc_exchange/ip', limit: 10, period: 1.minute) do |req|
+      req.ip if req.path == '/api/v1/auth/oidc_exchange' && req.post?
+    end
+
+    throttle('api/data_exports/ip', limit: 10, period: 1.minute) do |req|
+      req.ip if req.get? && req.path.match?(%r{\A/api/v1/households/[^/]+/data_exports/})
+    end
+
+    throttle('api/sync_batches/ip', limit: 30, period: 1.minute) do |req|
+      req.ip if req.post? && req.path.match?(%r{\A/api/v1/households/[^/]+/sync/batches\z})
+    end
+
+    throttle('api/medication_lookup/ip', limit: 60, period: 1.minute) do |req|
+      req.ip if req.get? && req.path.match?(%r{\A/api/v1/households/[^/]+/medication_lookup\z})
+    end
+
+    throttle('api/ai_medication_suggestions/ip', limit: 10, period: 1.minute) do |req|
+      req.ip if req.post? && req.path.match?(%r{\A/api/v1/households/[^/]+/ai_medication_suggestions\z})
+    end
+
+    throttle('api/admin/audit_logs/ip', limit: 100, period: 1.minute) do |req|
+      req.ip if req.get? && req.path.match?(%r{\A/api/v1/households/[^/]+/admin/audit_logs})
+    end
+
     throttle('mcp/ip', limit: 60, period: 1.minute) do |req|
       req.ip if req.path == MCP_PATH
     end
@@ -89,11 +113,32 @@ module Rack
 
       [
         429,
+        throttle_headers(request, match_data, retry_after),
+        throttle_body(request, retry_after)
+      ]
+    end
+
+    def self.throttle_headers(request, match_data, retry_after)
+      headers = {
+        'Retry-After' => retry_after.to_s,
+        'ratelimit-limit' => match_data[:limit].to_s,
+        'ratelimit-remaining' => '0',
+        'ratelimit-reset' => (match_data[:epoch_time] + retry_after).to_s
+      }
+      headers['Content-Type'] = request.path.start_with?('/api/') ? 'application/json' : 'text/plain'
+      headers
+    end
+
+    def self.throttle_body(request, retry_after)
+      return ["Rate limit exceeded. Retry in #{retry_after} seconds.\n"] unless request.path.start_with?('/api/')
+
+      [
         {
-          'Content-Type' => 'text/plain',
-          'Retry-After' => retry_after.to_s
-        },
-        ["Rate limit exceeded. Retry in #{retry_after} seconds.\n"]
+          error: {
+            code: 'rate_limited',
+            message: "Rate limit exceeded. Retry in #{retry_after} seconds."
+          }
+        }.to_json
       ]
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,29 @@ Rails.application.routes.draw do
   mount MedTrackerMcp::RackApp.new => '/mcp'
 
   namespace :api do
+    scope 'fhir/R4', module: 'fhir/r4', as: :fhir_r4 do
+      get :metadata, to: 'metadata#show'
+      get 'Patient', to: 'patients#index'
+      get 'Patient/:id', to: 'patients#show'
+      get 'Medication', to: 'medications#index'
+      get 'Medication/:id', to: 'medications#show'
+      get 'MedicationRequest', to: 'medication_requests#index'
+      get 'MedicationRequest/:id', to: 'medication_requests#show'
+      get 'MedicationStatement', to: 'medication_statements#index'
+      get 'MedicationStatement/:id', to: 'medication_statements#show'
+      get 'MedicationAdministration', to: 'medication_administrations#index'
+      get 'MedicationAdministration/:id', to: 'medication_administrations#show'
+    end
+
     namespace :v1 do
       get :capabilities, to: 'capabilities#show'
 
       namespace :auth do
         post :login, to: 'sessions#create'
+        post :oidc_exchange, to: 'sessions#oidc_exchange'
+        get :households, to: 'sessions#households'
+        get :sessions, to: 'sessions#index'
+        delete 'sessions/:id', to: 'sessions#revoke', as: :session
         post :refresh, to: 'sessions#refresh'
         delete :logout, to: 'sessions#destroy'
       end
@@ -18,14 +36,56 @@ Rails.application.routes.draw do
         resources :people, only: %i[index show create update]
         resources :locations, only: %i[index show]
         resources :medications, only: %i[index show create update]
-        resources :schedules, only: %i[index show create update]
-        resources :person_medications, only: %i[index show create update]
+        resources :medications, only: [] do
+          member do
+            patch :adjust_inventory
+            patch :mark_as_ordered
+            patch :mark_as_received
+          end
+        end
+        resources :dosage_options, only: %i[index show create update]
+        resources :health_events, only: %i[index show create update]
+        resources :schedules, only: %i[index show create update] do
+          member do
+            patch :pause
+            patch :resume
+          end
+        end
+        resources :person_medications, only: %i[index show create update] do
+          member do
+            patch :pause
+            patch :resume
+            patch :reorder
+          end
+        end
         resources :medication_takes, only: %i[index create]
         resource :notification_preference, only: %i[show update]
+        resources :native_device_tokens, only: %i[create destroy]
+        resource :push_subscription, only: %i[create destroy] do
+          post :test, on: :collection
+        end
+        get :medication_lookup, to: 'medication_lookup#show'
+        post :ai_medication_suggestions, to: 'ai_medication_suggestions#create'
         get :portable_export, to: 'portable_exports#show'
         get :mobile_snapshot, to: 'mobile_snapshots#show'
         post 'portable_imports/dry_run', to: 'portable_imports#dry_run'
         post :portable_imports, to: 'portable_imports#create'
+        get 'data_exports/:mode', to: 'data_exports#show', as: :data_export
+
+        namespace :sync do
+          get :snapshot, to: 'feeds#snapshot'
+          get :changes, to: 'feeds#changes'
+          post :batches, to: 'batches#create'
+        end
+
+        namespace :admin do
+          resource :settings, only: %i[show update], controller: 'settings'
+          resources :memberships, only: %i[index update destroy]
+          resources :invitations, only: %i[index create destroy]
+          resources :person_access_grants, only: %i[index create destroy]
+          resources :app_tokens, only: %i[index create destroy]
+          resources :audit_logs, only: %i[index]
+        end
       end
     end
   end
@@ -136,6 +196,7 @@ Rails.application.routes.draw do
       patch :experiments, on: :member
       resources :api_tokens, only: %i[create destroy], controller: 'profiles/api_tokens'
     end
+    get 'profile/data_exports/:mode', to: 'profiles/data_exports#show', as: :profile_data_export
     delete 'profile/avatar', to: 'profiles#avatar', as: :profile_avatar
 
     resources :reports, only: %i[index]

--- a/db/migrate/20260707110000_create_api_sync_safety_primitives.rb
+++ b/db/migrate/20260707110000_create_api_sync_safety_primitives.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class CreateApiSyncSafetyPrimitives < ActiveRecord::Migration[8.1]
+  def change
+    create_table :api_idempotency_keys do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: true
+      t.references :api_session, foreign_key: true
+      t.references :api_app_token, foreign_key: true
+      t.string :key, null: false
+      t.string :request_method, null: false
+      t.string :request_path, null: false
+      t.string :request_digest, null: false
+      t.integer :response_status, null: false
+      t.jsonb :response_body, null: false, default: {}
+      t.datetime :expires_at, null: false
+      t.timestamps
+
+      t.index %i[household_id key], unique: true
+      t.index :expires_at
+    end
+
+    create_table :api_change_events do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: true
+      t.references :household_membership, null: false, foreign_key: true
+      t.string :request_id
+      t.string :record_type, null: false
+      t.bigint :record_id, null: false
+      t.string :record_portable_id
+      t.string :action, null: false
+      t.jsonb :metadata, null: false, default: {}
+      t.datetime :occurred_at, null: false
+      t.timestamps
+
+      t.index %i[household_id occurred_at]
+      t.index %i[record_type record_id]
+      t.index %i[household_id record_portable_id]
+    end
+
+    create_table :api_tombstones do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: true
+      t.references :household_membership, null: false, foreign_key: true
+      t.string :record_type, null: false
+      t.string :record_portable_id, null: false
+      t.string :action, null: false, default: 'delete'
+      t.jsonb :metadata, null: false, default: {}
+      t.datetime :deleted_at, null: false
+      t.timestamps
+
+      t.index %i[household_id deleted_at]
+      t.index %i[household_id record_type record_portable_id], name: 'index_api_tombstones_on_household_record'
+    end
+
+    create_table :api_oidc_nonces do |t|
+      t.string :issuer, null: false
+      t.string :subject, null: false
+      t.string :nonce, null: false
+      t.datetime :used_at, null: false
+      t.timestamps
+
+      t.index %i[issuer subject nonce], unique: true
+      t.index :used_at
+    end
+  end
+end

--- a/db/migrate/20260707110100_add_portable_ids_to_health_events.rb
+++ b/db/migrate/20260707110100_add_portable_ids_to_health_events.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddPortableIdsToHealthEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :health_events, :portable_id, :string
+    backfill_portable_ids
+    change_column_null :health_events, :portable_id, false
+    change_column_default :health_events, :portable_id, from: nil, to: -> { 'gen_random_uuid()::text' }
+    add_index :health_events, %i[household_id portable_id], unique: true
+  end
+
+  def down
+    remove_index :health_events, column: %i[household_id portable_id]
+    change_column_default :health_events, :portable_id, from: -> { 'gen_random_uuid()::text' }, to: nil
+    remove_column :health_events, :portable_id
+  end
+
+  private
+
+  def backfill_portable_ids
+    rows = select_values('SELECT id FROM health_events WHERE portable_id IS NULL')
+
+    rows.each do |id|
+      execute <<~SQL.squish
+        UPDATE health_events
+        SET portable_id = #{quote(SecureRandom.uuid)}
+        WHERE id = #{quote(id)}
+      SQL
+    end
+  end
+end

--- a/db/migrate/20260707110200_add_privileged_proof_to_api_sessions.rb
+++ b/db/migrate/20260707110200_add_privileged_proof_to_api_sessions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPrivilegedProofToApiSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :api_sessions, :mfa_verified_at, :datetime
+    add_column :api_sessions, :oidc_mfa_verified, :boolean, null: false, default: false
+    add_index :api_sessions, :mfa_verified_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_110200) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_123000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_110200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -181,6 +181,60 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.index ["token_digest"], name: "index_api_app_tokens_on_token_digest", unique: true
   end
 
+  create_table "api_change_events", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "account_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "household_id", null: false
+    t.bigint "household_membership_id", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "occurred_at", null: false
+    t.string "record_portable_id"
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.string "request_id"
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_api_change_events_on_account_id"
+    t.index ["household_id", "occurred_at"], name: "index_api_change_events_on_household_id_and_occurred_at"
+    t.index ["household_id", "record_portable_id"], name: "index_api_change_events_on_household_id_and_record_portable_id"
+    t.index ["household_id"], name: "index_api_change_events_on_household_id"
+    t.index ["household_membership_id"], name: "index_api_change_events_on_household_membership_id"
+    t.index ["record_type", "record_id"], name: "index_api_change_events_on_record_type_and_record_id"
+  end
+
+  create_table "api_idempotency_keys", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "api_app_token_id"
+    t.bigint "api_session_id"
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "household_id", null: false
+    t.string "key", null: false
+    t.string "request_digest", null: false
+    t.string "request_method", null: false
+    t.string "request_path", null: false
+    t.jsonb "response_body", default: {}, null: false
+    t.integer "response_status", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_api_idempotency_keys_on_account_id"
+    t.index ["api_app_token_id"], name: "index_api_idempotency_keys_on_api_app_token_id"
+    t.index ["api_session_id"], name: "index_api_idempotency_keys_on_api_session_id"
+    t.index ["expires_at"], name: "index_api_idempotency_keys_on_expires_at"
+    t.index ["household_id", "key"], name: "index_api_idempotency_keys_on_household_id_and_key", unique: true
+    t.index ["household_id"], name: "index_api_idempotency_keys_on_household_id"
+  end
+
+  create_table "api_oidc_nonces", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "issuer", null: false
+    t.string "nonce", null: false
+    t.string "subject", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at", null: false
+    t.index ["issuer", "subject", "nonce"], name: "index_api_oidc_nonces_on_issuer_and_subject_and_nonce", unique: true
+    t.index ["used_at"], name: "index_api_oidc_nonces_on_used_at"
+  end
+
   create_table "api_sessions", force: :cascade do |t|
     t.datetime "access_expires_at", null: false
     t.string "access_token_digest", null: false
@@ -189,6 +243,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.string "device_name"
     t.bigint "household_membership_id"
     t.datetime "last_used_at", null: false
+    t.datetime "mfa_verified_at"
+    t.boolean "oidc_mfa_verified", default: false, null: false
     t.integer "permissions_version", default: 1, null: false
     t.datetime "refresh_expires_at", null: false
     t.string "refresh_token_digest", null: false
@@ -199,8 +255,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.index ["account_id"], name: "index_api_sessions_on_account_id"
     t.index ["household_membership_id", "revoked_at"], name: "index_api_sessions_on_membership_and_revoked_at"
     t.index ["household_membership_id"], name: "index_api_sessions_on_household_membership_id"
+    t.index ["mfa_verified_at"], name: "index_api_sessions_on_mfa_verified_at"
     t.index ["refresh_token_digest"], name: "index_api_sessions_on_refresh_token_digest", unique: true
     t.index ["revoked_at"], name: "index_api_sessions_on_revoked_at"
+  end
+
+  create_table "api_tombstones", force: :cascade do |t|
+    t.string "action", default: "delete", null: false
+    t.bigint "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at", null: false
+    t.bigint "household_id", null: false
+    t.bigint "household_membership_id", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.string "record_portable_id", null: false
+    t.string "record_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_api_tombstones_on_account_id"
+    t.index ["household_id", "deleted_at"], name: "index_api_tombstones_on_household_id_and_deleted_at"
+    t.index ["household_id", "record_type", "record_portable_id"], name: "index_api_tombstones_on_household_record"
+    t.index ["household_id"], name: "index_api_tombstones_on_household_id"
+    t.index ["household_membership_id"], name: "index_api_tombstones_on_household_membership_id"
   end
 
   create_table "app_settings", force: :cascade do |t|
@@ -272,10 +347,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.boolean "medical_help_sought", default: false, null: false
     t.text "notes"
     t.bigint "person_id", null: false
+    t.string "portable_id", default: -> { "gen_random_uuid()::text" }, null: false
     t.integer "severity"
     t.date "started_on", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["household_id", "portable_id"], name: "index_health_events_on_household_id_and_portable_id", unique: true
     t.index ["household_id"], name: "index_health_events_on_household_id"
     t.index ["id", "household_id"], name: "index_health_events_on_id_and_household_id", unique: true
     t.index ["person_id", "event_kind", "started_on"], name: "index_health_events_on_person_id_and_event_kind_and_started_on"
@@ -747,8 +824,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "api_app_tokens", "accounts"
   add_foreign_key "api_app_tokens", "household_memberships"
+  add_foreign_key "api_change_events", "accounts"
+  add_foreign_key "api_change_events", "household_memberships"
+  add_foreign_key "api_change_events", "households"
+  add_foreign_key "api_idempotency_keys", "accounts"
+  add_foreign_key "api_idempotency_keys", "api_app_tokens"
+  add_foreign_key "api_idempotency_keys", "api_sessions"
+  add_foreign_key "api_idempotency_keys", "households"
   add_foreign_key "api_sessions", "accounts"
   add_foreign_key "api_sessions", "household_memberships"
+  add_foreign_key "api_tombstones", "accounts"
+  add_foreign_key "api_tombstones", "household_memberships"
+  add_foreign_key "api_tombstones", "households"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred
   add_foreign_key "dosages", "households"
@@ -880,6 +967,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     person_access_grants
     household_invitations
     household_invitation_grants
+    api_change_events
+    api_idempotency_keys
+    api_tombstones
     security_audit_events
     active_storage_attachments
   ].each do |table_name|

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -33,6 +33,33 @@ paths:
           description: New access and refresh tokens.
         '401':
           description: Refresh token is invalid or expired.
+  /api/v1/auth/oidc_exchange:
+    post:
+      summary: Exchange a hosted OIDC ID token for an API session.
+      security: []
+      responses:
+        '201':
+          description: API session created.
+  /api/v1/auth/households:
+    get:
+      summary: List households available to the current API credential.
+      responses:
+        '200':
+          description: Household collection.
+  /api/v1/auth/sessions:
+    get:
+      summary: List active API sessions for the current account.
+      responses:
+        '200':
+          description: API session collection.
+  /api/v1/auth/sessions/{id}:
+    delete:
+      summary: Revoke an API session.
+      parameters:
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: API session revoked.
   /api/v1/auth/logout:
     delete:
       summary: Revoke the current API session or app token.
@@ -144,6 +171,113 @@ paths:
       responses:
         '200':
           description: Medication updated.
+  /api/v1/households/{household_id}/medications/{id}/adjust_inventory:
+    patch:
+      summary: Adjust medication inventory.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Medication inventory adjusted.
+  /api/v1/households/{household_id}/medications/{id}/mark_as_ordered:
+    patch:
+      summary: Mark a medication reorder as ordered.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Reorder status updated.
+  /api/v1/households/{household_id}/medications/{id}/mark_as_received:
+    patch:
+      summary: Mark a medication reorder as received.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Reorder status updated.
+  /api/v1/households/{household_id}/dosage_options:
+    get:
+      summary: List medication dosage options.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Dosage option collection.
+    post:
+      summary: Create a medication dosage option.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Dosage option created.
+  /api/v1/households/{household_id}/dosage_options/{id}:
+    get:
+      summary: Read a medication dosage option.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Dosage option resource.
+    patch:
+      summary: Update a medication dosage option.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Dosage option updated.
+    put:
+      summary: Replace a medication dosage option.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Dosage option updated.
+  /api/v1/households/{household_id}/health_events:
+    get:
+      summary: List visible health events.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Health event collection.
+    post:
+      summary: Create a health event.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Health event created.
+  /api/v1/households/{household_id}/health_events/{id}:
+    get:
+      summary: Read a health event.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Health event resource.
+    patch:
+      summary: Update a health event.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Health event updated.
+    put:
+      summary: Replace a health event.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Health event updated.
   /api/v1/households/{household_id}/schedules:
     get:
       summary: List visible schedules.
@@ -184,6 +318,24 @@ paths:
       responses:
         '200':
           description: Schedule updated.
+  /api/v1/households/{household_id}/schedules/{id}/pause:
+    patch:
+      summary: Pause a schedule.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Schedule paused.
+  /api/v1/households/{household_id}/schedules/{id}/resume:
+    patch:
+      summary: Resume a schedule.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Schedule resumed.
   /api/v1/households/{household_id}/person_medications:
     get:
       summary: List visible person medication assignments.
@@ -224,6 +376,33 @@ paths:
       responses:
         '200':
           description: Person medication updated.
+  /api/v1/households/{household_id}/person_medications/{id}/pause:
+    patch:
+      summary: Pause a person medication assignment.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Person medication paused.
+  /api/v1/households/{household_id}/person_medications/{id}/resume:
+    patch:
+      summary: Resume a person medication assignment.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Person medication resumed.
+  /api/v1/households/{household_id}/person_medications/{id}/reorder:
+    patch:
+      summary: Reorder a person medication assignment.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Person medication reordered.
   /api/v1/households/{household_id}/medication_takes:
     get:
       summary: List visible medication takes.
@@ -261,6 +440,62 @@ paths:
       responses:
         '200':
           description: Notification preference updated.
+  /api/v1/households/{household_id}/native_device_tokens:
+    post:
+      summary: Register a native device token.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Device token registered.
+  /api/v1/households/{household_id}/native_device_tokens/{id}:
+    delete:
+      summary: Revoke a native device token.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: Device token revoked.
+  /api/v1/households/{household_id}/push_subscription:
+    post:
+      summary: Register a web push subscription.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Push subscription registered.
+    delete:
+      summary: Revoke a web push subscription.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '204':
+          description: Push subscription revoked.
+  /api/v1/households/{household_id}/push_subscription/test:
+    post:
+      summary: Send a test push notification.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '204':
+          description: Test notification queued.
+  /api/v1/households/{household_id}/medication_lookup:
+    get:
+      summary: Search external medication lookup data.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Medication lookup results.
+  /api/v1/households/{household_id}/ai_medication_suggestions:
+    post:
+      summary: Generate medication setup suggestions.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Suggestion payload.
   /api/v1/households/{household_id}/portable_export:
     get:
       summary: Export an encrypted portable household bundle.
@@ -293,6 +528,178 @@ paths:
       responses:
         '201':
           description: Import applied.
+  /api/v1/households/{household_id}/data_exports/{mode}:
+    get:
+      summary: Export household data in a selected backup/profile mode.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - name: mode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Export payload.
+  /api/v1/households/{household_id}/sync/snapshot:
+    get:
+      summary: Read a portable v2 sync snapshot.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Sync snapshot.
+  /api/v1/households/{household_id}/sync/changes:
+    get:
+      summary: Read sync changes after a cursor.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Change feed.
+  /api/v1/households/{household_id}/sync/batches:
+    post:
+      summary: Apply transactional sync batch operations.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Batch applied.
+  /api/v1/households/{household_id}/admin/settings:
+    get:
+      summary: Read household administration settings.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Household settings.
+    patch:
+      summary: Update household administration settings.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Household settings updated.
+    put:
+      summary: Replace household administration settings.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Household settings updated.
+  /api/v1/households/{household_id}/admin/memberships:
+    get:
+      summary: List household memberships.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Membership collection.
+  /api/v1/households/{household_id}/admin/memberships/{id}:
+    patch:
+      summary: Update a household membership.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Membership updated.
+    put:
+      summary: Replace a household membership.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: Membership updated.
+    delete:
+      summary: Revoke a household membership.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: Membership revoked.
+  /api/v1/households/{household_id}/admin/invitations:
+    get:
+      summary: List household invitations.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Invitation collection.
+    post:
+      summary: Create a household invitation.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Invitation created.
+  /api/v1/households/{household_id}/admin/invitations/{id}:
+    delete:
+      summary: Revoke a household invitation.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: Invitation revoked.
+  /api/v1/households/{household_id}/admin/person_access_grants:
+    get:
+      summary: List person access grants.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Access grant collection.
+    post:
+      summary: Create a person access grant.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: Access grant created.
+  /api/v1/households/{household_id}/admin/person_access_grants/{id}:
+    delete:
+      summary: Revoke a person access grant.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: Access grant revoked.
+  /api/v1/households/{household_id}/admin/app_tokens:
+    get:
+      summary: List API app tokens.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: API app token collection.
+    post:
+      summary: Create an API app token.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '201':
+          description: API app token created.
+  /api/v1/households/{household_id}/admin/app_tokens/{id}:
+    delete:
+      summary: Revoke an API app token.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204':
+          description: API app token revoked.
+  /api/v1/households/{household_id}/admin/audit_logs:
+    get:
+      summary: List household security audit events.
+      parameters:
+        - $ref: '#/components/parameters/household_id'
+      responses:
+        '200':
+          description: Audit event collection.
 components:
   securitySchemes:
     bearerAuth:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ ensuring medications are given on time and safely.
 - [Audit & Compliance](audit-trail.md): details on versioning and data history.
 - [MCP Integration](mcp.md): set up the hosted MCP server and connect Codex,
   Claude Code, or VS Code to read medication context.
+- [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
 - [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -22,9 +22,13 @@
 - UI renders server-sent HTML; Turbo Streams for interactive updates.
 - Critical identity and medication flows are audited.
 - Role-based authorization controls admin/clinical actions.
+- The `/api/v1` surface supports hosted OIDC session exchange, portable IDs, idempotent writes, sync feeds,
+  transactional batches, self-service exports, household administration, and protected FHIR R4 read endpoints.
 
 Key entry points:
 - Routes: `config/routes.rb`
+- API contract: `docs/api/openapi.v1.yaml`
+- API capabilities: `/api/v1/capabilities`
 - Dashboard: `app/controllers/dashboard_controller.rb`
 - Admin area: `app/controllers/admin/*`
 - Medication models: `app/models/medicine.rb`, `app/models/prescription.rb`, `app/models/person_medicine.rb`, `app/models/medication_take.rb`

--- a/docs/security/api-backlog-security-review.md
+++ b/docs/security/api-backlog-security-review.md
@@ -1,0 +1,63 @@
+# API Backlog Security Review
+
+## Executive Summary
+
+| Field | Value |
+|-------|-------|
+| Application | MedTracker |
+| Review Date | 2026-07-07 |
+| Reviewer | Codex |
+| Scope | Local Rails API implementation for issues #551, #1480, #1485, #1486, #1487, #1488, #1489, and #1491 |
+| Overall Risk Level | Low after local verification, with accepted scanner caveats |
+
+This review is limited to the local repository, local development/test services, and GitHub CI evidence. It does not authorize production penetration testing, destructive testing, data exfiltration attempts, or testing against third-party services beyond mocked/local request specs.
+
+## Attack Surface
+
+The implementation touches these security-critical paths:
+
+- API bearer authentication, API app tokens, OIDC exchange, refresh, revocation, and household session selection.
+- Household-scoped API resource reads and writes, including portable ID lookup and cross-household rejection.
+- Batch mutation, sync, tombstone, backup, export, import, and FHIR read endpoints.
+- Owner/admin household administration endpoints and fresh MFA or upstream OIDC MFA proof checks.
+- Logs, OpenTelemetry spans, Rack::Attack throttle responses, and security audit metadata.
+
+## Automated Scan Results
+
+| Tool | Command | Status | Notes |
+|------|---------|--------|-------|
+| Brakeman | `task brakeman` | Pass | Brakeman 8.0.5, Rails 8.1.3, 0 warnings. A medium `permit!` finding in the API medication reorder endpoint was fixed with explicit permitted keys before the passing run. |
+| Bundler Audit | `bundler-audit check` | Pass | Host tool reported no vulnerabilities. `task test:exec CMD='bundle exec bundler-audit check'` could not run because the test container does not include the executable. |
+| Gitleaks | `gitleaks detect --source . --verbose` | Reviewed findings | History scan reported five findings in a deleted `_bmad` commit: one expired example JWT and four manifest hashes. Working-tree scan with `gitleaks dir . --verbose` reported ignored runtime files under `log/` and `tmp/`, primarily test token digests, idempotency keys, and Bootsnap cache strings. No current tracked application source finding was identified. |
+| Semgrep | `semgrep --config=auto .` | Tool failure | Semgrep was installed but failed before scanning with `Failed to create system store X509 authenticator: ca-certs: empty trust anchors`. No Semgrep result was available. |
+| RuboCop | `task rubocop` | Pass | 1354 files inspected, no offenses detected. |
+| RSpec | `task test` | Pass | 3821 examples, 0 failures, 1 expected pending OIDC configuration example. |
+
+## Manual Review Checklist
+
+- [x] Authentication rejects missing, expired, revoked, locked, stale-permission, and cross-household credentials.
+- [x] Authorization reuses Pundit policy scopes for every API read and write.
+- [x] Privileged household administration mutations require fresh local MFA/passkey or upstream OIDC MFA proof.
+- [x] Portable ID lookup never leaks whether an inaccessible cross-household record exists.
+- [x] Idempotency storage does not persist request bodies, PHI, passphrases, tokens, authorization codes, or backup contents.
+- [x] Batch mutation failures roll back every write in the batch.
+- [x] Portable exports exclude sessions, tokens, device tokens, push subscriptions, invitations, support sessions, audit internals, platform state, and Rails numeric IDs.
+- [x] FHIR endpoints expose only policy-authorized resources.
+- [x] Rate-limit responses include retry guidance without leaking sensitive request context.
+- [x] Logs, spans, errors, and security audit metadata redact PHI and secret material.
+
+## Findings
+
+No confirmed high-severity findings in the implemented local API backlog pass.
+
+- OIDC exchange uses the existing internal API session bearer-token model. It does not introduce Rodauth provider-side OAuth.
+- Privileged household administration API writes require fresh API-session OIDC MFA proof and write redacted security audit events.
+- Idempotency stores request digests and response envelopes for replay. It does not store raw request bodies.
+- API sync safety tables are household-scoped and included in the schema inventory contract.
+- The Brakeman mass-assignment warning on API reorder details was remediated by replacing `permit!` with explicit keys: `supplier`, `quantity`, and `expected_arrival_on`.
+
+## Accepted Risks
+
+- Full external OIDC issuer key discovery is not exercised in local tests; this pass validates the local exchange contract and records the hosted-OIDC direction for CI/provider integration follow-up.
+- Gitleaks history findings are accepted as pre-existing non-current-source noise from a deleted `_bmad` commit. Current-tree findings are ignored runtime artifacts in `log/` and `tmp/`.
+- Semgrep produced no scan result because the local installation failed during CA trust-store initialization before rule execution.

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -18,6 +18,9 @@ class SchemaInventory
     person_access_grants
     household_invitations
     household_invitation_grants
+    api_change_events
+    api_idempotency_keys
+    api_tombstones
     security_audit_events
     active_storage_attachments
   ].freeze
@@ -39,6 +42,7 @@ class SchemaInventory
     active_storage_blobs
     active_storage_variant_records
     api_app_tokens
+    api_oidc_nonces
     api_sessions
     app_settings
     barcode_catalog_entries

--- a/spec/models/api_app_token_spec.rb
+++ b/spec/models/api_app_token_spec.rb
@@ -31,6 +31,54 @@ RSpec.describe ApiAppToken do
     end
   end
 
+  describe '#active_for_membership?' do
+    let(:account) { accounts(:jane_doe) }
+    let(:membership) { api_membership_for(account) }
+
+    it 'requires an attached active membership with the current permissions version' do
+      app_token = described_class.issue_for(
+        account: account,
+        household_membership: membership,
+        name: 'RSpec token'
+      ).first
+
+      expect(app_token).to be_active_for_membership
+
+      app_token.update!(permissions_version: membership.permissions_version + 1)
+      expect(app_token).not_to be_active_for_membership
+
+      app_token.update!(permissions_version: membership.permissions_version)
+      create_backup_owner
+      membership.update!(status: :revoked)
+      expect(app_token).not_to be_active_for_membership
+    end
+
+    it 'rejects tokens with no membership' do
+      app_token = described_class.new(household_membership: nil)
+
+      expect(app_token).not_to be_active_for_membership
+    end
+  end
+
+  describe 'validations' do
+    let(:account) { accounts(:jane_doe) }
+    let(:household) { api_household }
+
+    it 'rejects household memberships from a different account' do
+      other_account = Account.create!(email: 'api-token-other-account@example.test', status: :verified)
+      token = described_class.new(
+        account: account,
+        household_membership: mismatched_membership(other_account),
+        name: 'Mismatched token',
+        token_digest: described_class.digest('mismatched-token'),
+        last_used_at: Time.current
+      )
+
+      expect(token).not_to be_valid
+      expect(token.errors[:household_membership]).to include('must belong to the account')
+    end
+  end
+
   def issue_app_token_at_issued_time
     travel_to(issued_at) do
       described_class.issue_for(
@@ -64,6 +112,25 @@ RSpec.describe ApiAppToken do
       date_of_birth: 30.years.ago.to_date,
       person_type: :adult,
       has_capacity: true
+    )
+  end
+
+  def mismatched_membership(account)
+    household.household_memberships.create!(
+      account: account,
+      person: api_person_for(account, household),
+      role: :member,
+      status: :active
+    )
+  end
+
+  def create_backup_owner
+    backup_account = Account.create!(email: "api-backup-owner-#{SecureRandom.hex(4)}@example.test", status: :verified)
+    membership.household.household_memberships.create!(
+      account: backup_account,
+      person: api_person_for(backup_account, membership.household),
+      role: :owner,
+      status: :active
     )
   end
 end

--- a/spec/requests/api/fhir/r4_spec.rb
+++ b/spec/requests/api/fhir/r4_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'FHIR R4 API' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'requires bearer authentication' do
+    get '/api/fhir/R4/metadata', as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'returns FHIR metadata' do
+    get '/api/fhir/R4/metadata', headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to include('resourceType' => 'CapabilityStatement', 'fhirVersion' => '4.0.1')
+  end
+
+  it 'searches and reads patients with household scoping' do
+    person = people(:john)
+
+    get '/api/fhir/R4/Patient', headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.fetch('resourceType')).to eq('Bundle')
+    expect(response.parsed_body.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(
+      person.portable_id
+    )
+
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to include('resourceType' => 'Patient', 'id' => person.portable_id)
+  end
+
+  it 'returns medication, request, statement, and administration resources with references' do
+    schedule = schedules(:john_paracetamol)
+    person_medication = create(:person_medication, person: people(:john), medication: medications(:ibuprofen))
+    take = create(:medication_take, schedule: schedule, household: schedule.household, taken_at: Time.current)
+
+    get "/api/fhir/R4/Medication/#{schedule.medication.portable_id}", headers: headers, as: :json
+    expect(response.parsed_body).to include('resourceType' => 'Medication', 'id' => schedule.medication.portable_id)
+
+    get "/api/fhir/R4/MedicationRequest/#{schedule.portable_id}", headers: headers, as: :json
+    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
+    expect(response.parsed_body.dig('medicationReference', 'reference')).to eq(
+      "Medication/#{schedule.medication.portable_id}"
+    )
+
+    get "/api/fhir/R4/MedicationStatement/#{person_medication.portable_id}", headers: headers, as: :json
+    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{person_medication.person.portable_id}")
+
+    get "/api/fhir/R4/MedicationAdministration/#{take.portable_id}", headers: headers, as: :json
+    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
+  end
+
+  it 'returns not found for inaccessible resources' do
+    other_household = Household.create!(name: 'FHIR Other Household', slug: 'fhir-other-household')
+    other_person = create(:person, household: other_household)
+
+    get "/api/fhir/R4/Patient/#{other_person.portable_id}", headers: headers, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/api/fhir/r4_spec.rb
+++ b/spec/requests/api/fhir/r4_spec.rb
@@ -14,30 +14,42 @@ RSpec.describe 'FHIR R4 API' do
     get '/api/fhir/R4/metadata', as: :json
 
     expect(response).to have_http_status(:unauthorized)
+    expect(response.media_type).to eq('application/fhir+json')
+    expect(fhir_json).to include('resourceType' => 'OperationOutcome')
   end
 
   it 'returns FHIR metadata' do
     get '/api/fhir/R4/metadata', headers: headers, as: :json
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body).to include('resourceType' => 'CapabilityStatement', 'fhirVersion' => '4.0.1')
+    expect(response.media_type).to eq('application/fhir+json')
+    expect(fhir_json).to include(
+      'resourceType' => 'CapabilityStatement',
+      'fhirVersion' => '4.0.1',
+      'format' => include('json', 'application/fhir+json')
+    )
+    patient = fhir_json.dig('rest', 0, 'resource').find { |resource| resource.fetch('type') == 'Patient' }
+    expect(patient.fetch('searchParam').pluck('name')).to include('_id', 'name', 'birthdate')
   end
 
   it 'searches and reads patients with household scoping' do
     person = people(:john)
 
-    get '/api/fhir/R4/Patient', headers: headers, as: :json
+    get "/api/fhir/R4/Patient?name=#{person.name}&_count=1", headers: headers
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body.fetch('resourceType')).to eq('Bundle')
-    expect(response.parsed_body.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(
+    expect(response.media_type).to eq('application/fhir+json')
+    expect(fhir_json).to include('resourceType' => 'Bundle', 'type' => 'searchset')
+    expect(fhir_json.fetch('link').pluck('relation')).to include('self')
+    expect(fhir_json.fetch('entry')).to all(include('search' => { 'mode' => 'match' }))
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to contain_exactly(
       person.portable_id
     )
 
     get "/api/fhir/R4/Patient/#{person.portable_id}", headers: headers, as: :json
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body).to include('resourceType' => 'Patient', 'id' => person.portable_id)
+    expect(fhir_json).to include('resourceType' => 'Patient', 'id' => person.portable_id)
   end
 
   it 'returns medication, request, statement, and administration resources with references' do
@@ -46,19 +58,57 @@ RSpec.describe 'FHIR R4 API' do
     take = create(:medication_take, schedule: schedule, household: schedule.household, taken_at: Time.current)
 
     get "/api/fhir/R4/Medication/#{schedule.medication.portable_id}", headers: headers, as: :json
-    expect(response.parsed_body).to include('resourceType' => 'Medication', 'id' => schedule.medication.portable_id)
+    expect(fhir_json).to include('resourceType' => 'Medication', 'id' => schedule.medication.portable_id)
 
     get "/api/fhir/R4/MedicationRequest/#{schedule.portable_id}", headers: headers, as: :json
-    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
-    expect(response.parsed_body.dig('medicationReference', 'reference')).to eq(
+    expect(fhir_json.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
+    expect(fhir_json.dig('medicationReference', 'reference')).to eq(
       "Medication/#{schedule.medication.portable_id}"
     )
 
     get "/api/fhir/R4/MedicationStatement/#{person_medication.portable_id}", headers: headers, as: :json
-    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{person_medication.person.portable_id}")
+    expect(fhir_json.dig('subject', 'reference')).to eq("Patient/#{person_medication.person.portable_id}")
 
     get "/api/fhir/R4/MedicationAdministration/#{take.portable_id}", headers: headers, as: :json
-    expect(response.parsed_body.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
+    expect(fhir_json.dig('subject', 'reference')).to eq("Patient/#{schedule.person.portable_id}")
+  end
+
+  it 'filters resources by supported FHIR search parameters' do
+    medication = medications(:paracetamol)
+    medication.update!(dmd_code: '123456', dmd_system: 'https://dmd.nhs.uk', dmd_concept_class: 'VMP')
+    schedule = schedules(:john_paracetamol)
+    take = create(
+      :medication_take,
+      schedule: schedule,
+      household: schedule.household,
+      taken_at: Time.zone.local(2026, 1, 2, 9)
+    )
+
+    get '/api/fhir/R4/Medication?code=123456', headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(medication.portable_id)
+
+    query = {
+      patient: "Patient/#{schedule.person.portable_id}",
+      medication: "Medication/#{medication.portable_id}"
+    }.to_query
+    get "/api/fhir/R4/MedicationRequest?#{query}", headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(schedule.portable_id)
+
+    get "/api/fhir/R4/MedicationAdministration?patient=#{schedule.person.portable_id}&date=2026-01-02", headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(take.portable_id)
+  end
+
+  it 'returns OperationOutcome for unsupported FHIR formats and search parameters' do
+    get '/api/fhir/R4/Patient?family=Smith', headers: headers
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.media_type).to eq('application/fhir+json')
+    expect(fhir_json).to include('resourceType' => 'OperationOutcome')
+
+    get '/api/fhir/R4/Patient?_format=xml', headers: headers
+
+    expect(response).to have_http_status(:not_acceptable)
+    expect(fhir_json.dig('issue', 0, 'code')).to eq('not-supported')
   end
 
   it 'returns not found for inaccessible resources' do
@@ -68,5 +118,10 @@ RSpec.describe 'FHIR R4 API' do
     get "/api/fhir/R4/Patient/#{other_person.portable_id}", headers: headers, as: :json
 
     expect(response).to have_http_status(:not_found)
+    expect(fhir_json).to include('resourceType' => 'OperationOutcome')
+  end
+
+  def fhir_json
+    ActiveSupport::JSON.decode(response.body)
   end
 end

--- a/spec/requests/api/fhir/r4_spec.rb
+++ b/spec/requests/api/fhir/r4_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe 'FHIR R4 API' do
       person.portable_id
     )
 
+    get '/api/fhir/R4/Patient?_count=1', headers: headers
+
+    expect(fhir_json.fetch('link').pluck('relation')).to include('next')
+
     get "/api/fhir/R4/Patient/#{person.portable_id}", headers: headers, as: :json
 
     expect(response).to have_http_status(:ok)
@@ -77,6 +81,14 @@ RSpec.describe 'FHIR R4 API' do
     medication = medications(:paracetamol)
     medication.update!(dmd_code: '123456', dmd_system: 'https://dmd.nhs.uk', dmd_concept_class: 'VMP')
     schedule = schedules(:john_paracetamol)
+    person_medication = create(:person_medication, person: people(:john), medication: medications(:ibuprofen))
+    stopped_schedule = create(
+      :schedule,
+      active: false,
+      person: schedule.person,
+      medication: schedule.medication,
+      household: schedule.household
+    )
     take = create(
       :medication_take,
       schedule: schedule,
@@ -94,8 +106,38 @@ RSpec.describe 'FHIR R4 API' do
     get "/api/fhir/R4/MedicationRequest?#{query}", headers: headers
     expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(schedule.portable_id)
 
-    get "/api/fhir/R4/MedicationAdministration?patient=#{schedule.person.portable_id}&date=2026-01-02", headers: headers
+    get '/api/fhir/R4/MedicationRequest?status=active', headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(schedule.portable_id)
+
+    get '/api/fhir/R4/MedicationRequest?status=stopped', headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(
+      stopped_schedule.portable_id
+    )
+
+    get '/api/fhir/R4/MedicationRequest?status=draft', headers: headers
+    expect(response).to have_http_status(:unprocessable_content)
+
+    get '/api/fhir/R4/MedicationStatement?status=active', headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(
+      person_medication.portable_id
+    )
+
+    person_medication.update!(active: false)
+
+    get '/api/fhir/R4/MedicationStatement?status=stopped', headers: headers
+    expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(
+      person_medication.portable_id
+    )
+
+    get '/api/fhir/R4/MedicationStatement?status=entered-in-error', headers: headers
+    expect(response).to have_http_status(:unprocessable_content)
+
+    get "/api/fhir/R4/MedicationAdministration?patient=#{schedule.person.portable_id}&date=2026-01-02&status=completed",
+        headers: headers
     expect(fhir_json.fetch('entry').map { |entry| entry.dig('resource', 'id') }).to include(take.portable_id)
+
+    get '/api/fhir/R4/MedicationAdministration?status=in-progress', headers: headers
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it 'returns OperationOutcome for unsupported FHIR formats and search parameters' do

--- a/spec/requests/api/v1/admin_api_spec.rb
+++ b/spec/requests/api/v1/admin_api_spec.rb
@@ -71,6 +71,30 @@ RSpec.describe 'API v1 household administration' do
     expect(ApiAppToken.find(app_token_id)).to be_revoked_at
   end
 
+  it 'lists app tokens with nullable and revoked timestamps' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+    active_token, = ApiAppToken.issue_for(
+      account: user.person.account,
+      household_membership: api_session.household_membership,
+      name: 'Active listed token'
+    )
+    revoked_token, = ApiAppToken.issue_for(
+      account: user.person.account,
+      household_membership: api_session.household_membership,
+      name: 'Revoked listed token'
+    )
+    revoked_token.update!(last_used_at: 1.hour.ago, revoked_at: Time.current)
+
+    get api_v1_household_admin_app_tokens_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    payloads = response.parsed_body.fetch('data').index_by { |token| token.fetch('id') }
+    expect(payloads.fetch(active_token.id)).to include('revoked_at' => nil)
+    expect(payloads.fetch(active_token.id).fetch('last_used_at')).to be_present
+    expect(payloads.fetch(revoked_token.id).fetch('last_used_at')).to be_present
+    expect(payloads.fetch(revoked_token.id).fetch('revoked_at')).to be_present
+  end
+
   it 'creates and revokes invitations without exposing invitation tokens' do
     api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
 
@@ -87,6 +111,30 @@ RSpec.describe 'API v1 household administration' do
 
     expect(response).to have_http_status(:no_content)
     expect(HouseholdInvitation.find(invitation_id)).to be_revoked
+  end
+
+  it 'returns validation errors for invalid invitations and lists revoked timestamps' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    post api_v1_household_admin_invitations_path(household_id),
+         params: { household_invitation: { email: '', membership_role: 'member' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    invitation = Household.find(household_id).household_invitations.create!(
+      email: 'revoked.invitation@example.test',
+      membership_role: 'member',
+      invited_by_membership: api_session.household_membership,
+      revoked_at: Time.current
+    )
+
+    get api_v1_household_admin_invitations_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    payload = response.parsed_body.fetch('data').find { |item| item.fetch('id') == invitation.id }
+    expect(payload.fetch('revoked_at')).to be_present
   end
 
   it 'creates and revokes person access grants for managed members' do
@@ -114,6 +162,60 @@ RSpec.describe 'API v1 household administration' do
 
     expect(response).to have_http_status(:no_content)
     expect(PersonAccessGrant.find(grant_id)).to be_revoked_at
+  end
+
+  it 'returns validation errors for invalid person access grants and lists revoked timestamps' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    post api_v1_household_admin_person_access_grants_path(household_id),
+         params: { person_access_grant: { access_level: 'manage' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    member_account = Account.create!(email: 'api.revoked.grant@example.test', status: :verified)
+    membership = Household.find(household_id).household_memberships.create!(account: member_account, role: :member)
+    grant = PersonAccessGrant.create!(
+      household_id: household_id,
+      household_membership: membership,
+      person: people(:john),
+      access_level: 'manage',
+      relationship_type: 'carer',
+      granted_by_membership: api_session.household_membership,
+      expires_at: 1.week.from_now,
+      revoked_at: Time.current
+    )
+
+    get api_v1_household_admin_person_access_grants_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    payload = response.parsed_body.fetch('data').find { |item| item.fetch('id') == grant.id }
+    expect(payload.fetch('expires_at')).to be_present
+    expect(payload.fetch('revoked_at')).to be_present
+  end
+
+  it 'returns validation errors for invalid household settings and membership updates' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    patch api_v1_household_admin_settings_path(household_id),
+          params: { household: { name: '' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    membership = Household.find(household_id)
+                          .household_memberships
+                          .where.not(id: api_session.household_membership_id)
+                          .first
+
+    patch api_v1_household_admin_membership_path(household_id, membership.id),
+          params: { household_membership: { role: '' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it 'lists household security audit events for managers only' do

--- a/spec/requests/api/v1/admin_api_spec.rb
+++ b/spec/requests/api/v1/admin_api_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 household administration' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+  let(:api_session) { ApiSession.lookup_by_access_token(login_data.fetch('access_token')) }
+
+  it 'reads household settings and memberships for household managers' do
+    get api_v1_household_admin_settings_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'id')).to eq(household_id)
+
+    get api_v1_household_admin_memberships_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.fetch('data')).not_to be_empty
+  end
+
+  it 'requires fresh privileged proof for admin mutations' do
+    patch api_v1_household_admin_settings_path(household_id),
+          params: { household: { name: 'API Admin Renamed Household' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:forbidden)
+    expect(response.parsed_body.dig('error', 'code')).to eq('fresh_privileged_action_required')
+
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    expect do
+      patch api_v1_household_admin_settings_path(household_id),
+            params: { household: { name: 'API Admin Renamed Household' } },
+            headers: headers,
+            as: :json
+    end.to change(SecurityAuditEvent, :count).by(1)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'name')).to eq('API Admin Renamed Household')
+    audit_event = SecurityAuditEvent.order(:created_at).last
+    expect(audit_event.metadata).not_to include('body', 'token', 'bundle')
+  end
+
+  it 'issues and revokes app tokens without storing the raw token in audit metadata' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    expect do
+      post api_v1_household_admin_app_tokens_path(household_id),
+           params: { api_app_token: { name: 'CLI app token' } },
+           headers: headers,
+           as: :json
+    end.to change(ApiAppToken, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    raw_token = response.parsed_body.dig('data', 'token')
+    app_token_id = response.parsed_body.dig('data', 'id')
+    expect(raw_token).to start_with(ApiAppToken::TOKEN_PREFIX)
+
+    security_metadata = SecurityAuditEvent.order(:created_at).last.metadata
+    expect(security_metadata.to_json).not_to include(raw_token)
+
+    delete api_v1_household_admin_app_token_path(household_id, app_token_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(ApiAppToken.find(app_token_id)).to be_revoked_at
+  end
+
+  it 'creates and revokes invitations without exposing invitation tokens' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+
+    post api_v1_household_admin_invitations_path(household_id),
+         params: { household_invitation: { email: 'api.invited@example.test', membership_role: 'member' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    invitation_id = response.parsed_body.dig('data', 'id')
+    expect(response.parsed_body['data'].to_json).not_to include('token')
+
+    delete api_v1_household_admin_invitation_path(household_id, invitation_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(HouseholdInvitation.find(invitation_id)).to be_revoked
+  end
+
+  it 'creates and revokes person access grants for managed members' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+    member_account = Account.create!(email: 'api.grant.member@example.test', status: :verified)
+    membership = Household.find(household_id).household_memberships.create!(account: member_account, role: :member)
+
+    post api_v1_household_admin_person_access_grants_path(household_id),
+         params: {
+           person_access_grant: {
+             household_membership_id: membership.id,
+             person_id: people(:john).id,
+             access_level: 'manage',
+             relationship_type: 'carer'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    grant_id = response.parsed_body.dig('data', 'id')
+    expect(response.parsed_body.dig('data', 'access_level')).to eq('manage')
+
+    delete api_v1_household_admin_person_access_grant_path(household_id, grant_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(PersonAccessGrant.find(grant_id)).to be_revoked_at
+  end
+
+  it 'lists household security audit events for managers only' do
+    SecurityAuditEvent.create!(
+      household_id: household_id,
+      actor_account: user.person.account,
+      actor_membership: api_session.household_membership,
+      event_type: 'api/admin/test',
+      metadata: { target_type: 'Household', outcome: 'success' },
+      request_id: 'audit-list-test'
+    )
+
+    get api_v1_household_admin_audit_logs_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.fetch('data').pluck('event_type')).to include('api/admin/test')
+  end
+
+  it 'rejects household administration for non-manager members' do
+    member_user = users(:jane)
+    member_login = api_login(member_user, household_id: household_id)
+
+    get api_v1_household_admin_settings_path(household_id),
+        headers: api_auth_headers(member_login.fetch('access_token')),
+        as: :json
+
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
     end
 
+    it 'rejects an unknown email address without revealing account existence' do
+      post api_v1_auth_login_path,
+           params: {
+             email: 'missing-api-user@example.test',
+             password: 'password'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
+    end
+
     it 'clears accumulated API password failures after successful password login' do
       create_api_household_for(user)
 
@@ -168,6 +180,41 @@ RSpec.describe 'API v1 auth sessions' do
 
       expect(response).to have_http_status(:created)
       expect(AccountLoginFailure.find_by(account_id: account.id)).to be_nil
+    end
+
+    it 'rejects a requested household that is not active for the account' do
+      create_api_household_for(user)
+
+      post api_v1_auth_login_path,
+           params: {
+             email: user.email_address,
+             password: 'password',
+             household_id: Household.maximum(:id).to_i + 10_000
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
+    end
+
+    it 'rejects login without an explicit household when the account has multiple active memberships' do
+      create_api_household_for(user)
+      second_household = create(:household)
+      second_household.household_memberships.create!(
+        account: account,
+        role: :member,
+        status: :active
+      )
+
+      post api_v1_auth_login_path,
+           params: {
+             email: user.email_address,
+             password: 'password'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_credentials')
     end
 
     it 'rejects a locked account without creating an API session' do
@@ -267,6 +314,84 @@ RSpec.describe 'API v1 auth sessions' do
       expect(ApiSession.order(:id).last.device_name).to eq('RSpec Mobile')
     end
 
+    it 'binds OIDC exchange to a requested household membership' do
+      household = account.household_memberships.active.first.household
+
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'household-nonce'),
+             nonce: 'household-nonce',
+             code_verifier: 'pkce-verifier',
+             household_id: household.id
+           },
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body.dig('data', 'household', 'id')).to eq(household.id)
+    end
+
+    it 'records OIDC MFA proof when the identity token includes an MFA authentication method' do
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'mfa-nonce', amr: %w[pwd otp]),
+             nonce: 'mfa-nonce',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(ApiSession.order(:id).last).to be_oidc_mfa_verified
+    end
+
+    it 'rejects OIDC exchange when required token inputs are missing' do
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'missing-verifier'),
+             nonce: 'missing-verifier'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             nonce: 'missing-token',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'rejects OIDC exchange with a blank subject' do
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: '', nonce: 'blank-subject'),
+             nonce: 'blank-subject',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'rejects linked OIDC accounts that have no active person user' do
+      household = create(:household)
+      linked_account = Account.create!(email: 'oidc-no-person@example.test', status: :verified)
+      AccountIdentity.create!(account: linked_account, provider: 'oidc', uid: 'no-person-sub')
+      household.household_memberships.create!(account: linked_account, role: :member, status: :active)
+
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'no-person-sub', nonce: 'no-person-nonce'),
+             nonce: 'no-person-nonce',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it 'rejects invalid issuer, audience, expiry, nonce, replay, locked account, and revoked membership cases' do
       invalid_cases = [
         [oidc_token(sub: 'jane-oidc-sub', issuer: 'https://evil.example.test', nonce: 'bad-issuer'), 'bad-issuer'],
@@ -356,6 +481,35 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response).to have_http_status(:unauthorized)
       expect(api_session.reload.revoked_at).to be_nil
     end
+
+    it 'rejects auth management for a bearer token after the account is locked' do
+      login_data = api_login(user)
+      headers = api_auth_headers(login_data.fetch('access_token'))
+      api_session = ApiSession.lookup_by_access_token(login_data.fetch('access_token'))
+      last_used_at = api_session.last_used_at
+      lock_account!(account)
+
+      get api_v1_auth_sessions_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(api_session.reload.last_used_at).to eq(last_used_at)
+    end
+
+    it 'rejects auth management for an unknown bearer token' do
+      headers = api_auth_headers('mt_unknown_access_token')
+
+      get api_v1_auth_households_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+
+      get api_v1_auth_sessions_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+
+      delete api_v1_auth_session_path(ApiSession.maximum(:id).to_i + 1), headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   describe 'POST /api/v1/auth/refresh' do
@@ -378,6 +532,15 @@ RSpec.describe 'API v1 auth sessions' do
 
       post api_v1_auth_refresh_path,
            params: { refresh_token: login_data.fetch('refresh_token') },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body.dig('error', 'code')).to eq('invalid_refresh_token')
+    end
+
+    it 'rejects an unknown refresh token' do
+      post api_v1_auth_refresh_path,
+           params: { refresh_token: 'mt_unknown_refresh_token' },
            as: :json
 
       expect(response).to have_http_status(:unauthorized)
@@ -453,6 +616,12 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
     end
 
+    it 'treats missing bearer tokens as an idempotent logout' do
+      delete api_v1_auth_logout_path, as: :json
+
+      expect(response).to have_http_status(:no_content)
+    end
+
     it 'records a revoked audit event' do
       login_data = api_login(user)
       headers = api_auth_headers(login_data.fetch('access_token'))
@@ -474,16 +643,17 @@ RSpec.describe 'API v1 auth sessions' do
     )
   end
 
-  def oidc_token(sub:, nonce:, issuer: oidc_issuer, audience: oidc_client_id, exp: 15.minutes.from_now.to_i)
+  def oidc_token(sub:, nonce:, **overrides)
     JWT.encode(
       {
-        iss: issuer,
-        aud: audience,
-        exp: exp,
+        iss: overrides.fetch(:issuer, oidc_issuer),
+        aud: overrides.fetch(:audience, oidc_client_id),
+        exp: overrides.fetch(:exp, 15.minutes.from_now.to_i),
         iat: Time.current.to_i,
         sub: sub,
-        nonce: nonce
-      },
+        nonce: nonce,
+        amr: overrides[:amr]
+      }.compact,
       oidc_client_secret,
       'HS256'
     )

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -336,6 +336,26 @@ RSpec.describe 'API v1 auth sessions' do
       expect(response).to have_http_status(:no_content)
       expect(ApiSession.find(session_id)).to be_revoked_at
     end
+
+    it 'rejects expired access tokens on auth session management endpoints' do
+      login_data = api_login(user)
+      headers = api_auth_headers(login_data.fetch('access_token'))
+      api_session = ApiSession.lookup_by_access_token(login_data.fetch('access_token'))
+      api_session.update!(access_expires_at: 1.minute.ago)
+
+      get api_v1_auth_households_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+
+      get api_v1_auth_sessions_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+
+      delete api_v1_auth_session_path(api_session.id), headers: headers, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(api_session.reload.revoked_at).to be_nil
+    end
   end
 
   describe 'POST /api/v1/auth/refresh' do

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe 'API v1 auth sessions' do
 
   let(:user) { users(:jane) }
   let(:account) { user.person.account }
+  let(:oidc_issuer) { 'https://issuer.example.test' }
+  let(:oidc_client_id) { 'medtracker-mobile-test' }
+  let(:oidc_client_secret) { 'oidc-test-secret' }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('OIDC_ISSUER_URL', nil).and_return(oidc_issuer)
+    allow(ENV).to receive(:fetch).with('OIDC_MOBILE_CLIENT_ID', nil).and_return(oidc_client_id)
+    allow(ENV).to receive(:fetch).with('OIDC_CLIENT_ID', nil).and_return(oidc_client_id)
+    allow(ENV).to receive(:fetch).with('OIDC_CLIENT_SECRET', nil).and_return(oidc_client_secret)
+  end
 
   describe 'POST /api/v1/auth/login' do
     before do
@@ -232,6 +243,101 @@ RSpec.describe 'API v1 auth sessions' do
     end
   end
 
+  describe 'POST /api/v1/auth/oidc_exchange' do
+    before do
+      AccountLockout.where(account_id: account.id).delete_all if defined?(AccountLockout)
+      AccountIdentity.find_or_create_by!(account: account, provider: 'oidc', uid: 'jane-oidc-sub')
+      ensure_api_household_for(user)
+    end
+
+    it 'exchanges a valid OIDC identity token for an API session' do
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'nonce-1'),
+             nonce: 'nonce-1',
+             code_verifier: 'pkce-verifier',
+             device_name: 'RSpec Mobile'
+           },
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body.dig('data', 'access_token')).to be_present
+      expect(response.parsed_body.dig('data', 'refresh_token')).to be_present
+      expect(response.parsed_body.dig('data', 'me', 'email_address')).to eq(user.email_address)
+      expect(ApiSession.order(:id).last.device_name).to eq('RSpec Mobile')
+    end
+
+    it 'rejects invalid issuer, audience, expiry, nonce, replay, locked account, and revoked membership cases' do
+      invalid_cases = [
+        [oidc_token(sub: 'jane-oidc-sub', issuer: 'https://evil.example.test', nonce: 'bad-issuer'), 'bad-issuer'],
+        [oidc_token(sub: 'jane-oidc-sub', audience: 'wrong-client', nonce: 'bad-audience'), 'bad-audience'],
+        [oidc_token(sub: 'jane-oidc-sub', exp: 1.minute.ago.to_i, nonce: 'expired'), 'expired'],
+        [oidc_token(sub: 'jane-oidc-sub', nonce: 'expected-nonce'), 'different-nonce']
+      ]
+
+      invalid_cases.each do |token, nonce|
+        post api_v1_auth_oidc_exchange_path,
+             params: { id_token: token, nonce: nonce, code_verifier: 'pkce-verifier' },
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body.dig('error', 'code')).to eq('invalid_oidc_exchange')
+      end
+
+      replay_token = oidc_token(sub: 'jane-oidc-sub', nonce: 'replay-nonce')
+      post api_v1_auth_oidc_exchange_path,
+           params: { id_token: replay_token, nonce: 'replay-nonce', code_verifier: 'pkce-verifier' },
+           as: :json
+      post api_v1_auth_oidc_exchange_path,
+           params: { id_token: replay_token, nonce: 'replay-nonce', code_verifier: 'pkce-verifier' },
+           as: :json
+      expect(response).to have_http_status(:unauthorized)
+
+      lock_account!(account)
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'locked-nonce'),
+             nonce: 'locked-nonce',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+      expect(response).to have_http_status(:unauthorized)
+      AccountLockout.where(account_id: account.id).delete_all
+
+      account.household_memberships.active.first.update!(status: :revoked)
+      post api_v1_auth_oidc_exchange_path,
+           params: {
+             id_token: oidc_token(sub: 'jane-oidc-sub', nonce: 'revoked-nonce'),
+             nonce: 'revoked-nonce',
+             code_verifier: 'pkce-verifier'
+           },
+           as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'API session household selection, listing, and revocation' do
+    it 'lists households, lists sessions, and revokes a selected session' do
+      login_data = api_login(user)
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_auth_households_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.fetch('data').first).to include('id', 'name', 'role')
+
+      get api_v1_auth_sessions_path, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      session_id = response.parsed_body.fetch('data').first.fetch('id')
+
+      delete api_v1_auth_session_path(session_id), headers: headers, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(ApiSession.find(session_id)).to be_revoked_at
+    end
+  end
+
   describe 'POST /api/v1/auth/refresh' do
     before do
       clear_2fa_for_account(account)
@@ -345,6 +451,21 @@ RSpec.describe 'API v1 auth sessions' do
       account_id: account.id,
       key: SecureRandom.hex(16),
       deadline: 30.minutes.from_now
+    )
+  end
+
+  def oidc_token(sub:, nonce:, issuer: oidc_issuer, audience: oidc_client_id, exp: 15.minutes.from_now.to_i)
+    JWT.encode(
+      {
+        iss: issuer,
+        aud: audience,
+        exp: exp,
+        iat: Time.current.to_i,
+        sub: sub,
+        nonce: nonce
+      },
+      oidc_client_secret,
+      'HS256'
     )
   end
 end

--- a/spec/requests/api/v1/capabilities_spec.rb
+++ b/spec/requests/api/v1/capabilities_spec.rb
@@ -17,8 +17,29 @@ RSpec.describe 'API v1 capabilities' do
     )
     expect(data.dig('authentication', 'methods')).to include('bearer_session', 'api_app_token')
     expect(data.dig('authentication', 'hosted_mobile')).to eq('oidc_authorization_code_pkce')
+    expect(data.dig('authentication', 'oidc_exchange')).to include(
+      'supported' => true,
+      'pkce_required' => true,
+      'session_listing' => true,
+      'session_revocation' => true
+    )
+    expect(data).to include('administration' => include('household' => true, 'fresh_mfa_required' => true))
     expect(data.dig('sync', 'portable_ids')).to be(true)
     expect(data.dig('sync', 'numeric_ids')).to eq('backward_compatible')
+    expect(data.dig('sync', 'idempotency_keys')).to be(true)
+    expect(data.dig('sync', 'etag_conflicts')).to be(true)
+    expect(data.dig('sync', 'change_feed')).to be(true)
+    expect(data.dig('sync', 'batch_mutations')).to be(true)
+    expect(data.dig('sync', 'tombstones')).to be(true)
+    expect(data['portable_formats']).to include('medtracker.portable.v2')
+    expect(data).to include(
+      'backups' => include('unencrypted_zip' => true, 'health_data_json' => true),
+      'fhir' => include(
+        'version' => 'R4',
+        'resources' => include('Patient', 'Medication', 'MedicationRequest', 'MedicationStatement',
+                               'MedicationAdministration')
+      )
+    )
     expect(data.dig('client_tools', 'cli')).to include('supported' => false, 'status' => 'deferred')
     expect(data.dig('client_tools', 'mcp_server')).to include(
       'supported' => true,

--- a/spec/requests/api/v1/data_exports_spec.rb
+++ b/spec/requests/api/v1/data_exports_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 data exports' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'returns health-data JSON exports through the shared export service' do
+    get api_v1_household_data_export_path(household_id, 'health_data_json'), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'format')).to eq('medtracker.health_data.v1')
+    expect(response.parsed_body.dig('data', 'records')).to include('people', 'medications')
+  end
+
+  it 'returns unencrypted backup ZIP payloads without token/session records' do
+    get api_v1_household_data_export_path(household_id, 'backup_zip'), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    data = response.parsed_body.fetch('data')
+    expect(data.fetch('content_type')).to eq('application/zip')
+    expect(data.fetch('filename')).to end_with('.zip')
+    expect(Base64.strict_decode64(data.fetch('base64')).byteslice(0, 2)).to eq('PK')
+  end
+
+  it 'requires a passphrase for encrypted migration bundles' do
+    get api_v1_household_data_export_path(household_id, 'encrypted_migration_bundle'), headers: headers, as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    get api_v1_household_data_export_path(household_id, 'encrypted_migration_bundle'),
+        headers: headers.merge('X-MedTracker-Portable-Passphrase' => 'correct horse battery staple'),
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'format')).to eq('medtracker.portable.encrypted.v1')
+  end
+end

--- a/spec/requests/api/v1/domain_parity_spec.rb
+++ b/spec/requests/api/v1/domain_parity_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe 'API v1 domain parity' do
     post api_v1_household_push_subscription_path(household_id),
          params: {
            push_subscription: {
-             endpoint: 'https://push.example.test/api-subscription',
+             endpoint: 'https://fcm.googleapis.com/fcm/send/api-subscription',
              keys: { p256dh: 'p256dh', auth: 'auth' }
            }
          },
@@ -320,17 +320,17 @@ RSpec.describe 'API v1 domain parity' do
 
     expect(response).to have_http_status(:created)
     expect(
-      user.person.account.push_subscriptions.find_by(endpoint: 'https://push.example.test/api-subscription')
+      user.person.account.push_subscriptions.find_by(endpoint: 'https://fcm.googleapis.com/fcm/send/api-subscription')
     ).to be_present
 
     delete api_v1_household_push_subscription_path(household_id),
-           params: { endpoint: 'https://push.example.test/api-subscription' },
+           params: { endpoint: 'https://fcm.googleapis.com/fcm/send/api-subscription' },
            headers: headers,
            as: :json
 
     expect(response).to have_http_status(:no_content)
     expect(
-      user.person.account.push_subscriptions.find_by(endpoint: 'https://push.example.test/api-subscription')
+      user.person.account.push_subscriptions.find_by(endpoint: 'https://fcm.googleapis.com/fcm/send/api-subscription')
     ).to be_nil
   end
 

--- a/spec/requests/api/v1/domain_parity_spec.rb
+++ b/spec/requests/api/v1/domain_parity_spec.rb
@@ -52,6 +52,42 @@ RSpec.describe 'API v1 domain parity' do
     expect(dosage_option.reload.medication).to eq(medications(:paracetamol))
   end
 
+  it 'rejects stale dosage option updates' do
+    dosage_option = dosages(:paracetamol_adult)
+
+    patch api_v1_household_dosage_option_path(household_id, dosage_option.portable_id),
+          params: { dosage_option: { amount: 375 } },
+          headers: headers.merge('If-Match' => '"stale-etag"'),
+          as: :json
+
+    expect(response).to have_http_status(:conflict)
+  end
+
+  it 'returns validation errors for invalid dosage option creates and updates' do
+    medication = medications(:paracetamol)
+
+    post api_v1_household_dosage_options_path(household_id),
+         params: {
+           dosage_option: {
+             medication_id: medication.portable_id,
+             amount: nil,
+             unit: nil,
+             frequency: nil
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    patch api_v1_household_dosage_option_path(household_id, dosages(:paracetamol_adult).portable_id),
+          params: { dosage_option: { amount: nil } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
   it 'creates health events with portable person and medication ids' do
     person = people(:john)
     medication = medications(:paracetamol)
@@ -74,6 +110,86 @@ RSpec.describe 'API v1 domain parity' do
     expect(response).to have_http_status(:created)
     expect(response.parsed_body.dig('data', 'person_portable_id')).to eq(person.portable_id)
     expect(response.parsed_body.dig('data', 'medication_portable_ids')).to contain_exactly(medication.portable_id)
+  end
+
+  it 'updates health events without requiring medication ids' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold symptoms',
+      started_on: '2026-02-25'
+    )
+
+    patch api_v1_household_health_event_path(household_id, event.portable_id),
+          params: { health_event: { title: 'Improving cold symptoms', started_on: '2026-02-25' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'title')).to eq('Improving cold symptoms')
+  end
+
+  it 'rejects stale health event updates' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold symptoms',
+      started_on: '2026-02-25'
+    )
+
+    patch api_v1_household_health_event_path(household_id, event.portable_id),
+          params: { health_event: { title: 'Stale cold symptoms', started_on: '2026-02-25' } },
+          headers: headers.merge('If-Match' => '"stale-etag"'),
+          as: :json
+
+    expect(response).to have_http_status(:conflict)
+  end
+
+  it 'returns validation errors for invalid health event creates and updates' do
+    post api_v1_household_health_events_path(household_id),
+         params: {
+           health_event: {
+             person_id: people(:john).portable_id,
+             event_kind: 'illness',
+             title: '',
+             started_on: ''
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    post api_v1_household_health_events_path(household_id),
+         params: {
+           health_event: {
+             person_id: people(:john).portable_id,
+             event_kind: 'illness',
+             title: 'Cold symptoms',
+             started_on: '2026-02-25'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    event_portable_id = response.parsed_body.dig('data', 'portable_id')
+
+    patch api_v1_household_health_event_path(household_id, event_portable_id),
+          params: {
+            health_event: {
+              event_kind: 'illness',
+              title: 'Cold symptoms',
+              started_on: '2026-02-25',
+              ended_on: '2026-02-24'
+            }
+          },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it 'records medication takes using portable schedule ids' do
@@ -149,6 +265,35 @@ RSpec.describe 'API v1 domain parity' do
     expect(response.parsed_body.dig('data', 'current_supply')).to eq('42.0')
   end
 
+  it 'returns validation errors for invalid inventory adjustments' do
+    medication = medications(:paracetamol)
+
+    patch adjust_inventory_api_v1_household_medication_path(household_id, medication.portable_id),
+          params: { adjustment: { new_quantity: -1, reason: 'Invalid cycle count' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'message')).to eq('Quantity cannot be negative')
+  end
+
+  it 'authenticates API app tokens for household-scoped reads' do
+    api_session = ApiSession.lookup_by_access_token(login_data.fetch('access_token'))
+    app_token, raw_token = ApiAppToken.issue_for(
+      account: user.person.account,
+      household_membership: api_session.household_membership,
+      name: 'Read test token'
+    )
+
+    get api_v1_household_medications_path(household_id),
+        headers: api_auth_headers(raw_token),
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.fetch('data')).not_to be_empty
+    expect(app_token.reload.last_used_at).to be_present
+  end
+
   it 'registers device tokens and push subscriptions through the API household scope' do
     post api_v1_household_native_device_tokens_path(household_id),
          params: { native_device_token: { device_token: 'api-device-token', platform: 'ios' } },
@@ -157,6 +302,11 @@ RSpec.describe 'API v1 domain parity' do
 
     expect(response).to have_http_status(:created)
     expect(user.person.account.native_device_tokens.find_by(device_token: 'api-device-token')).to be_present
+
+    delete api_v1_household_native_device_token_path(household_id, 'api-device-token'), headers: headers, as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(user.person.account.native_device_tokens.find_by(device_token: 'api-device-token')).to be_nil
 
     post api_v1_household_push_subscription_path(household_id),
          params: {
@@ -172,6 +322,54 @@ RSpec.describe 'API v1 domain parity' do
     expect(
       user.person.account.push_subscriptions.find_by(endpoint: 'https://push.example.test/api-subscription')
     ).to be_present
+
+    delete api_v1_household_push_subscription_path(household_id),
+           params: { endpoint: 'https://push.example.test/api-subscription' },
+           headers: headers,
+           as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(
+      user.person.account.push_subscriptions.find_by(endpoint: 'https://push.example.test/api-subscription')
+    ).to be_nil
+  end
+
+  it 'handles invalid and idempotent native device token requests' do
+    post api_v1_household_native_device_tokens_path(household_id),
+         params: { native_device_token: { device_token: '', platform: '' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    delete api_v1_household_native_device_token_path(household_id, 'missing-device-token'),
+           headers: headers,
+           as: :json
+
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it 'handles invalid, idempotent, and failed push subscription requests' do
+    post api_v1_household_push_subscription_path(household_id),
+         params: { push_subscription: { endpoint: '', keys: { p256dh: '', auth: '' } } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    delete api_v1_household_push_subscription_path(household_id),
+           params: { endpoint: 'https://push.example.test/missing' },
+           headers: headers,
+           as: :json
+
+    expect(response).to have_http_status(:no_content)
+
+    allow(PushNotificationService).to receive(:send_to_account).and_raise(StandardError)
+
+    post test_api_v1_household_push_subscription_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:service_unavailable)
+    expect(response.parsed_body.dig('error', 'code')).to eq('push_test_failed')
   end
 
   it 'uses household-scoped medication lookup from the API' do
@@ -216,6 +414,33 @@ RSpec.describe 'API v1 domain parity' do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'medication', 'description')).to eq('Paracetamol pain and fever relief')
+  end
+
+  it 'returns not found for AI medication suggestions when the feature is disabled' do
+    post api_v1_household_ai_medication_suggestions_path(household_id),
+         params: { medication: { name: 'Calpol Six Plus' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'requests AI medication suggestions with empty identity when medication params are absent' do
+    suggestion = AiMedication::Suggestion.new(
+      medication: { description: 'Fallback medication suggestion' },
+      doses: [],
+      sources: []
+    )
+    service = instance_double(AiMedication::SuggestionService, call: suggestion)
+
+    Household.find(household_id).update!(subscription_plan: 'family_plus')
+    allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
+    allow(AiMedication::SuggestionService).to receive(:new).and_return(service)
+
+    post api_v1_household_ai_medication_suggestions_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(service).to have_received(:call).with(medication_identity: {}, user: user)
   end
 
   it 'rejects cross-household portable ids as not found' do

--- a/spec/requests/api/v1/domain_parity_spec.rb
+++ b/spec/requests/api/v1/domain_parity_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe 'API v1 domain parity' do
     expect(response.parsed_body.dig('data', 'amount')).to eq('250.0')
   end
 
+  it 'updates dosage options without requiring clients to resend the medication id' do
+    dosage_option = dosages(:paracetamol_adult)
+
+    patch api_v1_household_dosage_option_path(household_id, dosage_option.portable_id),
+          params: { dosage_option: { amount: 375, frequency: 'Every 8 hours' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'amount')).to eq('375.0')
+    expect(response.parsed_body.dig('data', 'frequency')).to eq('Every 8 hours')
+    expect(dosage_option.reload.medication).to eq(medications(:paracetamol))
+  end
+
   it 'creates health events with portable person and medication ids' do
     person = people(:john)
     medication = medications(:paracetamol)

--- a/spec/requests/api/v1/domain_parity_spec.rb
+++ b/spec/requests/api/v1/domain_parity_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 domain parity' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'creates and reads dosage options using portable medication ids' do
+    medication = medications(:paracetamol)
+
+    post api_v1_household_dosage_options_path(household_id),
+         params: {
+           dosage_option: {
+             medication_id: medication.portable_id,
+             amount: 250,
+             unit: 'mg',
+             frequency: 'Twice daily',
+             default_max_daily_doses: 2,
+             default_min_hours_between_doses: 8,
+             default_dose_cycle: 'daily'
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    portable_id = response.parsed_body.dig('data', 'portable_id')
+    expect(response.parsed_body.dig('data', 'medication_portable_id')).to eq(medication.portable_id)
+
+    get api_v1_household_dosage_option_path(household_id, portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'amount')).to eq('250.0')
+  end
+
+  it 'creates health events with portable person and medication ids' do
+    person = people(:john)
+    medication = medications(:paracetamol)
+
+    post api_v1_household_health_events_path(household_id),
+         params: {
+           health_event: {
+             person_id: person.portable_id,
+             event_kind: 'illness',
+             severity: 'mild',
+             title: 'Cold symptoms',
+             notes: 'Managed at home',
+             started_on: '2026-02-25',
+             medication_ids: [medication.portable_id]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body.dig('data', 'person_portable_id')).to eq(person.portable_id)
+    expect(response.parsed_body.dig('data', 'medication_portable_ids')).to contain_exactly(medication.portable_id)
+  end
+
+  it 'records medication takes using portable schedule ids' do
+    schedule = schedules(:john_paracetamol)
+
+    expect do
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: SecureRandom.uuid,
+               source_type: 'schedule',
+               source_id: schedule.portable_id,
+               taken_at: '2026-02-25T08:30:00Z'
+             }
+           },
+           headers: headers,
+           as: :json
+    end.to change(MedicationTake, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body.dig('data', 'schedule_portable_id')).to eq(schedule.portable_id)
+  end
+
+  it 'pauses and resumes schedules by portable id' do
+    schedule = schedules(:john_paracetamol)
+
+    patch pause_api_v1_household_schedule_path(household_id, schedule.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'paused')).to be(true)
+
+    patch resume_api_v1_household_schedule_path(household_id, schedule.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'paused')).to be(false)
+  end
+
+  it 'pauses, resumes, and reorders person medications by portable id' do
+    first = create(:person_medication, :as_needed,
+                   person: people(:john), medication: medications(:ibuprofen), position: 1)
+    second = create(:person_medication, :as_needed,
+                    person: people(:john), medication: medications(:paracetamol), position: 2)
+
+    patch pause_api_v1_household_person_medication_path(household_id, second.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'paused')).to be(true)
+
+    patch resume_api_v1_household_person_medication_path(household_id, second.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'paused')).to be(false)
+
+    patch reorder_api_v1_household_person_medication_path(household_id, second.portable_id),
+          params: { direction: 'up' },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(first.reload.position).to eq(2)
+    expect(second.reload.position).to eq(1)
+  end
+
+  it 'adjusts medication inventory by portable id' do
+    medication = medications(:paracetamol)
+
+    patch adjust_inventory_api_v1_household_medication_path(household_id, medication.portable_id),
+          params: { adjustment: { new_quantity: 42, reason: 'Cycle count' } },
+          headers: headers,
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'current_supply')).to eq('42.0')
+  end
+
+  it 'registers device tokens and push subscriptions through the API household scope' do
+    post api_v1_household_native_device_tokens_path(household_id),
+         params: { native_device_token: { device_token: 'api-device-token', platform: 'ios' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(user.person.account.native_device_tokens.find_by(device_token: 'api-device-token')).to be_present
+
+    post api_v1_household_push_subscription_path(household_id),
+         params: {
+           push_subscription: {
+             endpoint: 'https://push.example.test/api-subscription',
+             keys: { p256dh: 'p256dh', auth: 'auth' }
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(
+      user.person.account.push_subscriptions.find_by(endpoint: 'https://push.example.test/api-subscription')
+    ).to be_present
+  end
+
+  it 'uses household-scoped medication lookup from the API' do
+    responder = instance_double(
+      MedicationFinderSearchResponder,
+      call: MedicationFinderSearchResponder::Result.new(
+        body: { results: [{ name: 'Calpol Six Plus' }], permissions: { can_create: true, can_update: false } },
+        status: :ok
+      )
+    )
+
+    allow(MedicationFinderSearchResponder).to receive(:new)
+      .with(hash_including(medication_scope: kind_of(ActiveRecord::Relation)))
+      .and_return(responder)
+
+    get api_v1_household_medication_lookup_path(household_id),
+        params: { q: 'calpol' },
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('results', 0, 'name')).to eq('Calpol Six Plus')
+    expect(MedicationFinderSearchResponder).to have_received(:new)
+  end
+
+  it 'returns AI medication suggestions through the API when the feature is enabled' do
+    suggestion = AiMedication::Suggestion.new(
+      medication: { description: 'Paracetamol pain and fever relief' },
+      doses: [],
+      sources: []
+    )
+    service = instance_double(AiMedication::SuggestionService, call: suggestion)
+
+    Household.find(household_id).update!(subscription_plan: 'family_plus')
+    allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
+    allow(AiMedication::SuggestionService).to receive(:new).and_return(service)
+
+    post api_v1_household_ai_medication_suggestions_path(household_id),
+         params: { medication: { name: 'Calpol Six Plus' } },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'medication', 'description')).to eq('Paracetamol pain and fever relief')
+  end
+
+  it 'rejects cross-household portable ids as not found' do
+    other_household = Household.create!(name: 'API Domain Other Household', slug: 'api-domain-other-household')
+    other_medication = create(:medication, household: other_household)
+    other_dosage = create(:dosage, medication: other_medication, household: other_household)
+
+    get api_v1_household_dosage_option_path(household_id, other_dosage.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/api/v1/medication_takes_spec.rb
+++ b/spec/requests/api/v1/medication_takes_spec.rb
@@ -51,4 +51,152 @@ RSpec.describe 'API v1 medication takes' do
       expect(response.parsed_body.dig('error', 'code')).to eq('unprocessable_content')
     end
   end
+
+  describe 'POST /api/v1/households/:household_id/medication_takes' do
+    it 'records takes from person medication sources' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      person_medication = person_medications(:jane_vitamin_d)
+
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: SecureRandom.uuid,
+               source_type: 'person_medication',
+               source_id: person_medication.portable_id,
+               taken_at: Time.current.iso8601
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body.dig('data', 'person_medication_portable_id')).to eq(person_medication.portable_id)
+    end
+
+    it 'returns not found for unknown source types' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: SecureRandom.uuid,
+               source_type: 'unknown',
+               source_id: schedules(:jane_ibuprofen).portable_id,
+               taken_at: Time.current.iso8601
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns unprocessable content for invalid taken_at values' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: SecureRandom.uuid,
+               source_type: 'schedule',
+               source_id: schedules(:jane_ibuprofen).portable_id,
+               taken_at: 'not-a-time'
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body.dig('error', 'message')).to eq('taken_at is invalid')
+    end
+
+    it 'returns existing takes for repeated client UUIDs' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      existing_take = medication_takes(:jane_morning_ibuprofen)
+      existing_take.update!(client_uuid: SecureRandom.uuid)
+
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: existing_take.client_uuid,
+               source_type: 'schedule',
+               source_id: schedules(:jane_ibuprofen).portable_id,
+               taken_at: Time.current.iso8601
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('data', 'id')).to eq(existing_take.id)
+    end
+
+    it 'records takes without idempotency client UUIDs' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      service = instance_double(TakeMedicationService)
+      take = create(
+        :medication_take,
+        schedule: schedules(:jane_ibuprofen),
+        person_medication: nil,
+        skip_stock_mutation: true
+      )
+      allow(TakeMedicationService).to receive(:new).and_return(service)
+      allow(service).to receive(:call).and_return(TakeMedicationService::Result.new(true, take, nil))
+
+      post api_v1_household_medication_takes_path(household_id),
+           params: {
+             medication_take: {
+               client_uuid: '',
+               source_type: 'schedule',
+               source_id: schedules(:jane_ibuprofen).portable_id,
+               taken_at: Time.current.iso8601
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(service).to have_received(:call).with(hash_including(client_uuid: ''))
+    end
+
+    it 'returns API failure messages from medication take service errors' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      service = instance_double(TakeMedicationService)
+      allow(TakeMedicationService).to receive(:new).and_return(service)
+      expected_messages = {
+        out_of_stock: 'Cannot take medication: out of stock',
+        cooldown: 'Cannot take medication: timing restrictions not met',
+        paused: 'Cannot take medication: paused',
+        selection_required: 'Choose a location to record this dose.',
+        invalid_source: 'Selected location is unavailable for this medication.',
+        invalid_amount: 'Invalid dose configured',
+        unknown_failure: 'Could not record medication take'
+      }
+
+      expected_messages.each do |error, message|
+        allow(service).to receive(:call).and_return(TakeMedicationService::Result.new(false, nil, error))
+
+        post api_v1_household_medication_takes_path(household_id),
+             params: {
+               medication_take: {
+                 client_uuid: SecureRandom.uuid,
+                 source_type: 'schedule',
+                 source_id: schedules(:jane_ibuprofen).portable_id,
+                 taken_at: Time.current.iso8601
+               }
+             },
+             headers: api_auth_headers(login_data.fetch('access_token')),
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body.dig('error', 'message')).to eq(message)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/person_medications_spec.rb
+++ b/spec/requests/api/v1/person_medications_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'API v1 person medications' do
-  fixtures :accounts, :people, :users, :households, :person_medications, :medications, :carer_relationships
+  fixtures :accounts, :people, :users, :households, :person_medications, :medications, :dosages, :carer_relationships
 
   let(:user) { users(:admin) }
   let(:household_id) { user.person.household.id }
@@ -61,6 +61,30 @@ RSpec.describe 'API v1 person medications' do
       expect(response.parsed_body.dig('data', 'administration_kind')).to eq('as_needed')
     end
 
+    it 'creates person medications from source dosage options' do
+      login_data = api_login(user)
+      person = people(:john)
+      medication = medications(:ibuprofen)
+      dosage_option = dosages(:ibuprofen_light)
+
+      post api_v1_household_person_medications_path(household_id),
+           params: {
+             person_medication: {
+               person_id: person.portable_id,
+               medication_id: medication.portable_id,
+               source_dosage_option_id: dosage_option.portable_id,
+               dose_amount: 200,
+               dose_unit: 'mg',
+               administration_kind: 'as_needed'
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')),
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(PersonMedication.order(:id).last.source_dosage_option_id).to eq(dosage_option.id)
+    end
+
     it 'fails validation when creating duplicate person medication' do
       login_data = api_login(user)
       person = people(:john)
@@ -114,6 +138,18 @@ RSpec.describe 'API v1 person medications' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.dig('data', 'notes')).to eq('Use with food')
+    end
+
+    it 'rejects stale person medication updates' do
+      login_data = api_login(user)
+      person_medication = person_medications(:john_vitamin_d)
+
+      patch api_v1_household_person_medication_path(household_id, person_medication.id),
+            params: { person_medication: { notes: 'Stale update' } },
+            headers: api_auth_headers(login_data.fetch('access_token')).merge('If-Match' => '"stale-etag"'),
+            as: :json
+
+      expect(response).to have_http_status(:conflict)
     end
 
     it 'fails validation when updating with invalid attributes' do

--- a/spec/requests/api/v1/portable_data_spec.rb
+++ b/spec/requests/api/v1/portable_data_spec.rb
@@ -86,6 +86,22 @@ RSpec.describe 'API v1 portable data' do
     expect(response.parsed_body.dig('error', 'message')).to eq('Portable passphrase header is required')
   end
 
+  it 'rejects portable imports without passphrase headers' do
+    post "/api/v1/households/#{household_id}/portable_imports/dry_run",
+         params: { bundle: encrypted_import_payload },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    post "/api/v1/households/#{household_id}/portable_imports",
+         params: { bundle: encrypted_import_payload },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
   it 'returns a portable mobile snapshot with portable relationship fields' do
     request_headers = headers
 

--- a/spec/requests/api/v1/rate_limiting_spec.rb
+++ b/spec/requests/api/v1/rate_limiting_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 rate limiting' do
+  include ActiveSupport::Testing::TimeHelpers
+
+  around do |example|
+    original_cache_store = Rack::Attack.cache.store
+    original_enabled = Rack::Attack.enabled
+
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+
+    example.run
+  ensure
+    Rack::Attack.cache.store = original_cache_store
+    Rack::Attack.enabled = original_enabled
+  end
+
+  before { freeze_time }
+
+  it 'returns JSON retry metadata for throttled API routes' do
+    10.times do
+      post api_v1_auth_oidc_exchange_path,
+           params: { id_token: 'invalid', nonce: 'nonce', code_verifier: 'verifier' },
+           as: :json
+    end
+
+    post api_v1_auth_oidc_exchange_path,
+         params: { id_token: 'invalid', nonce: 'nonce', code_verifier: 'verifier' },
+         as: :json
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.media_type).to eq('application/json')
+    expect(response.parsed_body.dig('error', 'code')).to eq('rate_limited')
+    expect(response.headers['Retry-After'].to_i).to be > 0
+    expect(response.headers['ratelimit-limit']).to eq('10')
+    expect(response.headers['ratelimit-remaining']).to eq('0')
+  end
+end

--- a/spec/requests/api/v1/schedules_spec.rb
+++ b/spec/requests/api/v1/schedules_spec.rb
@@ -75,6 +75,33 @@ RSpec.describe 'API v1 schedules' do
       expect(response.parsed_body.dig('data', 'dose_amount')).to eq('500.0')
     end
 
+    it 'creates schedules from source dosage options' do
+      person = people(:john)
+      medication = medications(:paracetamol)
+      dosage_option = dosages(:paracetamol_light)
+
+      post api_v1_household_schedules_path(household_id),
+           params: {
+             schedule: {
+               person_id: person.portable_id,
+               medication_id: medication.portable_id,
+               source_dosage_option_id: dosage_option.portable_id,
+               dose_amount: 500,
+               dose_unit: 'mg',
+               frequency: 'Daily',
+               start_date: '2026-02-25',
+               end_date: '2026-12-31',
+               max_daily_doses: 1,
+               dose_cycle: 'daily'
+             }
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(Schedule.order(:id).last.source_dosage_option_id).to eq(dosage_option.id)
+    end
+
     it 'returns validation errors for invalid payload' do
       person = people(:john)
       medication = medications(:paracetamol)
@@ -110,6 +137,15 @@ RSpec.describe 'API v1 schedules' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.dig('data', 'frequency')).to eq('Every 8 hours')
+    end
+
+    it 'rejects stale schedule updates' do
+      patch api_v1_household_schedule_path(household_id, schedules(:john_paracetamol).id),
+            params: { schedule: { frequency: 'Every 12 hours' } },
+            headers: headers.merge('If-Match' => '"stale-etag"'),
+            as: :json
+
+      expect(response).to have_http_status(:conflict)
     end
 
     it 'returns validation errors when updating a schedule with invalid attributes' do

--- a/spec/requests/api/v1/sync_safety_spec.rb
+++ b/spec/requests/api/v1/sync_safety_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 sync safety primitives' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'replays matching idempotent mutation responses without storing request bodies' do
+    idempotency_headers = headers.merge('Idempotency-Key' => SecureRandom.uuid)
+    payload = {
+      medication: {
+        name: 'API Idempotent Saline',
+        location_id: locations(:home).id,
+        dose_amount: 5,
+        dose_unit: 'ml',
+        current_supply: 100,
+        reorder_threshold: 10
+      }
+    }
+
+    expect do
+      post api_v1_household_medications_path(household_id), params: payload, headers: idempotency_headers, as: :json
+    end.to change(Medication, :count).by(1)
+
+    first_body = response.parsed_body
+    stored_key = ApiIdempotencyKey.find_by!(key: idempotency_headers.fetch('Idempotency-Key'))
+    expect(stored_key.request_digest).to be_present
+    expect(stored_key).not_to respond_to(:request_body)
+
+    expect do
+      post api_v1_household_medications_path(household_id), params: payload, headers: idempotency_headers, as: :json
+    end.not_to change(Medication, :count)
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body).to eq(first_body)
+    expect(response.headers['Idempotency-Replayed']).to eq('true')
+  end
+
+  it 'rejects reused idempotency keys with a different payload' do
+    idempotency_headers = headers.merge('Idempotency-Key' => SecureRandom.uuid)
+    payload = {
+      medication: {
+        name: 'API Idempotent Original',
+        location_id: locations(:home).id,
+        dose_amount: 5,
+        dose_unit: 'ml'
+      }
+    }
+
+    post api_v1_household_medications_path(household_id), params: payload, headers: idempotency_headers, as: :json
+
+    post api_v1_household_medications_path(household_id),
+         params: payload.deep_merge(medication: { name: 'API Idempotent Changed' }),
+         headers: idempotency_headers,
+         as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(response.parsed_body.dig('error', 'code')).to eq('idempotency_key_reused')
+  end
+
+  it 'finds resources by portable id without leaking cross-household records' do
+    medication = medications(:paracetamol)
+    other_household = Household.create!(name: 'Other Portable Household', slug: 'other-portable-household')
+    other_location = create(:location, household: other_household, name: 'Other Portable Location')
+    other_medication = create(:medication, household: other_household, location: other_location, name: 'Other Portable')
+
+    get api_v1_household_medication_path(household_id, medication.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'id')).to eq(medication.id)
+
+    get api_v1_household_medication_path(household_id, other_medication.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'uses etags and if-match to reject stale writes' do
+    medication = medications(:paracetamol)
+
+    get api_v1_household_medication_path(household_id, medication.id), headers: headers, as: :json
+
+    expect(response.headers['ETag']).to be_present
+    current_etag = response.headers.fetch('ETag')
+
+    patch api_v1_household_medication_path(household_id, medication.id),
+          params: { medication: { current_supply: 42 } },
+          headers: headers.merge('If-Match' => '"stale-etag"'),
+          as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(response.parsed_body.dig('error', 'code')).to eq('conflict')
+
+    patch api_v1_household_medication_path(household_id, medication.id),
+          params: { medication: { current_supply: 42 } },
+          headers: headers.merge('If-Match' => current_etag),
+          as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'current_supply')).to eq('42.0')
+  end
+
+  it 'records redacted API change metadata for successful writes' do
+    medication = medications(:paracetamol)
+
+    expect do
+      patch api_v1_household_medication_path(household_id, medication.id),
+            params: { medication: { name: 'Sensitive API Medicine', current_supply: 88 } },
+            headers: headers,
+            as: :json
+    end.to change(ApiChangeEvent, :count).by(1)
+
+    event = ApiChangeEvent.order(:created_at).last
+    expect(event).to have_attributes(
+      household_id: household_id,
+      record_type: 'Medication',
+      record_id: medication.id,
+      action: 'update'
+    )
+    expect(event.metadata.to_json).not_to include('Sensitive API Medicine')
+  end
+end

--- a/spec/requests/api/v1/sync_safety_spec.rb
+++ b/spec/requests/api/v1/sync_safety_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe 'API v1 sync safety primitives' do
     expect(response).to have_http_status(:not_found)
   end
 
+  it 'finds resources by future UUID version portable ids' do
+    portable_id = '01890f13-7d4a-7cc5-98f3-90d8d3934b8e'
+    medication = create(:medication, household: Household.find(household_id), portable_id: portable_id)
+
+    get api_v1_household_medication_path(household_id, medication.portable_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'portable_id')).to eq(portable_id)
+  end
+
   it 'uses etags and if-match to reject stale writes' do
     medication = medications(:paracetamol)
 

--- a/spec/requests/api/v1/sync_spec.rb
+++ b/spec/requests/api/v1/sync_spec.rb
@@ -111,4 +111,85 @@ RSpec.describe 'API v1 sync' do
     expect(response).to have_http_status(:created)
     expect(HealthEvent.exists?(event.id)).to be(false)
   end
+
+  it 'updates health events in batch mutations' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold',
+      started_on: '2026-02-25'
+    )
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'health_event',
+                 id: event.portable_id,
+                 attributes: { title: 'Recovered cold', severity: 'mild', ended_on: '2026-02-26' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(event.reload).to have_attributes(title: 'Recovered cold', severity: 'mild', ended_on: Date.new(2026, 2, 26))
+  end
+
+  it 'rejects unsupported batch actions before writing records' do
+    medication = medications(:paracetamol)
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'replace',
+                 resource_type: 'medication',
+                 id: medication.portable_id,
+                 attributes: { name: 'Unsupported Replace' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(medication.reload.name).not_to eq('Unsupported Replace')
+  end
+
+  it 'rolls back batch updates with invalid attributes' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Cold',
+      started_on: '2026-02-25'
+    )
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'health_event',
+                 id: event.portable_id,
+                 attributes: { title: '', ended_on: '2026-02-24' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(event.reload.title).to eq('Cold')
+  end
 end

--- a/spec/requests/api/v1/sync_spec.rb
+++ b/spec/requests/api/v1/sync_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v1 sync' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  let(:user) { users(:admin) }
+  let(:login_data) { api_login(user) }
+  let(:household_id) { login_data.dig('household', 'id') }
+  let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
+
+  it 'returns a portable v2 snapshot without sensitive platform records' do
+    get api_v1_household_sync_snapshot_path(household_id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    data = response.parsed_body.fetch('data')
+    expect(data.fetch('format')).to eq('medtracker.portable.v2')
+    expect(data.fetch('records')).to include('people', 'medications', 'schedules')
+    expect(data.fetch('records')).not_to include('api_sessions', 'api_app_tokens', 'native_device_tokens',
+                                                 'push_subscriptions', 'household_invitations',
+                                                 'security_audit_events')
+    expect(data.fetch('cursor')).to be_present
+  end
+
+  it 'returns cursor changes and tombstones' do
+    cursor = 5.minutes.ago.iso8601
+    medication = medications(:paracetamol)
+    ApiChangeEvent.create!(
+      household_id: household_id,
+      account: user.person.account,
+      household_membership: ApiSession.lookup_by_access_token(login_data.fetch('access_token')).household_membership,
+      record_type: 'Medication',
+      record_id: medication.id,
+      record_portable_id: medication.portable_id,
+      action: 'update',
+      occurred_at: 1.minute.ago,
+      metadata: { record_type: 'Medication' }
+    )
+    ApiTombstone.create!(
+      household_id: household_id,
+      account: user.person.account,
+      household_membership: ApiSession.lookup_by_access_token(login_data.fetch('access_token')).household_membership,
+      record_type: 'HealthEvent',
+      record_portable_id: SecureRandom.uuid,
+      deleted_at: Time.current
+    )
+
+    get api_v1_household_sync_changes_path(household_id),
+        params: { cursor: cursor },
+        headers: headers,
+        as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('data', 'changes').first).to include('record_type' => 'Medication')
+    expect(response.parsed_body.dig('data', 'tombstones').first).to include('record_type' => 'HealthEvent')
+  end
+
+  it 'applies batch mutations transactionally and rolls back invalid operations' do
+    medication = medications(:paracetamol)
+    original_name = medication.name
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'medication',
+                 id: medication.portable_id,
+                 attributes: { name: 'Batch Updated Paracetamol' }
+               },
+               {
+                 action: 'update',
+                 resource_type: 'unsupported_resource',
+                 id: medications(:ibuprofen).portable_id,
+                 attributes: { name: 'Invalid' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(medication.reload.name).to eq(original_name)
+  end
+
+  it 'records tombstones for batch deletes' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Resolved cold',
+      started_on: '2026-02-25'
+    )
+
+    expect do
+      post api_v1_household_sync_batches_path(household_id),
+           params: {
+             batch: {
+               operations: [
+                 { action: 'delete', resource_type: 'health_event', id: event.portable_id, attributes: {} }
+               ]
+             }
+           },
+           headers: headers,
+           as: :json
+    end.to change(ApiTombstone, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    expect(HealthEvent.exists?(event.id)).to be(false)
+  end
+end

--- a/spec/requests/profile_data_exports_spec.rb
+++ b/spec/requests/profile_data_exports_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe 'Profile data exports' do
     expect(response.media_type).to eq('application/json')
     expect(response.parsed_body.fetch('format')).to eq('medtracker.health_data.v1')
   end
+
+  it 'downloads a backup ZIP without sensitive platform records from the profile page' do
+    get profile_data_export_path('backup_zip')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('application/zip')
+    expect(response.headers.fetch('Content-Disposition')).to include('medtracker-backup-')
+    expect(response.body.byteslice(0, 2)).to eq('PK')
+    expect(response.body).not_to include('api_sessions', 'api_app_tokens', 'native_device_tokens',
+                                         'push_subscriptions', 'security_audit_events')
+  end
 end

--- a/spec/requests/profile_data_exports_spec.rb
+++ b/spec/requests/profile_data_exports_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Profile data exports' do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
+
+  before { sign_in(users(:admin)) }
+
+  it 'shows the self-service data backup entry point and warning' do
+    get profile_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Data backup')
+    expect(response.body).to include('Unencrypted ZIP exports are not password protected')
+  end
+
+  it 'downloads a health-data JSON export from the profile page' do
+    get profile_data_export_path('health_data_json')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('application/json')
+    expect(response.parsed_body.fetch('format')).to eq('medtracker.health_data.v1')
+  end
+end

--- a/spec/serializers/api/v1/dosage_option_serializer_spec.rb
+++ b/spec/serializers/api/v1/dosage_option_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::DosageOptionSerializer do
+  it 'serialises medication portable identity when present' do
+    dosage_option = create(:dosage)
+    json = described_class.new(dosage_option).as_json
+
+    expect(json).to include(
+      medication_id: dosage_option.medication_id,
+      medication_portable_id: dosage_option.medication.portable_id
+    )
+  end
+
+  it 'serialises missing medication association as a nil portable ID' do
+    updated_at = Time.zone.parse('2026-07-07 12:00:00')
+    json = described_class.new(missing_medication_dosage(updated_at)).as_json
+
+    expect(json[:medication_portable_id]).to be_nil
+    expect(json[:updated_at]).to eq(updated_at.iso8601)
+  end
+
+  def missing_medication_dosage(updated_at)
+    instance_double(
+      MedicationDosageOption,
+      id: 1, portable_id: SecureRandom.uuid, medication_id: nil, medication: nil,
+      amount: 5, unit: 'ml', frequency: 'daily', description: nil,
+      default_for_adults: false, default_for_children: false,
+      default_max_daily_doses: nil, default_min_hours_between_doses: nil,
+      default_dose_cycle: 'daily', current_supply: nil, reorder_threshold: nil,
+      updated_at: updated_at
+    )
+  end
+end

--- a/spec/serializers/api/v1/health_event_serializer_spec.rb
+++ b/spec/serializers/api/v1/health_event_serializer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::HealthEventSerializer do
+  fixtures :people, :medications
+
+  it 'serialises person and medication portable identities when present' do
+    event = HealthEvent.create!(
+      person: people(:jane),
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 7, 7)
+    )
+    HealthEventMedication.create!(health_event: event, medication: medications(:paracetamol))
+
+    json = described_class.new(event).as_json
+
+    expect(json).to include(
+      person_portable_id: people(:jane).portable_id,
+      medication_ids: [medications(:paracetamol).id],
+      medication_portable_ids: [medications(:paracetamol).portable_id]
+    )
+  end
+
+  it 'serialises missing optional date and association values as nil or empty arrays' do
+    updated_at = Time.zone.parse('2026-07-07 12:00:00')
+    json = described_class.new(missing_optional_event(updated_at)).as_json
+
+    expect(json).to include(
+      person_portable_id: nil,
+      started_on: nil,
+      ended_on: nil,
+      medication_portable_ids: []
+    )
+  end
+
+  def missing_optional_event(updated_at)
+    instance_double(
+      HealthEvent,
+      id: 1, portable_id: SecureRandom.uuid, person_id: nil, person: nil,
+      event_kind: 'illness', severity: nil, title: 'Cold', notes: nil,
+      started_on: nil, ended_on: nil, updated_at: updated_at,
+      medication_ids: [], medications: []
+    )
+  end
+end

--- a/spec/serializers/api/v1/medication_serializer_spec.rb
+++ b/spec/serializers/api/v1/medication_serializer_spec.rb
@@ -27,4 +27,24 @@ RSpec.describe Api::V1::MedicationSerializer do
       location_portable_id: medication.location.portable_id
     )
   end
+
+  it 'serialises medications without a location' do
+    json = described_class.new(medication_without_location).as_json
+
+    expect(json[:location_id]).to be_nil
+    expect(json[:location_portable_id]).to be_nil
+  end
+
+  def medication_without_location
+    instance_double(
+      Medication,
+      id: 1, portable_id: SecureRandom.uuid, name: 'Paracetamol',
+      display_name: 'Paracetamol', category: 'tablet', description: nil,
+      dose_amount: nil, dose_unit: nil, current_supply: nil,
+      reorder_threshold: nil, reorder_status: 'ok', location_id: nil,
+      location: nil, updated_at: Time.zone.parse('2026-07-07 12:00:00'),
+      low_stock?: false, out_of_stock?: false,
+      days_until_low_stock: nil, days_until_out_of_stock: nil
+    )
+  end
 end

--- a/spec/serializers/api/v1/medication_take_serializer_spec.rb
+++ b/spec/serializers/api/v1/medication_take_serializer_spec.rb
@@ -50,4 +50,34 @@ RSpec.describe Api::V1::MedicationTakeSerializer do
     expect(json[:schedule_id]).to be_nil
     expect(json[:schedule_portable_id]).to be_nil
   end
+
+  it 'serialises missing optional associations as nil portable IDs' do
+    json = described_class.new(missing_association_take).as_json
+
+    expect(json).to include(
+      schedule_portable_id: nil,
+      person_medication_portable_id: nil,
+      taken_from_medication_portable_id: nil,
+      taken_from_location_portable_id: nil,
+      dose_amount: nil,
+      taken_at: nil,
+      person_id: nil,
+      person_portable_id: nil,
+      medication_id: nil,
+      medication_portable_id: nil
+    )
+  end
+
+  def missing_association_take
+    instance_double(
+      MedicationTake,
+      id: 1, portable_id: SecureRandom.uuid, client_uuid: nil,
+      schedule_id: nil, schedule: nil, person_medication_id: nil,
+      person_medication: nil, taken_from_medication_id: nil,
+      taken_from_medication: nil, taken_from_location_id: nil,
+      taken_from_location: nil, dose_amount: nil, dose_unit: nil,
+      taken_at: nil, updated_at: Time.zone.parse('2026-07-07 12:00:00'),
+      person: nil, medication: nil
+    )
+  end
 end

--- a/spec/serializers/api/v1/person_medication_serializer_spec.rb
+++ b/spec/serializers/api/v1/person_medication_serializer_spec.rb
@@ -45,4 +45,27 @@ RSpec.describe Api::V1::PersonMedicationSerializer do
     expect(json[:active]).to be false
     expect(json[:paused]).to be true
   end
+
+  it 'serialises missing optional association and dose values as nil' do
+    updated_at = Time.zone.parse('2026-07-07 12:00:00')
+    json = described_class.new(missing_association_person_medication(updated_at)).as_json
+
+    expect(json).to include(
+      person_portable_id: nil,
+      medication_portable_id: nil,
+      dose_amount: nil,
+      updated_at: updated_at.iso8601
+    )
+  end
+
+  def missing_association_person_medication(updated_at)
+    instance_double(
+      PersonMedication,
+      id: 1, portable_id: SecureRandom.uuid, person_id: nil, person: nil,
+      medication_id: nil, medication: nil, dose_amount: nil, dose_unit: nil,
+      active?: false, paused?: true, dose_cycle: 'daily',
+      administration_kind: 'as_needed', notes: nil, position: nil,
+      updated_at: updated_at, max_daily_doses: nil, min_hours_between_doses: nil
+    )
+  end
 end

--- a/spec/serializers/api/v1/schedule_serializer_spec.rb
+++ b/spec/serializers/api/v1/schedule_serializer_spec.rb
@@ -48,4 +48,27 @@ RSpec.describe Api::V1::ScheduleSerializer do
     expect(json[:active]).to be false
     expect(json[:paused]).to be true
   end
+
+  it 'serialises missing optional associations as nil portable IDs' do
+    updated_at = Time.zone.parse('2026-07-07 12:00:00')
+    json = described_class.new(missing_association_schedule(updated_at)).as_json
+
+    expect(json).to include(
+      person_portable_id: nil,
+      medication_portable_id: nil,
+      start_date: nil,
+      end_date: nil
+    )
+  end
+
+  def missing_association_schedule(updated_at)
+    instance_double(
+      Schedule,
+      id: 1, portable_id: SecureRandom.uuid, person_id: nil, person: nil,
+      medication_id: nil, medication: nil, dose_amount: nil, dose_unit: nil,
+      frequency: nil, dose_cycle: 'daily', start_date: nil, end_date: nil,
+      active?: false, paused?: true, notes: nil, updated_at: updated_at,
+      max_daily_doses: nil, min_hours_between_doses: nil
+    )
+  end
 end

--- a/spec/serializers/fhir/r4/serializer_spec.rb
+++ b/spec/serializers/fhir/r4/serializer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fhir::R4::Serializer do
+  it 'serialises optional Patient and Medication fields only when present' do
+    patient = instance_double(Person, portable_id: 'person-portable-id', name: 'Jane Doe', date_of_birth: nil)
+    medication = instance_double(
+      Medication,
+      portable_id: 'medication-portable-id',
+      display_name: 'Paracetamol',
+      category: nil
+    )
+
+    expect(described_class.patient(patient)).not_to have_key(:birthDate)
+    expect(described_class.medication(medication).dig(:form, :text)).to be_nil
+  end
+
+  it 'serialises stopped medication requests and statements' do
+    schedule = stopped_schedule
+    person_medication = stopped_person_medication(schedule.person, schedule.medication)
+
+    expect(described_class.medication_request(schedule)[:status]).to eq('stopped')
+    expect(described_class.medication_statement(person_medication)[:status]).to eq('stopped')
+  end
+
+  it 'omits nil medication administration references and effective time' do
+    take = instance_double(
+      MedicationTake,
+      portable_id: 'take-portable-id',
+      schedule: nil,
+      person_medication: nil,
+      taken_from_medication: nil,
+      taken_at: nil
+    )
+
+    json = described_class.medication_administration(take)
+
+    expect(json[:subject]).to be_nil
+    expect(json[:medicationReference]).to be_nil
+    expect(json[:effectiveDateTime]).to be_nil
+  end
+
+  it 'builds a bundle by dispatching to the requested resource serializer' do
+    patient = instance_double(Person, portable_id: 'person-portable-id', name: 'Jane Doe', date_of_birth: nil)
+
+    json = described_class.bundle([patient], type: :patient)
+
+    expect(json).to include(resourceType: 'Bundle', total: 1)
+    expect(json.fetch(:entry).first.fetch(:resource)).to include(resourceType: 'Patient')
+  end
+
+  def stopped_schedule
+    person = instance_double(Person, portable_id: 'person-portable-id')
+    medication = instance_double(Medication, portable_id: 'medication-portable-id')
+    instance_double(
+      Schedule,
+      portable_id: 'schedule-portable-id', active?: false, person: person,
+      medication: medication, dose_amount: nil, dose_unit: nil
+    )
+  end
+
+  def stopped_person_medication(person, medication)
+    instance_double(
+      PersonMedication,
+      portable_id: 'person-medication-portable-id', active?: false,
+      person: person, medication: medication, dose_amount: nil, dose_unit: nil
+    )
+  end
+end

--- a/spec/serializers/fhir/r4/serializer_spec.rb
+++ b/spec/serializers/fhir/r4/serializer_spec.rb
@@ -3,17 +3,49 @@
 require 'rails_helper'
 
 RSpec.describe Fhir::R4::Serializer do
-  it 'serialises optional Patient and Medication fields only when present' do
-    patient = instance_double(Person, portable_id: 'person-portable-id', name: 'Jane Doe', date_of_birth: nil)
+  it 'serialises optional Patient fields only when present' do
+    patient = instance_double(
+      Person,
+      portable_id: 'person-portable-id',
+      name: 'Jane Doe',
+      date_of_birth: nil,
+      updated_at: Time.zone.parse('2026-01-01T10:30:00Z')
+    )
+
+    expect(described_class.patient(patient)).not_to have_key(:birthDate)
+    expect(described_class.patient(patient).dig(:meta, :lastUpdated)).to eq('2026-01-01T10:30:00Z')
+  end
+
+  it 'serialises optional Medication fields only when present' do
     medication = instance_double(
       Medication,
       portable_id: 'medication-portable-id',
       display_name: 'Paracetamol',
-      category: nil
+      category: nil,
+      dmd_code: nil,
+      dmd_system: nil,
+      dmd_concept_class: nil,
+      updated_at: Time.zone.parse('2026-01-01T10:30:00Z')
     )
 
-    expect(described_class.patient(patient)).not_to have_key(:birthDate)
     expect(described_class.medication(medication).dig(:form, :text)).to be_nil
+  end
+
+  it 'serialises dm+d coding only from stored medication identifiers' do
+    medication = instance_double(
+      Medication,
+      portable_id: 'medication-portable-id',
+      display_name: 'Paracetamol',
+      category: 'Analgesic',
+      dmd_code: '123456',
+      dmd_system: 'https://dmd.nhs.uk',
+      dmd_concept_class: 'VMP',
+      updated_at: Time.current
+    )
+
+    coding = described_class.medication(medication).dig(:code, :coding).first
+
+    expect(coding).to include(system: 'https://dmd.nhs.uk', code: '123456', display: 'Paracetamol')
   end
 
   it 'serialises stopped medication requests and statements' do
@@ -31,7 +63,8 @@ RSpec.describe Fhir::R4::Serializer do
       schedule: nil,
       person_medication: nil,
       taken_from_medication: nil,
-      taken_at: nil
+      taken_at: nil,
+      updated_at: Time.current
     )
 
     json = described_class.medication_administration(take)
@@ -56,7 +89,7 @@ RSpec.describe Fhir::R4::Serializer do
     instance_double(
       Schedule,
       portable_id: 'schedule-portable-id', active?: false, person: person,
-      medication: medication, dose_amount: nil, dose_unit: nil
+      medication: medication, dose_amount: nil, dose_unit: nil, updated_at: Time.current
     )
   end
 
@@ -64,7 +97,7 @@ RSpec.describe Fhir::R4::Serializer do
     instance_double(
       PersonMedication,
       portable_id: 'person-medication-portable-id', active?: false,
-      person: person, medication: medication, dose_amount: nil, dose_unit: nil
+      person: person, medication: medication, dose_amount: nil, dose_unit: nil, updated_at: Time.current
     )
   end
 end

--- a/spec/serializers/fhir/r4/serializer_spec.rb
+++ b/spec/serializers/fhir/r4/serializer_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Fhir::R4::Serializer do
     expect(described_class.patient(patient).dig(:meta, :lastUpdated)).to eq('2026-01-01T10:30:00Z')
   end
 
+  it 'serialises Patient birth dates when present' do
+    patient = instance_double(
+      Person,
+      portable_id: 'person-portable-id',
+      name: 'Jane Doe',
+      date_of_birth: Date.new(2000, 1, 2),
+      updated_at: nil
+    )
+
+    expect(described_class.patient(patient)).to include(birthDate: '2000-01-02')
+    expect(described_class.patient(patient)).not_to have_key(:meta)
+  end
+
   it 'serialises optional Medication fields only when present' do
     medication = instance_double(
       Medication,
@@ -56,6 +69,14 @@ RSpec.describe Fhir::R4::Serializer do
     expect(described_class.medication_statement(person_medication)[:status]).to eq('stopped')
   end
 
+  it 'serialises active medication requests and statements' do
+    schedule = active_schedule
+    person_medication = active_person_medication(schedule.person, schedule.medication)
+
+    expect(described_class.medication_request(schedule)[:status]).to eq('active')
+    expect(described_class.medication_statement(person_medication)[:status]).to eq('active')
+  end
+
   it 'omits nil medication administration references and effective time' do
     take = instance_double(
       MedicationTake,
@@ -72,6 +93,13 @@ RSpec.describe Fhir::R4::Serializer do
     expect(json[:subject]).to be_nil
     expect(json[:medicationReference]).to be_nil
     expect(json[:effectiveDateTime]).to be_nil
+  end
+
+  it 'serialises medication administrations from direct person medications' do
+    json = described_class.medication_administration(direct_person_medication_take)
+
+    expect(json.dig(:subject, :reference)).to eq('Patient/person-portable-id')
+    expect(json.dig(:medicationReference, :reference)).to eq('Medication/medication-portable-id')
   end
 
   it 'builds a bundle by dispatching to the requested resource serializer' do
@@ -98,6 +126,36 @@ RSpec.describe Fhir::R4::Serializer do
       PersonMedication,
       portable_id: 'person-medication-portable-id', active?: false,
       person: person, medication: medication, dose_amount: nil, dose_unit: nil, updated_at: Time.current
+    )
+  end
+
+  def active_schedule
+    person = instance_double(Person, portable_id: 'person-portable-id')
+    medication = instance_double(Medication, portable_id: 'medication-portable-id')
+    instance_double(
+      Schedule,
+      portable_id: 'schedule-portable-id', active?: true, person: person,
+      medication: medication, dose_amount: nil, dose_unit: nil, updated_at: Time.current
+    )
+  end
+
+  def active_person_medication(person, medication)
+    instance_double(
+      PersonMedication,
+      portable_id: 'person-medication-portable-id', active?: true,
+      person: person, medication: medication, dose_amount: nil, dose_unit: nil, updated_at: Time.current
+    )
+  end
+
+  def direct_person_medication_take
+    person_medication = active_person_medication(
+      instance_double(Person, portable_id: 'person-portable-id'),
+      instance_double(Medication, portable_id: 'medication-portable-id')
+    )
+    instance_double(
+      MedicationTake,
+      portable_id: 'take-portable-id', schedule: nil, person_medication: person_medication,
+      taken_from_medication: nil, taken_at: Time.zone.parse('2026-01-02T09:00:00Z'), updated_at: Time.current
     )
   end
 end

--- a/spec/services/api/change_recorder_spec.rb
+++ b/spec/services/api/change_recorder_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::ChangeRecorder do
+  fixtures :accounts
+
+  let(:account) { accounts(:jane_doe) }
+  let(:household) { Household.create!(name: 'Change Recorder Spec', slug: "change-recorder-#{SecureRandom.hex(4)}") }
+  let(:person) { create_person_for(account, household) }
+  let(:membership) do
+    household.household_memberships.create!(account: account, person: person, role: :owner, status: :active)
+  end
+  let(:credential) { instance_double(ApiSession, account: account) }
+
+  it 'records persisted record changes with portable metadata' do
+    change_recorder.record(person, action: 'updated')
+
+    expect(ApiChangeEvent.count).to eq(1)
+
+    event = ApiChangeEvent.order(:id).last
+    expect(event).to have_attributes(
+      household: household,
+      account: account,
+      household_membership: membership,
+      request_id: 'request-123',
+      record_type: 'Person',
+      record_id: person.id,
+      record_portable_id: person.portable_id,
+      action: 'updated'
+    )
+    expect(event.metadata).to include('portable_id' => person.portable_id)
+  end
+
+  it 'skips changes without the required tenant and record context' do
+    expect do
+      invalid_contexts.each { |context| record_context(context) }
+    end.not_to change(ApiChangeEvent, :count)
+  end
+
+  it 'records persisted records that do not expose portable IDs' do
+    change_recorder.record(account, action: 'updated')
+
+    event = ApiChangeEvent.order(:id).last
+    expect(event.record_type).to eq('Account')
+    expect(event.record_portable_id).to be_nil
+    expect(event.metadata).not_to have_key('portable_id')
+  end
+
+  def create_person_for(account, household)
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'Change Recorder Person',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+
+  def change_recorder
+    described_class.new(household: household, credential: credential, membership: membership, request: request)
+  end
+
+  def request
+    instance_double(ActionDispatch::Request, request_id: 'request-123')
+  end
+
+  def invalid_contexts
+    [
+      missing_household_context,
+      missing_credential_context,
+      blank_credential_context,
+      missing_membership_context,
+      missing_record_context,
+      unpersisted_record_context
+    ]
+  end
+
+  def missing_household_context
+    { household: nil, credential: credential, membership: membership, record: person }
+  end
+
+  def missing_credential_context
+    { household: household, credential: nil, membership: membership, record: person }
+  end
+
+  def blank_credential_context
+    blank_credential = instance_double(ApiSession, account: nil)
+
+    { household: household, credential: blank_credential, membership: membership, record: person }
+  end
+
+  def missing_membership_context
+    { household: household, credential: credential, membership: nil, record: person }
+  end
+
+  def missing_record_context
+    { household: household, credential: credential, membership: membership, record: nil }
+  end
+
+  def unpersisted_record_context
+    { household: household, credential: credential, membership: membership, record: Person.new }
+  end
+
+  def record_context(context)
+    described_class.new(
+      household: context.fetch(:household),
+      credential: context.fetch(:credential),
+      membership: context.fetch(:membership),
+      request: request
+    ).record(context.fetch(:record), action: 'updated')
+  end
+end

--- a/spec/services/api/fresh_privileged_action_spec.rb
+++ b/spec/services/api/fresh_privileged_action_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FreshPrivilegedAction do
+  it 'requires an API session credential' do
+    app_token = instance_double(ApiAppToken)
+
+    expect(described_class.new(credential: app_token)).not_to be_satisfied
+  end
+
+  it 'requires an OIDC MFA verified session' do
+    session = ApiSession.new(oidc_mfa_verified: false, mfa_verified_at: Time.current)
+
+    expect(described_class.new(credential: session)).not_to be_satisfied
+  end
+
+  it 'requires an MFA proof timestamp' do
+    session = ApiSession.new(oidc_mfa_verified: true, mfa_verified_at: nil)
+
+    expect(described_class.new(credential: session)).not_to be_satisfied
+  end
+
+  it 'rejects stale MFA proof timestamps' do
+    session = ApiSession.new(oidc_mfa_verified: true, mfa_verified_at: 16.minutes.ago)
+
+    expect(described_class.new(credential: session)).not_to be_satisfied
+  end
+
+  it 'accepts fresh OIDC MFA proof timestamps' do
+    session = ApiSession.new(oidc_mfa_verified: true, mfa_verified_at: 1.minute.ago)
+
+    expect(described_class.new(credential: session)).to be_satisfied
+  end
+end

--- a/spec/services/api/idempotency_store_spec.rb
+++ b/spec/services/api/idempotency_store_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::IdempotencyStore do
+  fixtures :accounts
+
+  let(:account) { accounts(:jane_doe) }
+  let(:household) do
+    Household.create!(name: 'Idempotency Store Spec', slug: "idempotency-store-#{SecureRandom.hex(4)}")
+  end
+  let(:person) { create_person_for(account, household) }
+  let(:membership) do
+    household.household_memberships.create!(account: account, person: person, role: :owner, status: :active)
+  end
+  let(:api_session) { ApiSession.issue_for(account: account, household_membership: membership).first }
+
+  it 'is active only for keyed mutating requests with tenant and credential context' do
+    active_request = request_double(method: 'POST', key: 'active-key')
+
+    expect(described_class.new(request: active_request, credential: api_session, household: household)).to be_active
+    expect(described_class.new(request: request_double(method: 'GET', key: 'active-key'),
+                               credential: api_session, household: household)).not_to be_active
+    expect(described_class.new(request: request_double(method: 'POST', key: nil),
+                               credential: api_session, household: household)).not_to be_active
+    expect(described_class.new(request: active_request, credential: nil, household: household)).not_to be_active
+    expect(described_class.new(request: active_request, credential: api_session, household: nil)).not_to be_active
+  end
+
+  it 'returns an empty lookup result when no key has been stored' do
+    result = described_class.new(
+      request: request_double(method: 'POST', key: 'missing-key'),
+      credential: api_session,
+      household: household
+    ).lookup
+
+    expect(result.record).to be_nil
+    expect(result.replayed).to be false
+    expect(result.conflict).to be false
+  end
+
+  it 'stores non-PHI response metadata and normalises invalid JSON response bodies' do
+    request = request_double(method: 'POST', key: 'store-key')
+    response = instance_double(ActionDispatch::Response, status: 201, body: 'not-json')
+
+    expect do
+      described_class.new(request: request, credential: api_session, household: household).store!(response)
+    end.to change(ApiIdempotencyKey, :count).by(1)
+
+    key = ApiIdempotencyKey.order(:id).last
+    expect(key).to have_attributes(
+      household: household,
+      account: account,
+      api_session: api_session,
+      response_status: 201,
+      response_body: {}
+    )
+  end
+
+  it 'stores app-token idempotency attribution' do
+    app_token = ApiAppToken.issue_for(
+      account: account,
+      household_membership: membership,
+      name: 'Idempotency app token'
+    ).first
+    request = request_double(method: 'PATCH', key: 'app-token-key')
+    response = instance_double(ActionDispatch::Response, status: 200, body: '{"ok":true}')
+
+    described_class.new(request: request, credential: app_token, household: household).store!(response)
+
+    key = ApiIdempotencyKey.order(:id).last
+    expect(key.api_session).to be_nil
+    expect(key.api_app_token).to eq(app_token)
+  end
+
+  it 'does not store inactive or failed responses' do
+    inactive_request = request_double(method: 'GET', key: 'inactive-key')
+    failed_response = instance_double(ActionDispatch::Response, status: 500, body: '{}')
+
+    expect do
+      described_class.new(
+        request: inactive_request,
+        credential: api_session,
+        household: household
+      ).store!(failed_response)
+      described_class.new(request: request_double(method: 'POST', key: 'failed-key'),
+                          credential: api_session, household: household).store!(failed_response)
+    end.not_to change(ApiIdempotencyKey, :count)
+  end
+
+  it 'ignores duplicate stores for the same key' do
+    request = request_double(method: 'POST', key: 'duplicate-key')
+    response = instance_double(ActionDispatch::Response, status: 201, body: '{"ok":true}')
+    store = described_class.new(request: request, credential: api_session, household: household)
+
+    expect do
+      2.times { store.store!(response) }
+    end.to change(ApiIdempotencyKey, :count).by(1)
+  end
+
+  def request_double(method:, key:)
+    instance_double(
+      ActionDispatch::Request,
+      headers: { 'Idempotency-Key' => key },
+      request_method: method,
+      path: '/api/v1/households/1/sync/batches',
+      filtered_parameters: { 'controller' => 'sync', 'action' => 'create', 'payload' => { 'safe' => true } },
+      post?: method == 'POST',
+      patch?: method == 'PATCH',
+      put?: method == 'PUT',
+      delete?: method == 'DELETE'
+    )
+  end
+
+  def create_person_for(account, household)
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'Idempotency Store Person',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Add sync safety primitives for API sessions, idempotency, tombstones, and portable record lookup.
- Tighten authentication, rate limiting, and privileged action handling across the API surface.
- Complete the FHIR R4 response contract with `application/fhir+json`, `OperationOutcome`, truthful CapabilityStatement search metadata, searchset Bundle links, supported search filters, `meta.lastUpdated`, and stored dm+d coding.
- Expand profile export, FHIR, admin, and sync coverage while keeping sensitive platform/session records out of portable payloads.

## Audit matrix
| Issue | Closure evidence in this PR |
| --- | --- |
| #1480 | Profile data backup card, health-data JSON download, backup ZIP download, excluded token/session/platform records, and redacted portable export audit metadata are covered by `spec/requests/profile_data_exports_spec.rb`, `spec/requests/api/v1/data_exports_spec.rb`, and `spec/services/portable_data/exporter_spec.rb`. |
| #1485 | Idempotency replay/conflict handling, portable ID lookup, stale write rejection, API change recording, and rollback behavior are covered by `spec/requests/api/v1/sync_safety_spec.rb` and `spec/services/api/idempotency_store_spec.rb`. |
| #1486 | Hosted OIDC PKCE session exchange, household binding, replay/account-state failures, MFA proof, refresh/logout, and token redaction are covered by `spec/requests/api/v1/auth/sessions_spec.rb`. |
| #1487 | Portable-ID-first API parity for dosage options, health events, takes, schedules, person medications, inventory adjustment, push/native tokens, lookup, AI suggestions, and cross-household rejection is covered by `spec/requests/api/v1/domain_parity_spec.rb`. |
| #1488 | Household admin API settings, memberships, app tokens, invitations, grants, audit logs, non-manager denial, fresh privileged proof, and audit-safe privileged mutations are covered by `spec/requests/api/v1/admin_api_spec.rb`. |
| #1489 | Sync snapshot, cursor changes, tombstones, transactional batch mutations, portable v2 payloads, v1 compatibility, and excluded platform state are covered by `spec/requests/api/v1/sync_spec.rb`, `spec/requests/api/v1/portable_data_spec.rb`, and `spec/requests/api/v1/data_exports_spec.rb`. |
| #1491 | Sensitive API rate limits, JSON retry metadata, PHI-safe span/audit redaction, and Brakeman evidence are covered by `spec/requests/api/v1/rate_limiting_spec.rb`, `config/initializers/rack_attack.rb`, `spec/lib/otel/span_sanitizer_spec.rb`, and `task brakeman`. |
| #1527 | CapabilityStatement now advertises only implemented resources, interactions, formats, and search parameters; covered by `spec/requests/api/fhir/r4_spec.rb`. |
| #1528 | FHIR endpoints now return `application/fhir+json` resources and FHIR `OperationOutcome` errors for auth, not-found, invalid search, and unsupported formats; covered by `spec/requests/api/fhir/r4_spec.rb`. |
| #1529 | FHIR searches now use explicit supported filters and paged searchset Bundles with `self`/`next` links and `entry.search.mode`; covered by `spec/requests/api/fhir/r4_spec.rb`. |
| #1530 | FHIR serializers now expose stable portable IDs, `meta.lastUpdated`, references, stored dm+d coding, and omit unsupported clinical data; covered by `spec/serializers/fhir/r4/serializer_spec.rb`. |

## Out of scope for this PR
- #1490 remains a separate client-tools PR.
- #1531 remains a separate integration-contract decision/docs PR after this API/FHIR implementation lands.

Closes #1480.
Closes #1485.
Closes #1486.
Closes #1487.
Closes #1488.
Closes #1489.
Closes #1491.
Closes #1527.
Closes #1528.
Closes #1529.
Closes #1530.

## Verification
- `task rubocop`
- `task brakeman`
- `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
