### PR TITLE
fix(exports): audit downloads and prevent caching

### DIFF
--- a/app/controllers/api/v1/data_exports_controller.rb
+++ b/app/controllers/api/v1/data_exports_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class DataExportsController < BaseController
+      before_action :no_store
+
       def show
         render json: { data: export_service.call }
       rescue DataExports::ProfileExportService::Error, PortableData::Encryptor::Error => e

--- a/app/controllers/profiles/data_exports_controller.rb
+++ b/app/controllers/profiles/data_exports_controller.rb
@@ -3,6 +3,7 @@
 module Profiles
   class DataExportsController < ApplicationController
     before_action :require_authentication
+    before_action :no_store
 
     def show
       result = export_service.call

--- a/app/services/data_exports/profile_export_service.rb
+++ b/app/services/data_exports/profile_export_service.rb
@@ -40,20 +40,20 @@ module DataExports
     end
 
     def backup_zip
-      json = JSON.pretty_generate(portable_payload.merge(format: 'medtracker.backup.v1'))
-      {
-        filename: "medtracker-backup-#{Time.current.utc.strftime('%Y%m%d%H%M%S')}.zip",
-        content_type: 'application/zip',
-        base64: Base64.strict_encode64(zip_file('medtracker-backup.json', json))
-      }
+      portable_exporter(passphrase: nil).export_unencrypted(export_mode: mode) do |payload|
+        json = JSON.pretty_generate(payload.merge(format: 'medtracker.backup.v1'))
+        {
+          filename: "medtracker-backup-#{Time.current.utc.strftime('%Y%m%d%H%M%S')}.zip",
+          content_type: 'application/zip',
+          base64: Base64.strict_encode64(zip_file('medtracker-backup.json', json))
+        }
+      end
     end
 
     def health_data_json
-      portable_payload.merge(format: 'medtracker.health_data.v1')
-    end
-
-    def portable_payload
-      @portable_payload ||= portable_exporter(passphrase: nil).payload
+      portable_exporter(passphrase: nil).export_unencrypted(export_mode: mode) do |payload|
+        payload.merge(format: 'medtracker.health_data.v1')
+      end
     end
 
     def portable_exporter(passphrase:)

--- a/app/services/portable_data/exporter.rb
+++ b/app/services/portable_data/exporter.rb
@@ -13,14 +13,25 @@ module PortableData
     end
 
     def call
-      envelope = Encryptor.encrypt(payload, passphrase: passphrase)
-      record_audit_event(payload)
+      export_payload = payload
+      envelope = Encryptor.encrypt(export_payload, passphrase: passphrase)
+      record_audit_event(export_payload, export_mode: 'encrypted_migration_bundle')
       envelope
     end
 
+    def export_unencrypted(export_mode:, event_type: 'portable_data.exported')
+      export_payload = payload
+      result = yield(export_payload)
+      record_audit_event(export_payload, event_type: event_type, encrypted: false, export_mode: export_mode)
+      result
+    end
+
     def mobile_snapshot
-      payload.tap do |export_payload|
-        record_audit_event(export_payload, event_type: 'portable_data.mobile_snapshot_read', encrypted: false)
+      export_unencrypted(
+        export_mode: 'mobile_snapshot',
+        event_type: 'portable_data.mobile_snapshot_read'
+      ) do |export_payload|
+        export_payload
       end
     end
 
@@ -141,7 +152,7 @@ module PortableData
                                                           .order(:id)
     end
 
-    def record_audit_event(payload, event_type: 'portable_data.exported', encrypted: true)
+    def record_audit_event(payload, export_mode:, event_type: 'portable_data.exported', encrypted: true)
       SecurityAuditEvent.create!(
         household: household,
         actor_account: membership.account,
@@ -151,7 +162,8 @@ module PortableData
         ip: request&.remote_ip,
         metadata: {
           record_counts: record_counts(payload),
-          encrypted: encrypted
+          encrypted: encrypted,
+          export_mode: export_mode
         }
       )
     end

--- a/spec/requests/api/v1/data_exports_spec.rb
+++ b/spec/requests/api/v1/data_exports_spec.rb
@@ -11,33 +11,62 @@ RSpec.describe 'API v1 data exports' do
   let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
 
   it 'returns health-data JSON exports through the shared export service' do
-    get api_v1_household_data_export_path(household_id, 'health_data_json'), headers: headers, as: :json
+    expect do
+      get api_v1_household_data_export_path(household_id, 'health_data_json'), headers: headers, as: :json
+    end.to change(export_audit_events, :count).by(1)
 
     expect(response).to have_http_status(:ok)
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
     expect(response.parsed_body.dig('data', 'format')).to eq('medtracker.health_data.v1')
     expect(response.parsed_body.dig('data', 'records')).to include('people', 'medications')
+    expect(export_audit_events.last.metadata).to include(
+      'encrypted' => false,
+      'export_mode' => 'health_data_json',
+      'record_counts' => be_present
+    )
   end
 
   it 'returns unencrypted backup ZIP payloads without token/session records' do
-    get api_v1_household_data_export_path(household_id, 'backup_zip'), headers: headers, as: :json
+    expect do
+      get api_v1_household_data_export_path(household_id, 'backup_zip'), headers: headers, as: :json
+    end.to change(export_audit_events, :count).by(1)
 
     expect(response).to have_http_status(:ok)
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
     data = response.parsed_body.fetch('data')
     expect(data.fetch('content_type')).to eq('application/zip')
     expect(data.fetch('filename')).to end_with('.zip')
     expect(Base64.strict_decode64(data.fetch('base64')).byteslice(0, 2)).to eq('PK')
+    expect(export_audit_events.last.metadata).to include(
+      'encrypted' => false,
+      'export_mode' => 'backup_zip',
+      'record_counts' => be_present
+    )
   end
 
   it 'requires a passphrase for encrypted migration bundles' do
     get api_v1_household_data_export_path(household_id, 'encrypted_migration_bundle'), headers: headers, as: :json
 
     expect(response).to have_http_status(:unprocessable_content)
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
 
-    get api_v1_household_data_export_path(household_id, 'encrypted_migration_bundle'),
-        headers: headers.merge('X-MedTracker-Portable-Passphrase' => 'correct horse battery staple'),
-        as: :json
+    expect do
+      get api_v1_household_data_export_path(household_id, 'encrypted_migration_bundle'),
+          headers: headers.merge('X-MedTracker-Portable-Passphrase' => 'correct horse battery staple'),
+          as: :json
+    end.to change(export_audit_events, :count).by(1)
 
     expect(response).to have_http_status(:ok)
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
     expect(response.parsed_body.dig('data', 'format')).to eq('medtracker.portable.encrypted.v1')
+    expect(export_audit_events.last.metadata).to include(
+      'encrypted' => true,
+      'export_mode' => 'encrypted_migration_bundle',
+      'record_counts' => be_present
+    )
+  end
+
+  def export_audit_events
+    SecurityAuditEvent.where(event_type: 'portable_data.exported')
   end
 end

--- a/spec/requests/profile_data_exports_spec.rb
+++ b/spec/requests/profile_data_exports_spec.rb
@@ -16,21 +16,41 @@ RSpec.describe 'Profile data exports' do
   end
 
   it 'downloads a health-data JSON export from the profile page' do
-    get profile_data_export_path('health_data_json')
+    expect do
+      get profile_data_export_path('health_data_json')
+    end.to change(export_audit_events, :count).by(1)
 
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq('application/json')
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
     expect(response.parsed_body.fetch('format')).to eq('medtracker.health_data.v1')
+    expect(export_audit_events.last.metadata).to include(
+      'encrypted' => false,
+      'export_mode' => 'health_data_json',
+      'record_counts' => be_present
+    )
   end
 
   it 'downloads a backup ZIP without sensitive platform records from the profile page' do
-    get profile_data_export_path('backup_zip')
+    expect do
+      get profile_data_export_path('backup_zip')
+    end.to change(export_audit_events, :count).by(1)
 
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq('application/zip')
+    expect(response.headers.fetch('Cache-Control')).to include('no-store')
     expect(response.headers.fetch('Content-Disposition')).to include('medtracker-backup-')
     expect(response.body.byteslice(0, 2)).to eq('PK')
     expect(response.body).not_to include('api_sessions', 'api_app_tokens', 'native_device_tokens',
                                          'push_subscriptions', 'security_audit_events')
+    expect(export_audit_events.last.metadata).to include(
+      'encrypted' => false,
+      'export_mode' => 'backup_zip',
+      'record_counts' => be_present
+    )
+  end
+
+  def export_audit_events
+    SecurityAuditEvent.where(event_type: 'portable_data.exported')
   end
 end


### PR DESCRIPTION
## Summary

Profile and API backup and health exports previously bypassed the security ledger because they read the portable payload directly. Export responses could also retain the default Rails cache policy even though they contain health data.

This change adds one audited unencrypted export boundary that records only after the artifact has been generated successfully. Every successful export now stores redacted record counts, the export mode, and encryption state without copying health data into audit metadata. Both export controllers also apply the Rails no-store response policy to JSON, ZIP, encrypted, and error responses.

Closes #1545