### PR TITLE
feat(audit): capture forensic request context

### DIFF
--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -21,6 +21,7 @@ module Admin
 
       @total_count = result.total_count
       @versions = result.versions
+      record_audit_log_access('index')
 
       render Components::Admin::AuditLogs::IndexView.new(
         versions: @versions,
@@ -39,6 +40,7 @@ module Admin
       @version = policy_scope(PaperTrail::Version.all, policy_scope_class: AuditLogPolicy::Scope).find(params.expect(:id))
       authorize @version, policy_class: AuditLogPolicy
       detail = Admin::AuditLogDetailQuery.new(version: @version).call
+      record_audit_log_access('show', version_id: @version.id)
 
       render Components::Admin::AuditLogs::ShowView.new(version: @version, detail: detail)
     end
@@ -47,6 +49,14 @@ module Admin
 
     def authorize_audit_access
       authorize :audit_log, :index?, policy_class: AuditLogPolicy
+    end
+
+    def record_audit_log_access(action, version_id: nil)
+      Audit::Event.record!(
+        household: current_household,
+        event_type: 'audit_log.accessed',
+        metadata: { action: action, outcome: 'success', version_id: version_id }.compact
+      )
     end
   end
 end

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -25,13 +25,12 @@ module Api
         end
 
         def audit_admin_action!(event_type:, target:, outcome:)
-          SecurityAuditEvent.create!(
+          Audit::Event.record!(
             household: current_household,
             actor_account: current_account,
             actor_membership: current_membership,
             event_type: event_type,
-            request_id: request.request_id,
-            ip: request.remote_ip,
+            request: request,
             metadata: {
               target_type: target.class.name,
               target_id: target.id,

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -5,6 +5,7 @@ module Api
     class BaseController < ActionController::API
       include ErrorRendering
       include Pundit::Authorization
+      include Audit::Authorization
 
       around_action :with_api_request_context
       around_action :with_api_idempotency
@@ -19,16 +20,17 @@ module Api
 
       private
 
-      def with_api_request_context
+      def with_api_request_context(&)
         authenticate_api_request!
         return if performed?
 
         TenantContext.with(account: current_account, household: nil, request_id: request.request_id) do
           bind_api_session_context!
           bind_api_household_context! unless performed?
-          yield unless performed?
+          audit_api_request(&) unless performed?
         end
       ensure
+        Audit::Context.clear!
         Current.reset
       end
 
@@ -89,6 +91,36 @@ module Api
         Current.membership = @current_membership
         TenantContext.set_household!(@current_household)
         TenantContext.set_membership!(@current_membership)
+        Audit::Context.start!(
+          request: request,
+          account: current_account,
+          user: current_user,
+          membership: @current_membership,
+          credential: @current_api_session
+        )
+      end
+
+      def audit_api_request
+        yield
+        record_api_request_event
+      rescue StandardError
+        record_api_request_event(outcome: 'error')
+        raise
+      end
+
+      def record_api_request_event(outcome: nil)
+        status = response.status
+        Audit::Event.record!(
+          household: current_household,
+          event_type: 'api.request',
+          metadata: {
+            http_method: request.request_method,
+            controller: controller_path,
+            action: action_name,
+            outcome: outcome || (status < 400 ? 'success' : 'failure'),
+            status: status
+          }
+        )
       end
 
       def bearer_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include Pundit::Authorization
+  include Audit::Authorization
   include Pagy::Method
   include TurboNativeDetectable
   include TenantDomTargetsHelper
@@ -45,11 +46,13 @@ class ApplicationController < ActionController::Base
   def with_current_context(&)
     Current.account = current_account
     Current.request_id = request.request_id
+    Audit::Context.start!(request:, account: current_account, user: current_user, credential: :web)
     Time.use_zone(current_account_time_zone) { with_current_tenant_context(&) }
   rescue StandardError => e
     Otel::ExceptionRecorder.record(e, source: 'request')
     raise
   ensure
+    Audit::Context.clear!
     Current.reset
   end
 
@@ -63,12 +66,12 @@ class ApplicationController < ActionController::Base
 
       if @current_membership
         TenantContext.set_membership!(@current_membership)
-        PaperTrail.request.controller_info = info_for_paper_trail
+        refresh_audit_context
         yield
       elsif active_support_access_session
         @current_support_access_session = active_support_access_session
         Current.support_access_session = @current_support_access_session
-        PaperTrail.request.controller_info = info_for_paper_trail
+        refresh_audit_context
         yield
       else
         user_not_authorized
@@ -105,12 +108,16 @@ class ApplicationController < ActionController::Base
   end
 
   def info_for_paper_trail
-    {
-      ip: request.remote_ip,
-      request_id: request.request_id,
-      household_id: Current.household&.id,
-      actor_membership_id: Current.membership&.id
-    }
+    PaperTrail.request.controller_info
+  end
+
+  def refresh_audit_context
+    Audit::Context.refresh!(
+      account: current_account,
+      user: current_user,
+      membership: Current.membership,
+      support_access_session: Current.support_access_session
+    )
   end
 
   def support_authorization_context

--- a/app/controllers/concerns/audit/authorization.rb
+++ b/app/controllers/concerns/audit/authorization.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Audit
+  module Authorization
+    def authorize(record, query = nil, policy_class: nil)
+      result = super
+      resolved_policy_class = policy_class || policy(record).class
+      Audit::Context.authorized!(
+        policy_class: resolved_policy_class,
+        query: query || "#{action_name}?"
+      )
+      result
+    end
+  end
+end

--- a/app/controllers/platform/support_access_sessions_controller.rb
+++ b/app/controllers/platform/support_access_sessions_controller.rb
@@ -42,12 +42,11 @@ module Platform
     end
 
     def record_support_access_event(support_session, event_type)
-      SecurityAuditEvent.create!(
+      Audit::Event.record!(
         household: support_session.household,
         actor_account: current_account,
         event_type: event_type,
-        request_id: request.request_id,
-        ip: request.remote_ip,
+        request: request,
         metadata: {
           support_access_session_id: support_session.id
         }

--- a/app/mcp/med_tracker_mcp/context.rb
+++ b/app/mcp/med_tracker_mcp/context.rb
@@ -51,18 +51,35 @@ module MedTrackerMcp
     end
 
     def with_current(&)
-      TenantContext.with(
-        account: account,
-        household: household,
-        membership: membership,
-        request_id: request.request_id,
-        &
-      )
+      TenantContext.with(**tenant_context) do
+        bind_audit_context
+        yield
+      end
     ensure
+      Audit::Context.clear!
       Current.reset
     end
 
     private
+
+    def tenant_context
+      {
+        account: account,
+        household: household,
+        membership: membership,
+        request_id: request.request_id
+      }
+    end
+
+    def bind_audit_context
+      Audit::Context.start!(
+        request: request,
+        account: account,
+        user: user,
+        membership: membership,
+        credential: api_credential
+      )
+    end
 
     def valid_session?
       api_credential.present? && !revoked? && unexpired?

--- a/app/mcp/med_tracker_mcp/rack_app.rb
+++ b/app/mcp/med_tracker_mcp/rack_app.rb
@@ -42,7 +42,7 @@ module MedTrackerMcp
     def record_audit_event(request, context, outcome, response)
       context_data = context.to_h
 
-      SecurityAuditEvent.create!(audit_event_attributes(request, context_data, outcome, response))
+      Audit::Event.record!(**audit_event_attributes(request, context_data, outcome, response))
     rescue StandardError => e
       Rails.logger.warn("MCP audit event failed: #{e.class}: #{e.message}")
     end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Current < ActiveSupport::CurrentAttributes
-  attribute :account, :household, :membership, :request_id, :support_access_session
+  attribute :account, :household, :membership, :request_id, :support_access_session, :audit_context
 end

--- a/app/services/admin/membership_role_updater.rb
+++ b/app/services/admin/membership_role_updater.rb
@@ -54,13 +54,12 @@ module Admin
     end
 
     def record_audit_event(previous_role)
-      SecurityAuditEvent.create!(
+      Audit::Event.record!(
         household: membership.household,
         actor_account: actor_account,
         actor_membership: actor_membership,
         event_type: 'household_membership.role_updated',
-        request_id: request.request_id,
-        ip: request.remote_ip,
+        request: request,
         metadata: {
           target_account_id: membership.account_id,
           target_membership_id: membership.id,

--- a/app/services/ai_medication/audit_logger.rb
+++ b/app/services/ai_medication/audit_logger.rb
@@ -5,9 +5,9 @@ module AiMedication
     ITEM_TYPE = 'AiMedicationSuggestion'
 
     def record(user:, medication_identity:, suggestion:)
-      # rubocop:disable Rails/SkipsModelValidations
-      PaperTrail::Version.insert(version_attrs(user:, medication_identity:, suggestion:))
-      # rubocop:enable Rails/SkipsModelValidations
+      # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
+      Audit::VersionEvent.record!(**version_attrs(user:, medication_identity:, suggestion:))
+      # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
     rescue StandardError => e
       Rails.logger.error("AiMedication::AuditLogger failed: #{e.class}: #{e.message}")
     end

--- a/app/services/audit/context.rb
+++ b/app/services/audit/context.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Audit
+  class Context
+    SESSION_REFERENCE_SALT = 'med-tracker/audit-session-reference/v1'
+    CONTEXT_KEYS = %i[
+      actor_account_id actor_user_id actor_membership_id active_role permissions_version household_id
+      support_access_session_id authentication_method session_reference request_id ip policy_class policy_query
+    ].freeze
+
+    class << self
+      def start!(request:, credential:, **actor)
+        Current.audit_context = build_context(
+          request:,
+          credential:,
+          **actor
+        )
+        sync_paper_trail!
+        current
+      end
+
+      def refresh!(account:, user:, membership: nil, support_access_session: nil)
+        actor = actor_context(account:, user:, membership:, support_access_session:)
+        Current.audit_context = current.merge(actor).compact
+        sync_paper_trail!
+        current
+      end
+
+      def authorized!(policy_class:, query:)
+        Current.audit_context = current.merge(
+          policy_class: policy_class.to_s,
+          policy_query: query.to_s
+        )
+        sync_paper_trail!
+        current
+      end
+
+      def current
+        Current.audit_context || {}
+      end
+
+      def merge(overrides)
+        current.merge(normalize_overrides(overrides)).compact
+      end
+
+      def clear!
+        Current.audit_context = nil
+        PaperTrail.request.controller_info = {}
+        PaperTrail.request.whodunnit = nil
+      end
+
+      private
+
+      def build_context(request:, credential:, **actor)
+        actor_context(**actor).merge(
+          authentication_context(request:, credential:),
+          request_id: request.request_id,
+          ip: request.remote_ip
+        ).compact
+      end
+
+      def actor_context(account:, user:, membership: nil, support_access_session: nil)
+        {
+          actor_account_id: account&.id,
+          actor_user_id: user&.id,
+          actor_membership_id: membership&.id,
+          active_role: active_role(account:, membership:, support_access_session:),
+          permissions_version: membership&.permissions_version,
+          household_id: membership&.household_id || support_access_session&.household_id,
+          support_access_session_id: support_access_session&.id
+        }
+      end
+
+      def active_role(account:, membership:, support_access_session:)
+        return membership.role if membership
+        return 'platform_admin' if account&.platform_admin && support_access_session
+
+        'authenticated' if account
+      end
+
+      def authentication_context(request:, credential:)
+        case credential
+        when ApiSession
+          { authentication_method: 'api_session', session_reference: "api_session:#{credential.id}" }
+        when ApiAppToken
+          { authentication_method: 'api_app_token', session_reference: "api_app_token:#{credential.id}" }
+        when :web
+          { authentication_method: 'web', session_reference: web_session_reference(request) }
+        else
+          { authentication_method: credential.to_s.presence }
+        end
+      end
+
+      def web_session_reference(request)
+        session_id = request.session.id.to_s
+        return if session_id.blank?
+
+        digest = OpenSSL::HMAC.hexdigest('SHA256', session_reference_key, session_id)
+        "web:#{digest}"
+      end
+
+      def session_reference_key
+        Rails.application.key_generator.generate_key(SESSION_REFERENCE_SALT, 32)
+      end
+
+      def normalize_overrides(overrides)
+        values = overrides.to_h.symbolize_keys
+        {
+          actor_user_id: values.delete(:whodunnit),
+          actor_membership_id: values[:actor_membership_id],
+          household_id: values[:household_id],
+          request_id: values[:request_id],
+          ip: values[:ip]
+        }.compact.merge(values.slice(*CONTEXT_KEYS))
+      end
+
+      def sync_paper_trail!
+        context = current
+        PaperTrail.request.whodunnit = context[:actor_user_id]&.to_s
+        PaperTrail.request.controller_info = {
+          ip: context[:ip],
+          request_id: context[:request_id],
+          household_id: context[:household_id],
+          actor_membership_id: context[:actor_membership_id],
+          audit_context: context
+        }.compact
+      end
+    end
+  end
+end

--- a/app/services/audit/event.rb
+++ b/app/services/audit/event.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Audit
+  class Event
+    class << self
+      def record!(**attributes)
+        context = Context.merge(attributes.delete(:audit_context).to_h)
+        SecurityAuditEvent.create!(event_attributes(attributes, context))
+      end
+
+      private
+
+      def event_attributes(attributes, context)
+        request = attributes.delete(:request)
+        identity_attributes(attributes).merge(
+          event_type: attributes.fetch(:event_type),
+          request_id: request&.request_id || attributes[:request_id] || context[:request_id],
+          ip: request&.remote_ip || attributes[:ip] || context[:ip],
+          metadata: Redactor.call(attributes.fetch(:metadata, {})),
+          audit_context: context
+        )
+      end
+
+      def identity_attributes(attributes)
+        {
+          household: attributes[:household],
+          household_id: attributes[:household_id],
+          actor_account: attributes[:actor_account] || Current.account,
+          actor_account_id: attributes[:actor_account_id],
+          actor_membership: attributes[:actor_membership] || Current.membership,
+          actor_membership_id: attributes[:actor_membership_id]
+        }.compact
+      end
+    end
+  end
+end

--- a/app/services/audit/redactor.rb
+++ b/app/services/audit/redactor.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Audit
+  class Redactor
+    FILTERED = '[FILTERED]'
+    SENSITIVE_KEYS = %w[
+      access_token auth authorization bearer cookie endpoint id_token p256dh password password_digest password_hash
+      public_key refresh_token secret session_id token token_digest webauthn_id
+    ].freeze
+
+    class << self
+      def call(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, nested_value), redacted|
+            redacted[key] = sensitive?(key) ? FILTERED : call(nested_value)
+          end
+        when Array
+          value.map { |nested_value| call(nested_value) }
+        else
+          value
+        end
+      end
+
+      private
+
+      def sensitive?(key)
+        SENSITIVE_KEYS.include?(key.to_s.downcase)
+      end
+    end
+  end
+end

--- a/app/services/audit/version_event.rb
+++ b/app/services/audit/version_event.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Audit
+  class VersionEvent
+    class << self
+      def record!(**attributes)
+        audit_context = audit_context_for(attributes)
+        PaperTrail::Version.insert( # rubocop:disable Rails/SkipsModelValidations
+          version_attributes(attributes, audit_context)
+        )
+      end
+
+      private
+
+      def audit_context_for(attributes)
+        direct_context = attributes.slice(:whodunnit, :ip, :request_id, :household_id, :actor_membership_id)
+        Context.merge(attributes.delete(:context).to_h.merge(direct_context).compact)
+      end
+
+      def version_attributes(attributes, audit_context)
+        {
+          item_type: attributes.fetch(:item_type),
+          item_id: attributes.fetch(:item_id),
+          event: attributes.fetch(:event),
+          object: serialized_object(attributes.fetch(:object)),
+          whodunnit: audit_context[:actor_user_id]&.to_s,
+          ip: audit_context[:ip],
+          request_id: audit_context[:request_id],
+          household_id: audit_context[:household_id],
+          actor_membership_id: audit_context[:actor_membership_id],
+          audit_context: audit_context,
+          created_at: attributes.fetch(:created_at, Time.current)
+        }
+      end
+
+      def serialized_object(object)
+        object.is_a?(String) ? object : object.to_json
+      end
+    end
+  end
+end

--- a/app/services/auth_token_audit_logger.rb
+++ b/app/services/auth_token_audit_logger.rb
@@ -5,13 +5,13 @@ class AuthTokenAuditLogger
   HASHED_FIELDS = %i[endpoint user_agent].freeze
 
   def record(account:, token_type:, action:, metadata: {}, context: nil)
-    # rubocop:disable Rails/SkipsModelValidations
-    PaperTrail::Version.insert(version_attrs(account:, token_type:, action:, metadata:, context:))
-    # rubocop:enable Rails/SkipsModelValidations
+    # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
+    Audit::VersionEvent.record!(**version_attrs(account:, token_type:, action:, metadata:, context:))
+    # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
     security_event_attrs = security_event_attrs(account:, token_type:, action:, metadata:, context:)
     return if security_event_attrs[:household_id].blank?
 
-    SecurityAuditEvent.create!(security_event_attrs)
+    Audit::Event.record!(**security_event_attrs, audit_context: context.to_h)
   rescue StandardError => e
     Rails.logger.error("AuthTokenAuditLogger failed: #{e.class}: #{e.message}")
   end

--- a/app/services/external_lookup/audit_logger.rb
+++ b/app/services/external_lookup/audit_logger.rb
@@ -5,12 +5,12 @@ module ExternalLookup
     ITEM_TYPE = 'ExternalMedicineLookup'
 
     def record(source:, event:, query:, result_status:, **details)
-      # rubocop:disable Rails/SkipsModelValidations
+      # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
       # PaperTrail::Version is a gem storage table — there are no meaningful validations to run.
       # We use insert to bypass PaperTrail's before_create callbacks, which would attempt to
       # resolve the item type string into a matching ActiveRecord class.
-      PaperTrail::Version.insert(version_attrs(source:, event:, query:, result_status:, **details))
-      # rubocop:enable Rails/SkipsModelValidations
+      Audit::VersionEvent.record!(**version_attrs(source:, event:, query:, result_status:, **details))
+      # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
     rescue StandardError => e
       Rails.logger.error("ExternalLookup::AuditLogger failed: #{e.class}: #{e.message}")
     end

--- a/app/services/portable_data/exporter.rb
+++ b/app/services/portable_data/exporter.rb
@@ -153,13 +153,12 @@ module PortableData
     end
 
     def record_audit_event(payload, export_mode:, event_type: 'portable_data.exported', encrypted: true)
-      SecurityAuditEvent.create!(
+      Audit::Event.record!(
         household: household,
         actor_account: membership.account,
         actor_membership: membership,
         event_type: event_type,
-        request_id: request&.request_id,
-        ip: request&.remote_ip,
+        request: request,
         metadata: {
           record_counts: record_counts(payload),
           encrypted: encrypted,

--- a/app/services/portable_data/importer.rb
+++ b/app/services/portable_data/importer.rb
@@ -110,13 +110,12 @@ module PortableData
     end
 
     def record_audit_event
-      SecurityAuditEvent.create!(
+      Audit::Event.record!(
         household: household,
         actor_account: membership.account,
         actor_membership: membership,
         event_type: 'portable_data.imported',
-        request_id: request&.request_id,
-        ip: request&.remote_ip,
+        request: request,
         metadata: {
           record_counts: counts,
           dry_run: false

--- a/db/migrate/20260709130000_add_forensic_audit_context.rb
+++ b/db/migrate/20260709130000_add_forensic_audit_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddForensicAuditContext < ActiveRecord::Migration[8.1]
+  def change
+    add_column :versions, :object_changes, :text
+    add_column :versions, :audit_context, :jsonb, default: {}, null: false
+    add_column :security_audit_events, :audit_context, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_123000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -743,6 +743,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_123000) do
   create_table "security_audit_events", force: :cascade do |t|
     t.bigint "actor_account_id"
     t.bigint "actor_membership_id"
+    t.jsonb "audit_context", default: {}, null: false
     t.datetime "created_at", null: false
     t.string "event_type", null: false
     t.bigint "household_id", null: false
@@ -789,6 +790,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_123000) do
 
   create_table "versions", force: :cascade do |t|
     t.bigint "actor_membership_id"
+    t.jsonb "audit_context", default: {}, null: false
     t.datetime "created_at"
     t.string "event", null: false
     t.bigint "household_id"
@@ -796,6 +798,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_123000) do
     t.bigint "item_id", null: false
     t.string "item_type", null: false
     t.text "object"
+    t.text "object_changes"
     t.string "request_id"
     t.string "whodunnit"
     t.index ["actor_membership_id"], name: "index_versions_on_actor_membership_id"

--- a/spec/controllers/api/v1/base_controller_spec.rb
+++ b/spec/controllers/api/v1/base_controller_spec.rb
@@ -36,10 +36,20 @@ RSpec.describe Api::V1::BaseController do # rubocop:disable RSpec/MultipleMemoiz
   end
 
   let(:account) { instance_double(Account, present?: true, verified?: true) }
-  let(:user) { instance_double(User, present?: true, active?: true) }
+  let(:user) { instance_double(User, id: 1, present?: true, active?: true) }
   let(:person) { instance_double(Person, user: user) }
   let(:household) { instance_double(Household, id: 1) }
-  let(:membership) { instance_double(HouseholdMembership, active?: true, household: household, id: 1) }
+  let(:membership) do
+    instance_double(
+      HouseholdMembership,
+      active?: true,
+      household: household,
+      household_id: 1,
+      id: 1,
+      role: 'owner',
+      permissions_version: 1
+    )
+  end
 
   let(:api_session) do
     instance_double(
@@ -57,6 +67,7 @@ RSpec.describe Api::V1::BaseController do # rubocop:disable RSpec/MultipleMemoiz
     allow(ApiSession).to receive(:lookup_by_access_token).and_return(api_session)
     allow(ApiAppToken).to receive(:lookup_by_token).and_return(nil)
     allow(ApiAuthState).to receive(:locked_out?).and_return(false)
+    allow(Audit::Event).to receive(:record!)
 
     # Instead of stubbing is_a?, we can stub lookup_api_credential to return our object
     # Or rely on the fact that is_a? might be defined if we create the double right
@@ -135,7 +146,7 @@ RSpec.describe Api::V1::BaseController do # rubocop:disable RSpec/MultipleMemoiz
     end
 
     context 'when user is not active' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:user) { instance_double(User, present?: true, active?: false) }
+      let(:user) { instance_double(User, id: 1, present?: true, active?: false) }
 
       it 'returns unauthorized' do
         get :index

--- a/spec/requests/admin/audit_logs_spec.rb
+++ b/spec/requests/admin/audit_logs_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe 'Admin::AuditLogs' do
     context 'when authenticated as administrator' do
       before { sign_in(admin) }
 
+      it 'records access to the audit log', :aggregate_failures do
+        expect do
+          get admin_audit_logs_path
+        end.to change { SecurityAuditEvent.where(event_type: 'audit_log.accessed').count }.by(1)
+
+        event = SecurityAuditEvent.where(event_type: 'audit_log.accessed').order(:created_at).last
+        expect(event.metadata).to include('action' => 'index', 'outcome' => 'success')
+        expect(event.audit_context).to include(
+          'active_role' => 'owner',
+          'policy_class' => 'AuditLogPolicy',
+          'policy_query' => 'index?'
+        )
+      end
+
       it 'returns success' do
         get admin_audit_logs_path
         expect(response).to have_http_status(:success)

--- a/spec/requests/api/v1/admin_api_spec.rb
+++ b/spec/requests/api/v1/admin_api_spec.rb
@@ -39,11 +39,13 @@ RSpec.describe 'API v1 household administration' do
             params: { household: { name: 'API Admin Renamed Household' } },
             headers: headers,
             as: :json
-    end.to change(SecurityAuditEvent, :count).by(1)
+    end.to change {
+      SecurityAuditEvent.where(event_type: 'api/admin/household_settings/updated').count
+    }.by(1)
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body.dig('data', 'name')).to eq('API Admin Renamed Household')
-    audit_event = SecurityAuditEvent.order(:created_at).last
+    audit_event = SecurityAuditEvent.where(event_type: 'api/admin/household_settings/updated').order(:created_at).last
     expect(audit_event.metadata).not_to include('body', 'token', 'bundle')
   end
 

--- a/spec/requests/api/v1/medications_spec.rb
+++ b/spec/requests/api/v1/medications_spec.rb
@@ -9,6 +9,34 @@ RSpec.describe 'API v1 medications' do
   let(:user) { users(:admin) }
 
   describe 'GET /api/v1/households/:household_id/medications collection' do
+    it 'records high-risk API access without persisting the bearer token', :aggregate_failures do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      access_token = login_data.fetch('access_token')
+
+      expect do
+        get api_v1_household_medications_path(household_id),
+            headers: api_auth_headers(access_token),
+            as: :json
+      end.to change { SecurityAuditEvent.where(event_type: 'api.request').count }.by(1)
+
+      event = SecurityAuditEvent.where(event_type: 'api.request').order(:created_at).last
+      expect(event.audit_context).to include(
+        'authentication_method' => 'api_session',
+        'active_role' => 'owner',
+        'policy_class' => 'MedicationPolicy',
+        'policy_query' => 'index?'
+      )
+      expect(event.metadata).to include(
+        'http_method' => 'GET',
+        'controller' => 'api/v1/medications',
+        'action' => 'index',
+        'outcome' => 'success',
+        'status' => 200
+      )
+      expect(event.attributes.to_json).not_to include(access_token)
+    end
+
     it 'returns only medications in the signed-in user scope' do
       login_data = api_login(user)
       household_id = login_data.dig('household', 'id')
@@ -167,6 +195,29 @@ RSpec.describe 'API v1 medications' do
   end
 
   describe 'PATCH /api/v1/households/:household_id/medications/:id' do
+    it 'attributes PaperTrail changes to the API session and authorization decision', :aggregate_failures do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      access_token = login_data.fetch('access_token')
+      medication = medications(:paracetamol)
+
+      patch api_v1_household_medication_path(household_id, medication.id),
+            params: { medication: { current_supply: 91 } },
+            headers: api_auth_headers(access_token),
+            as: :json
+
+      version = PaperTrail::Version.where(item: medication).order(:created_at).last
+      expect(version.audit_context).to include(
+        'authentication_method' => 'api_session',
+        'active_role' => 'owner',
+        'policy_class' => 'MedicationPolicy',
+        'policy_query' => 'update?'
+      )
+      expect(version.audit_context.fetch('session_reference')).to match(/\Aapi_session:\d+\z/)
+      expect(version.object_changes).to be_present
+      expect(version.attributes.to_json).not_to include(access_token)
+    end
+
     it 'updates a medication with valid attributes' do
       login_data = api_login(user)
       household_id = login_data.dig('household', 'id')

--- a/spec/requests/api/v1/portable_data_spec.rb
+++ b/spec/requests/api/v1/portable_data_spec.rb
@@ -109,12 +109,16 @@ RSpec.describe 'API v1 portable data' do
       get "/api/v1/households/#{household_id}/mobile_snapshot",
           headers: request_headers,
           as: :json
-    end.to change(SecurityAuditEvent, :count).by(1)
+    end.to change {
+      SecurityAuditEvent.where(event_type: 'portable_data.mobile_snapshot_read').count
+    }.by(1).and change {
+      SecurityAuditEvent.where(event_type: 'api.request').count
+    }.by(1)
 
     expect(response).to have_http_status(:ok)
     snapshot = response.parsed_body.fetch('data')
     medication = snapshot.dig('records', 'medications').first
-    audit_event = SecurityAuditEvent.order(:created_at).last
+    audit_event = SecurityAuditEvent.where(event_type: 'portable_data.mobile_snapshot_read').order(:created_at).last
 
     expect(snapshot).to include('format' => 'medtracker.portable.v1')
     expect(snapshot.dig('records', 'people').first).to include('portable_id')

--- a/spec/requests/mcp/server_spec.rb
+++ b/spec/requests/mcp/server_spec.rb
@@ -89,7 +89,16 @@ RSpec.describe 'MedTracker MCP server' do
       request_id: be_present
     )
     expect(audit_event.metadata).to include('method' => 'tools/call', 'outcome' => 'ok')
+    expect(audit_event.audit_context).to include(
+      'authentication_method' => 'api_app_token',
+      'session_reference' => "api_app_token:#{app_token.id}",
+      'actor_account_id' => accounts(:jane_doe).id,
+      'actor_membership_id' => membership.id,
+      'active_role' => 'member',
+      'permissions_version' => membership.permissions_version
+    )
     expect(audit_event.metadata.to_json).not_to include(raw_token)
+    expect(audit_event.audit_context.to_json).not_to include(raw_token)
   end
 
   it 'does not let audit write failures replace the transport response' do
@@ -163,12 +172,20 @@ RSpec.describe 'MedTracker MCP server' do
   end
 
   def raw_token
-    @raw_token ||= ApiAppToken.issue_for(
+    @raw_token ||= issued_app_token.last
+  end
+
+  def app_token
+    issued_app_token.first
+  end
+
+  def issued_app_token
+    @issued_app_token ||= ApiAppToken.issue_for(
       account: accounts(:jane_doe),
       household_membership: membership,
       name: 'RSpec MCP server token',
       audit_context: { request_id: 'mcp-server-token' }
-    ).last
+    )
   end
 
   def membership

--- a/spec/services/audit/context_spec.rb
+++ b/spec/services/audit/context_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Context do
+  fixtures :accounts, :people, :users
+
+  let(:account) { accounts(:admin) }
+  let(:user) { users(:admin) }
+  let(:household) { user.person.household || create(:household) }
+  let(:membership) do
+    household.household_memberships.find_or_create_by!(account: account) do |record|
+      record.person = user.person
+      record.role = :owner
+      record.status = :active
+    end
+  end
+  let(:request) do
+    instance_double(
+      ActionDispatch::Request,
+      request_id: 'req-audit-context',
+      remote_ip: '192.0.2.10',
+      session: Struct.new(:id).new('raw-browser-session-id')
+    )
+  end
+
+  after { described_class.clear! }
+
+  it 'captures actor, role, request, and opaque web-session context', :aggregate_failures do
+    described_class.start!(request:, account:, user:, membership:, credential: :web)
+
+    expect(described_class.current).to include(
+      actor_account_id: account.id,
+      actor_user_id: user.id,
+      actor_membership_id: membership.id,
+      active_role: 'owner',
+      permissions_version: membership.permissions_version,
+      authentication_method: 'web',
+      request_id: 'req-audit-context',
+      ip: '192.0.2.10'
+    )
+    expect(described_class.current.fetch(:session_reference)).to start_with('web:')
+    expect(described_class.current.to_json).not_to include('raw-browser-session-id')
+  end
+
+  it 'captures the successful policy and query in PaperTrail metadata', :aggregate_failures do
+    described_class.start!(request:, account:, user:, membership:, credential: :web)
+    described_class.authorized!(policy_class: MedicationPolicy, query: :update?)
+
+    expect(described_class.current).to include(
+      policy_class: 'MedicationPolicy',
+      policy_query: 'update?'
+    )
+    expect(PaperTrail.request.controller_info.fetch(:audit_context)).to include(
+      policy_class: 'MedicationPolicy',
+      policy_query: 'update?'
+    )
+  end
+
+  it 'clears request-local context and PaperTrail metadata' do
+    described_class.start!(request:, account:, user:, membership:, credential: :web)
+
+    described_class.clear!
+
+    expect(Current.audit_context).to be_nil
+    expect(PaperTrail.request.controller_info).to eq({})
+    expect(PaperTrail.request.whodunnit).to be_nil
+  end
+end

--- a/spec/services/audit/event_spec.rb
+++ b/spec/services/audit/event_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Event do
+  fixtures :accounts, :people, :users
+
+  let(:account) { accounts(:admin) }
+  let(:user) { users(:admin) }
+  let(:household) { user.person.household || create(:household) }
+  let(:membership) do
+    household.household_memberships.find_or_create_by!(account: account) do |record|
+      record.person = user.person
+      record.role = :owner
+      record.status = :active
+    end
+  end
+
+  before do
+    Current.account = account
+    Current.household = household
+    Current.membership = membership
+    Current.audit_context = {
+      actor_account_id: account.id,
+      actor_user_id: user.id,
+      actor_membership_id: membership.id,
+      active_role: membership.role,
+      policy_class: 'MedicationPolicy',
+      policy_query: 'update?'
+    }
+  end
+
+  after { Current.reset }
+
+  it 'writes normalized context and recursively redacts secret metadata', :aggregate_failures do
+    event = record_event
+
+    expect_event_identity(event)
+    expect_event_context(event)
+    expect_redacted_metadata(event)
+  end
+
+  it 'does not swallow persistence failures' do
+    allow(SecurityAuditEvent).to receive(:create!).and_raise(ActiveRecord::StatementInvalid, 'audit unavailable')
+
+    expect do
+      described_class.record!(household: household, event_type: 'security.test')
+    end.to raise_error(ActiveRecord::StatementInvalid, 'audit unavailable')
+  end
+
+  def record_event
+    described_class.record!(
+      household: household,
+      event_type: 'security.test',
+      metadata: {
+        outcome: 'success',
+        access_token: 'raw-access-token',
+        nested: { password: 'raw-password', safe_value: 'kept' }
+      }
+    )
+  end
+
+  def expect_event_identity(event)
+    expect(event).to have_attributes(
+      actor_account: account,
+      actor_membership: membership,
+      event_type: 'security.test'
+    )
+  end
+
+  def expect_event_context(event)
+    expect(event.audit_context).to include(
+      'active_role' => 'owner',
+      'policy_class' => 'MedicationPolicy',
+      'policy_query' => 'update?'
+    )
+  end
+
+  def expect_redacted_metadata(event)
+    expect(event.metadata).to include('outcome' => 'success', 'nested' => include('safe_value' => 'kept'))
+    expect(event.metadata.to_json).not_to include('raw-access-token', 'raw-password')
+  end
+end

--- a/spec/services/auth_token_audit_logger_spec.rb
+++ b/spec/services/auth_token_audit_logger_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe AuthTokenAuditLogger do
     end
 
     def expect_tenant_security_event
+      expect_security_event_identity
+      expect_security_event_context
+    end
+
+    def expect_security_event_identity
       expect(security_event).to have_attributes(
         household_id: security_household.id,
         actor_account_id: account.id,
@@ -84,6 +89,16 @@ RSpec.describe AuthTokenAuditLogger do
         'account_id' => account.id,
         'token_type' => 'api_session',
         'action' => 'created'
+      )
+    end
+
+    def expect_security_event_context
+      expect(security_event.audit_context).to include(
+        'actor_user_id' => user.id,
+        'actor_membership_id' => security_membership.id,
+        'household_id' => security_household.id,
+        'request_id' => 'req-security-001',
+        'ip' => '10.0.0.2'
       )
     end
 


### PR DESCRIPTION
## Why

Audit records could show that something happened without consistently showing which account, household role, credential, request, and authorization decision allowed it. That makes incident investigation slower and leaves important evidence split across unrelated logging paths.

## What this changes

- Gives web, API, MCP, support, import/export, authentication, and privilege-change audit records one redacted attribution context.
- Records the active membership role, permission generation, authentication method, opaque session reference, request details, and successful Pundit policy decision without storing bearer tokens or cookies.
- Adds PaperTrail changesets so reviewers can see the fields that changed as well as reconstruct the prior record.
- Records API access and audit-log access, including successful, failed, and error outcomes.
- Routes manual audit writers through shared services so later integrity controls have one dependable input contract.

This is the first ordered part of #509. It establishes trustworthy attribution and coverage; the following PR adds the tamper-evident database ledger. It does not claim that existing audit rows are already immutable.