### PR TITLE
feat(mcp): add read-only agent context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'solid_queue'
 gem 'bootsnap', require: false
 # Use Phlex for views [https://github.com/phlex-rb/phlex-rails]
 gem 'csv'
+gem 'mcp', require: false
 gem 'phlex-rails'
 gem 'ruby_llm', require: false
 gem 'ruby_ui', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
       rake (~> 13.3)
     googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
+    hana (1.3.7)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -257,6 +258,11 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.6)
@@ -282,6 +288,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
+    mcp (0.22.0)
+      json_schemer (>= 2.4)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
@@ -694,6 +702,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     sin_lru_redux (2.5.2)
     solid_cable (4.0.0)
       actioncable (>= 7.2)
@@ -829,6 +838,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   lograge
+  mcp
   mutant
   mutant-rspec
   omniauth_openid_connect

--- a/app/controllers/api/v1/capabilities_controller.rb
+++ b/app/controllers/api/v1/capabilities_controller.rb
@@ -49,7 +49,13 @@ module Api
       def client_tools
         {
           cli: deferred_client_tool,
-          mcp_server: deferred_client_tool,
+          mcp_server: {
+            supported: true,
+            transport: 'streamable_http',
+            endpoint: '/mcp',
+            tools: MedTrackerMcp::Server::TOOLS.map(&:name_value),
+            resources: MedTrackerMcp::Server::RESOURCES.map { |resource| resource::URI }
+          },
           diagnostics: %w[request_id retry_after]
         }
       end

--- a/app/mcp/med_tracker_mcp/context.rb
+++ b/app/mcp/med_tracker_mcp/context.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  class Context
+    class Error < StandardError; end
+
+    class AuthenticationError < Error
+      attr_reader :status, :code
+
+      def initialize(message = 'Authentication required')
+        @status = :unauthorized
+        @code = 'unauthorized'
+        super
+      end
+    end
+
+    attr_reader :request
+
+    class << self
+      def resolve!(request)
+        new(request).tap(&:authenticate!)
+      end
+    end
+
+    def initialize(request)
+      @request = request
+    end
+
+    def authenticate!
+      raise AuthenticationError unless valid_session?
+      raise AuthenticationError unless valid_account_and_user?
+      raise AuthenticationError if ApiAuthState.locked_out?(account)
+      raise AuthenticationError unless active_membership?
+
+      api_credential.touch_last_used!
+      self
+    end
+
+    def to_h
+      {
+        account: account,
+        account_id: account.id,
+        household: household,
+        household_id: household.id,
+        membership: membership,
+        membership_id: membership.id,
+        api_credential: api_credential,
+        request_id: request.request_id,
+        remote_ip: request.remote_ip
+      }
+    end
+
+    def with_current(&)
+      TenantContext.with(
+        account: account,
+        household: household,
+        membership: membership,
+        request_id: request.request_id,
+        &
+      )
+    ensure
+      Current.reset
+    end
+
+    private
+
+    def valid_session?
+      api_credential.present? && !revoked? && unexpired?
+    end
+
+    def valid_account_and_user?
+      account.present? && account.verified? && user.present? && user.active?
+    end
+
+    def active_membership?
+      api_credential.active_for_membership?
+    end
+
+    def revoked?
+      api_credential.revoked_at.present?
+    end
+
+    def unexpired?
+      return api_credential.access_expires_at.future? if api_credential.is_a?(ApiSession)
+
+      api_credential.is_a?(ApiAppToken)
+    end
+
+    def api_credential
+      @api_credential ||= begin
+        token = bearer_token
+        ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
+      end
+    end
+
+    def account
+      api_credential.account
+    end
+
+    def household
+      membership.household
+    end
+
+    def membership
+      api_credential.household_membership
+    end
+
+    def user
+      account.person&.user
+    end
+
+    def bearer_token
+      scheme, token = request.headers['Authorization'].to_s.split(' ', 2)
+      return token if scheme == 'Bearer'
+
+      nil
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/prompts/household_review_prompt.rb
+++ b/app/mcp/med_tracker_mcp/prompts/household_review_prompt.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'mcp'
+
+module MedTrackerMcp
+  module Prompts
+    class HouseholdReviewPrompt < MCP::Prompt
+      prompt_name 'medtracker_household_review'
+      title 'MedTracker Household Review'
+      description 'Review visible medication schedules, inventory risks, and recent health history for a household.'
+
+      class << self
+        def template(_args, server_context:)
+          context = ToolContext.new(server_context)
+          MCP::Prompt::Result.new(
+            description: 'Review MedTracker household medication context.',
+            messages: [MCP::Prompt::Message.new(role: 'user', content: content(context))]
+          )
+        end
+
+        private
+
+        def content(context)
+          {
+            type: 'text',
+            text: <<~TEXT.squish
+              Review the visible MedTracker household context for #{context.household.name}. Focus on missed or taken
+              doses today, low inventory, people with active medication schedules, and recent health-history patterns.
+              Do not infer access beyond the authenticated household membership.
+            TEXT
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/rack_app.rb
+++ b/app/mcp/med_tracker_mcp/rack_app.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'mcp'
+
+module MedTrackerMcp
+  class RackApp
+    def call(env)
+      request = ActionDispatch::Request.new(env)
+      context = Context.resolve!(request)
+
+      context.with_current do
+        audit_request(request, context) do
+          transport_for(context).call(env)
+        end
+      end
+    rescue Context::AuthenticationError => e
+      unauthorized_response(e)
+    end
+
+    private
+
+    def transport_for(context)
+      MCP::Server::Transports::StreamableHTTPTransport.new(
+        Server.build(server_context: context.to_h),
+        stateless: true,
+        enable_json_response: true
+      )
+    end
+
+    def audit_request(request, context)
+      response = nil
+      outcome = 'ok'
+
+      response = yield
+    rescue StandardError
+      outcome = 'error'
+      raise
+    ensure
+      record_audit_event(request, context, outcome, response)
+    end
+
+    def record_audit_event(request, context, outcome, response)
+      context_data = context.to_h
+
+      SecurityAuditEvent.create!(
+        household: context_data.fetch(:household),
+        actor_account: context_data.fetch(:account),
+        actor_membership: context_data.fetch(:membership),
+        event_type: 'mcp.request',
+        request_id: context_data.fetch(:request_id),
+        ip: context_data.fetch(:remote_ip),
+        metadata: {
+          method: json_rpc_method(request),
+          outcome: outcome,
+          status: response&.first
+        }.compact
+      )
+    end
+
+    def json_rpc_method(request)
+      request.body.rewind
+      JSON.parse(request.body.read).fetch('method', nil)
+    rescue JSON::ParserError
+      nil
+    ensure
+      request.body.rewind
+    end
+
+    def unauthorized_response(error)
+      body = {
+        error: {
+          code: error.code,
+          message: error.message
+        }
+      }
+
+      [Rack::Utils.status_code(error.status), { 'Content-Type' => 'application/json' }, [JSON.generate(body)]]
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/rack_app.rb
+++ b/app/mcp/med_tracker_mcp/rack_app.rb
@@ -42,24 +42,35 @@ module MedTrackerMcp
     def record_audit_event(request, context, outcome, response)
       context_data = context.to_h
 
-      SecurityAuditEvent.create!(
+      SecurityAuditEvent.create!(audit_event_attributes(request, context_data, outcome, response))
+    rescue StandardError => e
+      Rails.logger.warn("MCP audit event failed: #{e.class}: #{e.message}")
+    end
+
+    def audit_event_attributes(request, context_data, outcome, response)
+      {
         household: context_data.fetch(:household),
         actor_account: context_data.fetch(:account),
         actor_membership: context_data.fetch(:membership),
         event_type: 'mcp.request',
         request_id: context_data.fetch(:request_id),
         ip: context_data.fetch(:remote_ip),
-        metadata: {
-          method: json_rpc_method(request),
-          outcome: outcome,
-          status: response&.first
-        }.compact
-      )
+        metadata: audit_event_metadata(request, outcome, response)
+      }
+    end
+
+    def audit_event_metadata(request, outcome, response)
+      {
+        method: json_rpc_method(request),
+        outcome: outcome,
+        status: response&.first
+      }.compact
     end
 
     def json_rpc_method(request)
       request.body.rewind
-      JSON.parse(request.body.read).fetch('method', nil)
+      parsed = JSON.parse(request.body.read)
+      parsed.fetch('method', nil) if parsed.is_a?(Hash)
     rescue JSON::ParserError
       nil
     ensure

--- a/app/mcp/med_tracker_mcp/resources/household_snapshot.rb
+++ b/app/mcp/med_tracker_mcp/resources/household_snapshot.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'mcp'
+
+module MedTrackerMcp
+  module Resources
+    class HouseholdSnapshot
+      URI = 'medtracker://household/snapshot'
+
+      class << self
+        def definition
+          MCP::Resource.new(
+            uri: URI,
+            name: 'household_snapshot',
+            title: 'Household Snapshot',
+            description: 'Policy-scoped MedTracker household snapshot for the authenticated membership.',
+            mime_type: 'application/json'
+          )
+        end
+
+        def read(server_context:)
+          Tools::HouseholdSnapshotTool.call(server_context: server_context).structured_content
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/resources/household_snapshot.rb
+++ b/app/mcp/med_tracker_mcp/resources/household_snapshot.rb
@@ -19,7 +19,13 @@ module MedTrackerMcp
         end
 
         def read(server_context:)
-          Tools::HouseholdSnapshotTool.call(server_context: server_context).structured_content
+          payload = Tools::HouseholdSnapshotTool.call(server_context: server_context).to_h.fetch(:structuredContent)
+
+          MCP::Resource::TextContents.new(
+            uri: URI,
+            mime_type: 'application/json',
+            text: JSON.generate(payload)
+          )
         end
       end
     end

--- a/app/mcp/med_tracker_mcp/server.rb
+++ b/app/mcp/med_tracker_mcp/server.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'mcp'
+
+module MedTrackerMcp
+  class Server
+    TOOLS = [
+      Tools::CurrentUserTool,
+      Tools::HouseholdSnapshotTool,
+      Tools::TodayScheduleTool,
+      Tools::InventoryRisksTool,
+      Tools::HealthHistorySummaryTool
+    ].freeze
+
+    RESOURCES = [
+      Resources::HouseholdSnapshot
+    ].freeze
+
+    PROMPTS = [
+      Prompts::HouseholdReviewPrompt
+    ].freeze
+
+    class << self
+      def build(server_context:)
+        MCP::Server.new(
+          name: 'med_tracker',
+          title: 'MedTracker MCP',
+          version: version,
+          description: 'Authenticated read-only medication context for MedTracker households.',
+          instructions: instructions,
+          tools: TOOLS,
+          prompts: PROMPTS,
+          resources: RESOURCES.map(&:definition),
+          server_context: server_context,
+          capabilities: capabilities
+        ).tap do |server|
+          define_resource_reader(server)
+        end
+      end
+
+      private
+
+      def define_resource_reader(server)
+        server.resources_read_handler do |params, server_context:|
+          resource = RESOURCES.find { |candidate| params.fetch(:uri) == candidate::URI }
+          raise MCP::Server::ResourceNotFoundError.new(params.fetch(:uri), params) unless resource
+
+          [resource.read(server_context: server_context).to_h]
+        end
+      end
+
+      def version
+        Rails.application.config.respond_to?(:x) ? Rails.application.config.x.app_version.presence || '0.1.0' : '0.1.0'
+      end
+
+      def instructions
+        'Use these tools for read-only medication context. Never request or expose raw authentication tokens.'
+      end
+
+      def capabilities
+        {
+          tools: { listChanged: false },
+          prompts: { listChanged: false },
+          resources: { listChanged: false }
+        }
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tool_context.rb
+++ b/app/mcp/med_tracker_mcp/tool_context.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  class ToolContext
+    attr_reader :server_context
+
+    def initialize(server_context)
+      @server_context = server_context
+    end
+
+    def account
+      value(:account)
+    end
+
+    def household
+      value(:household)
+    end
+
+    def membership
+      value(:membership)
+    end
+
+    def request_id
+      value(:request_id)
+    end
+
+    def remote_ip
+      value(:remote_ip)
+    end
+
+    def with_current(&)
+      TenantContext.with(account: account, household: household, membership: membership, request_id: request_id, &)
+    end
+
+    def policy_scope(scope)
+      Pundit.policy_scope!(AuthorizationContext.current, scope)
+    end
+
+    private
+
+    def value(key)
+      server_context[key]
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/base_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/base_tool.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'mcp'
+
+module MedTrackerMcp
+  module Tools
+    class BaseTool < MCP::Tool
+      class << self
+        private
+
+        def tool_context(server_context)
+          ToolContext.new(server_context)
+        end
+
+        def response(payload, summary)
+          MCP::Tool::Response.new(
+            [{ type: 'text', text: summary }],
+            structured_content: payload
+          )
+        end
+
+        def error_response(message)
+          MCP::Tool::Response.new(
+            [{ type: 'text', text: message }],
+            error: true
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/current_user_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/current_user_tool.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  module Tools
+    class CurrentUserTool < BaseTool
+      tool_name 'medtracker_current_user'
+      description 'Return the authenticated MedTracker API user profile.'
+      input_schema(properties: {}, required: [])
+
+      class << self
+        def call(server_context:)
+          context = tool_context(server_context)
+          context.with_current do
+            payload = {
+              format: 'medtracker.mcp.current_user.v1',
+              user: Api::V1::MeSerializer.new(context.account.person.user).as_json
+            }
+
+            response(payload, 'Authenticated MedTracker user profile.')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/health_history_summary_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/health_history_summary_tool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  module Tools
+    class HealthHistorySummaryTool < BaseTool
+      MAX_RANGE_DAYS = 180
+
+      tool_name 'medtracker_health_history_summary'
+      description 'Return a bounded health-history summary for visible people.'
+      input_schema(
+        properties: {
+          start_date: { type: 'string', description: 'Inclusive ISO8601 start date.' },
+          end_date: { type: 'string', description: 'Inclusive ISO8601 end date.' },
+          person_ids: { type: 'array', items: { type: 'integer' } }
+        },
+        required: []
+      )
+
+      class << self
+        def call(server_context:, start_date: nil, end_date: nil, person_ids: nil)
+          dates = date_range(start_date, end_date)
+          return error_response('Health history date range cannot exceed 180 days.') if range_too_large?(dates)
+
+          context = tool_context(server_context)
+          context.with_current do
+            people = visible_people(context, person_ids)
+            result = Reports::HealthHistoryQuery.new(
+              people: people,
+              start_date: dates.fetch(:start_date),
+              end_date: dates.fetch(:end_date)
+            ).call
+
+            response(payload(result, dates), 'Bounded MedTracker health-history summary.')
+          end
+        rescue ArgumentError
+          error_response('start_date and end_date must be valid ISO8601 dates.')
+        end
+
+        private
+
+        def date_range(start_date, end_date)
+          end_on = end_date.present? ? Date.iso8601(end_date.to_s) : Time.zone.today
+          start_on = start_date.present? ? Date.iso8601(start_date.to_s) : end_on - 30.days
+
+          { start_date: start_on, end_date: end_on }
+        end
+
+        def range_too_large?(dates)
+          (dates.fetch(:end_date) - dates.fetch(:start_date)).to_i > MAX_RANGE_DAYS
+        end
+
+        def visible_people(context, person_ids)
+          scope = context.policy_scope(Person).includes(:locations, :notification_preference).order(:name, :id)
+          person_ids.present? ? scope.where(id: person_ids) : scope
+        end
+
+        def payload(result, dates)
+          {
+            format: 'medtracker.mcp.health_history_summary.v1',
+            start_date: dates.fetch(:start_date).iso8601,
+            end_date: dates.fetch(:end_date).iso8601,
+            people: people_payloads(result),
+            medication_takes: medication_take_payloads(result),
+            suspected_side_effects: suspected_side_effect_payloads(result),
+            notable_illnesses: notable_illness_payloads(result),
+            illness_patterns: result.illness_patterns
+          }
+        end
+
+        def people_payloads(result)
+          result.people.map { |person| Api::V1::PersonSerializer.new(person).as_json }
+        end
+
+        def medication_take_payloads(result)
+          result.medication_takes.map { |entry| medication_take_payload(entry) }
+        end
+
+        def suspected_side_effect_payloads(result)
+          result.suspected_side_effects.map { |entry| health_event_payload(entry) }
+        end
+
+        def notable_illness_payloads(result)
+          result.notable_illnesses.map { |entry| health_event_payload(entry) }
+        end
+
+        def medication_take_payload(entry)
+          {
+            person_id: entry.person.id,
+            person_name: entry.person.name,
+            taken_at: entry.taken_at.iso8601,
+            medication_name: entry.medication_name,
+            dose: entry.dose_display,
+            source_type: entry.source_type,
+            location_name: entry.location_name
+          }
+        end
+
+        def health_event_payload(entry)
+          {
+            person_id: entry.person.id,
+            person_name: entry.person.name,
+            event_kind: entry.event_kind,
+            title: entry.title,
+            started_on: entry.started_on&.iso8601,
+            ended_on: entry.ended_on&.iso8601,
+            severity: entry.severity,
+            medication_names: entry.medication_names
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/household_snapshot_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/household_snapshot_tool.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  module Tools
+    class HouseholdSnapshotTool < BaseTool
+      tool_name 'medtracker_household_snapshot'
+      description 'Return a policy-scoped MedTracker household snapshot for the authenticated membership.'
+      input_schema(properties: {}, required: [])
+
+      class << self
+        def call(server_context:)
+          context = tool_context(server_context)
+          context.with_current do
+            snapshot = PortableData::Exporter.new(
+              household: context.household,
+              membership: context.membership,
+              passphrase: nil,
+              request: nil
+            ).mobile_snapshot
+
+            payload = {
+              format: 'medtracker.mcp.household_snapshot.v1',
+              snapshot: snapshot
+            }
+
+            response(payload, 'Policy-scoped MedTracker household snapshot.')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/inventory_risks_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/inventory_risks_tool.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  module Tools
+    class InventoryRisksTool < BaseTool
+      tool_name 'medtracker_inventory_risks'
+      description 'Return visible medications that are low-stock or out-of-stock.'
+      input_schema(properties: {}, required: [])
+
+      class << self
+        def call(server_context:)
+          context = tool_context(server_context)
+          context.with_current do
+            medications = context.policy_scope(Medication)
+                                 .includes(:location, :schedules, :person_medications)
+                                 .order(:name, :id)
+                                 .select { |medication| medication.low_stock? || medication.out_of_stock? }
+
+            payload = {
+              format: 'medtracker.mcp.inventory_risks.v1',
+              medications: medications.map { |medication| Api::V1::MedicationSerializer.new(medication).as_json }
+            }
+
+            response(payload, 'Visible low-stock and out-of-stock medications.')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/mcp/med_tracker_mcp/tools/today_schedule_tool.rb
+++ b/app/mcp/med_tracker_mcp/tools/today_schedule_tool.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module MedTrackerMcp
+  module Tools
+    class TodayScheduleTool < BaseTool
+      tool_name 'medtracker_today_schedule'
+      description 'Return visible schedules and medications already taken today.'
+      input_schema(properties: {}, required: [])
+
+      class << self
+        def call(server_context:)
+          context = tool_context(server_context)
+          context.with_current do
+            response(payload(context), 'Visible MedTracker schedule context for today.')
+          end
+        end
+
+        private
+
+        def payload(context)
+          {
+            format: 'medtracker.mcp.today_schedule.v1',
+            date: Time.zone.today.iso8601,
+            schedules: schedule_payloads(context),
+            taken_today: taken_today_payloads(context)
+          }
+        end
+
+        def schedule_payloads(context)
+          context.policy_scope(Schedule)
+                 .includes(:person, :medication)
+                 .order(:person_id, :id)
+                 .map { |schedule| Api::V1::ScheduleSerializer.new(schedule).as_json }
+        end
+
+        def taken_today_payloads(context)
+          people = context.policy_scope(Person).includes(:locations, :notification_preference)
+
+          Reports::TodayTakenMedicationsQuery.new(people: people).call.map { |group| taken_today_payload(group) }
+        end
+
+        def taken_today_payload(group)
+          {
+            person_id: group.person.id,
+            person_name: group.person.name,
+            medications: group.medications.map(&:to_h)
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,6 +4,7 @@ module Rack
   class Attack
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     MEDICATION_LOOKUP_PATH = %r{\A/households/[^/]+/medication-finder/search(?:\.[a-z]+)?\z}
+    MCP_PATH = '/mcp'
 
     throttle('req/ip', limit: 300, period: 5.minutes, &:ip)
 
@@ -37,6 +38,10 @@ module Rack
 
     throttle('api/auth/refresh/ip', limit: 30, period: 1.minute) do |req|
       req.ip if req.path == '/api/v1/auth/refresh' && req.post?
+    end
+
+    throttle('mcp/ip', limit: 60, period: 1.minute) do |req|
+      req.ip if req.path == MCP_PATH
     end
 
     throttle('admin/audit_logs/ip', limit: 100, period: 1.minute) do |req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount MedTrackerMcp::RackApp.new => '/mcp'
+
   namespace :api do
     namespace :v1 do
       get :capabilities, to: 'capabilities#show'

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -14,6 +14,13 @@ The following models have audit trail enabled:
 - **Medication**: Track changes to medication definitions and stock
 - **MedicationTake**: Track all medication doses (critical for patient safety)
 
+## Security Audit Events
+
+Security-sensitive operational events are stored in `security_audit_events`.
+MCP requests write `event_type: mcp.request` with the request ID, IP address,
+household, actor account, actor membership, JSON-RPC method, outcome, and HTTP
+status. Raw bearer tokens are not stored.
+
 ## Accessing Audit Logs
 
 - **URL**: `/admin/audit_logs`

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ ensuring medications are given on time and safely.
 - [Testing Guide](testing.md): run the RSpec and Capybara/Playwright test suites.
 - [Design & Architecture](design.md): explore the domain model and safety guardrails.
 - [Audit & Compliance](audit-trail.md): details on versioning and data history.
+- [MCP Integration](mcp.md): authenticated read-only agent access for medication context.
 - [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.
 
 ---

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,73 @@
+# MedTracker MCP
+
+MedTracker exposes an authenticated Model Context Protocol endpoint at `/mcp`.
+It uses the Ruby MCP SDK Streamable HTTP transport and the same bearer
+credentials as the mobile API: API sessions and API app tokens.
+
+## Why MCP exists
+
+The MCP gives agents a small, explicit read-only surface for household medication
+context. It is for assisted review workflows where an agent needs current
+MedTracker context without scraping HTML pages or learning the full REST API.
+
+Good MCP use cases:
+
+- Summarize today's visible medication schedule for the authenticated household membership.
+- Check low-stock and out-of-stock medication context before a caregiver review.
+- Review recent health history across people the membership is allowed to see.
+- Fetch a portable household snapshot for offline or agent-side analysis.
+
+## Endpoint
+
+Use JSON-RPC over Streamable HTTP:
+
+```http
+POST /mcp
+Authorization: Bearer <api-session-or-api-app-token>
+Accept: application/json
+Content-Type: application/json
+```
+
+Capabilities are advertised from `GET /api/v1/capabilities` under
+`data.client_tools.mcp_server`.
+
+## Tools
+
+The server currently exposes read-only tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `medtracker_current_user` | Returns the authenticated API user profile. |
+| `medtracker_household_snapshot` | Returns a policy-scoped portable household snapshot. |
+| `medtracker_today_schedule` | Returns visible schedules and medications taken today. |
+| `medtracker_inventory_risks` | Returns visible medication inventory risks. |
+| `medtracker_health_history_summary` | Returns a bounded recent health-history summary. |
+
+The health-history tool defaults to the last 30 days and rejects ranges over
+180 days.
+
+## Resources and prompts
+
+The MCP resource `medtracker://household/snapshot` returns the same structured
+payload as `medtracker_household_snapshot`.
+
+The prompt `medtracker_household_review` gives an agent a safe review brief for
+visible schedules, inventory risk, and recent health history.
+
+## Security boundary
+
+MCP access is tenant-scoped by the bearer credential's household membership.
+The endpoint rejects revoked credentials, expired API sessions, locked-out
+accounts, inactive users, inactive memberships, and stale API credentials.
+
+Tools use the same Pundit policy scopes as the API and never receive the raw
+bearer token. Every authenticated MCP request writes a `SecurityAuditEvent` with
+`event_type: mcp.request`, request ID, IP address, household, actor account,
+actor membership, JSON-RPC method, outcome, and HTTP status.
+
+## When not to use MCP
+
+Do not use the MCP for writes, medication administration, clinical source of
+truth exports, or workflows that require formal API versioning. Use the REST API
+for mobile sync and any state change. Use the encrypted portable export/import
+flow for backup, migration, and restore workflows.

--- a/docs/superpowers/plans/2026-07-07-medtracker-mcp.html
+++ b/docs/superpowers/plans/2026-07-07-medtracker-mcp.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MedTracker MCP Implementation Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #172033;
+      --muted: #59677a;
+      --border: #d9e2e7;
+      --teal: #0f766e;
+      --teal-dark: #0f3f3a;
+      --amber: #b45309;
+      --red: #b91c1c;
+      --slate: #0f172a;
+      --code: #e2e8f0;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font: 16px/1.55 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: var(--bg);
+    }
+
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+
+    header {
+      border-left: 6px solid var(--teal);
+      padding: 20px 24px;
+      background: var(--panel);
+      box-shadow: 0 1px 8px rgb(15 23 42 / 8%);
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: 34px;
+      line-height: 1.15;
+    }
+
+    h2 {
+      margin: 34px 0 14px;
+      color: var(--teal-dark);
+      font-size: 24px;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 19px;
+    }
+
+    p {
+      margin: 0 0 12px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 22px;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    .lede {
+      color: var(--muted);
+      margin-bottom: 0;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px;
+    }
+
+    .decision {
+      border-top: 4px solid var(--teal);
+    }
+
+    .warning {
+      border-top: 4px solid var(--amber);
+    }
+
+    .no {
+      border-top: 4px solid var(--red);
+    }
+
+    .tasks {
+      display: grid;
+      gap: 16px;
+    }
+
+    code,
+    pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.95em;
+    }
+
+    code {
+      background: #eef3f6;
+      border: 1px solid #dce5ea;
+      border-radius: 4px;
+      padding: 1px 5px;
+    }
+
+    pre {
+      overflow-x: auto;
+      background: var(--slate);
+      color: var(--code);
+      padding: 14px;
+      border-radius: 8px;
+    }
+
+    .meta {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 8px 12px;
+      margin-top: 14px;
+    }
+
+    .meta dt {
+      font-weight: 700;
+    }
+
+    .meta dd {
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>MedTracker MCP Implementation Plan</h1>
+    <p class="lede"><strong>For agentic workers:</strong> REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development, recommended, or superpowers:executing-plans to implement this plan task by task. Steps use checkbox syntax in the task details for tracking.</p>
+    <dl class="meta">
+      <dt>Goal</dt>
+      <dd>Add a secure, policy-aware Model Context Protocol server for MedTracker using <code>modelcontextprotocol/ruby-sdk</code>, starting with read-focused household context tools and explicitly deferring higher-risk writes.</dd>
+      <dt>Architecture</dt>
+      <dd>Mount the Ruby SDK <code>StreamableHTTPTransport</code> in Rails, authenticate with existing API app tokens, bind the same account, household, and membership context as <code>Api::V1::BaseController</code>, and expose MCP tools, resources, and prompts through service objects that reuse existing serializers, queries, Pundit scopes, tenant context, and audit events.</dd>
+      <dt>Tech Stack</dt>
+      <dd>Rails 8, Ruby, RSpec, Pundit, PaperTrail, SecurityAuditEvent, OpenTelemetry, <code>modelcontextprotocol/ruby-sdk</code>.</dd>
+    </dl>
+  </header>
+
+  <section>
+    <h2>Product Decision</h2>
+    <div class="grid">
+      <div class="card decision">
+        <h3>Why add an MCP?</h3>
+        <p>MedTracker already has structured medication, schedule, adherence, inventory, health-event, and household-context data. MCP makes that data usable by AI clients without teaching every assistant the app's bespoke REST API, route structure, and portable export format.</p>
+        <p>The strongest v1 use case is assisted review: "What doses are due today?", "Which medication needs reordering?", "Summarise this person's recent medication history", and "Prepare a clinician handoff from my household data."</p>
+      </div>
+
+      <div class="card decision">
+        <h3>Advantages</h3>
+        <ul>
+          <li><strong>Lower integration cost:</strong> one MCP contract works across MCP-capable clients instead of custom client glue per assistant.</li>
+          <li><strong>Safer AI access:</strong> tools can be narrow, typed, audited, policy-scoped, and easier to reason about than free-form database or API access.</li>
+          <li><strong>Better context quality:</strong> resources and prompts can provide domain-shaped context rather than raw JSON dumps.</li>
+          <li><strong>Reuses existing boundaries:</strong> the app already has API tokens, tenant context, serializers, Pundit policies, portable snapshots, and audit logging.</li>
+          <li><strong>Future product signal:</strong> <code>Api::V1::CapabilitiesController</code> already advertises <code>client_tools.mcp_server</code> as deferred, so this fills an existing product slot.</li>
+        </ul>
+      </div>
+
+      <div class="card no">
+        <h3>When not to build it</h3>
+        <ul>
+          <li>Do not build MCP if the goal is only mobile sync or CRUD integration; the existing REST API is the right surface for that.</li>
+          <li>Do not build it until authorization, tenant binding, audit logging, rate limiting, and token revocation are first-class in the MCP path.</li>
+          <li>Do not expose write tools until read tools have production telemetry and misuse patterns are understood.</li>
+          <li>Do not use MCP for emergency or clinical decision support; MCP responses must remain informational and user-mediated.</li>
+          <li>Do not expose raw portable exports as a default tool result; context should be minimized by task and person access.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Key Interfaces</h2>
+    <div class="card">
+      <ul>
+        <li>Add <code>gem "mcp", require: false</code> or the exact gem name required by the current <code>modelcontextprotocol/ruby-sdk</code> release after confirming Bundler resolution.</li>
+        <li>Mount <code>MCP::Server::Transports::StreamableHTTPTransport.new(server, stateless: true)</code> at <code>/mcp</code>.</li>
+        <li>Create <code>app/mcp/med_tracker_mcp/server.rb</code> to assemble server metadata, tools, resources, prompts, and SDK configuration.</li>
+        <li>Create <code>app/mcp/med_tracker_mcp/context.rb</code> to authenticate bearer tokens with <code>ApiSession.lookup_by_access_token</code> and <code>ApiAppToken.lookup_by_token</code>, then bind <code>TenantContext</code>, <code>Current.account</code>, <code>Current.household</code>, and <code>Current.membership</code>.</li>
+        <li>Create read-only v1 tools: <code>medtracker_current_user</code>, <code>medtracker_household_snapshot</code>, <code>medtracker_today_schedule</code>, <code>medtracker_inventory_risks</code>, and <code>medtracker_health_history_summary</code>.</li>
+        <li>Create one prompt: <code>medtracker_prepare_clinician_handoff</code>, which asks the client model to summarise tool and resource output without inventing medical advice.</li>
+        <li>Update <code>Api::V1::CapabilitiesController</code> so <code>client_tools.mcp_server.supported</code> becomes <code>true</code> only after the route and auth tests pass.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section>
+    <h2>Implementation Tasks</h2>
+    <div class="tasks">
+      <div class="card">
+        <h3>Task 1: SDK dependency and boot wiring</h3>
+        <p><strong>Files:</strong> <code>Gemfile</code>, <code>config/application.rb</code> if autoload paths need <code>app/mcp</code>, <code>spec/lib/runtime_stack_contract_spec.rb</code>.</p>
+        <ul>
+          <li><input type="checkbox" disabled> Write a failing spec proving the MCP SDK constant can load in the test container.</li>
+          <li><input type="checkbox" disabled> Add the SDK gem and run <code>task test TEST_FILE=spec/lib/runtime_stack_contract_spec.rb</code>.</li>
+          <li><input type="checkbox" disabled> Run <code>task rubocop</code>.</li>
+          <li><input type="checkbox" disabled> Commit with <code>feat(mcp): add ruby sdk dependency</code>.</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Task 2: Authenticated MCP context</h3>
+        <p><strong>Files:</strong> <code>app/mcp/med_tracker_mcp/context.rb</code>, <code>spec/mcp/med_tracker_mcp/context_spec.rb</code>.</p>
+        <ul>
+          <li><input type="checkbox" disabled> Write failing specs for missing bearer token, revoked token, locked account, inactive membership, stale permissions version, and successful app-token binding.</li>
+          <li><input type="checkbox" disabled> Implement a small context object that mirrors <code>Api::V1::BaseController</code> authentication rules and returns a plain context hash for <code>server_context</code>.</li>
+          <li><input type="checkbox" disabled> Include <code>request_id</code>, account ID, household ID, membership ID, and trace metadata; never include raw token values.</li>
+          <li><input type="checkbox" disabled> Run <code>task test TEST_FILE=spec/mcp/med_tracker_mcp/context_spec.rb</code>.</li>
+          <li><input type="checkbox" disabled> Commit with <code>feat(mcp): bind authenticated tenant context</code>.</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Task 3: Read-only MCP tools and resources</h3>
+        <p><strong>Files:</strong> <code>app/mcp/med_tracker_mcp/tools/*.rb</code>, <code>app/mcp/med_tracker_mcp/resources/*.rb</code>, <code>spec/mcp/med_tracker_mcp/tools/*_spec.rb</code>.</p>
+        <ul>
+          <li><input type="checkbox" disabled> Write failing specs for each tool returning only policy-scoped household data.</li>
+          <li><input type="checkbox" disabled> Implement tools using existing services and serializers: <code>Api::V1::MeSerializer</code>, <code>PortableData::Exporter#mobile_snapshot</code>, <code>Reports::TodayTakenMedicationsQuery</code>, <code>Reports::HealthHistoryQuery</code>, and medication inventory/reorder query services.</li>
+          <li><input type="checkbox" disabled> Return compact MCP text and JSON payloads with stable keys, ISO8601 times, and no raw database errors.</li>
+          <li><input type="checkbox" disabled> Reject unbounded date ranges; default health history to the last 30 days and cap it at 180 days.</li>
+          <li><input type="checkbox" disabled> Run <code>task test TEST_FILE=spec/mcp/med_tracker_mcp/tools</code>.</li>
+          <li><input type="checkbox" disabled> Commit with <code>feat(mcp): expose read only medication context tools</code>.</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Task 4: Server mount, prompt, capabilities, and audits</h3>
+        <p><strong>Files:</strong> <code>app/mcp/med_tracker_mcp/server.rb</code>, <code>config/routes.rb</code>, <code>app/controllers/api/v1/capabilities_controller.rb</code>, <code>spec/requests/mcp/server_spec.rb</code>, <code>spec/requests/api/v1/capabilities_spec.rb</code>.</p>
+        <ul>
+          <li><input type="checkbox" disabled> Write request specs for unauthenticated <code>/mcp</code>, authenticated initialize/list-tools, and capability flag output.</li>
+          <li><input type="checkbox" disabled> Mount the SDK Streamable HTTP transport in stateless mode.</li>
+          <li><input type="checkbox" disabled> Add an SDK configuration <code>around_request</code> hook that records method/tool name, request ID, membership ID, and outcome through existing audit and telemetry paths.</li>
+          <li><input type="checkbox" disabled> Add <code>medtracker_prepare_clinician_handoff</code> as a prompt that instructs clients to summarise facts, uncertainties, and suggested questions, not prescribe treatment.</li>
+          <li><input type="checkbox" disabled> Run <code>task test TEST_FILE=spec/requests/mcp/server_spec.rb</code> and <code>task test TEST_FILE=spec/requests/api/v1/capabilities_spec.rb</code>.</li>
+          <li><input type="checkbox" disabled> Commit with <code>feat(mcp): mount hosted streamable http server</code>.</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Task 5: Documentation, security review, and final gates</h3>
+        <p><strong>Files:</strong> <code>docs/mcp.md</code>, <code>docs/api/openapi.v1.yaml</code> if capability docs are mirrored there, <code>docs/security-review.md</code> if the security model changes.</p>
+        <ul>
+          <li><input type="checkbox" disabled> Document purpose, supported tools, token setup, revocation, limitations, and "not medical advice" boundaries.</li>
+          <li><input type="checkbox" disabled> Add a short admin/operator note for hosted deployment: route path, stateless transport, logs, audit events, and rate-limit expectations.</li>
+          <li><input type="checkbox" disabled> Run <code>task rubocop</code>, <code>task brakeman</code>, and <code>task test</code>.</li>
+          <li><input type="checkbox" disabled> Commit with <code>docs(mcp): document agent access boundaries</code>.</li>
+          <li><input type="checkbox" disabled> Finish with <code>git pull --rebase</code>, <code>git push</code>, and <code>git status</code> showing the branch is up to date.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Test Plan</h2>
+    <div class="card warning">
+      <ul>
+        <li><strong>Auth:</strong> missing, malformed, expired, revoked, locked-out, inactive membership, stale permissions version, and valid app-token cases.</li>
+        <li><strong>Authorization:</strong> household manager sees full household-scoped data; carer, parent, and clinician users only see policy-granted people and medication records.</li>
+        <li><strong>Tenant safety:</strong> cross-household IDs never leak; tools use Pundit scopes and tenant context rather than raw model lookups.</li>
+        <li><strong>Tool behavior:</strong> output is bounded, deterministic, JSON-serializable, and stable for empty households, no medications, no takes today, and invalid date ranges.</li>
+        <li><strong>Observability:</strong> each MCP request has request ID, tool name, actor membership, success/failure outcome, and no raw bearer token in logs or spans.</li>
+        <li><strong>Security gates:</strong> <code>task brakeman</code> plus manual review of auth, authorization, token handling, rate limiting, audit trails, and health-data minimization.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section>
+    <h2>Assumptions and Defaults</h2>
+    <div class="card">
+      <ul>
+        <li>V1 is hosted Streamable HTTP MCP, not a local stdio-only helper, because MedTracker's value is authenticated household data.</li>
+        <li>V1 is read-only. Medication-taking and mutation tools are deferred until there is an explicit confirmation UX and stronger misuse telemetry.</li>
+        <li>Existing API app tokens are the initial credential type; no new OAuth provider is introduced in this plan.</li>
+        <li>All implementation commands use <code>task</code>; no direct <code>bundle exec rspec</code> or <code>docker compose</code> commands.</li>
+        <li>SDK details are based on current Context7 docs for <code>/modelcontextprotocol/ruby-sdk</code>: <code>MCP::Server</code>, class-based tools/resources, prompts, <code>server_context</code>, SDK configuration hooks, and Rails-mounted <code>StreamableHTTPTransport</code>.</li>
+      </ul>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/spec/lib/runtime_stack_contract_spec.rb
+++ b/spec/lib/runtime_stack_contract_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe RuntimeStackContract do
     expect(playwright_version).to start_with("#{expected_versions.fetch(:playwright)}.")
   end
 
+  it 'loads the MCP Ruby SDK server primitives used by the hosted MCP endpoint' do
+    require 'mcp'
+
+    expect(MCP::Server).to be_a(Class)
+    expect(MCP::Tool).to be_a(Class)
+    expect(MCP::Server::Transports::StreamableHTTPTransport).to be_a(Class)
+  end
+
   it 'documents locked dependency versions in both agent guides' do
     agent_guide_paths.each do |path|
       document = read_file(path)

--- a/spec/mcp/med_tracker_mcp/context_spec.rb
+++ b/spec/mcp/med_tracker_mcp/context_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedTrackerMcp::Context do
+  fixtures :accounts, :people, :users, :households
+
+  describe '.resolve!' do
+    it 'returns a token-scoped server context for a valid app token' do
+      context = described_class.resolve!(request_for(raw_token))
+
+      expect(context.to_h).to include(
+        account: account,
+        account_id: account.id,
+        household: household,
+        household_id: household.id,
+        membership: membership,
+        membership_id: membership.id,
+        request_id: 'mcp-request-123',
+        remote_ip: '203.0.113.10'
+      )
+      expect(context.to_h.fetch(:api_credential)).to eq(app_token)
+      expect(context.to_h.values).not_to include(raw_token)
+    end
+
+    it 'binds tenant state only while yielding through the context' do
+      context = described_class.resolve!(request_for(raw_token))
+      Current.reset
+
+      current_state = nil
+      context.with_current do
+        current_state = [Current.account, Current.household, Current.membership, Current.request_id]
+      end
+
+      expect(current_state).to eq([account, household, membership, 'mcp-request-123'])
+      expect([Current.account, Current.household, Current.membership, Current.request_id]).to all(be_nil)
+    end
+
+    it 'rejects requests without bearer tokens' do
+      expect_authentication_failure(request_for(nil))
+    end
+
+    it 'rejects unknown bearer tokens' do
+      expect_authentication_failure(request_for('not-a-real-token'))
+    end
+
+    it 'rejects revoked app tokens' do
+      app_token.revoke!(audit_context: { request_id: 'revoke-request' })
+
+      expect_authentication_failure(request_for(raw_token))
+    end
+
+    it 'rejects locked accounts' do
+      AccountLockout.create!(
+        account: account,
+        key: 'mcp-lockout',
+        deadline: 1.hour.from_now,
+        created_at: Time.current,
+        updated_at: Time.current
+      )
+
+      expect_authentication_failure(request_for(raw_token))
+    end
+
+    it 'rejects inactive memberships' do
+      raw_token
+      membership.update!(status: :suspended)
+
+      expect_authentication_failure(request_for(raw_token))
+    end
+
+    it 'rejects tokens with stale membership permissions' do
+      raw_token
+      membership.update!(permissions_version: membership.permissions_version + 1)
+
+      expect_authentication_failure(request_for(raw_token))
+    end
+  end
+
+  def request_for(token)
+    Struct.new(:headers, :request_id, :remote_ip, keyword_init: true).new(
+      headers: token ? { 'Authorization' => "Bearer #{token}" } : {},
+      request_id: 'mcp-request-123',
+      remote_ip: '203.0.113.10'
+    )
+  end
+
+  def expect_authentication_failure(request)
+    expect do
+      described_class.resolve!(request)
+    end.to raise_error(described_class::AuthenticationError) { |error|
+      expect(error).to have_attributes(
+        status: :unauthorized,
+        code: 'unauthorized',
+        message: 'Authentication required'
+      )
+    }
+  end
+
+  def account
+    accounts(:jane_doe)
+  end
+
+  def household
+    households(:fixture_household)
+  end
+
+  def person
+    people(:jane)
+  end
+
+  def membership
+    @membership ||= household.household_memberships.find_or_create_by!(account: account) do |household_membership|
+      household_membership.person = person
+      household_membership.role = :member
+      household_membership.status = :active
+    end
+  end
+
+  def app_token
+    token_pair.first
+  end
+
+  def raw_token
+    token_pair.last
+  end
+
+  def token_pair
+    @token_pair ||= ApiAppToken.issue_for(
+      account: account,
+      household_membership: membership,
+      name: 'RSpec MCP token',
+      audit_context: { request_id: 'issue-request' }
+    )
+  end
+end

--- a/spec/mcp/med_tracker_mcp/tools_spec.rb
+++ b/spec/mcp/med_tracker_mcp/tools_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MedTrackerMcp::Tools do
+  fixtures :accounts, :people, :users, :households, :locations, :medications, :schedules,
+           :person_medications, :medication_takes
+
+  before do
+    grant_jane_manage_access!
+    medications(:ibuprofen).update!(current_supply: 1, reorder_threshold: 5, supply_at_last_restock: 30)
+  end
+
+  it 'returns the current API user profile' do
+    payload = call_tool(MedTrackerMcp::Tools::CurrentUserTool)
+
+    expect(payload.fetch(:format)).to eq('medtracker.mcp.current_user.v1')
+    expect(payload.dig(:user, :email_address)).to eq(users(:jane).email_address)
+    expect(payload.dig(:user, :person, :id)).to eq(people(:jane).id)
+  end
+
+  it 'returns a policy-scoped household snapshot' do
+    payload = call_tool(MedTrackerMcp::Tools::HouseholdSnapshotTool)
+
+    expect(payload.fetch(:format)).to eq('medtracker.mcp.household_snapshot.v1')
+    people = payload.dig(:snapshot, :records, :people)
+    expect(people.pluck(:portable_id)).to contain_exactly(
+      people(:jane).portable_id,
+      people(:child_patient).portable_id
+    )
+  end
+
+  it 'returns today schedule context with taken medication summaries' do
+    payload = call_tool(MedTrackerMcp::Tools::TodayScheduleTool)
+
+    expect(payload.fetch(:format)).to eq('medtracker.mcp.today_schedule.v1')
+    expect(payload.fetch(:schedules).pluck(:id)).to include(schedules(:jane_ibuprofen).id)
+    expect(payload.fetch(:taken_today)).to include(
+      hash_including(person_id: people(:jane).id, medications: [hash_including(name: 'Ibuprofen')])
+    )
+  end
+
+  it 'returns inventory risks from visible medications only' do
+    payload = call_tool(MedTrackerMcp::Tools::InventoryRisksTool)
+
+    expect(payload.fetch(:format)).to eq('medtracker.mcp.inventory_risks.v1')
+    expect(payload.fetch(:medications)).to include(hash_including(id: medications(:ibuprofen).id, low_stock: true))
+    expect(payload.fetch(:medications).pluck(:id)).not_to include(medications(:paracetamol).id)
+  end
+
+  it 'returns a bounded health history summary for visible people' do
+    payload = call_tool(
+      MedTrackerMcp::Tools::HealthHistorySummaryTool,
+      start_date: 10.days.ago.to_date.iso8601,
+      end_date: Time.zone.today.iso8601
+    )
+
+    expect(payload.fetch(:format)).to eq('medtracker.mcp.health_history_summary.v1')
+    expect(payload.fetch(:people).pluck(:id)).to contain_exactly(people(:jane).id, people(:child_patient).id)
+    expect(payload.fetch(:medication_takes).pluck(:medication_name)).to include('Ibuprofen')
+  end
+
+  it 'describes the household snapshot resource' do
+    resource = MedTrackerMcp::Resources::HouseholdSnapshot.definition
+
+    expect(resource.to_h).to include(
+      uri: 'medtracker://household/snapshot',
+      name: 'household_snapshot',
+      mimeType: 'application/json'
+    )
+  end
+
+  def call_tool(tool, **arguments)
+    context.with_current do
+      tool.call(**arguments, server_context: context.to_h).to_h.fetch(:structuredContent)
+    end
+  end
+
+  def context
+    @context ||= MedTrackerMcp::Context.resolve!(request_for(raw_token))
+  end
+
+  def request_for(token)
+    Struct.new(:headers, :request_id, :remote_ip, keyword_init: true).new(
+      headers: { 'Authorization' => "Bearer #{token}" },
+      request_id: 'tool-request',
+      remote_ip: '203.0.113.20'
+    )
+  end
+
+  def raw_token
+    @raw_token ||= ApiAppToken.issue_for(
+      account: accounts(:jane_doe),
+      household_membership: membership,
+      name: 'RSpec MCP tools token',
+      audit_context: { request_id: 'tool-token' }
+    ).last
+  end
+
+  def membership
+    @membership ||= households(:fixture_household).household_memberships.find_or_create_by!(
+      account: accounts(:jane_doe)
+    ) do |household_membership|
+      household_membership.person = people(:jane)
+      household_membership.role = :member
+      household_membership.status = :active
+    end
+  end
+
+  def grant_jane_manage_access!
+    PersonAccessGrant.find_or_create_by!(
+      household: households(:fixture_household),
+      household_membership: membership,
+      person: people(:jane)
+    ) do |grant|
+      grant.access_level = :manage
+      grant.relationship_type = :self
+      grant.granted_by_membership = membership
+    end
+  end
+end

--- a/spec/mcp/med_tracker_mcp/tools_spec.rb
+++ b/spec/mcp/med_tracker_mcp/tools_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MedTrackerMcp::Tools do
 
   before do
     grant_jane_manage_access!
+    grant_child_manage_access!
     medications(:ibuprofen).update!(current_supply: 1, reorder_threshold: 5, supply_at_last_restock: 30)
   end
 
@@ -115,6 +116,18 @@ RSpec.describe MedTrackerMcp::Tools do
     ) do |grant|
       grant.access_level = :manage
       grant.relationship_type = :self
+      grant.granted_by_membership = membership
+    end
+  end
+
+  def grant_child_manage_access!
+    PersonAccessGrant.find_or_create_by!(
+      household: households(:fixture_household),
+      household_membership: membership,
+      person: people(:child_patient)
+    ) do |grant|
+      grant.access_level = :manage
+      grant.relationship_type = :parent
       grant.granted_by_membership = membership
     end
   end

--- a/spec/requests/api/v1/capabilities_spec.rb
+++ b/spec/requests/api/v1/capabilities_spec.rb
@@ -23,7 +23,15 @@ RSpec.describe 'API v1 capabilities' do
     expect(data.dig('client_tools', 'mcp_server')).to include(
       'supported' => true,
       'transport' => 'streamable_http',
-      'endpoint' => '/mcp'
+      'endpoint' => '/mcp',
+      'tools' => include(
+        'medtracker_current_user',
+        'medtracker_household_snapshot',
+        'medtracker_today_schedule',
+        'medtracker_inventory_risks',
+        'medtracker_health_history_summary'
+      ),
+      'resources' => include('medtracker://household/snapshot')
     )
   end
 end

--- a/spec/requests/api/v1/capabilities_spec.rb
+++ b/spec/requests/api/v1/capabilities_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'API v1 capabilities' do
     expect(data.dig('sync', 'portable_ids')).to be(true)
     expect(data.dig('sync', 'numeric_ids')).to eq('backward_compatible')
     expect(data.dig('client_tools', 'cli')).to include('supported' => false, 'status' => 'deferred')
-    expect(data.dig('client_tools', 'mcp_server')).to include('supported' => false, 'status' => 'deferred')
+    expect(data.dig('client_tools', 'mcp_server')).to include(
+      'supported' => true,
+      'transport' => 'streamable_http',
+      'endpoint' => '/mcp'
+    )
   end
 end

--- a/spec/requests/mcp/server_spec.rb
+++ b/spec/requests/mcp/server_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe 'MedTracker MCP server' do
     expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
   end
 
+  it 'throttles repeated MCP requests at the Rack boundary' do
+    with_rack_attack_enabled do
+      60.times { mcp_post('tools/list', headers: mcp_headers.except('Authorization')) }
+      expect(response).to have_http_status(:unauthorized)
+
+      mcp_post('tools/list', headers: mcp_headers.except('Authorization'))
+    end
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.headers['Retry-After'].to_i).to be_positive
+  end
+
   it 'initializes the server and publishes read-only tools, resources, and prompts' do
     mcp_post(
       'initialize',
@@ -80,6 +92,31 @@ RSpec.describe 'MedTracker MCP server' do
     expect(audit_event.metadata.to_json).not_to include(raw_token)
   end
 
+  it 'does not let audit write failures replace the transport response' do
+    allow(SecurityAuditEvent).to receive(:create!).and_raise(ActiveRecord::ConnectionNotEstablished, 'audit offline')
+
+    mcp_post('tools/list')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('result', 'tools').pluck('name')).to include('medtracker_current_user')
+  end
+
+  it 'keeps batch JSON-RPC request auditing from replacing the transport response' do
+    post '/mcp',
+         params: [
+           { jsonrpc: '2.0', id: next_request_id, method: 'tools/list', params: {} }
+         ],
+         headers: mcp_headers,
+         as: :json
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body.dig('error', 'message')).to include('JSON-RPC body must be a single request object')
+
+    audit_event = SecurityAuditEvent.where(event_type: 'mcp.request').order(:created_at).last
+    expect(audit_event.metadata).to include('status' => 400)
+    expect(audit_event.metadata).not_to have_key('method')
+  end
+
   it 'reads the household snapshot resource through the MCP resource API' do
     mcp_post(
       'resources/read',
@@ -110,6 +147,19 @@ RSpec.describe 'MedTracker MCP server' do
       'Authorization' => "Bearer #{raw_token}",
       'Accept' => 'application/json'
     }
+  end
+
+  def with_rack_attack_enabled
+    original_cache_store = Rack::Attack.cache.store
+    original_enabled = Rack::Attack.enabled
+
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+
+    yield
+  ensure
+    Rack::Attack.cache.store = original_cache_store
+    Rack::Attack.enabled = original_enabled
   end
 
   def raw_token

--- a/spec/requests/mcp/server_spec.rb
+++ b/spec/requests/mcp/server_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'MedTracker MCP server' do
+  fixtures :accounts, :people, :users, :households, :locations, :medications, :schedules,
+           :person_medications, :medication_takes
+
+  before do
+    grant_jane_manage_access!
+  end
+
+  it 'rejects unauthenticated MCP requests' do
+    mcp_post('tools/list', headers: mcp_headers.except('Authorization'))
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(response.parsed_body.dig('error', 'code')).to eq('unauthorized')
+  end
+
+  it 'initializes the server and publishes read-only tools, resources, and prompts' do
+    mcp_post(
+      'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'RSpec MCP client', version: '1.0' }
+      }
+    )
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('result', 'serverInfo')).to include(
+      'name' => 'med_tracker',
+      'title' => 'MedTracker MCP'
+    )
+
+    mcp_post('tools/list')
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('result', 'tools').pluck('name')).to include(
+      'medtracker_current_user',
+      'medtracker_household_snapshot',
+      'medtracker_today_schedule',
+      'medtracker_inventory_risks',
+      'medtracker_health_history_summary'
+    )
+
+    mcp_post('resources/list')
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('result', 'resources')).to include(
+      hash_including('uri' => 'medtracker://household/snapshot', 'name' => 'household_snapshot')
+    )
+
+    mcp_post('prompts/list')
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig('result', 'prompts')).to include(
+      hash_including('name' => 'medtracker_household_review')
+    )
+  end
+
+  it 'runs tools inside the authenticated tenant context and audits the MCP request' do
+    mcp_post(
+      'tools/call',
+      params: {
+        name: 'medtracker_current_user',
+        arguments: {}
+      }
+    )
+
+    expect(response).to have_http_status(:ok)
+    result = response.parsed_body.fetch('result')
+    expect(result.dig('structuredContent', 'user', 'email_address')).to eq(users(:jane).email_address)
+
+    audit_event = SecurityAuditEvent.where(event_type: 'mcp.request').order(:created_at).last
+    expect(audit_event).to have_attributes(
+      household: households(:fixture_household),
+      actor_account: accounts(:jane_doe),
+      actor_membership: membership,
+      request_id: be_present
+    )
+    expect(audit_event.metadata).to include('method' => 'tools/call', 'outcome' => 'ok')
+    expect(audit_event.metadata.to_json).not_to include(raw_token)
+  end
+
+  it 'reads the household snapshot resource through the MCP resource API' do
+    mcp_post(
+      'resources/read',
+      params: { uri: 'medtracker://household/snapshot' }
+    )
+
+    expect(response).to have_http_status(:ok)
+    contents = response.parsed_body.dig('result', 'contents')
+    expect(contents).to include(hash_including('uri' => 'medtracker://household/snapshot'))
+    snapshot = JSON.parse(contents.first.fetch('text'))
+    expect(snapshot).to include('format' => 'medtracker.mcp.household_snapshot.v1')
+  end
+
+  def mcp_post(method, params: {}, headers: mcp_headers)
+    post '/mcp',
+         params: { jsonrpc: '2.0', id: next_request_id, method: method, params: params },
+         headers: headers,
+         as: :json
+  end
+
+  def next_request_id
+    @next_request_id ||= 0
+    @next_request_id += 1
+  end
+
+  def mcp_headers
+    {
+      'Authorization' => "Bearer #{raw_token}",
+      'Accept' => 'application/json'
+    }
+  end
+
+  def raw_token
+    @raw_token ||= ApiAppToken.issue_for(
+      account: accounts(:jane_doe),
+      household_membership: membership,
+      name: 'RSpec MCP server token',
+      audit_context: { request_id: 'mcp-server-token' }
+    ).last
+  end
+
+  def membership
+    @membership ||= households(:fixture_household).household_memberships.find_or_create_by!(
+      account: accounts(:jane_doe)
+    ) do |household_membership|
+      household_membership.person = people(:jane)
+      household_membership.role = :member
+      household_membership.status = :active
+    end
+  end
+
+  def grant_jane_manage_access!
+    PersonAccessGrant.find_or_create_by!(
+      household: households(:fixture_household),
+      household_membership: membership,
+      person: people(:jane)
+    ) do |grant|
+      grant.access_level = :manage
+      grant.relationship_type = :self
+      grant.granted_by_membership = membership
+    end
+  end
+end


### PR DESCRIPTION
## Why this is useful

This gives MedTracker a purpose-built agent doorway for medication context. Assistants no longer need to scrape pages, guess REST shapes, or ask for broad data exports just to answer practical household questions.

The useful bit is the shape of the boundary: an agent gets exactly the context it needs to help with daily review, stock risk, recent health history, and household medication summaries, while MedTracker keeps authentication, tenant membership, Pundit scoping, and audit logging in charge.

That opens up higher-value workflows without widening the product surface area: caregiver daily briefs, low-stock review, appointment prep, medication history summaries, and safer agent-side analysis of the existing portable household snapshot.

## What changed

- Adds the Ruby MCP SDK and mounts a Streamable HTTP MCP endpoint at `/mcp`.
- Reuses existing API sessions and API app tokens for authentication.
- Resolves every MCP request into the current account, household, and membership context.
- Exposes read-only tools for current user, household snapshot, today schedule, inventory risks, and bounded health history.
- Adds a household snapshot MCP resource and a household review prompt.
- Advertises MCP support through `/api/v1/capabilities`.
- Documents how to use the endpoint and when not to use it.

## Boundaries

This is intentionally read-only. State changes, medication administration, mobile sync, backup, restore, and formal API workflows stay on the existing REST and portable-data surfaces.

Every authenticated MCP request writes a `mcp.request` security audit event with the household, actor account, actor membership, JSON-RPC method, outcome, request ID, and IP address. Raw bearer tokens are not passed into tools or stored in audit metadata.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->