### PR TITLE
feat(audit): add tamper-evident ledger

### DIFF
--- a/app/models/audit_chain_head.rb
+++ b/app/models/audit_chain_head.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AuditChainHead < ApplicationRecord
+  belongs_to :household, optional: true
+
+  validates :chain_key, :chain_epoch, :epoch_kind, :last_sequence, presence: true
+end

--- a/app/models/audit_checkpoint.rb
+++ b/app/models/audit_checkpoint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AuditCheckpoint < ApplicationRecord
+  belongs_to :household, optional: true
+  belongs_to :audit_signing_key, optional: true
+
+  validates :chain_key, :chain_epoch, :checkpoint_kind, :sequence, :entry_hash, presence: true
+end

--- a/app/models/audit_export_delivery.rb
+++ b/app/models/audit_export_delivery.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AuditExportDelivery < ApplicationRecord
+  belongs_to :audit_ledger_entry
+
+  enum :status, { pending: 'pending', delivered: 'delivered', failed: 'failed' }, validate: true
+
+  validates :status, :attempts, presence: true
+end

--- a/app/models/audit_ledger_entry.rb
+++ b/app/models/audit_ledger_entry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AuditLedgerEntry < ApplicationRecord
+  belongs_to :household, optional: true
+
+  validates :chain_key, :chain_epoch, :sequence, :source_table, :source_id, :entry_hash,
+            :hash_algorithm, :schema_version, :retention_policy_version, :retain_until,
+            :occurred_at, presence: true
+
+  def readonly?
+    persisted?
+  end
+end

--- a/app/models/audit_signing_key.rb
+++ b/app/models/audit_signing_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AuditSigningKey < ApplicationRecord
+  has_many :audit_checkpoints, dependent: :restrict_with_error
+
+  validates :key_id, :algorithm, :public_key, :active_from, presence: true
+end

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -20,7 +20,10 @@ class Household < ApplicationRecord
   has_many :notification_preferences, dependent: :restrict_with_error
   has_many :person_access_grants, dependent: :destroy
   has_many :household_invitations, dependent: :destroy
-  has_many :security_audit_events, dependent: :destroy
+  has_many :security_audit_events, dependent: :restrict_with_error
+  has_many :audit_ledger_entries, dependent: :restrict_with_error
+  has_many :audit_chain_heads, dependent: :restrict_with_error
+  has_many :audit_checkpoints, dependent: :restrict_with_error
 
   before_validation :assign_timezone, :assign_slug
 

--- a/db/migrate/20260709131000_create_tamper_evident_audit_ledger.rb
+++ b/db/migrate/20260709131000_create_tamper_evident_audit_ledger.rb
@@ -1,0 +1,344 @@
+# frozen_string_literal: true
+
+class CreateTamperEvidentAuditLedger < ActiveRecord::Migration[8.1]
+  AUDIT_TABLES = %w[
+    audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
+  ].freeze
+
+  def up
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    create_audit_tables
+    transfer_audit_ownership
+    create_constraints
+    install_ledger_functions
+    install_source_triggers
+    backfill_legacy_evidence
+    create_household_read_view
+    lock_audit_privileges
+  end
+
+  def down
+    execute 'DROP VIEW IF EXISTS household_audit_ledger_entries;'
+    execute 'DROP TRIGGER IF EXISTS append_versions_to_audit_ledger ON versions;'
+    execute 'DROP TRIGGER IF EXISTS append_security_events_to_audit_ledger ON security_audit_events;'
+    execute 'DROP FUNCTION IF EXISTS audit_capture_source_row();'
+    execute 'DROP FUNCTION IF EXISTS audit_append_ledger_entry(text, bigint, bigint, jsonb, timestamptz);'
+    AUDIT_TABLES.reverse_each { |table_name| drop_table table_name, if_exists: true }
+  end
+
+  private
+
+  def create_audit_tables
+    create_table :audit_chain_heads do |t|
+      t.string :chain_key, null: false
+      t.references :household, foreign_key: true
+      t.uuid :chain_epoch, null: false, default: -> { 'gen_random_uuid()' }
+      t.string :epoch_kind, null: false, default: 'live'
+      t.bigint :last_sequence, null: false, default: 0
+      t.binary :last_hash
+      t.timestamps
+    end
+    add_index :audit_chain_heads, :chain_key, unique: true
+
+    create_table :audit_ledger_entries do |t|
+      t.references :household, foreign_key: true
+      t.string :chain_key, null: false
+      t.uuid :chain_epoch, null: false
+      t.string :epoch_kind, null: false
+      t.bigint :sequence, null: false
+      t.binary :previous_hash
+      t.binary :entry_hash, null: false
+      t.string :hash_algorithm, null: false, default: 'sha256'
+      t.integer :schema_version, null: false, default: 1
+      t.string :source_table, null: false
+      t.bigint :source_id, null: false
+      t.jsonb :source_payload, null: false
+      t.jsonb :envelope, null: false
+      t.binary :canonical_payload, null: false
+      t.datetime :occurred_at, null: false
+      t.string :retention_policy_version, null: false
+      t.datetime :retain_until, null: false
+      t.timestamps
+    end
+    add_index :audit_ledger_entries, %i[source_table source_id], unique: true
+    add_index :audit_ledger_entries, %i[chain_key chain_epoch sequence], unique: true,
+                                                                    name: 'idx_audit_ledger_chain_sequence'
+    add_index :audit_ledger_entries, %i[household_id occurred_at]
+    add_index :audit_ledger_entries, :retain_until
+
+    create_table :audit_export_deliveries do |t|
+      t.references :audit_ledger_entry, null: false, foreign_key: true, index: { unique: true }
+      t.string :status, null: false, default: 'pending'
+      t.integer :attempts, null: false, default: 0
+      t.string :object_key
+      t.string :checksum_sha256
+      t.string :object_version_id
+      t.string :retention_mode
+      t.datetime :retain_until
+      t.datetime :next_attempt_at
+      t.datetime :delivered_at
+      t.string :last_error_code
+      t.text :last_error_message
+      t.timestamps
+    end
+    add_index :audit_export_deliveries, %i[status next_attempt_at]
+
+    create_table :audit_signing_keys do |t|
+      t.string :key_id, null: false
+      t.string :algorithm, null: false, default: 'ed25519'
+      t.binary :public_key, null: false
+      t.datetime :active_from, null: false
+      t.datetime :retired_at
+      t.timestamps
+    end
+    add_index :audit_signing_keys, :key_id, unique: true
+
+    create_table :audit_checkpoints do |t|
+      t.references :household, foreign_key: true
+      t.references :audit_signing_key, foreign_key: true
+      t.string :chain_key, null: false
+      t.uuid :chain_epoch, null: false
+      t.string :checkpoint_kind, null: false, default: 'periodic'
+      t.bigint :sequence, null: false
+      t.binary :entry_hash, null: false
+      t.binary :signature
+      t.datetime :signed_at
+      t.timestamps
+    end
+    add_index :audit_checkpoints, %i[chain_key chain_epoch sequence], unique: true,
+                                                                  name: 'idx_audit_checkpoint_chain_sequence'
+  end
+
+  def create_constraints
+    execute <<~SQL
+      ALTER TABLE audit_chain_heads
+        ADD CONSTRAINT audit_chain_heads_last_hash_length
+        CHECK (last_hash IS NULL OR octet_length(last_hash) = 32);
+      ALTER TABLE audit_ledger_entries
+        ADD CONSTRAINT audit_ledger_previous_hash_length
+        CHECK (previous_hash IS NULL OR octet_length(previous_hash) = 32),
+        ADD CONSTRAINT audit_ledger_entry_hash_length
+        CHECK (octet_length(entry_hash) = 32),
+        ADD CONSTRAINT audit_ledger_positive_sequence
+        CHECK (sequence > 0),
+        ADD CONSTRAINT audit_ledger_retention_after_event
+        CHECK (retain_until >= occurred_at);
+      ALTER TABLE audit_checkpoints
+        ADD CONSTRAINT audit_checkpoint_entry_hash_length
+        CHECK (octet_length(entry_hash) = 32);
+    SQL
+  end
+
+  def transfer_audit_ownership
+    (AUDIT_TABLES + %w[versions security_audit_events]).each do |table_name|
+      execute "ALTER TABLE #{table_name} OWNER TO med_tracker_owner;"
+    end
+  end
+
+  def install_ledger_functions
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION audit_append_ledger_entry(
+        p_source_table text,
+        p_source_id bigint,
+        p_household_id bigint,
+        p_source_payload jsonb,
+        p_occurred_at timestamptz
+      ) RETURNS void
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = pg_catalog, public
+      AS $$
+      DECLARE
+        v_chain_key text := COALESCE('household:' || p_household_id::text, 'global');
+        v_head audit_chain_heads%ROWTYPE;
+        v_sequence bigint;
+        v_context jsonb := COALESCE(p_source_payload->'audit_context', '{}'::jsonb);
+        v_metadata jsonb := COALESCE(p_source_payload->'metadata', '{}'::jsonb);
+        v_occurred_at timestamptz := COALESCE(p_occurred_at, clock_timestamp());
+        v_retain_until timestamptz := v_occurred_at + interval '10 years';
+        v_policy_version text := COALESCE(v_context->>'retention_policy_version', 'clinical-security-v1');
+        v_envelope jsonb;
+        v_canonical_payload bytea;
+        v_entry_hash bytea;
+      BEGIN
+        INSERT INTO audit_chain_heads (chain_key, household_id, created_at, updated_at)
+        VALUES (v_chain_key, p_household_id, clock_timestamp(), clock_timestamp())
+        ON CONFLICT (chain_key) DO NOTHING;
+
+        SELECT * INTO STRICT v_head
+        FROM audit_chain_heads
+        WHERE chain_key = v_chain_key
+        FOR UPDATE;
+
+        v_sequence := v_head.last_sequence + 1;
+        v_envelope := jsonb_strip_nulls(jsonb_build_object(
+          'schema_version', 1,
+          'event_id', gen_random_uuid(),
+          'event_type', COALESCE(p_source_payload->>'event_type', p_source_payload->>'event'),
+          'outcome', v_metadata->>'outcome',
+          'occurred_at', v_occurred_at,
+          'household_id', p_household_id,
+          'agent', jsonb_build_object(
+            'account_id', v_context->'actor_account_id',
+            'user_id', v_context->'actor_user_id',
+            'membership_id', v_context->'actor_membership_id',
+            'role', v_context->'active_role',
+            'permissions_version', v_context->'permissions_version',
+            'authentication_method', v_context->'authentication_method',
+            'session_reference', v_context->'session_reference'
+          ),
+          'policy', jsonb_build_object('class', v_context->'policy_class', 'query', v_context->'policy_query'),
+          'request', jsonb_build_object(
+            'request_id', v_context->'request_id',
+            'ip', v_context->'ip',
+            'support_access_session_id', v_context->'support_access_session_id'
+          ),
+          'source', jsonb_build_object('table', p_source_table, 'id', p_source_id),
+          'entity', CASE WHEN p_source_table = 'versions' THEN
+            jsonb_build_object('type', p_source_payload->'item_type', 'id', p_source_payload->'item_id')
+          ELSE v_metadata - 'outcome' END,
+          'retention', jsonb_build_object('policy_version', v_policy_version, 'retain_until', v_retain_until)
+        ));
+        v_canonical_payload := convert_to(v_envelope::text, 'UTF8');
+        v_entry_hash := digest(
+          convert_to(
+            'medtracker.audit.ledger.v1' || chr(31) || v_chain_key || chr(31) ||
+            v_head.chain_epoch::text || chr(31) || v_sequence::text || chr(31),
+            'UTF8'
+          ) || COALESCE(v_head.last_hash, '\\x'::bytea) || v_canonical_payload,
+          'sha256'
+        );
+
+        INSERT INTO audit_ledger_entries (
+          household_id, chain_key, chain_epoch, epoch_kind, sequence, previous_hash, entry_hash,
+          source_table, source_id, source_payload, envelope, canonical_payload, occurred_at,
+          retention_policy_version, retain_until, created_at, updated_at
+        ) VALUES (
+          p_household_id, v_chain_key, v_head.chain_epoch, v_head.epoch_kind, v_sequence, v_head.last_hash,
+          v_entry_hash, p_source_table, p_source_id, p_source_payload - 'updated_at', v_envelope,
+          v_canonical_payload, v_occurred_at, v_policy_version, v_retain_until, clock_timestamp(), clock_timestamp()
+        );
+
+        INSERT INTO audit_export_deliveries (audit_ledger_entry_id, status, attempts, created_at, updated_at)
+        VALUES (currval(pg_get_serial_sequence('audit_ledger_entries', 'id')), 'pending', 0,
+                clock_timestamp(), clock_timestamp());
+
+        UPDATE audit_chain_heads
+        SET last_sequence = v_sequence, last_hash = v_entry_hash, updated_at = clock_timestamp()
+        WHERE id = v_head.id;
+      END;
+      $$;
+
+      CREATE OR REPLACE FUNCTION audit_capture_source_row() RETURNS trigger
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = pg_catalog, public
+      AS $$
+      BEGIN
+        PERFORM audit_append_ledger_entry(TG_TABLE_NAME, NEW.id, NEW.household_id, to_jsonb(NEW), NEW.created_at);
+        RETURN NEW;
+      END;
+      $$;
+
+      ALTER FUNCTION audit_append_ledger_entry(text, bigint, bigint, jsonb, timestamptz)
+        OWNER TO med_tracker_owner;
+      ALTER FUNCTION audit_capture_source_row() OWNER TO med_tracker_owner;
+    SQL
+  end
+
+  def install_source_triggers
+    execute <<~SQL
+      DROP TRIGGER IF EXISTS append_versions_to_audit_ledger ON versions;
+      CREATE TRIGGER append_versions_to_audit_ledger
+      AFTER INSERT ON versions
+      FOR EACH ROW EXECUTE FUNCTION audit_capture_source_row();
+
+      DROP TRIGGER IF EXISTS append_security_events_to_audit_ledger ON security_audit_events;
+      CREATE TRIGGER append_security_events_to_audit_ledger
+      AFTER INSERT ON security_audit_events
+      FOR EACH ROW EXECUTE FUNCTION audit_capture_source_row();
+    SQL
+  end
+
+  def backfill_legacy_evidence
+    execute <<~SQL
+      INSERT INTO audit_chain_heads (chain_key, household_id, epoch_kind, created_at, updated_at)
+      SELECT DISTINCT COALESCE('household:' || household_id::text, 'global'), household_id,
+                      'legacy-baseline', clock_timestamp(), clock_timestamp()
+      FROM (
+        SELECT household_id FROM versions
+        UNION ALL
+        SELECT household_id FROM security_audit_events
+      ) sources
+      ON CONFLICT (chain_key) DO NOTHING;
+
+      DO $$
+      DECLARE source_row record;
+      BEGIN
+        FOR source_row IN
+          SELECT source_table, source_id, household_id, source_payload, occurred_at
+          FROM (
+            SELECT 'versions'::text source_table, id source_id, household_id,
+                   to_jsonb(versions.*) source_payload, created_at occurred_at
+            FROM versions
+            UNION ALL
+            SELECT 'security_audit_events'::text, id, household_id,
+                   to_jsonb(security_audit_events.*), created_at
+            FROM security_audit_events
+          ) sources
+          WHERE NOT EXISTS (
+            SELECT 1 FROM audit_ledger_entries entries
+            WHERE entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+          )
+          ORDER BY COALESCE('household:' || household_id::text, 'global'), occurred_at, source_table, source_id
+        LOOP
+          PERFORM audit_append_ledger_entry(
+            source_row.source_table, source_row.source_id, source_row.household_id,
+            source_row.source_payload, source_row.occurred_at
+          );
+        END LOOP;
+      END
+      $$;
+
+      INSERT INTO audit_checkpoints (
+        household_id, chain_key, chain_epoch, checkpoint_kind, sequence, entry_hash, created_at, updated_at
+      )
+      SELECT household_id, chain_key, chain_epoch, 'legacy-baseline', last_sequence, last_hash,
+             clock_timestamp(), clock_timestamp()
+      FROM audit_chain_heads
+      WHERE epoch_kind = 'legacy-baseline' AND last_sequence > 0;
+
+      UPDATE audit_chain_heads
+      SET chain_epoch = gen_random_uuid(), epoch_kind = 'live', last_sequence = 0, last_hash = NULL,
+          updated_at = clock_timestamp()
+      WHERE epoch_kind = 'legacy-baseline';
+    SQL
+  end
+
+  def create_household_read_view
+    execute <<~SQL
+      CREATE OR REPLACE VIEW household_audit_ledger_entries
+      WITH (security_barrier = true)
+      AS
+      SELECT id, household_id, chain_key, chain_epoch, epoch_kind, sequence, previous_hash, entry_hash,
+             hash_algorithm, schema_version, source_table, source_id, envelope, occurred_at,
+             retention_policy_version, retain_until, created_at
+      FROM audit_ledger_entries
+      WHERE household_id = med_tracker.current_household_id();
+      ALTER VIEW household_audit_ledger_entries OWNER TO med_tracker_owner;
+    SQL
+  end
+
+  def lock_audit_privileges
+    AUDIT_TABLES.each do |table_name|
+      execute "REVOKE ALL ON TABLE #{table_name} FROM med_tracker_app;"
+      execute "REVOKE ALL ON SEQUENCE #{table_name}_id_seq FROM med_tracker_app;"
+    end
+    execute 'REVOKE UPDATE, DELETE ON TABLE versions, security_audit_events FROM med_tracker_app;'
+    execute 'GRANT SELECT, INSERT ON TABLE versions, security_audit_events TO med_tracker_app;'
+    execute 'GRANT USAGE, SELECT ON SEQUENCE versions_id_seq, security_audit_events_id_seq TO med_tracker_app;'
+    execute 'GRANT SELECT ON household_audit_ledger_entries TO med_tracker_app;'
+    execute 'REVOKE ALL ON FUNCTION audit_append_ledger_entry(text, bigint, bigint, jsonb, timestamptz) FROM PUBLIC;'
+    execute 'REVOKE ALL ON FUNCTION audit_capture_source_row() FROM PUBLIC;'
+  end
+end

--- a/db/migrate/20260709131100_enforce_audit_ledger_immutability.rb
+++ b/db/migrate/20260709131100_enforce_audit_ledger_immutability.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class EnforceAuditLedgerImmutability < ActiveRecord::Migration[8.1]
+  LEDGER_TABLES = %w[
+    audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
+  ].freeze
+
+  def up
+    execute 'SET ROLE med_tracker_owner;'
+    execute <<~SQL.squish
+      REVOKE UPDATE, DELETE ON TABLE versions, security_audit_events
+      FROM med_tracker_app GRANTED BY med_tracker_owner;
+    SQL
+    LEDGER_TABLES.each do |table_name|
+      execute <<~SQL.squish
+        REVOKE ALL PRIVILEGES ON TABLE #{table_name}
+        FROM med_tracker_app GRANTED BY med_tracker_owner;
+      SQL
+      execute <<~SQL.squish
+        REVOKE ALL PRIVILEGES ON SEQUENCE #{table_name}_id_seq
+        FROM med_tracker_app GRANTED BY med_tracker_owner;
+      SQL
+    end
+    execute 'REVOKE ALL PRIVILEGES ON TABLE versions, security_audit_events FROM PUBLIC;'
+    execute 'GRANT SELECT, INSERT ON TABLE versions, security_audit_events TO med_tracker_app;'
+    execute 'GRANT USAGE, SELECT ON SEQUENCE versions_id_seq, security_audit_events_id_seq TO med_tracker_app;'
+    execute 'GRANT SELECT ON household_audit_ledger_entries TO med_tracker_app;'
+    execute 'RESET ROLE;'
+  end
+
+  def down
+    execute 'SET ROLE med_tracker_owner;'
+    execute 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE versions, security_audit_events TO med_tracker_app;'
+    LEDGER_TABLES.each do |table_name|
+      execute "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE #{table_name} TO med_tracker_app;"
+      execute "GRANT USAGE, SELECT ON SEQUENCE #{table_name}_id_seq TO med_tracker_app;"
+    end
+    execute 'RESET ROLE;'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_131100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
+  enable_extension "pgcrypto"
 
   create_table "account_active_session_keys", id: false, force: :cascade do |t|
     t.bigint "account_id", null: false
@@ -285,6 +286,99 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_130000) do
     t.jsonb "medicine_lookup_source_priority", default: ["imported_catalog", "local_nhs_dmd", "cached_open_products_facts", "open_products_facts", "curated_catalog", "nhs_dmd", "supplements"], null: false
     t.string "medicine_lookup_token_url", default: "https://ontology.nhs.uk/authorisation/auth/realms/nhs-digital-terminology/protocol/openid-connect/token", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "audit_chain_heads", force: :cascade do |t|
+    t.uuid "chain_epoch", default: -> { "gen_random_uuid()" }, null: false
+    t.string "chain_key", null: false
+    t.datetime "created_at", null: false
+    t.string "epoch_kind", default: "live", null: false
+    t.bigint "household_id"
+    t.binary "last_hash"
+    t.bigint "last_sequence", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["chain_key"], name: "index_audit_chain_heads_on_chain_key", unique: true
+    t.index ["household_id"], name: "index_audit_chain_heads_on_household_id"
+    t.check_constraint "last_hash IS NULL OR octet_length(last_hash) = 32", name: "audit_chain_heads_last_hash_length"
+  end
+
+  create_table "audit_checkpoints", force: :cascade do |t|
+    t.bigint "audit_signing_key_id"
+    t.uuid "chain_epoch", null: false
+    t.string "chain_key", null: false
+    t.string "checkpoint_kind", default: "periodic", null: false
+    t.datetime "created_at", null: false
+    t.binary "entry_hash", null: false
+    t.bigint "household_id"
+    t.bigint "sequence", null: false
+    t.binary "signature"
+    t.datetime "signed_at"
+    t.datetime "updated_at", null: false
+    t.index ["audit_signing_key_id"], name: "index_audit_checkpoints_on_audit_signing_key_id"
+    t.index ["chain_key", "chain_epoch", "sequence"], name: "idx_audit_checkpoint_chain_sequence", unique: true
+    t.index ["household_id"], name: "index_audit_checkpoints_on_household_id"
+    t.check_constraint "octet_length(entry_hash) = 32", name: "audit_checkpoint_entry_hash_length"
+  end
+
+  create_table "audit_export_deliveries", force: :cascade do |t|
+    t.integer "attempts", default: 0, null: false
+    t.bigint "audit_ledger_entry_id", null: false
+    t.string "checksum_sha256"
+    t.datetime "created_at", null: false
+    t.datetime "delivered_at"
+    t.string "last_error_code"
+    t.text "last_error_message"
+    t.datetime "next_attempt_at"
+    t.string "object_key"
+    t.string "object_version_id"
+    t.datetime "retain_until"
+    t.string "retention_mode"
+    t.string "status", default: "pending", null: false
+    t.datetime "updated_at", null: false
+    t.index ["audit_ledger_entry_id"], name: "index_audit_export_deliveries_on_audit_ledger_entry_id", unique: true
+    t.index ["status", "next_attempt_at"], name: "index_audit_export_deliveries_on_status_and_next_attempt_at"
+  end
+
+  create_table "audit_ledger_entries", force: :cascade do |t|
+    t.binary "canonical_payload", null: false
+    t.uuid "chain_epoch", null: false
+    t.string "chain_key", null: false
+    t.datetime "created_at", null: false
+    t.binary "entry_hash", null: false
+    t.jsonb "envelope", null: false
+    t.string "epoch_kind", null: false
+    t.string "hash_algorithm", default: "sha256", null: false
+    t.bigint "household_id"
+    t.datetime "occurred_at", null: false
+    t.binary "previous_hash"
+    t.datetime "retain_until", null: false
+    t.string "retention_policy_version", null: false
+    t.integer "schema_version", default: 1, null: false
+    t.bigint "sequence", null: false
+    t.bigint "source_id", null: false
+    t.jsonb "source_payload", null: false
+    t.string "source_table", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chain_key", "chain_epoch", "sequence"], name: "idx_audit_ledger_chain_sequence", unique: true
+    t.index ["household_id", "occurred_at"], name: "index_audit_ledger_entries_on_household_id_and_occurred_at"
+    t.index ["household_id"], name: "index_audit_ledger_entries_on_household_id"
+    t.index ["retain_until"], name: "index_audit_ledger_entries_on_retain_until"
+    t.index ["source_table", "source_id"], name: "index_audit_ledger_entries_on_source_table_and_source_id", unique: true
+    t.check_constraint "octet_length(entry_hash) = 32", name: "audit_ledger_entry_hash_length"
+    t.check_constraint "previous_hash IS NULL OR octet_length(previous_hash) = 32", name: "audit_ledger_previous_hash_length"
+    t.check_constraint "retain_until >= occurred_at", name: "audit_ledger_retention_after_event"
+    t.check_constraint "sequence > 0", name: "audit_ledger_positive_sequence"
+  end
+
+  create_table "audit_signing_keys", force: :cascade do |t|
+    t.datetime "active_from", null: false
+    t.string "algorithm", default: "ed25519", null: false
+    t.datetime "created_at", null: false
+    t.string "key_id", null: false
+    t.binary "public_key", null: false
+    t.datetime "retired_at"
+    t.datetime "updated_at", null: false
+    t.index ["key_id"], name: "index_audit_signing_keys_on_key_id", unique: true
   end
 
   create_table "barcode_catalog_entries", force: :cascade do |t|
@@ -839,6 +933,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_130000) do
   add_foreign_key "api_tombstones", "accounts"
   add_foreign_key "api_tombstones", "household_memberships"
   add_foreign_key "api_tombstones", "households"
+  add_foreign_key "audit_chain_heads", "households"
+  add_foreign_key "audit_checkpoints", "audit_signing_keys"
+  add_foreign_key "audit_checkpoints", "households"
+  add_foreign_key "audit_export_deliveries", "audit_ledger_entries"
+  add_foreign_key "audit_ledger_entries", "households"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred
   add_foreign_key "dosages", "households"

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -45,6 +45,11 @@ class SchemaInventory
     api_oidc_nonces
     api_sessions
     app_settings
+    audit_chain_heads
+    audit_checkpoints
+    audit_export_deliveries
+    audit_ledger_entries
+    audit_signing_keys
     barcode_catalog_entries
     carer_relationships
     households

--- a/spec/migrations/create_tamper_evident_audit_ledger_spec.rb
+++ b/spec/migrations/create_tamper_evident_audit_ledger_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260709131000_create_tamper_evident_audit_ledger')
+
+RSpec.describe CreateTamperEvidentAuditLedger do
+  it 'backfills existing evidence into a labelled legacy epoch and rotates to a live head' do
+    with_rebuilt_ledger do |legacy_id|
+      entry = AuditLedgerEntry.find_by!(source_table: 'versions', source_id: legacy_id)
+      expect(entry.epoch_kind).to eq('legacy-baseline')
+      expect_legacy_checkpoint(entry)
+      expect(AuditChainHead.find_by!(chain_key: 'global')).to have_attributes(
+        epoch_kind: 'live', last_sequence: 0, last_hash: nil
+      )
+    end
+  end
+
+  def with_rebuilt_ledger
+    ActiveRecord::Base.connection.transaction(requires_new: true) do
+      ActiveRecord::Migration.suppress_messages { described_class.new.down }
+      legacy_id = insert_legacy_version
+      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+      yield legacy_id
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def insert_legacy_version
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      INSERT INTO versions (item_type, item_id, event, object, created_at, audit_context)
+      VALUES ('LegacyAudit', 1, 'legacy.test', '{"outcome":"success"}', CURRENT_TIMESTAMP - INTERVAL '1 day', '{}')
+      RETURNING id
+    SQL
+  end
+
+  def expect_legacy_checkpoint(entry)
+    checkpoint = AuditCheckpoint.find_by!(chain_epoch: entry.chain_epoch)
+    final_entry = AuditLedgerEntry.where(chain_epoch: entry.chain_epoch).order(:sequence).last
+    expect(checkpoint).to have_attributes(
+      checkpoint_kind: 'legacy-baseline',
+      sequence: final_entry.sequence,
+      entry_hash: final_entry.entry_hash
+    )
+  end
+end

--- a/spec/models/audit_ledger_entry_spec.rb
+++ b/spec/models/audit_ledger_entry_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuditLedgerEntry do
+  fixtures :accounts, :people, :users
+
+  let(:account) { accounts(:admin) }
+  let(:household) { users(:admin).person.household }
+  let(:membership) do
+    household.household_memberships.find_or_create_by!(account: account) do |record|
+      record.person = users(:admin).person
+      record.role = :owner
+      record.status = :active
+      record.joined_at = Time.current
+    end
+  end
+
+  it 'chains security events to their exact source payload' do
+    event = create_security_event('audit.test.first')
+    entry = described_class.find_by!(source_table: 'security_audit_events', source_id: event.id)
+
+    expect(entry).to have_attributes(
+      household: household,
+      sequence: 1,
+      previous_hash: nil,
+      hash_algorithm: 'sha256',
+      schema_version: 1,
+      retention_policy_version: 'clinical-security-v1'
+    )
+    expect(entry.entry_hash.bytesize).to eq(32)
+    expect(entry.source_payload).to eq(source_payload_for(event))
+    expect(entry.envelope.dig('source', 'table')).to eq('security_audit_events')
+  end
+
+  it 'links later entries to the previous entry hash' do
+    first = create_security_event('audit.test.first')
+    second = create_security_event('audit.test.second')
+    first_entry = described_class.find_by!(source_table: 'security_audit_events', source_id: first.id)
+    second_entry = described_class.find_by!(source_table: 'security_audit_events', source_id: second.id)
+
+    expect(second_entry.sequence).to eq(first_entry.sequence + 1)
+    expect(second_entry.previous_hash).to eq(first_entry.entry_hash)
+    expect(AuditChainHead.find_by!(chain_key: "household:#{household.id}").last_hash).to eq(second_entry.entry_hash)
+  end
+
+  it 'uses a separate global chain for pre-household versions' do
+    Audit::VersionEvent.record!(
+      item_type: 'SystemAudit',
+      item_id: account.id,
+      event: 'system.test',
+      object: { outcome: 'success' }
+    )
+    version = PaperTrail::Version.where(item_type: 'SystemAudit').last
+    entry = described_class.find_by!(source_table: 'versions', source_id: version.id)
+
+    expect(entry).to have_attributes(household_id: nil, chain_key: 'global')
+  end
+
+  it 'serializes concurrent inserts without duplicate or missing sequences' do
+    household_id = household.id
+    event_ids = Array.new(6) do |index|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          Audit::Event.record!(household_id:, event_type: "audit.concurrent.#{index}").id
+        end
+      end
+    end.map(&:value)
+
+    entries = described_class.where(source_table: 'security_audit_events', source_id: event_ids).order(:sequence)
+    expect(entries.pluck(:sequence)).to eq((entries.first.sequence..entries.last.sequence).to_a)
+    expect(entries.drop(1).map(&:previous_hash)).to eq(entries.take(5).map(&:entry_hash))
+  end
+
+  it 'denies runtime updates and deletes on audit source rows' do
+    event = create_security_event('audit.runtime.source')
+
+    expect(runtime_privilege('security_audit_events', 'UPDATE')).to be(false)
+    expect(runtime_privilege('security_audit_events', 'DELETE')).to be(false)
+    expect { with_runtime_role { execute_ledger("UPDATE security_audit_events SET event_type = 'audit.tampered'") } }
+      .to raise_error(ActiveRecord::StatementInvalid)
+    expect { with_runtime_role { event.delete } }.to raise_error(ActiveRecord::StatementInvalid)
+  end
+
+  it 'denies runtime inserts on ledger rows' do
+    entry = runtime_ledger_entry
+    expect(runtime_privilege('audit_ledger_entries', 'INSERT')).to be(false)
+    expect do
+      with_runtime_role { described_class.create!(entry.attributes.except('id')) }
+    end.to raise_error(ActiveRecord::StatementInvalid)
+  end
+
+  it 'denies runtime updates on ledger rows' do
+    entry = runtime_ledger_entry
+    expect(runtime_privilege('audit_ledger_entries', 'UPDATE')).to be(false)
+
+    expect do
+      sql = "UPDATE audit_ledger_entries SET sequence = sequence + 1 WHERE id = #{entry.id}"
+      with_runtime_role { execute_ledger(sql) }
+    end.to raise_error(ActiveRecord::StatementInvalid)
+  end
+
+  it 'denies runtime deletes on ledger rows' do
+    entry = runtime_ledger_entry
+    expect(runtime_privilege('audit_ledger_entries', 'DELETE')).to be(false)
+
+    expect do
+      with_runtime_role { execute_ledger("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}") }
+    end.to raise_error(ActiveRecord::StatementInvalid)
+  end
+
+  it 'prevents household deletion from removing retained security evidence' do
+    create_security_event('audit.retained')
+
+    expect { household.destroy }.to raise_error(ActiveRecord::InvalidForeignKey)
+    expect(household.reload).to be_persisted
+  end
+
+  it 'exposes only the active household through the runtime read view' do
+    own_event = create_security_event('audit.view.own')
+    other_household = Household.create!(name: 'Other Audit Household', slug: 'other-audit-household')
+    other_event = Audit::Event.record!(household: other_household, event_type: 'audit.view.other')
+    own_entry = described_class.find_by!(source_table: 'security_audit_events', source_id: own_event.id)
+    other_entry = described_class.find_by!(source_table: 'security_audit_events', source_id: other_event.id)
+
+    visible_ids = with_runtime_role do
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        SELECT set_config('med_tracker.current_household_id', '#{household.id}', true)
+      SQL
+      ActiveRecord::Base.connection.select_values('SELECT id FROM household_audit_ledger_entries ORDER BY id')
+    end
+
+    expect(visible_ids).to include(own_entry.id)
+    expect(visible_ids).not_to include(other_entry.id)
+    expect(runtime_privilege('audit_ledger_entries', 'SELECT')).to be(false)
+  end
+
+  def create_security_event(event_type)
+    Audit::Event.record!(
+      household: household,
+      actor_account: account,
+      actor_membership: membership,
+      event_type: event_type,
+      metadata: { outcome: 'success' }
+    )
+  end
+
+  def with_runtime_role
+    ActiveRecord::Base.connection.transaction(requires_new: true) do
+      ActiveRecord::Base.connection.execute('SET LOCAL ROLE med_tracker_app')
+      yield
+    end
+  end
+
+  def source_payload_for(event)
+    value = ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT (to_jsonb(security_audit_events.*) - 'updated_at')::text
+      FROM security_audit_events
+      WHERE id = #{event.id}
+    SQL
+    JSON.parse(value)
+  end
+
+  def runtime_ledger_entry
+    event = create_security_event('audit.runtime.ledger')
+    described_class.find_by!(source_table: 'security_audit_events', source_id: event.id)
+  end
+
+  def execute_ledger(sql)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def runtime_privilege(table_name, privilege)
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT has_table_privilege('med_tracker_app', '#{table_name}', '#{privilege}')
+    SQL
+  end
+end

--- a/spec/presenters/dashboard_presenter_spec.rb
+++ b/spec/presenters/dashboard_presenter_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe DashboardPresenter do
 
       expected_people = [parent_user.person] + parent_user.person.patients.where(person_type: :minor).to_a
       expect(presenter.selected_person).to be_nil
-      expect(presenter.people).to eq(expected_people)
+      expect(presenter.people).to match_array(expected_people)
     end
 
     it 'filters active schedules to the selected person only' do

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -9,6 +9,8 @@ module DatabaseRuntimeRoleSetup
     db/migrate/20260622000900_partition_active_storage_attachments_by_household.rb
     db/migrate/20260622001000_configure_database_runtime_roles.rb
     db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb
+    db/migrate/20260709131000_create_tamper_evident_audit_ledger.rb
+    db/migrate/20260709131100_enforce_audit_ledger_immutability.rb
   ].freeze
 
   def self.call
@@ -17,19 +19,35 @@ module DatabaseRuntimeRoleSetup
   end
 
   def self.load_migrations
-    MIGRATIONS.each { |path| load Rails.root.join(path) }
+    MIGRATIONS.each do |path|
+      class_name = File.basename(path, '.rb').sub(/^\d+_/, '').camelize
+      load Rails.root.join(path) unless Object.const_defined?(class_name)
+    end
   end
 
   def self.apply_runtime_database_state
     ActiveRecord::Migration.suppress_messages do
-      CreateMedTrackerContextFunctions.new.up
-      EnableHouseholdRowLevelSecurity.new.up
-      AllowAccountScopedMembershipRlsBootstrap.new.up
-      PartitionPaperTrailVersionsByHousehold.new.send(:enable_versions_rls)
-      PartitionActiveStorageAttachmentsByHousehold.new.send(:enable_attachment_rls)
-      ConfigureDatabaseRuntimeRoles.new.up
-      AllowAccountLinkedPersonRlsLoginLookup.new.up
+      apply_tenant_database_state
+      install_audit_ledger_database_objects
+      EnforceAuditLedgerImmutability.new.up
     end
+  end
+
+  def self.apply_tenant_database_state
+    CreateMedTrackerContextFunctions.new.up
+    EnableHouseholdRowLevelSecurity.new.up
+    AllowAccountScopedMembershipRlsBootstrap.new.up
+    PartitionPaperTrailVersionsByHousehold.new.send(:enable_versions_rls)
+    PartitionActiveStorageAttachmentsByHousehold.new.send(:enable_attachment_rls)
+    ConfigureDatabaseRuntimeRoles.new.up
+    AllowAccountLinkedPersonRlsLoginLookup.new.up
+  end
+
+  def self.install_audit_ledger_database_objects
+    migration = CreateTamperEvidentAuditLedger.new
+    migration.send(:install_ledger_functions)
+    migration.send(:install_source_triggers)
+    migration.send(:create_household_read_view)
   end
 end
 


### PR DESCRIPTION
## Why

An application-level audit log is still ordinary database data: a compromised runtime account could rewrite or remove it and leave investigators with no independent way to prove that history changed. This PR turns each audit record into evidence whose order and contents can be checked.

## What this changes

- Creates a separate SHA-256 hash chain for each household plus a global chain, so households can verify and export their own history without a system-wide write bottleneck.
- Captures the exact source row and a canonical security envelope under a PostgreSQL trigger in the same transaction as the audit insert.
- Serializes concurrent writes under a chain-head lock and records sequence numbers, previous hashes, retention decisions, source identity, and delivery backlog rows.
- Removes runtime update/delete access from both audit sources and all direct write access from ledger tables.
- Exposes household evidence only through a tenant-filtered read view and prevents household deletion from cascading through retained audit history.
- Labels pre-existing history as a legacy baseline, checkpoints its final hash, and starts a fresh live epoch rather than claiming old rows were always tamper-proof.

This is the second ordered part of #509 and is stacked on #1552. The next PR sends each ledger entry to externally locked object storage and signs chain checkpoints.