### PR TITLE
fix(security): tighten delegated medication access

### DIFF
--- a/app/components/admin/users/form_view.rb
+++ b/app/components/admin/users/form_view.rb
@@ -304,7 +304,7 @@ module Components
                 render RubyUI::ComboboxList.new do
                   render(RubyUI::ComboboxEmptyState.new { t('admin.users.form.select_role') })
 
-                  HouseholdMembership.roles.each_key do |role|
+                  ::Admin::MembershipRoleUpdater::ALLOWED_ROLES.each do |role|
                     render RubyUI::ComboboxItem.new do
                       render RubyUI::ComboboxRadio.new(
                         name: field_name,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,6 +36,14 @@ module Admin
       @user = User.new(user_params)
       authorize @user
 
+      unless create_membership_role_valid?
+        respond_to do |format|
+          format.html { render_user_form_with_errors }
+          format.turbo_stream { render_user_form_with_errors }
+        end
+        return
+      end
+
       if account_already_exists?
         respond_to do |format|
           format.html { render_user_form_with_errors }
@@ -156,6 +164,22 @@ module Admin
 
       @user.errors.add(:email_address, :taken)
       true
+    end
+
+    def create_membership_role_valid?
+      requested_role = @user.membership_role.presence || 'member'
+      return true if ::Admin::MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
+
+      @user.errors.add(:membership_role, create_membership_role_error(requested_role))
+      false
+    end
+
+    def create_membership_role_error(requested_role)
+      if requested_role == ::Admin::MembershipRoleUpdater::OWNER_ROLE
+        t('admin.membership_roles.owner_rejected')
+      else
+        t('admin.membership_roles.invalid_role')
+      end
     end
 
     def create_user_with_account!
@@ -315,7 +339,7 @@ module Admin
 
     def membership_role
       requested_role = @user.membership_role.presence
-      return requested_role if HouseholdMembership.roles.key?(requested_role)
+      return requested_role if ::Admin::MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
 
       :member
     end

--- a/app/controllers/api/v1/medications_controller.rb
+++ b/app/controllers/api/v1/medications_controller.rb
@@ -18,6 +18,7 @@ module Api
       def create
         medication = Medication.new(medication_params)
         medication.household = current_household
+        medication.created_by_membership_id = current_membership.id
         medication.paper_trail_event = 'api_create'
         authorize medication
 

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -234,7 +234,9 @@ class MedicationsController < ApplicationController
   end
 
   def build_medication_from_request
-    Medication.new(onboarding_builder.merge_create_attributes(medication_params.to_h.deep_symbolize_keys))
+    Medication.new(onboarding_builder.merge_create_attributes(medication_params.to_h.deep_symbolize_keys)).tap do |medication|
+      medication.created_by_membership_id = Current.membership&.id
+    end
   end
 
   def redirect_update_success

--- a/app/policies/medication_policy.rb
+++ b/app/policies/medication_policy.rb
@@ -56,7 +56,15 @@ class MedicationPolicy < ApplicationPolicy
       household_scope = scope.where(household: household)
       return household_scope if household_manager?
 
-      household_scope.where(id: granted_medication_ids_for(:view))
+      granted_scope = household_scope.where(id: granted_medication_ids_for(:view))
+      granted_scope.or(delegated_created_unlinked_scope(household_scope))
+    end
+
+    def delegated_created_unlinked_scope(household_scope)
+      household_scope
+        .where(created_by_membership_id: membership&.id)
+        .where.not(id: Schedule.where(household: household).select(:medication_id))
+        .where.not(id: PersonMedication.where(household: household).select(:medication_id))
     end
   end
 
@@ -66,7 +74,7 @@ class MedicationPolicy < ApplicationPolicy
     return false unless active_membership? && same_household?(record)
     return true if household_manager?
 
-    granted_medication_ids_for(:view).include?(record.id)
+    granted_medication_ids_for(:view).include?(record.id) || delegated_created_unlinked_medication?
   end
 
   def can_refill_in_household?
@@ -81,5 +89,12 @@ class MedicationPolicy < ApplicationPolicy
     return true if record.is_a?(Class) || record.location_id.blank?
 
     same_household?(record.location)
+  end
+
+  def delegated_created_unlinked_medication?
+    return false unless record.created_by_membership_id == membership&.id
+
+    Schedule.where(household: household, medication: record).none? &&
+      PersonMedication.where(household: household, medication: record).none?
   end
 end

--- a/app/policies/medication_policy.rb
+++ b/app/policies/medication_policy.rb
@@ -54,7 +54,7 @@ class MedicationPolicy < ApplicationPolicy
       return scope.none unless active_membership?
 
       household_scope = scope.where(household: household)
-      return household_scope if household_manager? || any_person_grant_allows?(:manage)
+      return household_scope if household_manager?
 
       household_scope.where(id: granted_medication_ids_for(:view))
     end

--- a/app/services/admin/membership_role_updater.rb
+++ b/app/services/admin/membership_role_updater.rb
@@ -2,6 +2,9 @@
 
 module Admin
   class MembershipRoleUpdater
+    OWNER_ROLE = 'owner'
+    ALLOWED_ROLES = %w[administrator member].freeze
+
     Result = Data.define(:success?, :message)
 
     def initialize(membership:, role:, actor_account:, actor_membership:, request:)
@@ -13,7 +16,7 @@ module Admin
     end
 
     def call
-      return Result.new(false, I18n.t('admin.membership_roles.owner_rejected')) if role == 'owner'
+      return Result.new(false, I18n.t('admin.membership_roles.owner_rejected')) if role == OWNER_ROLE
       return Result.new(false, I18n.t('admin.membership_roles.invalid_role')) unless allowed_role?
 
       previous_role = membership.role
@@ -29,7 +32,7 @@ module Admin
     attr_reader :membership, :role, :actor_account, :actor_membership, :request
 
     def allowed_role?
-      %w[administrator member].include?(role)
+      ALLOWED_ROLES.include?(role)
     end
 
     def record_audit_event(previous_role)

--- a/app/services/medication_stock_source_resolver.rb
+++ b/app/services/medication_stock_source_resolver.rb
@@ -59,7 +59,10 @@ class MedicationStockSourceResolver
     context = authorization_context
     return Medication.where(id: source.medication_id) unless context
 
-    MedicationPolicy::Scope.new(context, Medication.all).resolve
+    policy_scope = MedicationPolicy::Scope.new(context, Medication.all).resolve
+    return policy_scope if household_manager_context?(context)
+
+    policy_scope.where(id: source_person_medication_ids(context))
   end
 
   def authorization_context
@@ -72,5 +75,35 @@ class MedicationStockSourceResolver
     return unless membership
 
     AuthorizationContext.new(account: account, household: membership.household, membership: membership)
+  end
+
+  def household_manager_context?(context)
+    membership = context.membership
+    return true if membership&.active? && (membership.owner? || membership.administrator?)
+
+    platform_support_context?(context)
+  end
+
+  def platform_support_context?(context)
+    context.account&.platform_admin&.active? &&
+      Current.support_access_session&.active? &&
+      Current.support_access_session.household_id == context.household&.id
+  end
+
+  def source_person_medication_ids(context)
+    person_id = source_person_id
+    return [source.medication_id] if person_id.blank?
+
+    ids = [source.medication_id]
+    ids.concat(Schedule.where(household: context.household, person_id: person_id).pluck(:medication_id))
+    ids.concat(PersonMedication.where(household: context.household, person_id: person_id).pluck(:medication_id))
+    ids.compact.uniq
+  end
+
+  def source_person_id
+    return source.person_id if source.respond_to?(:person_id) && source.person_id.present?
+    return source.person&.id if source.respond_to?(:person)
+
+    nil
   end
 end

--- a/app/services/portable_data/importer.rb
+++ b/app/services/portable_data/importer.rb
@@ -53,7 +53,10 @@ module PortableData
 
       payload_person_ids = referenced_person_portable_ids
       manageable_ids = manageable_payload_person_ids(payload_person_ids)
-      return if payload_person_ids.present? && (payload_person_ids - manageable_ids).empty?
+      if payload_person_ids.present? && (payload_person_ids - manageable_ids).empty?
+        authorize_record_writes!(manageable_ids)
+        return
+      end
 
       raise Pundit::NotAuthorizedError
     end
@@ -146,6 +149,60 @@ module PortableData
         access_level: :manage,
         revoked_at: nil
       }
+    end
+
+    def authorize_record_writes!(manageable_person_portable_ids)
+      authorized_ids = medication_portable_ids_for(manageable_person_portable_ids)
+      return if medication_rows_authorized?(authorized_ids) && dosage_rows_authorized?(authorized_ids)
+
+      raise Pundit::NotAuthorizedError
+    end
+
+    def medication_portable_ids_for(manageable_person_portable_ids)
+      (
+        payload_medication_portable_ids_for(manageable_person_portable_ids) +
+        existing_medication_portable_ids_for(manageable_person_portable_ids)
+      ).compact_blank.uniq
+    end
+
+    def payload_medication_portable_ids_for(manageable_person_portable_ids)
+      schedule_ids = records(:schedules).filter_map do |row|
+        row[:medication_portable_id] if manageable_person_portable_ids.include?(row[:person_portable_id])
+      end
+      person_medication_ids = records(:person_medications).filter_map do |row|
+        row[:medication_portable_id] if manageable_person_portable_ids.include?(row[:person_portable_id])
+      end
+
+      schedule_ids + person_medication_ids
+    end
+
+    def existing_medication_portable_ids_for(manageable_person_portable_ids)
+      schedule_medication_portable_ids_for(manageable_person_portable_ids) +
+        person_medication_portable_ids_for(manageable_person_portable_ids)
+    end
+
+    def schedule_medication_portable_ids_for(manageable_person_portable_ids)
+      Schedule.joins(:person, :medication)
+              .where(household: household, people: { portable_id: manageable_person_portable_ids })
+              .pluck('medications.portable_id')
+    end
+
+    def person_medication_portable_ids_for(manageable_person_portable_ids)
+      PersonMedication.joins(:person, :medication)
+                      .where(household: household, people: { portable_id: manageable_person_portable_ids })
+                      .pluck('medications.portable_id')
+    end
+
+    def medication_rows_authorized?(authorized_medication_portable_ids)
+      records(:medications).all? do |row|
+        authorized_medication_portable_ids.include?(row[:portable_id])
+      end
+    end
+
+    def dosage_rows_authorized?(authorized_medication_portable_ids)
+      records(:dosage_options).all? do |row|
+        authorized_medication_portable_ids.include?(row[:medication_portable_id])
+      end
     end
 
     def records(name)

--- a/app/services/portable_data/importer.rb
+++ b/app/services/portable_data/importer.rb
@@ -152,8 +152,8 @@ module PortableData
     end
 
     def authorize_record_writes!(manageable_person_portable_ids)
-      authorized_ids = medication_portable_ids_for(manageable_person_portable_ids)
-      return if medication_rows_authorized?(authorized_ids) && dosage_rows_authorized?(authorized_ids)
+      ids = medication_portable_ids_for(manageable_person_portable_ids)
+      return if records(:locations).empty? && medication_rows_authorized?(ids) && dosage_rows_authorized?(ids)
 
       raise Pundit::NotAuthorizedError
     end

--- a/db/migrate/20260709123000_add_created_by_membership_to_medications.rb
+++ b/db/migrate/20260709123000_add_created_by_membership_to_medications.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddCreatedByMembershipToMedications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :medications, :created_by_membership_id, :bigint unless column_exists?(
+      :medications,
+      :created_by_membership_id
+    )
+    add_index :medications, :created_by_membership_id unless index_exists?(:medications, :created_by_membership_id)
+
+    add_foreign_key :medications,
+                    :household_memberships,
+                    column: :created_by_membership_id unless foreign_key_exists?(
+                      :medications,
+                      :household_memberships,
+                      column: :created_by_membership_id
+                    )
+    add_foreign_key :medications,
+                    :household_memberships,
+                    column: %i[created_by_membership_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: 'fk_medications_created_by_membership_id_household' unless foreign_key_exists?(
+                      :medications,
+                      :household_memberships,
+                      name: 'fk_medications_created_by_membership_id_household'
+                    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -417,6 +417,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.string "barcode"
     t.string "category"
     t.datetime "created_at", null: false
+    t.bigint "created_by_membership_id"
     t.decimal "current_supply", precision: 10, scale: 2
     t.jsonb "default_schedule_config", default: {}, null: false
     t.integer "default_schedule_type", default: 1, null: false
@@ -445,6 +446,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
     t.index ["barcode"], name: "index_medications_on_barcode", unique: true, where: "((barcode IS NOT NULL) AND ((barcode)::text <> ''::text))"
     t.index ["barcode"], name: "index_medications_on_barcode_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["category"], name: "index_medications_on_category_trigram", opclass: :gin_trgm_ops, using: :gin
+    t.index ["created_by_membership_id"], name: "index_medications_on_created_by_membership_id"
     t.index ["default_schedule_type"], name: "index_medications_on_default_schedule_type"
     t.index ["dmd_code"], name: "index_medications_on_dmd_code"
     t.index ["dmd_code"], name: "index_medications_on_dmd_code_trigram", opclass: :gin_trgm_ops, using: :gin
@@ -788,6 +790,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120500) do
   add_foreign_key "medication_takes", "schedules", column: ["schedule_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_medication_takes_schedule_id_household"
   add_foreign_key "medication_takes", "schedules", deferrable: :deferred
   add_foreign_key "medications", "households"
+  add_foreign_key "medications", "household_memberships", column: "created_by_membership_id"
+  add_foreign_key "medications", "household_memberships", column: ["created_by_membership_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_medications_created_by_membership_id_household"
   add_foreign_key "medications", "locations", column: ["location_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_medications_location_id_household"
   add_foreign_key "medications", "locations", deferrable: :deferred
   add_foreign_key "native_device_tokens", "accounts"

--- a/spec/policies/medication_policy_spec.rb
+++ b/spec/policies/medication_policy_spec.rb
@@ -57,4 +57,15 @@ RSpec.describe MedicationPolicy, type: :policy do
     expect(manager_scope).not_to include(other_medication)
     expect(member_scope).to contain_exactly(granted_medication)
   end
+
+  it 'does not expand member medication scope beyond granted people for manage grants' do
+    medication
+    granted_medication = household_policy_medication(household)
+    household_policy_person_medication(household, person: person, medication: granted_medication)
+    grant_policy_person_access(member, person, access_level: :manage)
+
+    member_scope = described_class::Scope.new(member.fetch(:context), Medication.all).resolve
+
+    expect(member_scope).to contain_exactly(granted_medication)
+  end
 end

--- a/spec/requests/admin/user_mutation_boundary_spec.rb
+++ b/spec/requests/admin/user_mutation_boundary_spec.rb
@@ -44,6 +44,39 @@ RSpec.describe 'Admin user mutation boundary' do
     expect(household.person_access_grants.exists?(household_membership: membership, person: dependent)).to be(false)
   end
 
+  it 'rejects owner memberships during admin user creation' do
+    email = 'owner-create-attempt@example.test'
+
+    expect do
+      post admin_users_path, params: { user: new_user_params(email: email, membership_role: 'owner') }
+    end.not_to(change { household.household_memberships.owner.count })
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(Account.exists?(email: email)).to be(false)
+  end
+
+  it 'allows supported membership roles during admin user creation' do
+    {
+      'administrator' => 'created-administrator@example.test',
+      'member' => 'created-member@example.test'
+    }.each do |role, email|
+      expect do
+        post admin_users_path, params: { user: new_user_params(email: email, membership_role: role) }
+      end.to change { household.household_memberships.where(role: role).count }.by(1)
+
+      expect(response).to redirect_to(admin_users_path)
+    end
+  end
+
+  it 'does not render owner as a selectable create-time household role' do
+    get new_admin_user_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('user_membership_role_administrator')
+    expect(response.body).to include('user_membership_role_member')
+    expect(response.body).not_to include('user_membership_role_owner')
+  end
+
   it 'updates a membership role through the dedicated endpoint and records an audit event' do
     member = users(:jane)
     membership = household.household_memberships.find_by!(account: member.person.account)
@@ -134,5 +167,21 @@ RSpec.describe 'Admin user mutation boundary' do
       membership.status = :active
       membership.save!
     end
+  end
+
+  def new_user_params(email:, membership_role:)
+    {
+      email_address: email,
+      password: 'password',
+      password_confirmation: 'password',
+      membership_role: membership_role,
+      dependent_access_level: 'record',
+      dependent_relationship_type: 'professional',
+      person_attributes: {
+        name: "Created #{membership_role.titleize}",
+        date_of_birth: '1990-01-01',
+        location_ids: [locations(:home).id]
+      }
+    }
   end
 end

--- a/spec/requests/api/v1/medications_spec.rb
+++ b/spec/requests/api/v1/medications_spec.rb
@@ -105,6 +105,54 @@ RSpec.describe 'API v1 medications' do
       expect(response.parsed_body.dig('data', 'name')).to eq('New API Medication')
     end
 
+    it 'keeps delegated api-created medications visible to the creating membership' do
+      scoped_user = users(:jane)
+      household = scoped_user.person.household
+      membership = household.household_memberships.find_or_create_by!(account: scoped_user.person.account) do |record|
+        record.person = scoped_user.person
+        record.role = :member
+        record.status = :active
+      end
+      membership.update!(person: scoped_user.person, role: :member, status: :active)
+      managed_person = create(:person, household: household, name: 'Delegated Medication Creator')
+      location = create(:location, household: household, name: 'Delegated API Shelf')
+      household.person_access_grants.where(household_membership: membership).destroy_all
+      household.person_access_grants.create!(
+        household_membership: membership,
+        person: managed_person,
+        access_level: :manage,
+        relationship_type: :family_member,
+        granted_by_membership: membership
+      )
+      login_data = api_login(scoped_user, household_id: household.id)
+
+      post api_v1_household_medications_path(household.id),
+           params: {
+             medication: {
+               name: 'Delegated API Medication', location_id: location.id,
+               dose_amount: 5, dose_unit: 'ml', current_supply: 100, reorder_threshold: 10
+             }
+           },
+           headers: api_auth_headers(login_data.fetch('access_token')), as: :json
+
+      expect(response).to have_http_status(:created)
+
+      created_id = response.parsed_body.dig('data', 'id')
+      get api_v1_household_medication_path(household.id, created_id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('data', 'id')).to eq(created_id)
+
+      get api_v1_household_medications_path(household.id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      returned_ids = response.parsed_body.fetch('data').map { |medication| medication.fetch('id') }
+      expect(returned_ids).to include(created_id)
+    end
+
     it 'returns unprocessable content with invalid attributes' do
       login_data = api_login(user)
       household_id = login_data.dig('household', 'id')

--- a/spec/requests/api/v1/medications_spec.rb
+++ b/spec/requests/api/v1/medications_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'API v1 medications' do
-  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships, :medications
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships, :medications,
+           :person_medications
 
   let(:user) { users(:admin) }
 
@@ -20,6 +21,41 @@ RSpec.describe 'API v1 medications' do
 
       returned_ids = response.parsed_body.fetch('data').map { |m| m.fetch('id') }
       expect(returned_ids).to include(medications(:paracetamol).id)
+    end
+
+    it 'omits unrelated medications for delegated members with manage grants' do
+      scoped_user = users(:jane)
+      household = scoped_user.person.household
+      membership = household.household_memberships.find_or_create_by!(account: scoped_user.person.account) do |record|
+        record.person = scoped_user.person
+        record.role = :member
+        record.status = :active
+      end
+      membership.update!(person: scoped_user.person, role: :member, status: :active)
+      visible_person = create(:person, household: household, name: 'Delegated Medication Visible')
+      hidden_person = create(:person, household: household, name: 'Delegated Medication Hidden')
+      visible_medication = create(:medication, household: household, location: locations(:home), name: 'Visible Stock')
+      hidden_medication = create(:medication, household: household, location: locations(:home), name: 'Hidden Stock')
+      create(:person_medication, household: household, person: visible_person, medication: visible_medication)
+      create(:person_medication, household: household, person: hidden_person, medication: hidden_medication)
+      login_data = api_login(scoped_user, household_id: household.id)
+      household.person_access_grants.where(household_membership: membership).destroy_all
+      household.person_access_grants.create!(
+        household_membership: membership,
+        person: visible_person,
+        access_level: :manage,
+        relationship_type: :family_member,
+        granted_by_membership: membership
+      )
+
+      get api_v1_household_medications_path(household.id),
+          headers: api_auth_headers(login_data.fetch('access_token')),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      returned_ids = response.parsed_body.fetch('data').map { |m| m.fetch('id') }
+      expect(returned_ids).to include(visible_medication.id)
+      expect(returned_ids).not_to include(hidden_medication.id)
     end
   end
 

--- a/spec/services/medication_stock_source_resolver_spec.rb
+++ b/spec/services/medication_stock_source_resolver_spec.rb
@@ -137,6 +137,57 @@ RSpec.describe MedicationStockSourceResolver do
         expect(resolver.resolve_selected(medication.id.to_s)).to eq(medication)
       end
     end
+
+    context 'when a delegated user selects matching stock for another person' do
+      it 'returns nil' do
+        granted_person = create(:person, household: fixture_household)
+        hidden_person = create(:person, household: fixture_household)
+        source_medication = matching_medication(name: 'Shared Rescue Spray', current_supply: 20)
+        hidden_medication = matching_medication(name: 'Shared Rescue Spray', current_supply: 20)
+        source = linked_person_medication(granted_person, source_medication)
+        linked_person_medication(hidden_person, hidden_medication)
+        context = delegated_context_for(granted_person)
+
+        resolver = described_class.new(user: context, source: source, taken_at: taken_at)
+
+        expect(resolver.resolve_selected(hidden_medication.id)).to be_nil
+      end
+    end
+
+    context 'when a delegated user selects alternate matching stock for the same granted person' do
+      it 'returns the selected medication' do
+        granted_person = create(:person, household: fixture_household)
+        source_medication = matching_medication(name: 'Shared Same Person Spray', current_supply: 20)
+        alternate_medication = matching_medication(name: 'Shared Same Person Spray', current_supply: 20)
+        source = linked_person_medication(granted_person, source_medication)
+        linked_person_medication(granted_person, alternate_medication)
+        context = delegated_context_for(granted_person)
+
+        resolver = described_class.new(user: context, source: source, taken_at: taken_at)
+
+        expect(resolver.resolve_selected(alternate_medication.id)).to eq(alternate_medication)
+      end
+    end
+
+    context 'when a household manager selects matching stock for another person' do
+      it 'returns the selected medication' do
+        granted_person = create(:person, household: fixture_household)
+        hidden_person = create(:person, household: fixture_household)
+        source_medication = matching_medication(name: 'Shared Manager Spray', current_supply: 20)
+        hidden_medication = matching_medication(name: 'Shared Manager Spray', current_supply: 20)
+        source = create(
+          :person_medication,
+          household: fixture_household,
+          person: granted_person,
+          medication: source_medication
+        )
+        create(:person_medication, household: fixture_household, person: hidden_person, medication: hidden_medication)
+
+        resolver = described_class.new(user: users(:john), source: source, taken_at: taken_at)
+
+        expect(resolver.resolve_selected(hidden_medication.id)).to eq(hidden_medication)
+      end
+    end
   end
 
   describe '#selection_required?' do
@@ -185,5 +236,48 @@ RSpec.describe MedicationStockSourceResolver do
 
   def fixture_household
     users(:john).person.account.first_active_household_membership.household
+  end
+
+  def delegated_context_for(person)
+    account = Account.create!(email: "stock-source-delegate-#{SecureRandom.hex(4)}@example.test", status: :verified)
+    membership = delegated_membership_for(account)
+    grant_manage_access_to(membership, person)
+    AuthorizationContext.new(account: account, household: fixture_household, membership: membership)
+  end
+
+  def delegated_membership_for(account)
+    fixture_household.household_memberships.create!(
+      account: account,
+      person: create(:person, household: fixture_household, account: account),
+      role: :member,
+      status: :active
+    )
+  end
+
+  def grant_manage_access_to(membership, person)
+    fixture_household.person_access_grants.create!(
+      household_membership: membership,
+      person: person,
+      access_level: :manage,
+      relationship_type: :family_member,
+      granted_by_membership: membership
+    )
+  end
+
+  def matching_medication(name:, current_supply:)
+    create(
+      :medication,
+      household: fixture_household,
+      location: create(:location, household: fixture_household),
+      name: name,
+      dose_amount: 500,
+      dose_unit: 'mg',
+      current_supply: current_supply,
+      supply_at_last_restock: current_supply
+    )
+  end
+
+  def linked_person_medication(person, medication)
+    create(:person_medication, household: fixture_household, person: person, medication: medication)
   end
 end

--- a/spec/services/portable_data/importer_spec.rb
+++ b/spec/services/portable_data/importer_spec.rb
@@ -244,6 +244,26 @@ RSpec.describe PortableData::Importer do
      NotificationPreference].index_with(&:count)
   end
 
+  def manager_location_payload(location:, name:, description:)
+    payload = portable_payload.deep_dup
+    payload[:records] = payload[:records].transform_values { [] }
+    payload[:records][:locations] = [
+      { portable_id: location.portable_id, name: name, description: description }
+    ]
+    payload
+  end
+
+  def expect_manager_location_import_allowed(membership, label)
+    location = create(:location, household: membership.household, portable_id: "#{label.downcase}-location-portable")
+    payload = manager_location_payload(location: location, name: "#{label} Updated Location",
+                                       description: "#{label} description")
+    result = import_result(household: membership.household, membership: membership, payload: payload, dry_run: false)
+
+    expect(result).to be_applied
+    expect(location.reload).to have_attributes(name: "#{label} Updated Location",
+                                               description: "#{label} description")
+  end
+
   def expect_import_creates_portable_graph(household:, membership:, envelope:)
     before_counts = portable_record_counts
     apply_import(household: household, membership: membership, envelope: envelope)
@@ -350,6 +370,25 @@ RSpec.describe PortableData::Importer do
     expect(result.errors).to be_empty
   end
 
+  it 'rejects member location writes before the import writer mutates records' do
+    household = create(:household)
+    manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
+    location = create(:location, household: household, portable_id: 'location-portable', name: 'Original Shelf')
+    original_description = location.description
+    membership = member_membership(household, person: manageable_person)
+    grant_manage_access(household: household, membership: membership, person: manageable_person)
+    payload = solo_person_payload_for(manageable_person)
+    payload[:records][:locations] = [
+      { portable_id: location.portable_id, name: 'Delegated Rename', description: 'Changed by import' }
+    ]
+
+    expect do
+      import_result(household: household, membership: membership, payload: payload, dry_run: false)
+    end.to raise_error(Pundit::NotAuthorizedError)
+
+    expect(location.reload).to have_attributes(name: 'Original Shelf', description: original_description)
+  end
+
   it 'rejects member medication writes for medications outside granted people' do
     household = create(:household)
     manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
@@ -414,6 +453,16 @@ RSpec.describe PortableData::Importer do
 
     expect(result).to be_applied
     expect(dosage.reload.amount).to eq(10)
+  end
+
+  it 'keeps owner location imports unrestricted within the household' do
+    household = create(:household)
+    expect_manager_location_import_allowed(owner_membership(household), 'Owner')
+  end
+
+  it 'keeps administrator location imports unrestricted within the household' do
+    household = create(:household)
+    expect_manager_location_import_allowed(administrator_membership(household), 'Administrator')
   end
 
   it 'keeps owner and administrator medication imports unrestricted within the household' do

--- a/spec/services/portable_data/importer_spec.rb
+++ b/spec/services/portable_data/importer_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe PortableData::Importer do
     )
   end
 
+  def administrator_membership(household)
+    household.household_memberships.create!(
+      account: account("portable-import-administrator-#{SecureRandom.hex(4)}@example.test"),
+      role: :administrator,
+      status: :active
+    )
+  end
+
   def import_result(household:, membership:, payload: portable_payload, dry_run: true)
     described_class.new(
       household: household,
@@ -170,7 +178,7 @@ RSpec.describe PortableData::Importer do
     payload = portable_payload.deep_dup
     empty_record_types.each { |record_type| payload[:records][record_type] = [] }
     payload[:records][:people] = [
-      payload[:records][:people].first.merge(portable_id: person.portable_id)
+      payload[:records][:people].first.merge(portable_id: person.portable_id, location_portable_ids: [])
     ]
     payload
   end
@@ -191,6 +199,43 @@ RSpec.describe PortableData::Importer do
       schedule_type: 'daily',
       start_date: '2026-01-01',
       end_date: '2026-12-31'
+    }
+  end
+
+  def medication_update_payload_for(person:, medication:, current_supply:)
+    payload = solo_person_payload_for(person)
+    payload[:records][:medications] = [
+      {
+        portable_id: medication.portable_id,
+        location_portable_id: medication.location.portable_id,
+        name: medication.name,
+        dose_amount: medication.dose_amount,
+        dose_unit: medication.dose_unit,
+        current_supply: current_supply,
+        reorder_threshold: 2
+      }
+    ]
+    payload
+  end
+
+  def dosage_update_payload_for(person:, dosage:, amount:)
+    payload = solo_person_payload_for(person)
+    payload[:records][:dosage_options] = [dosage_update_row(dosage, amount)]
+    payload
+  end
+
+  def dosage_update_row(dosage, amount)
+    {
+      portable_id: dosage.portable_id,
+      medication_portable_id: dosage.medication.portable_id,
+      amount: amount,
+      unit: dosage.unit,
+      frequency: dosage.frequency,
+      default_max_daily_doses: dosage.default_max_daily_doses,
+      default_min_hours_between_doses: dosage.default_min_hours_between_doses,
+      default_dose_cycle: dosage.default_dose_cycle,
+      current_supply: 7,
+      reorder_threshold: 1
     }
   end
 
@@ -303,6 +348,92 @@ RSpec.describe PortableData::Importer do
 
     expect(result).not_to be_applied
     expect(result.errors).to be_empty
+  end
+
+  it 'rejects member medication writes for medications outside granted people' do
+    household = create(:household)
+    manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
+    unmanaged_person = create(:person, household: household, portable_id: 'unmanaged-person-portable')
+    medication = create(:medication, household: household, current_supply: 20)
+    create(:person_medication, household: household, person: unmanaged_person, medication: medication)
+    membership = member_membership(household, person: manageable_person)
+    grant_manage_access(household: household, membership: membership, person: manageable_person)
+    payload = medication_update_payload_for(person: manageable_person, medication: medication, current_supply: 99)
+
+    expect do
+      import_result(household: household, membership: membership, payload: payload, dry_run: false)
+    end.to raise_error(Pundit::NotAuthorizedError)
+
+    expect(medication.reload.current_supply).to eq(20)
+  end
+
+  it 'allows member medication writes for medications linked to granted people' do
+    household = create(:household)
+    manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
+    medication = create(:medication, household: household, current_supply: 20)
+    create(:person_medication, household: household, person: manageable_person, medication: medication)
+    membership = member_membership(household, person: manageable_person)
+    grant_manage_access(household: household, membership: membership, person: manageable_person)
+    payload = medication_update_payload_for(person: manageable_person, medication: medication, current_supply: 33)
+
+    result = import_result(household: household, membership: membership, payload: payload, dry_run: false)
+
+    expect(result).to be_applied
+    expect(medication.reload.current_supply).to eq(33)
+  end
+
+  it 'rejects member dosage option writes for medications outside granted people' do
+    household = create(:household)
+    manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
+    unmanaged_person = create(:person, household: household, portable_id: 'unmanaged-person-portable')
+    medication = create(:medication, household: household)
+    create(:person_medication, household: household, person: unmanaged_person, medication: medication)
+    dosage = create(:dosage, medication: medication, amount: 5)
+    membership = member_membership(household, person: manageable_person)
+    grant_manage_access(household: household, membership: membership, person: manageable_person)
+    payload = dosage_update_payload_for(person: manageable_person, dosage: dosage, amount: 10)
+
+    expect do
+      import_result(household: household, membership: membership, payload: payload, dry_run: false)
+    end.to raise_error(Pundit::NotAuthorizedError)
+
+    expect(dosage.reload.amount).to eq(5)
+  end
+
+  it 'allows member dosage option writes for medications linked to granted people' do
+    household = create(:household)
+    manageable_person = create(:person, household: household, portable_id: 'manageable-person-portable')
+    medication = create(:medication, household: household)
+    create(:person_medication, household: household, person: manageable_person, medication: medication)
+    dosage = create(:dosage, medication: medication, amount: 5)
+    membership = member_membership(household, person: manageable_person)
+    grant_manage_access(household: household, membership: membership, person: manageable_person)
+    payload = dosage_update_payload_for(person: manageable_person, dosage: dosage, amount: 10)
+
+    result = import_result(household: household, membership: membership, payload: payload, dry_run: false)
+
+    expect(result).to be_applied
+    expect(dosage.reload.amount).to eq(10)
+  end
+
+  it 'keeps owner and administrator medication imports unrestricted within the household' do
+    household = create(:household)
+    unmanaged_person = create(:person, household: household, portable_id: 'unmanaged-person-portable')
+
+    [owner_membership(household), administrator_membership(household)].each_with_index do |membership, index|
+      medication = create(:medication, household: household, current_supply: 20 + index)
+      create(:person_medication, household: household, person: unmanaged_person, medication: medication)
+      payload = medication_update_payload_for(
+        person: unmanaged_person,
+        medication: medication,
+        current_supply: 80 + index
+      )
+
+      result = import_result(household: household, membership: membership, payload: payload, dry_run: false)
+
+      expect(result).to be_applied
+      expect(medication.reload.current_supply).to eq(80 + index)
+    end
   end
 
   it 'derives person access from person-medication medication take sources' do

--- a/spec/services/take_medication_service_spec.rb
+++ b/spec/services/take_medication_service_spec.rb
@@ -261,6 +261,24 @@ RSpec.describe TakeMedicationService do
     end
   end
 
+  describe '#call with delegated stock source selection' do
+    it 'rejects another persons matching medication and leaves inventory unchanged' do
+      setup = delegated_stock_source_setup
+
+      result = service.call(
+        source: setup.fetch(:source),
+        amount_override: nil,
+        taken_from_medication_id: setup.fetch(:hidden_medication).id,
+        user: setup.fetch(:context),
+        taken_at: Time.current
+      )
+
+      expect(result.error).to eq(:invalid_source)
+      expect(setup.fetch(:hidden_medication).reload.current_supply).to eq(20)
+      expect(MedicationTake.where(person_medication: setup.fetch(:source))).to be_empty
+    end
+  end
+
   describe 'taken_at override' do
     let(:schedule) { schedules(:john_paracetamol) }
     let(:custom_time) { 2.hours.ago }
@@ -684,6 +702,65 @@ RSpec.describe TakeMedicationService do
       current_supply: 12,
       reorder_threshold: 2
     )
+  end
+
+  def delegated_context_for(household:, person:)
+    account = Account.create!(email: "take-delegate-#{SecureRandom.hex(4)}@example.test", status: :verified)
+    membership = delegated_membership_for(household, account)
+    grant_manage_access_to(household, membership, person)
+    AuthorizationContext.new(account: account, household: household, membership: membership)
+  end
+
+  def delegated_membership_for(household, account)
+    household.household_memberships.create!(
+      account: account,
+      person: create(:person, household: household, account: account),
+      role: :member,
+      status: :active
+    )
+  end
+
+  def grant_manage_access_to(household, membership, person)
+    household.person_access_grants.create!(
+      household_membership: membership,
+      person: person,
+      access_level: :manage,
+      relationship_type: :family_member,
+      granted_by_membership: membership
+    )
+  end
+
+  def create_stock_source_medication(household, name:, current_supply:)
+    create(
+      :medication,
+      household: household,
+      location: create(:location, household: household),
+      name: name,
+      dose_amount: 500,
+      dose_unit: 'mg',
+      current_supply: current_supply,
+      supply_at_last_restock: current_supply
+    )
+  end
+
+  def delegated_stock_source_setup
+    household = user.person.account.first_active_household_membership.household
+    granted_person = create(:person, household: household)
+    hidden_person = create(:person, household: household)
+    source_medication = delegated_rescue_spray(household)
+    hidden_medication = delegated_rescue_spray(household)
+    source = link_stock_source(household: household, person: granted_person, medication: source_medication)
+    link_stock_source(household: household, person: hidden_person, medication: hidden_medication)
+    context = delegated_context_for(household: household, person: granted_person)
+    { source: source, hidden_medication: hidden_medication, context: context }
+  end
+
+  def delegated_rescue_spray(household)
+    create_stock_source_medication(household, name: 'Delegated Rescue Spray', current_supply: 20)
+  end
+
+  def link_stock_source(household:, person:, medication:)
+    create(:person_medication, household: household, person: person, medication: medication)
   end
 
   def fixture_household


### PR DESCRIPTION
## Summary

This tightens delegated medication access boundaries across admin user creation, portable import, medication collection scoping, and stock source selection.

- Blocks household admin-created owner memberships and removes owner from the admin user role selector.
- Rejects delegated portable imports that try to write medications or dosage options outside the actor's granted people.
- Keeps delegated medication collection scope limited to medications linked to granted people.
- Prevents delegated medication takes from selecting another person's matching stock source while preserving household manager behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->