### PR TITLE
refactor(components): move database reads to query boundaries

### DIFF
--- a/app/components/admin/audit_logs/show_view.rb
+++ b/app/components/admin/audit_logs/show_view.rb
@@ -10,10 +10,11 @@ module Components
         # Fields that should never be displayed in audit logs for security
         SENSITIVE_FIELDS = %w[password_digest password_hash token token_digest].freeze
 
-        attr_reader :version
+        attr_reader :version, :detail
 
-        def initialize(version:)
+        def initialize(version:, detail:)
           @version = version
+          @detail = detail
           super()
         end
 
@@ -101,15 +102,7 @@ module Components
         end
 
         def user_name
-          return @user_name if defined?(@user_name)
-
-          @user_name = if version.whodunnit.blank?
-                         I18n.t('admin.audit_logs.show.system')
-                       else
-                         user = User.find_by(id: version.whodunnit)
-
-                         user ? user.name : "User ##{version.whodunnit}"
-                       end
+          detail.actor_name
         end
 
         def render_changes_section
@@ -207,17 +200,7 @@ module Components
         end
 
         def medication_take_record
-          return @medication_take_record if defined?(@medication_take_record)
-
-          @medication_take_record = if version.item_type == 'MedicationTake' && version.item_id.present?
-                                      medication_take_relation.find_by(id: version.item_id)
-                                    end
-        end
-
-        def medication_take_relation
-          MedicationTake.includes(:taken_from_medication, :taken_from_location,
-                                  schedule: %i[medication person],
-                                  person_medication: %i[medication person])
+          detail.medication_take
         end
 
         def external_lookup?
@@ -246,11 +229,7 @@ module Components
 
         def compute_new_state
           # Try to get the next version's object (which represents state after this change)
-          next_version = PaperTrail::Version
-                         .where(item_type: version.item_type, item_id: version.item_id)
-                         .where('id > ?', version.id)
-                         .order(:id)
-                         .first
+          next_version = detail.next_version
 
           if next_version&.object.present?
             # The next version's object is the state after this version's change
@@ -265,7 +244,7 @@ module Components
           model_class = version.item_type.safe_constantize
           return nil unless model_class
 
-          record = model_class.find_by(id: version.item_id)
+          record = detail.current_record
           return nil unless record
 
           # Convert to hash, excluding sensitive fields
@@ -356,26 +335,16 @@ module Components
           }.compact
         end
 
-        def medication_take_payload_source_record(data)
-          return medication_take_record.source if medication_take_record&.source
-
-          schedule_id = data['schedule_id'].presence
-          return Schedule.includes(:medication, :person).find_by(id: schedule_id) if schedule_id
-
-          person_medication_id = data['person_medication_id'].presence
-          return unless person_medication_id
-
-          PersonMedication.includes(:medication, :person).find_by(id: person_medication_id)
+        def medication_take_payload_source_record(_data)
+          detail.source_record
         end
 
-        def medication_take_payload_stock_source(data)
-          medication_take_record&.inventory_medication ||
-            Medication.find_by(id: data['taken_from_medication_id'].presence)
+        def medication_take_payload_stock_source(_data)
+          detail.stock_source
         end
 
-        def medication_take_payload_stock_location(data)
-          medication_take_record&.inventory_location ||
-            Location.find_by(id: data['taken_from_location_id'].presence)
+        def medication_take_payload_stock_location(_data)
+          detail.stock_location
         end
       end
     end

--- a/app/components/admin/users/index_view.rb
+++ b/app/components/admin/users/index_view.rb
@@ -7,10 +7,11 @@ module Components
       class IndexView < Components::Base
         include Phlex::Rails::Helpers::TurboFrameTag
 
-        attr_reader :users, :search_params, :current_user, :pagy_obj
+        attr_reader :users, :search_params, :current_user, :pagy_obj, :access_summary
 
-        def initialize(users:, search_params: {}, current_user: nil, pagy: nil)
+        def initialize(users:, access_summary:, search_params: {}, current_user: nil, pagy: nil)
           @users = users
+          @access_summary = access_summary
           @search_params = search_params
           @current_user = current_user
           @pagy_obj = pagy
@@ -28,6 +29,7 @@ module Components
               div(class: 'rounded-[2rem] border border-border bg-card shadow-sm overflow-x-auto p-4') do
                 render Components::Admin::Users::UsersTable.new(
                   users: users,
+                  access_summary: access_summary,
                   search_params: search_params,
                   current_user: current_user
                 )

--- a/app/components/admin/users/user_row.rb
+++ b/app/components/admin/users/user_row.rb
@@ -7,13 +7,12 @@ module Components
       class UserRow < Components::Base
         include Phlex::Rails::Helpers::FormWith
 
-        attr_reader :user, :current_user, :household
+        attr_reader :user, :current_user, :access_summary
 
-        def initialize(user:, current_user: nil, household: nil, membership_role: nil)
+        def initialize(user:, access_summary:, current_user: nil)
           @user = user
+          @access_summary = access_summary
           @current_user = current_user
-          @household = household || Current.household
-          @membership_role = membership_role
           super()
         end
 
@@ -43,17 +42,10 @@ module Components
         private
 
         def membership_role
-          return @membership_role if @membership_role
-
-          lookup_membership_role
-        end
-
-        def lookup_membership_role
           account_id = user.person&.account_id
-          return no_membership_label unless household && account_id
+          return no_membership_label unless account_id
 
-          membership = household.household_memberships.active.find_by(account_id: account_id)
-          membership&.role&.titleize || no_membership_label
+          access_summary.membership_role_for(account_id)&.titleize || no_membership_label
         end
 
         def no_membership_label
@@ -61,9 +53,7 @@ module Components
         end
 
         def render_system_access_badge
-          account = user.person&.account
-
-          if account&.platform_admin&.active?
+          if access_summary.platform_admin?(user.person&.account_id)
             render RubyUI::Badge.new(variant: :destructive) { t('admin.users.table.system_administrator') }
           else
             render RubyUI::Badge.new(variant: :tonal) { t('admin.users.table.household_user') }

--- a/app/components/admin/users/users_table.rb
+++ b/app/components/admin/users/users_table.rb
@@ -7,13 +7,13 @@ module Components
       class UsersTable < Components::Base
         include Phlex::Rails::Helpers::FormWith
 
-        attr_reader :users, :search_params, :current_user, :household
+        attr_reader :users, :search_params, :current_user, :access_summary
 
-        def initialize(users:, search_params: {}, current_user: nil, household: nil)
+        def initialize(users:, access_summary:, search_params: {}, current_user: nil)
           @users = users
+          @access_summary = access_summary
           @search_params = search_params
           @current_user = current_user
-          @household = household || Current.household
           super()
         end
 
@@ -139,8 +139,7 @@ module Components
               render Components::Admin::Users::UserRow.new(
                 user: user,
                 current_user: current_user,
-                household: household,
-                membership_role: membership_role_for(user)
+                access_summary: access_summary
               )
             end
           end
@@ -148,24 +147,9 @@ module Components
 
         def membership_role_for(user)
           account_id = user.person&.account_id
-          return no_membership_label unless household && account_id
+          return no_membership_label unless account_id
 
-          membership = memberships_by_account_id[account_id]
-          membership&.role&.titleize || no_membership_label
-        end
-
-        def memberships_by_account_id
-          return @memberships_by_account_id if defined?(@memberships_by_account_id)
-
-          account_ids = users.filter_map { |user| user.person&.account_id }.uniq
-          @memberships_by_account_id = if household && account_ids.any?
-                                         household.household_memberships
-                                                  .active
-                                                  .where(account_id: account_ids)
-                                                  .index_by(&:account_id)
-                                       else
-                                         {}
-                                       end
+          access_summary.membership_role_for(account_id)&.titleize || no_membership_label
         end
 
         def no_membership_label
@@ -173,38 +157,11 @@ module Components
         end
 
         def system_access_label_for(user)
-          if platform_admin_account_ids.include?(user.person&.account_id)
+          if access_summary.platform_admin?(user.person&.account_id)
             t('admin.users.table.system_administrator')
           else
             t('admin.users.table.household_user')
           end
-        end
-
-        def platform_admin_account_ids
-          return @platform_admin_account_ids if defined?(@platform_admin_account_ids)
-
-          @platform_admin_account_ids = if platform_admin_accounts_loaded?
-                                          preloaded_platform_admin_account_ids
-                                        else
-                                          PlatformAdmin.active
-                                                       .where(account_id: memberships_by_account_id.keys)
-                                                       .pluck(:account_id)
-                                                       .to_set
-                                        end
-        end
-
-        def platform_admin_accounts_loaded?
-          loaded_accounts.all? { |account| account.association(:platform_admin).loaded? }
-        end
-
-        def preloaded_platform_admin_account_ids
-          loaded_accounts.filter_map do |account|
-            account.id if account.platform_admin&.active?
-          end.to_set
-        end
-
-        def loaded_accounts
-          @loaded_accounts ||= users.filter_map { |user| user.person&.account }
         end
 
         def render_status_badge(user)

--- a/app/components/platform/users/index_view.rb
+++ b/app/components/platform/users/index_view.rb
@@ -6,11 +6,12 @@ module Components
       class IndexView < Components::Base
         include Phlex::Rails::Helpers::FormWith
 
-        attr_reader :users, :current_user
+        attr_reader :users, :current_user, :access_summary
 
-        def initialize(users:, current_user:)
+        def initialize(users:, current_user:, access_summary:)
           @users = users
           @current_user = current_user
+          @access_summary = access_summary
           super()
         end
 
@@ -100,27 +101,12 @@ module Components
         end
 
         def household_role_for(user)
-          membership = memberships_by_account_id[user.person&.account_id]
-          membership&.role&.titleize || t('admin.users.form.no_membership', default: 'No membership')
+          role = access_summary.membership_role_for(user.person&.account_id)
+          role&.titleize || t('admin.users.form.no_membership', default: 'No membership')
         end
 
         def platform_admin?(user)
-          platform_admin_account_ids.include?(user.person&.account_id)
-        end
-
-        def memberships_by_account_id
-          @memberships_by_account_id ||= HouseholdMembership.active
-                                                            .where(account_id: account_ids)
-                                                            .order(:id)
-                                                            .index_by(&:account_id)
-        end
-
-        def platform_admin_account_ids
-          @platform_admin_account_ids ||= PlatformAdmin.active.where(account_id: account_ids).pluck(:account_id).to_set
-        end
-
-        def account_ids
-          @account_ids ||= users.filter_map { |user| user.person&.account_id }.uniq
+          access_summary.platform_admin?(user.person&.account_id)
         end
       end
     end

--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -38,8 +38,9 @@ module Admin
     def show
       @version = policy_scope(PaperTrail::Version.all, policy_scope_class: AuditLogPolicy::Scope).find(params.expect(:id))
       authorize @version, policy_class: AuditLogPolicy
+      detail = Admin::AuditLogDetailQuery.new(version: @version).call
 
-      render Components::Admin::AuditLogs::ShowView.new(version: @version)
+      render Components::Admin::AuditLogs::ShowView.new(version: @version, detail: detail)
     end
 
     private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,8 +11,10 @@ module Admin
         household: admin_target_household
       ).call
       @pagy, users = pagy(:offset, users)
+      access_summary = user_access_summary(users)
       render Components::Admin::Users::IndexView.new(
         users: users,
+        access_summary: access_summary,
         search_params: search_params,
         current_user: current_user,
         pagy: @pagy
@@ -144,8 +146,10 @@ module Admin
         household: admin_target_household
       ).call
       @pagy, users = pagy(:offset, users)
+      access_summary = user_access_summary(users)
       Components::Admin::Users::IndexView.new(
         users: users,
+        access_summary: access_summary,
         search_params: search_params,
         current_user: current_user,
         pagy: @pagy
@@ -232,13 +236,23 @@ module Admin
     end
 
     def user_row_streams(user)
+      rendered_user = User.includes(person: :account).find(user.id)
+      access_summary = user_access_summary([rendered_user])
       [
         turbo_stream.replace(
           "user_#{user.id}",
-          Components::Admin::Users::UserRow.new(user: user.reload, current_user: current_user)
+          Components::Admin::Users::UserRow.new(
+            user: rendered_user,
+            current_user: current_user,
+            access_summary: access_summary
+          )
         ),
         turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
       ]
+    end
+
+    def user_access_summary(users)
+      Admin::UserAccessSummaryQuery.new(users: users, household: admin_target_household).call
     end
   end
 end

--- a/app/controllers/platform/users_controller.rb
+++ b/app/controllers/platform/users_controller.rb
@@ -4,7 +4,12 @@ module Platform
   class UsersController < BaseController
     def index
       users = User.includes(person: :account).order(:email_address)
-      render Components::Platform::Users::IndexView.new(users: users, current_user: current_user)
+      access_summary = Admin::UserAccessSummaryQuery.new(users: users).call
+      render Components::Platform::Users::IndexView.new(
+        users: users,
+        current_user: current_user,
+        access_summary: access_summary
+      )
     end
 
     def update

--- a/app/services/admin/audit_logs_query.rb
+++ b/app/services/admin/audit_logs_query.rb
@@ -81,4 +81,105 @@ module Admin
       scope.reorder(nil).where.not(column => [nil, '']).distinct.pluck(column)
     end
   end
+
+  class AuditLogDetailQuery
+    Result = Data.define(
+      :actor_name,
+      :medication_take,
+      :next_version,
+      :current_record,
+      :source_record,
+      :stock_source,
+      :stock_location
+    )
+
+    attr_reader :version
+
+    def initialize(version:)
+      @version = version
+    end
+
+    def call
+      medication_take = medication_take_record
+      object_data = parsed_object_data
+      next_version = following_version
+
+      Result.new(
+        actor_name: AuditActorResolver.new.name_for(version.whodunnit),
+        medication_take: medication_take,
+        next_version: next_version,
+        current_record: current_record(next_version),
+        source_record: source_record(medication_take, object_data),
+        stock_source: stock_source(medication_take, object_data),
+        stock_location: stock_location(medication_take, object_data)
+      )
+    end
+
+    private
+
+    def medication_take_record
+      return unless version.item_type == 'MedicationTake' && version.item_id.present?
+
+      MedicationTake.includes(
+        :taken_from_location,
+        taken_from_medication: :location,
+        schedule: [{ medication: :location }, :person],
+        person_medication: [{ medication: :location }, :person]
+      ).find_by(id: version.item_id)
+    end
+
+    def following_version
+      return if version.event == 'destroy'
+
+      PaperTrail::Version.where(item_type: version.item_type, item_id: version.item_id)
+                         .where('id > ?', version.id)
+                         .order(:id)
+                         .first
+    end
+
+    def current_record(next_version)
+      return if next_version&.object.present?
+
+      version.item_type.safe_constantize&.find_by(id: version.item_id)
+    rescue StandardError
+      nil
+    end
+
+    def source_record(medication_take, data)
+      return medication_take.source if medication_take&.source
+
+      schedule_id = data['schedule_id'].presence
+      return Schedule.includes(:medication, :person).find_by(id: schedule_id) if schedule_id
+
+      person_medication_id = data['person_medication_id'].presence
+      return unless person_medication_id
+
+      PersonMedication.includes(:medication, :person).find_by(id: person_medication_id)
+    end
+
+    def stock_source(medication_take, data)
+      inventory_medication = medication_take&.inventory_medication
+      return inventory_medication if inventory_medication
+
+      medication_id = data['taken_from_medication_id'].presence
+      Medication.find_by(id: medication_id) if medication_id
+    end
+
+    def stock_location(medication_take, data)
+      inventory_location = medication_take&.inventory_location
+      return inventory_location if inventory_location
+
+      location_id = data['taken_from_location_id'].presence
+      Location.find_by(id: location_id) if location_id
+    end
+
+    def parsed_object_data
+      return {} unless version.item_type == 'MedicationTake' && version.object.present?
+
+      data = YAML.safe_load(version.object, permitted_classes: ActiveRecord.yaml_column_permitted_classes)
+      data.is_a?(Hash) ? data.stringify_keys : {}
+    rescue StandardError
+      {}
+    end
+  end
 end

--- a/app/services/admin/users_index_query.rb
+++ b/app/services/admin/users_index_query.rb
@@ -107,4 +107,49 @@ module Admin
       { 'desc' => :desc }.fetch(direction, :asc)
     end
   end
+
+  class UserAccessSummaryQuery
+    Result = Data.define(:membership_roles_by_account_id, :platform_admin_account_ids) do
+      def membership_role_for(account_id)
+        membership_roles_by_account_id[account_id]
+      end
+
+      def platform_admin?(account_id)
+        platform_admin_account_ids.include?(account_id)
+      end
+    end
+
+    attr_reader :users, :household
+
+    def initialize(users:, household: nil)
+      @users = users
+      @household = household
+    end
+
+    def call
+      Result.new(
+        membership_roles_by_account_id: membership_roles_by_account_id,
+        platform_admin_account_ids: platform_admin_account_ids
+      )
+    end
+
+    private
+
+    def membership_roles_by_account_id
+      membership_scope.index_by(&:account_id).transform_values(&:role)
+    end
+
+    def membership_scope
+      scope = household ? household.household_memberships : HouseholdMembership.all
+      scope.active.where(account_id: account_ids).order(:id)
+    end
+
+    def platform_admin_account_ids
+      PlatformAdmin.active.where(account_id: account_ids).pluck(:account_id).to_set
+    end
+
+    def account_ids
+      @account_ids ||= users.filter_map { |user| user.person&.account_id }.uniq
+    end
+  end
 end

--- a/spec/components/admin/audit_logs/show_view_spec.rb
+++ b/spec/components/admin/audit_logs/show_view_spec.rb
@@ -19,14 +19,15 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
 
   describe 'initialization' do
     it 'accepts a version' do
-      view = described_class.new(version: version)
+      view = view_for(version)
 
       expect(view.version).to eq(version)
+      expect(view.detail).to be_a(Admin::AuditLogDetailQuery::Result)
     end
   end
 
   describe 'helper methods' do
-    subject(:view) { described_class.new(version: version) }
+    subject(:view) { view_for(version) }
 
     describe '#user_name' do
       it 'returns the user name when whodunnit is present' do
@@ -207,20 +208,28 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
       expect(payload['logged_by_name']).to eq(admin.name)
     end
 
-    it 'looks up the logged-by user once per render' do
+    it 'does not look up the logged-by user while rendering' do
       version = medication_take_version
+      view = view_for(version)
 
-      expect(count_user_queries { render_inline(described_class.new(version: version)) }).to eq(1)
+      expect(count_user_queries { render_inline(view) }).to eq(0)
+    end
+
+    it 'does not execute SQL while rendering an audit detail' do
+      version = medication_take_version
+      view = view_for(version)
+
+      expect(count_queries { render_inline(view) }).to eq(0)
     end
 
     def medication_take_summary
-      rendered = render_inline(described_class.new(version: medication_take_version))
+      rendered = render_inline(view_for(medication_take_version))
 
       rendered.at_css('[data-testid="audit-log-medication-take-summary"]')
     end
 
     def medication_take_payload
-      rendered = render_inline(described_class.new(version: medication_take_version))
+      rendered = render_inline(view_for(medication_take_version))
       JSON.parse(rendered.css('pre code').last.text)
     end
 
@@ -237,5 +246,22 @@ RSpec.describe Components::Admin::AuditLogs::ShowView, type: :component do
       ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
       count
     end
+
+    def count_queries(&)
+      count = 0
+      subscriber = lambda do |_name, _start, _finish, _id, payload|
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        count += 1
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      count
+    end
+  end
+
+  def view_for(version)
+    detail = Admin::AuditLogDetailQuery.new(version: version).call
+    described_class.new(version: version, detail: detail)
   end
 end

--- a/spec/components/admin/users/users_table_spec.rb
+++ b/spec/components/admin/users/users_table_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
 
   describe 'rendering' do
     it 'renders a table' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       expect(rendered.css('table')).to be_present
     end
 
     it 'renders mobile cards and keeps the desktop table' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       expect(rendered.css('[data-testid="admin-users-mobile-list"]')).to be_present
       expect(rendered.css('[data-testid="admin-users-desktop-table"] table')).to be_present
@@ -44,7 +44,7 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
     end
 
     it 'keeps canonical row selectors unique when card representations render' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       expect(rendered.css("[data-user-id='#{target_user.id}']").length).to eq(1)
       expect(rendered.css("[data-user-card-id='#{target_user.id}']")).to be_present
@@ -54,21 +54,21 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
     end
 
     it 'renders table headers' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       headers = rendered.css('th').map(&:text)
       expect(headers).to include('Name', 'Email address', 'Role', 'Activation', 'Verification', 'Actions')
     end
 
     it 'renders a row for each user' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       rows = rendered.css('tbody tr')
       expect(rows.length).to eq(user_list.count)
     end
 
     it 'renders edit links with outline button styling' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       row = rendered.css("[data-user-id='#{target_user.id}']").first
       edit_link = row.css('a').find { |link| link.text.include?('Edit') }
@@ -77,7 +77,7 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
     end
 
     it 'renders the household membership role instead of the legacy user role' do
-      rendered = render_inline(described_class.new(users: [target_user], current_user: current_user))
+      rendered = render_inline(table_component(users: [target_user]))
 
       expect(rendered.text).to include('Administrator')
       expect(User.column_names).not_to include('role')
@@ -87,7 +87,7 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
       users = User.where(id: [current_user.id, target_user.id]).includes(person: :account).to_a
 
       expect(count_membership_role_queries do
-        render_inline(described_class.new(users: users, current_user: current_user, household: household))
+        render_inline(table_component(users: users))
       end).to eq(1)
     end
 
@@ -98,15 +98,27 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
         household: household
       ).call.to_a
 
-      expect(count_row_association_queries do
-        render_inline(described_class.new(users: users, current_user: current_user, household: household))
-      end).to eq(0)
+      component = table_component(users: users)
+
+      expect(count_row_association_queries { render_inline(component) }).to eq(0)
+    end
+
+    it 'does not execute SQL while rendering preloaded users' do
+      users = Admin::UsersIndexQuery.new(
+        scope: User.where(id: [current_user.id, target_user.id]),
+        filters: {},
+        household: household
+      ).call.to_a
+
+      component = table_component(users: users)
+
+      expect(count_queries { render_inline(component) }).to eq(0)
     end
   end
 
   describe 'sortable headers' do
     it 'renders sortable links for Name, Email, and Role' do
-      rendered = render_inline(described_class.new(users: user_list, current_user: current_user))
+      rendered = render_inline(table_component)
 
       sortable_links = rendered.css('th a')
       link_texts = sortable_links.map(&:text).join
@@ -116,32 +128,20 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
     end
 
     it 'includes sort direction in header links' do
-      rendered = render_inline(described_class.new(
-                                 users: user_list,
-                                 search_params: { sort: 'name', direction: 'asc' },
-                                 current_user: current_user
-                               ))
+      rendered = render_inline(table_component(search_params: { sort: 'name', direction: 'asc' }))
 
       name_link = rendered.css('th a').find { |a| a.text.include?('Name') }
       expect(name_link['href']).to include('direction=desc')
     end
 
     it 'renders sort indicator for active sort column' do
-      rendered = render_inline(described_class.new(
-                                 users: user_list,
-                                 search_params: { sort: 'name', direction: 'asc' },
-                                 current_user: current_user
-                               ))
+      rendered = render_inline(table_component(search_params: { sort: 'name', direction: 'asc' }))
 
       expect(rendered.text).to include('↑')
     end
 
     it 'renders descending indicator when direction is desc' do
-      rendered = render_inline(described_class.new(
-                                 users: user_list,
-                                 search_params: { sort: 'name', direction: 'desc' },
-                                 current_user: current_user
-                               ))
+      rendered = render_inline(table_component(search_params: { sort: 'name', direction: 'desc' }))
 
       expect(rendered.text).to include('↓')
     end
@@ -149,10 +149,20 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
 
   describe 'with empty user list' do
     it 'renders the table with no body rows' do
-      rendered = render_inline(described_class.new(users: [], current_user: current_user))
+      rendered = render_inline(table_component(users: []))
 
       expect(rendered.css('tbody tr').length).to eq(0)
     end
+  end
+
+  def table_component(users: user_list, search_params: {})
+    access_summary = Admin::UserAccessSummaryQuery.new(users: users, household: household).call
+    described_class.new(
+      users: users,
+      access_summary: access_summary,
+      search_params: search_params,
+      current_user: current_user
+    )
   end
 
   def count_membership_role_queries(&)
@@ -175,6 +185,18 @@ RSpec.describe Components::Admin::Users::UsersTable, type: :component do
 
       sql = payload[:sql]
       count += 1 if sql.match?(/FROM "(people|accounts|platform_admins)"/)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+    count
+  end
+
+  def count_queries(&)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      count += 1
     end
 
     ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)

--- a/spec/requests/platform/users_spec.rb
+++ b/spec/requests/platform/users_spec.rb
@@ -91,4 +91,34 @@ RSpec.describe 'Platform users' do
     AccountOtpKey.create!(id: account.id, key: secret, last_use: 5.minutes.ago)
     post '/otp-auth', params: { otp: ROTP::TOTP.new(visible_secret).at(Time.current) }
   end
+
+  describe Components::Platform::Users::IndexView, type: :component do
+    fixtures :accounts, :people, :users
+
+    it 'does not execute SQL while rendering preloaded users' do
+      current_user = users(:admin)
+      user_list = User.where(id: [current_user.id, users(:jane).id]).includes(person: :account).to_a
+      access_summary = Admin::UserAccessSummaryQuery.new(users: user_list).call
+
+      expect(count_queries do
+        render_inline(described_class.new(
+                        users: user_list,
+                        current_user: current_user,
+                        access_summary: access_summary
+                      ))
+      end).to eq(0)
+    end
+
+    def count_queries(&)
+      count = 0
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        count += 1
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      count
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Admin and platform user components previously assembled membership and system-access data while rendering. Audit detail components also resolved actors, adjacent versions, current records, medication sources, and stock records from inside the view.

This change moves those reads into two explicit query boundaries. Controllers now pass immutable access summaries and fully loaded audit detail data into Phlex components, including Turbo row refreshes. The rendered HTML and authorization behavior stay the same, while focused instrumentation specs now require zero SQL statements during all three component renders.

Closes #1546