### PR TITLE
feat(perf): Reuse health history events

### DIFF
--- a/app/services/reports/health_history_query.rb
+++ b/app/services/reports/health_history_query.rb
@@ -32,9 +32,9 @@ module Reports
       Result.new(
         people: people_records,
         medication_takes: medication_take_entries,
-        suspected_side_effects: health_event_entries(health_events.suspected_side_effect),
-        notable_illnesses: health_event_entries(health_events.illness),
-        illness_patterns: HealthEvents::PatternSummary.new(events: health_events.illness).call
+        suspected_side_effects: health_event_entries(suspected_side_effects),
+        notable_illnesses: health_event_entries(illnesses),
+        illness_patterns: HealthEvents::PatternSummary.new(events: illnesses).call
       )
     end
 
@@ -107,7 +107,7 @@ module Reports
     end
 
     def health_event_entries(scope)
-      scope.order(:started_on, :id).map do |event|
+      scope.sort_by { |event| [event.started_on, event.id] }.map do |event|
         HealthEventEntry.new(
           event: event,
           medication_names: event.health_event_medications.map(&:medication_name)
@@ -126,7 +126,15 @@ module Reports
                              .includes(:person, :health_event_medications)
                              .where(person_id: person_ids)
                              .where(started_on: ..end_date, ended_on: start_date..)
-                         )
+                         ).to_a
+    end
+
+    def suspected_side_effects
+      @suspected_side_effects ||= health_events.select(&:suspected_side_effect?)
+    end
+
+    def illnesses
+      @illnesses ||= health_events.select(&:illness?)
     end
   end
 end

--- a/spec/services/reports/health_history_query_spec.rb
+++ b/spec/services/reports/health_history_query_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::HealthHistoryQuery do
-  fixtures :people, :locations, :medications, :dosages
+  fixtures :accounts, :people, :locations, :medications, :dosages
 
   let(:person) { people(:john) }
   let(:start_date) { Date.new(2026, 2, 1) }
@@ -67,6 +67,16 @@ RSpec.describe Reports::HealthHistoryQuery do
     expect(result.notable_illnesses.sole.duration_days).to eq(3)
   end
 
+  it 'loads matching health events once for report sections and patterns' do
+    create_suspected_side_effect
+    create_illness_episode(Date.new(2026, 2, 1), Date.new(2026, 2, 3), 'Cold')
+    create_illness_episode(Date.new(2026, 2, 20), Date.new(2026, 2, 22), 'Cold')
+
+    expect(count_health_event_queries do
+      described_class.new(people: Person.where(id: person.id), start_date: start_date, end_date: end_date).call
+    end).to eq(1)
+  end
+
   def create_illness_episode(started_on, ended_on, title)
     HealthEvent.create!(
       person: person,
@@ -89,5 +99,19 @@ RSpec.describe Reports::HealthHistoryQuery do
       medical_help_sought: true
     )
     HealthEventMedication.create!(health_event: side_effect, medication: medications(:paracetamol))
+  end
+
+  def count_health_event_queries(&)
+    count = 0
+
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      count += 1 if sql.include?('FROM "health_events"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
   end
 end


### PR DESCRIPTION
## What changed

The health history query now loads its date-filtered health events once, partitions the loaded records by event kind in memory, and reuses the illness records for both the report section and pattern analysis. Existing started-on and ID ordering is preserved.

## Why it was a bottleneck

The report previously applied Active Record enum scopes three times to the same eager-loaded relation: once for side effects and twice for illnesses. Each scope evaluation issued another health-events query and repeated its eager-loading work.

## Measurement used

A focused ActiveSupport::Notifications spec measured 3 health-events queries before the change and now enforces 1 query.

## Expected impact

Each health history report avoids two repeated health-event queries and the associated eager-load work, with no change to report contents or ordering.

## Tests run

- task test TEST_FILE=spec/services/reports/health_history_query_spec.rb
- task rubocop
- task test