### PR TITLE
feat(audit): preserve evidence outside the app database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'rotp'
 # QR code generation for OTP setup [https://github.com/whomwah/rqrcode]
 gem 'rqrcode'
 # WebAuthn support for passkeys [https://github.com/cedarcode/webauthn-ruby]
+gem 'aws-sdk-s3', require: false
 gem 'webauthn'
 # Web push notifications (VAPID) [https://github.com/pushpad/web-push]
 gem 'web-push'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,25 @@ GEM
     android_key_attestation (0.3.0)
     ast (2.4.3)
     attr_required (1.0.2)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1267.0)
+    aws-sdk-core (3.254.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.227.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -250,6 +269,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.20.0)
     json-jwt (1.17.1)
       activesupport (>= 4.2)
@@ -826,6 +846,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-s3
   bcrypt
   bootsnap
   brakeman

--- a/app/models/audit_checkpoint.rb
+++ b/app/models/audit_checkpoint.rb
@@ -3,6 +3,7 @@
 class AuditCheckpoint < ApplicationRecord
   belongs_to :household, optional: true
   belongs_to :audit_signing_key, optional: true
+  has_one :audit_export_delivery, dependent: :restrict_with_error
 
   validates :chain_key, :chain_epoch, :checkpoint_kind, :sequence, :entry_hash, presence: true
 end

--- a/app/models/audit_export_delivery.rb
+++ b/app/models/audit_export_delivery.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 class AuditExportDelivery < ApplicationRecord
-  belongs_to :audit_ledger_entry
+  belongs_to :audit_ledger_entry, optional: true
+  belongs_to :audit_checkpoint, optional: true
 
   enum :status, { pending: 'pending', delivered: 'delivered', failed: 'failed' }, validate: true
 
   validates :status, :attempts, presence: true
+  validate :exactly_one_export_record
+
+  def export_record
+    audit_ledger_entry || audit_checkpoint
+  end
+
+  private
+
+  def exactly_one_export_record
+    return if [audit_ledger_entry, audit_checkpoint].one?(&:present?)
+
+    errors.add(:base, 'must reference exactly one audit record')
+  end
 end

--- a/app/services/audit/checkpoint_signer.rb
+++ b/app/services/audit/checkpoint_signer.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'openssl'
+
+module Audit
+  class CheckpointSigner
+    class AlreadySigned < StandardError; end
+
+    CHECKPOINT_SQL = <<~SQL.squish.freeze
+      SELECT audit_record_signed_checkpoint(
+        $1, $2, $3, $4::uuid, $5::bigint, $6, $7, $8::timestamptz, $9
+      )
+    SQL
+
+    def initialize(key_id:, private_key_pem:)
+      @key_id = key_id
+      @private_key = OpenSSL::PKey.read(private_key_pem)
+      raise ArgumentError, 'checkpoint signing key must be Ed25519' unless private_key.oid == 'ED25519'
+    end
+
+    def sign(entry)
+      ensure_unsigned!(entry)
+      signed_at = Time.current.utc
+      signature = private_key.sign(nil, payload_for(entry, signed_at:))
+      checkpoint_id = record_checkpoint(entry, signed_at:, signature:)
+      AuditCheckpoint.find(checkpoint_id)
+    rescue ActiveRecord::StatementInvalid => e
+      raise AlreadySigned, 'checkpoint is already signed by another key' if e.message.include?('already signed')
+
+      raise
+    end
+
+    def payload_for(entry, signed_at: nil)
+      checkpoint = AuditCheckpoint.find_by(chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+                                           sequence: entry.sequence)
+      signed_at ||= checkpoint&.signed_at
+      [
+        'medtracker.audit.checkpoint.v1', key_id, entry.chain_key, entry.chain_epoch,
+        entry.sequence, entry.entry_hash.unpack1('H*'), signed_at&.utc&.iso8601(6)
+      ].join("\u001F")
+    end
+
+    private
+
+    attr_reader :key_id, :private_key
+
+    def ensure_unsigned!(entry)
+      existing = AuditCheckpoint.find_by(chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+                                         sequence: entry.sequence)
+      raise AlreadySigned, 'checkpoint is already signed by another key' if existing&.signature.present?
+    end
+
+    def record_checkpoint(entry, signed_at:, signature:)
+      ActiveRecord::Base.connection
+                        .select_value(CHECKPOINT_SQL, 'Audit checkpoint', checkpoint_binds(entry, signed_at, signature))
+                        .to_i
+    end
+
+    def checkpoint_binds(entry, signed_at, signature)
+      checkpoint_values(entry, signed_at, signature).map.with_index do |value, index|
+        ActiveRecord::Relation::QueryAttribute.new("audit_checkpoint_#{index}", value, ActiveRecord::Type::String.new)
+      end
+    end
+
+    def checkpoint_values(entry, signed_at, signature)
+      [
+        key_id, Base64.strict_encode64(private_key.public_to_der), entry.chain_key, entry.chain_epoch,
+        entry.sequence, entry.entry_hash.unpack1('H*'), Base64.strict_encode64(signature),
+        signed_at.iso8601(6), 'periodic'
+      ]
+    end
+  end
+end

--- a/app/services/audit/object_lock/configuration.rb
+++ b/app/services/audit/object_lock/configuration.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Audit
+  module ObjectLock
+    class Configuration
+      class Invalid < StandardError; end
+
+      RETENTION_MODES = %w[GOVERNANCE COMPLIANCE].freeze
+      ENCRYPTION_MODES = %w[AES256 aws:kms].freeze
+
+      attr_reader :bucket, :region, :expected_owner, :retention_mode, :server_side_encryption,
+                  :kms_key_id, :endpoint
+
+      def initialize(environment = ENV)
+        @environment = environment
+        @bucket = required('AUDIT_WORM_BUCKET')
+        @region = required('AUDIT_WORM_REGION')
+        @expected_owner = required('AUDIT_WORM_EXPECTED_OWNER')
+        @retention_mode = environment.fetch('AUDIT_WORM_RETENTION_MODE', 'GOVERNANCE').upcase
+        @server_side_encryption = environment.fetch('AUDIT_WORM_SSE', 'aws:kms')
+        @kms_key_id = environment['AUDIT_WORM_KMS_KEY_ID'].presence
+        @endpoint = environment['AUDIT_WORM_ENDPOINT'].presence
+        validate!
+      end
+
+      def force_path_style?
+        ActiveModel::Type::Boolean.new.cast(@environment['AUDIT_WORM_FORCE_PATH_STYLE'])
+      end
+
+      def compliance_approved?
+        ActiveModel::Type::Boolean.new.cast(@environment['AUDIT_WORM_COMPLIANCE_APPROVED'])
+      end
+
+      def to_h
+        {
+          bucket:, region:, expected_owner:, retention_mode:, server_side_encryption:,
+          kms_key_id:, endpoint:, force_path_style: force_path_style?
+        }.compact
+      end
+
+      private
+
+      def required(name)
+        @environment[name].presence || raise(Invalid, "#{name} is required")
+      end
+
+      def validate!
+        raise Invalid, "unsupported retention mode: #{retention_mode}" unless RETENTION_MODES.include?(retention_mode)
+        raise Invalid, 'COMPLIANCE retention requires records-governance approval' if compliance_without_approval?
+        raise Invalid, "unsupported server-side encryption: #{server_side_encryption}" unless encryption_valid?
+        raise Invalid, 'a KMS key is required for aws:kms encryption' if kms_key_missing?
+      end
+
+      def compliance_without_approval?
+        retention_mode == 'COMPLIANCE' && !compliance_approved?
+      end
+
+      def encryption_valid?
+        ENCRYPTION_MODES.include?(server_side_encryption)
+      end
+
+      def kms_key_missing?
+        server_side_encryption == 'aws:kms' && kms_key_id.blank?
+      end
+    end
+  end
+end

--- a/app/services/audit/object_lock/delivery_exporter.rb
+++ b/app/services/audit/object_lock/delivery_exporter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Audit
+  module ObjectLock
+    class DeliveryExporter
+      def initialize(adapter:)
+        @adapter = adapter
+      end
+
+      def deliver(delivery)
+        delivery.with_lock do
+          return true if delivery.delivered?
+
+          delivery.update!(attempts: delivery.attempts + 1)
+          persist_success(delivery, adapter.write(delivery.export_record))
+        end
+        true
+      rescue RetryableError => e
+        persist_failure(delivery, e, status: :pending, code: 'retryable', retry_at: next_retry(delivery.attempts))
+        false
+      rescue ConfigurationError, IntegrityError => e
+        persist_failure(delivery, e, status: :failed, code: error_code(e))
+        false
+      end
+
+      private
+
+      attr_reader :adapter
+
+      def persist_success(delivery, result)
+        delivery.update!(
+          status: :delivered, object_key: result.object_key, checksum_sha256: result.checksum_sha256,
+          object_version_id: result.version_id, retention_mode: result.retention_mode,
+          retain_until: result.retain_until, delivered_at: Time.current,
+          next_attempt_at: nil, last_error_code: nil, last_error_message: nil
+        )
+      end
+
+      def persist_failure(delivery, error, status:, code:, retry_at: nil)
+        delivery.reload
+        delivery.update!(
+          status:, attempts: delivery.attempts + 1, next_attempt_at: retry_at, last_error_code: code,
+          last_error_message: error.message.to_s.first(500)
+        )
+      end
+
+      def next_retry(attempts)
+        Time.current + [2**attempts, 300].min.seconds
+      end
+
+      def error_code(error)
+        error.is_a?(ConfigurationError) ? 'configuration' : 'integrity'
+      end
+    end
+  end
+end

--- a/app/services/audit/object_lock/record_serializer.rb
+++ b/app/services/audit/object_lock/record_serializer.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'digest'
+require 'json'
+
+module Audit
+  module ObjectLock
+    class RecordSerializer
+      attr_reader :record
+
+      def initialize(record)
+        @record = record
+      end
+
+      def body
+        @body ||= JSON.generate(deep_sort(payload))
+      end
+
+      def object_key
+        record.is_a?(AuditLedgerEntry) ? ledger_object_key : checkpoint_object_key
+      end
+
+      def checksum_sha256
+        @checksum_sha256 ||= Digest::SHA256.hexdigest(body)
+      end
+
+      def checksum_sha256_base64
+        Base64.strict_encode64([checksum_sha256].pack('H*'))
+      end
+
+      def retain_until
+        return record.retain_until if record.is_a?(AuditLedgerEntry)
+
+        checkpoint_entry.retain_until
+      end
+
+      private
+
+      def payload
+        record.is_a?(AuditLedgerEntry) ? ledger_payload : checkpoint_payload
+      end
+
+      def ledger_payload
+        {
+          evidence_type: 'ledger_entry', export_schema_version: 1,
+          chain: chain_payload,
+          hash: ledger_hash_payload,
+          source: source_payload,
+          envelope: record.envelope,
+          canonical_payload: Base64.strict_encode64(record.canonical_payload),
+          occurred_at: timestamp(record.occurred_at),
+          retention: retention_payload
+        }
+      end
+
+      def checkpoint_payload
+        {
+          evidence_type: 'signed_checkpoint', export_schema_version: 1,
+          chain: chain_payload,
+          checkpoint_kind: record.checkpoint_kind,
+          entry_hash: hex(record.entry_hash),
+          signed_at: timestamp(record.signed_at),
+          signing_key: signing_key_payload,
+          signature: Base64.strict_encode64(record.signature)
+        }
+      end
+
+      def ledger_hash_payload
+        {
+          algorithm: record.hash_algorithm,
+          previous: hex(record.previous_hash),
+          value: hex(record.entry_hash)
+        }
+      end
+
+      def source_payload
+        { table: record.source_table, id: record.source_id, payload: record.source_payload }
+      end
+
+      def retention_payload
+        { policy_version: record.retention_policy_version, retain_until: timestamp(record.retain_until) }
+      end
+
+      def signing_key_payload
+        key = record.audit_signing_key
+        { key_id: key.key_id, algorithm: key.algorithm, public_key: Base64.strict_encode64(key.public_key) }
+      end
+
+      def chain_payload
+        {
+          key: record.chain_key, epoch: record.chain_epoch, sequence: record.sequence,
+          epoch_kind: record.try(:epoch_kind)
+        }.compact
+      end
+
+      def ledger_object_key
+        object_key_for('audit-ledger')
+      end
+
+      def checkpoint_object_key
+        object_key_for('audit-checkpoints')
+      end
+
+      def object_key_for(prefix)
+        filename = "#{format('%020d', record.sequence)}-#{hex(record.entry_hash)}.json"
+        [prefix, 'v1', chain_path, record.chain_epoch, filename].join('/')
+      end
+
+      def chain_path
+        record.chain_key.gsub(/[^a-zA-Z0-9._-]/, '/')
+      end
+
+      def checkpoint_entry
+        @checkpoint_entry ||= AuditLedgerEntry.find_by!(
+          chain_key: record.chain_key, chain_epoch: record.chain_epoch,
+          sequence: record.sequence, entry_hash: record.entry_hash
+        )
+      end
+
+      def timestamp(value)
+        value&.utc&.iso8601(6)
+      end
+
+      def hex(value)
+        value&.unpack1('H*')
+      end
+
+      def deep_sort(value)
+        case value
+        when Hash then value.to_h { |key, child| [key.to_s, deep_sort(child)] }.sort.to_h
+        when Array then value.map { |child| deep_sort(child) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/app/services/audit/object_lock/runner.rb
+++ b/app/services/audit/object_lock/runner.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Audit
+  module ObjectLock
+    class Runner
+      DEFAULT_INTERVAL = 15
+      DEFAULT_BATCH_SIZE = 100
+
+      def self.from_environment(environment = ENV)
+        configuration = Configuration.new(environment)
+        adapter = S3Adapter.new(configuration:)
+        signer = Audit::CheckpointSigner.new(
+          key_id: environment.fetch('AUDIT_SIGNING_KEY_ID'),
+          private_key_pem: signing_key(environment)
+        )
+        new(adapter:, signer:, delivery_exporter: DeliveryExporter.new(adapter:))
+      end
+
+      def self.signing_key(environment)
+        if environment['AUDIT_SIGNING_PRIVATE_KEY_FILE'].present?
+          return File.binread(environment['AUDIT_SIGNING_PRIVATE_KEY_FILE'])
+        end
+
+        environment.fetch('AUDIT_SIGNING_PRIVATE_KEY')
+      end
+
+      def initialize(adapter:, signer:, delivery_exporter:, **options)
+        @adapter = adapter
+        @signer = signer
+        @delivery_exporter = delivery_exporter
+        @checkpoint_entries = options[:checkpoint_entries] || method(:default_checkpoint_entries)
+        @pending_deliveries = options[:pending_deliveries] || method(:default_pending_deliveries)
+        @clock = options[:clock] || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        @validation_interval = options.fetch(:validation_interval, 300)
+        @stopped = false
+      end
+
+      def startup!
+        adapter.validate!
+        @last_validation_at = clock.call
+      end
+
+      def run_once
+        validate_if_due
+        checkpoint_entries.call.each { |entry| sign_unless_completed(entry) }
+        pending_deliveries.call.each { |delivery| delivery_exporter.deliver(delivery) }
+      end
+
+      def run_forever(interval: ENV.fetch('AUDIT_EXPORT_INTERVAL_SECONDS', DEFAULT_INTERVAL).to_i)
+        startup!
+        until stopped?
+          run_once
+          sleep interval unless stopped?
+        end
+      end
+
+      def stop!
+        @stopped = true
+      end
+
+      private
+
+      attr_reader :adapter, :signer, :delivery_exporter, :checkpoint_entries, :pending_deliveries,
+                  :clock, :validation_interval
+
+      def stopped?
+        @stopped
+      end
+
+      def validate_if_due
+        return if @last_validation_at && clock.call - @last_validation_at < validation_interval
+
+        startup!
+      end
+
+      def sign_unless_completed(entry)
+        signer.sign(entry)
+      rescue Audit::CheckpointSigner::AlreadySigned
+        nil
+      end
+
+      def default_checkpoint_entries
+        (unsigned_checkpoint_entries + current_chain_entries).uniq(&:id)
+      end
+
+      def unsigned_checkpoint_entries
+        AuditCheckpoint.where(signature: nil).filter_map do |checkpoint|
+          AuditLedgerEntry.find_by(
+            chain_key: checkpoint.chain_key, chain_epoch: checkpoint.chain_epoch,
+            sequence: checkpoint.sequence, entry_hash: checkpoint.entry_hash
+          )
+        end
+      end
+
+      def current_chain_entries
+        AuditChainHead.where('last_sequence > 0').filter_map do |head|
+          AuditLedgerEntry.find_by(
+            chain_key: head.chain_key, chain_epoch: head.chain_epoch,
+            sequence: head.last_sequence, entry_hash: head.last_hash
+          )
+        end
+      end
+
+      def default_pending_deliveries
+        AuditExportDelivery.pending
+                           .where('next_attempt_at IS NULL OR next_attempt_at <= ?', Time.current)
+                           .order(:created_at)
+                           .limit(DEFAULT_BATCH_SIZE)
+      end
+    end
+  end
+end

--- a/app/services/audit/object_lock/s3_adapter.rb
+++ b/app/services/audit/object_lock/s3_adapter.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-s3'
+
+module Audit
+  module ObjectLock
+    WriteResult = Data.define(:object_key, :checksum_sha256, :version_id, :retention_mode, :retain_until)
+
+    class Error < StandardError; end
+    class ConfigurationError < Error; end
+    class RetryableError < Error; end
+    class IntegrityError < Error; end
+
+    class S3Adapter
+      def initialize(configuration:, client: nil)
+        @configuration = configuration
+        @client = client || Aws::S3::Client.new(client_options)
+      end
+
+      def validate!
+        client.head_bucket(bucket:, expected_bucket_owner:)
+        validate_versioning!
+        validate_object_lock!
+        validate_encryption!
+        true
+      rescue Aws::S3::Errors::ServiceError => e
+        raise ConfigurationError, "audit Object Lock bucket validation failed: #{e.class.name}"
+      end
+
+      def write(record)
+        serializer = RecordSerializer.new(record)
+        response = client.put_object(put_attributes(serializer))
+        result(serializer, response.version_id)
+      rescue Aws::S3::Errors::PreconditionFailed
+        verify_existing(serializer)
+      rescue Aws::S3::Errors::ServiceError => e
+        raise RetryableError, "audit Object Lock write failed: #{e.class.name}"
+      end
+
+      private
+
+      attr_reader :configuration, :client
+
+      def bucket
+        configuration.bucket
+      end
+
+      def expected_bucket_owner
+        configuration.expected_owner
+      end
+
+      def client_options
+        {
+          region: configuration.region, endpoint: configuration.endpoint,
+          force_path_style: configuration.force_path_style?
+        }.compact
+      end
+
+      def validate_versioning!
+        response = client.get_bucket_versioning(bucket:, expected_bucket_owner:)
+        raise ConfigurationError, 'audit bucket versioning must be Enabled' unless response.status == 'Enabled'
+      end
+
+      def validate_object_lock!
+        response = client.get_object_lock_configuration(bucket:, expected_bucket_owner:)
+        return if response.object_lock_configuration&.object_lock_enabled == 'Enabled'
+
+        raise ConfigurationError, 'audit bucket Object Lock must be Enabled'
+      end
+
+      def validate_encryption!
+        response = client.get_bucket_encryption(bucket:, expected_bucket_owner:)
+        algorithms = response.server_side_encryption_configuration.rules.filter_map do |rule|
+          rule.apply_server_side_encryption_by_default&.sse_algorithm
+        end
+        return if algorithms.include?(configuration.server_side_encryption)
+
+        raise ConfigurationError, 'audit bucket encryption does not match the configured mode'
+      end
+
+      def put_attributes(serializer)
+        {
+          bucket:, key: serializer.object_key, body: serializer.body,
+          expected_bucket_owner:, if_none_match: '*', checksum_algorithm: 'SHA256',
+          checksum_sha256: serializer.checksum_sha256_base64,
+          metadata: { 'content-sha256' => serializer.checksum_sha256 },
+          server_side_encryption: configuration.server_side_encryption,
+          ssekms_key_id: configuration.kms_key_id,
+          object_lock_mode: configuration.retention_mode,
+          object_lock_retain_until_date: serializer.retain_until
+        }.compact
+      end
+
+      def verify_existing(serializer)
+        response = client.head_object(
+          bucket:, key: serializer.object_key, expected_bucket_owner:, checksum_mode: 'ENABLED'
+        )
+        validate_existing_checksum!(response, serializer)
+        validate_existing_retention!(response, serializer)
+        validate_existing_mode!(response)
+        result(serializer, response.version_id)
+      rescue Aws::S3::Errors::ServiceError => e
+        raise RetryableError, "existing audit object could not be verified: #{e.class.name}"
+      end
+
+      def validate_existing_checksum!(response, serializer)
+        return if checksum_matches?(response, serializer)
+
+        raise IntegrityError, 'existing audit object checksum does not match'
+      end
+
+      def validate_existing_retention!(response, serializer)
+        return if retention_covers?(response, serializer)
+
+        raise IntegrityError, 'existing audit object retention is too short'
+      end
+
+      def validate_existing_mode!(response)
+        return if response.object_lock_mode == configuration.retention_mode
+
+        raise IntegrityError, 'existing audit object retention mode does not match'
+      end
+
+      def checksum_matches?(response, serializer)
+        response.checksum_sha256 == serializer.checksum_sha256_base64 ||
+          response.metadata['content-sha256'] == serializer.checksum_sha256
+      end
+
+      def retention_covers?(response, serializer)
+        response.object_lock_retain_until_date && response.object_lock_retain_until_date >= serializer.retain_until
+      end
+
+      def result(serializer, version_id)
+        WriteResult.new(
+          object_key: serializer.object_key, checksum_sha256: serializer.checksum_sha256,
+          version_id:, retention_mode: configuration.retention_mode, retain_until: serializer.retain_until
+        )
+      end
+    end
+  end
+end

--- a/bin/audit-exporter
+++ b/bin/audit-exporter
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+
+runner = Audit::ObjectLock::Runner.from_environment
+Signal.trap('TERM') { runner.stop! }
+Signal.trap('INT') { runner.stop! }
+runner.run_forever

--- a/compose.yaml
+++ b/compose.yaml
@@ -267,6 +267,46 @@ services:
       timeout: 10s
       start_period: 60s
 
+  audit-exporter-prod:
+    extends:
+      file: compose/base.yml
+      service: rails
+    profiles: [prod]
+    networks: [prod]
+    build:
+      target: app
+    command: bin/audit-exporter
+    depends_on:
+      db-prod:
+        condition: service_healthy
+      migrate-prod:
+        condition: service_completed_successfully
+    environment:
+      RAILS_ENV: production
+      DATABASE_URL: postgresql://medtracker_audit_exporter:local_audit_exporter_only@db-prod:5432/medtracker
+      DATABASE_ROLE: med_tracker_audit_exporter
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-local-prod-testing-only-not-for-real-use}
+      APP_URL: ${APP_URL:-http://localhost}
+      AUDIT_WORM_BUCKET: ${AUDIT_WORM_BUCKET:-}
+      AUDIT_WORM_REGION: ${AUDIT_WORM_REGION:-eu-west-2}
+      AUDIT_WORM_EXPECTED_OWNER: ${AUDIT_WORM_EXPECTED_OWNER:-}
+      AUDIT_WORM_RETENTION_MODE: ${AUDIT_WORM_RETENTION_MODE:-GOVERNANCE}
+      AUDIT_WORM_COMPLIANCE_APPROVED: ${AUDIT_WORM_COMPLIANCE_APPROVED:-false}
+      AUDIT_WORM_SSE: ${AUDIT_WORM_SSE:-aws:kms}
+      AUDIT_WORM_KMS_KEY_ID: ${AUDIT_WORM_KMS_KEY_ID:-}
+      AUDIT_WORM_ENDPOINT: ${AUDIT_WORM_ENDPOINT:-}
+      AUDIT_WORM_FORCE_PATH_STYLE: ${AUDIT_WORM_FORCE_PATH_STYLE:-false}
+      AUDIT_SIGNING_KEY_ID: ${AUDIT_SIGNING_KEY_ID:-}
+      AUDIT_SIGNING_PRIVATE_KEY: ${AUDIT_SIGNING_PRIVATE_KEY:-}
+      AUDIT_SIGNING_PRIVATE_KEY_FILE: ${AUDIT_SIGNING_PRIVATE_KEY_FILE:-}
+      AWS_ACCESS_KEY_ID: ${AUDIT_WORM_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AUDIT_WORM_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AUDIT_WORM_SESSION_TOKEN:-}
+    ports: []
+    restart: unless-stopped
+    healthcheck:
+      disable: true
+
 networks:
   dev:
   test:

--- a/compose/init-roles.sql
+++ b/compose/init-roles.sql
@@ -7,18 +7,30 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
     CREATE ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
   END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_audit_exporter') THEN
+    CREATE ROLE med_tracker_audit_exporter NOLOGIN NOSUPERUSER NOBYPASSRLS;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_audit_exporter') THEN
+    CREATE ROLE medtracker_audit_exporter LOGIN PASSWORD 'local_audit_exporter_only';
+  END IF;
 END
 $$;
 
 ALTER ROLE med_tracker_owner NOLOGIN;
 ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+ALTER ROLE med_tracker_audit_exporter NOLOGIN NOSUPERUSER NOBYPASSRLS;
+ALTER ROLE medtracker_audit_exporter LOGIN NOSUPERUSER NOBYPASSRLS;
 
 GRANT med_tracker_owner TO medtracker;
 GRANT med_tracker_app TO medtracker;
+GRANT med_tracker_audit_exporter TO medtracker_audit_exporter;
 
 ALTER DATABASE medtracker OWNER TO med_tracker_owner;
 ALTER SCHEMA public OWNER TO med_tracker_owner;
 
 GRANT CONNECT ON DATABASE medtracker TO med_tracker_owner, med_tracker_app;
+GRANT CONNECT ON DATABASE medtracker TO med_tracker_audit_exporter;
 GRANT USAGE, CREATE ON SCHEMA public TO med_tracker_owner;
 GRANT USAGE ON SCHEMA public TO med_tracker_app;

--- a/db/migrate/20260709143000_configure_audit_object_lock_exporter.rb
+++ b/db/migrate/20260709143000_configure_audit_object_lock_exporter.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+class ConfigureAuditObjectLockExporter < ActiveRecord::Migration[8.1]
+  EXPORTER_ROLE = 'med_tracker_audit_exporter'
+
+  def up
+    add_checkpoint_deliveries
+    install_exporter_role
+    install_checkpoint_function
+    lock_exporter_privileges
+  end
+
+  def down
+    execute "REVOKE ALL ON FUNCTION audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text) FROM #{EXPORTER_ROLE};"
+    execute 'DROP FUNCTION IF EXISTS audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text);'
+    remove_check_constraint :audit_export_deliveries, name: 'audit_export_delivery_exactly_one_record'
+    remove_reference :audit_export_deliveries, :audit_checkpoint, foreign_key: true
+    change_column_null :audit_export_deliveries, :audit_ledger_entry_id, false
+  end
+
+  private
+
+  def add_checkpoint_deliveries
+    change_column_null :audit_export_deliveries, :audit_ledger_entry_id, true
+    add_reference :audit_export_deliveries, :audit_checkpoint, foreign_key: true, index: { unique: true }
+    add_check_constraint :audit_export_deliveries,
+                         '(audit_ledger_entry_id IS NULL) <> (audit_checkpoint_id IS NULL)',
+                         name: 'audit_export_delivery_exactly_one_record'
+  end
+
+  def install_exporter_role
+    return if role_exists?(EXPORTER_ROLE)
+
+    raise ActiveRecord::IrreversibleMigration, exporter_bootstrap_message unless can_create_roles?
+
+    execute "CREATE ROLE #{EXPORTER_ROLE} NOLOGIN NOSUPERUSER NOBYPASSRLS;"
+  end
+
+  def install_checkpoint_function
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION audit_record_signed_checkpoint(
+        p_key_id text,
+        p_public_key_base64 text,
+        p_chain_key text,
+        p_chain_epoch uuid,
+        p_sequence bigint,
+        p_entry_hash_hex text,
+        p_signature_base64 text,
+        p_signed_at timestamptz,
+        p_checkpoint_kind text
+      ) RETURNS bigint
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = pg_catalog, public
+      AS $$
+      DECLARE
+        v_entry audit_ledger_entries%ROWTYPE;
+        v_key audit_signing_keys%ROWTYPE;
+        v_checkpoint audit_checkpoints%ROWTYPE;
+      BEGIN
+        SELECT * INTO STRICT v_entry
+        FROM audit_ledger_entries
+        WHERE chain_key = p_chain_key
+          AND chain_epoch = p_chain_epoch
+          AND sequence = p_sequence
+          AND entry_hash = decode(p_entry_hash_hex, 'hex');
+
+        INSERT INTO audit_signing_keys (key_id, algorithm, public_key, active_from, created_at, updated_at)
+        VALUES (p_key_id, 'ed25519', decode(p_public_key_base64, 'base64'), p_signed_at,
+                clock_timestamp(), clock_timestamp())
+        ON CONFLICT (key_id) DO NOTHING;
+
+        SELECT * INTO STRICT v_key FROM audit_signing_keys WHERE key_id = p_key_id;
+        IF v_key.public_key <> decode(p_public_key_base64, 'base64') THEN
+          RAISE EXCEPTION 'audit signing key id is already registered with different key material';
+        END IF;
+
+        SELECT * INTO v_checkpoint
+        FROM audit_checkpoints
+        WHERE chain_key = p_chain_key AND chain_epoch = p_chain_epoch AND sequence = p_sequence
+        FOR UPDATE;
+
+        IF FOUND AND v_checkpoint.signature IS NOT NULL THEN
+          RAISE EXCEPTION 'audit checkpoint is already signed';
+        END IF;
+
+        IF FOUND THEN
+          UPDATE audit_checkpoints
+          SET audit_signing_key_id = v_key.id,
+              signature = decode(p_signature_base64, 'base64'),
+              signed_at = p_signed_at,
+              updated_at = clock_timestamp()
+          WHERE id = v_checkpoint.id
+          RETURNING * INTO v_checkpoint;
+        ELSE
+          INSERT INTO audit_checkpoints (
+            household_id, audit_signing_key_id, chain_key, chain_epoch, checkpoint_kind,
+            sequence, entry_hash, signature, signed_at, created_at, updated_at
+          ) VALUES (
+            v_entry.household_id, v_key.id, p_chain_key, p_chain_epoch, p_checkpoint_kind,
+            p_sequence, decode(p_entry_hash_hex, 'hex'), decode(p_signature_base64, 'base64'),
+            p_signed_at, clock_timestamp(), clock_timestamp()
+          ) RETURNING * INTO v_checkpoint;
+        END IF;
+
+        INSERT INTO audit_export_deliveries (
+          audit_checkpoint_id, status, attempts, created_at, updated_at
+        ) VALUES (
+          v_checkpoint.id, 'pending', 0, clock_timestamp(), clock_timestamp()
+        ) ON CONFLICT (audit_checkpoint_id) DO NOTHING;
+
+        RETURN v_checkpoint.id;
+      END;
+      $$;
+
+      ALTER FUNCTION audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text)
+        OWNER TO med_tracker_owner;
+      REVOKE ALL ON FUNCTION audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text)
+        FROM PUBLIC;
+    SQL
+  end
+
+  def lock_exporter_privileges
+    execute <<~SQL.squish
+      REVOKE ALL PRIVILEGES ON TABLE
+      audit_chain_heads, audit_ledger_entries, audit_export_deliveries, audit_signing_keys, audit_checkpoints,
+      versions, security_audit_events
+      FROM #{EXPORTER_ROLE};
+    SQL
+    execute <<~SQL.squish
+      REVOKE ALL PRIVILEGES ON SEQUENCE
+      audit_chain_heads_id_seq, audit_ledger_entries_id_seq, audit_export_deliveries_id_seq,
+      audit_signing_keys_id_seq, audit_checkpoints_id_seq
+      FROM #{EXPORTER_ROLE};
+    SQL
+    execute "GRANT USAGE ON SCHEMA public TO #{EXPORTER_ROLE};"
+    execute <<~SQL.squish
+      GRANT SELECT ON TABLE audit_chain_heads, audit_ledger_entries, audit_checkpoints, audit_signing_keys
+      TO #{EXPORTER_ROLE};
+    SQL
+    execute "GRANT SELECT, UPDATE ON TABLE audit_export_deliveries TO #{EXPORTER_ROLE};"
+    execute <<~SQL.squish
+      GRANT EXECUTE ON FUNCTION
+      audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text)
+      TO #{EXPORTER_ROLE};
+    SQL
+  end
+
+  def role_exists?(role_name)
+    select_value("SELECT COUNT(*) FROM pg_roles WHERE rolname = #{quote(role_name)}").to_i.positive?
+  end
+
+  def can_create_roles?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper OR rolcreaterole, false)
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
+  end
+
+  def exporter_bootstrap_message
+    'Database role med_tracker_audit_exporter is missing. Create it as NOLOGIN, NOSUPERUSER, NOBYPASSRLS before migrating.'
+  end
+end

--- a/db/migrate/20260709143100_enforce_recent_household_row_level_security.rb
+++ b/db/migrate/20260709143100_enforce_recent_household_row_level_security.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class EnforceRecentHouseholdRowLevelSecurity < ActiveRecord::Migration[8.1]
+  TABLES = %w[
+    health_events health_event_medications notification_events
+    api_change_events api_idempotency_keys api_tombstones
+  ].freeze
+
+  def up
+    install_policies
+  end
+
+  def down
+    TABLES.each do |table_name|
+      execute "DROP POLICY IF EXISTS household_tenant_isolation ON #{quote_table_name(table_name)};"
+    end
+  end
+
+  def install_policies
+    TABLES.each { |table_name| install_policy(table_name) }
+  end
+
+  private
+
+  def install_policy(table_name)
+    quoted_table = quote_table_name(table_name)
+    execute "ALTER TABLE #{quoted_table} ENABLE ROW LEVEL SECURITY;"
+    execute "ALTER TABLE #{quoted_table} FORCE ROW LEVEL SECURITY;"
+    execute "DROP POLICY IF EXISTS household_tenant_isolation ON #{quoted_table};"
+    execute <<~SQL.squish
+      CREATE POLICY household_tenant_isolation ON #{quoted_table}
+      USING (household_id = med_tracker.current_household_id())
+      WITH CHECK (household_id = med_tracker.current_household_id());
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_131100) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_143100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -322,7 +322,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_131100) do
 
   create_table "audit_export_deliveries", force: :cascade do |t|
     t.integer "attempts", default: 0, null: false
-    t.bigint "audit_ledger_entry_id", null: false
+    t.bigint "audit_checkpoint_id"
+    t.bigint "audit_ledger_entry_id"
     t.string "checksum_sha256"
     t.datetime "created_at", null: false
     t.datetime "delivered_at"
@@ -335,8 +336,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_131100) do
     t.string "retention_mode"
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
+    t.index ["audit_checkpoint_id"], name: "index_audit_export_deliveries_on_audit_checkpoint_id", unique: true
     t.index ["audit_ledger_entry_id"], name: "index_audit_export_deliveries_on_audit_ledger_entry_id", unique: true
     t.index ["status", "next_attempt_at"], name: "index_audit_export_deliveries_on_status_and_next_attempt_at"
+    t.check_constraint "(audit_ledger_entry_id IS NULL) <> (audit_checkpoint_id IS NULL)", name: "audit_export_delivery_exactly_one_record"
   end
 
   create_table "audit_ledger_entries", force: :cascade do |t|
@@ -936,6 +939,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_131100) do
   add_foreign_key "audit_chain_heads", "households"
   add_foreign_key "audit_checkpoints", "audit_signing_keys"
   add_foreign_key "audit_checkpoints", "households"
+  add_foreign_key "audit_export_deliveries", "audit_checkpoints"
   add_foreign_key "audit_export_deliveries", "audit_ledger_entries"
   add_foreign_key "audit_ledger_entries", "households"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -90,6 +90,28 @@ RSpec.describe YAML do
       .to eq('${DATABASE_ROLE:-med_tracker_app}')
   end
 
+  it 'runs the audit exporter with isolated database and WORM credentials' do
+    exporter = compose_config.dig('services', 'audit-exporter-prod')
+    web_environment = compose_config.dig('services', 'web-prod', 'environment')
+
+    expect(exporter['command']).to eq('bin/audit-exporter')
+    expect(exporter.dig('environment', 'DATABASE_ROLE')).to eq('med_tracker_audit_exporter')
+    expect(exporter.dig('environment', 'DATABASE_URL')).to include('medtracker_audit_exporter:')
+    expect(exporter['environment']).to include(
+      'AUDIT_WORM_BUCKET', 'AUDIT_WORM_EXPECTED_OWNER', 'AUDIT_SIGNING_KEY_ID', 'AUDIT_SIGNING_PRIVATE_KEY',
+      'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'
+    )
+    expect(web_environment).not_to include(
+      'AUDIT_WORM_BUCKET', 'AUDIT_SIGNING_PRIVATE_KEY', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'
+    )
+  end
+
+  it 'does not grant the audit exporter login an application or owner role' do
+    expect(init_roles_sql).to include('GRANT med_tracker_audit_exporter TO medtracker_audit_exporter;')
+    expect(init_roles_sql).not_to include('GRANT med_tracker_app TO medtracker_audit_exporter;')
+    expect(init_roles_sql).not_to include('GRANT med_tracker_owner TO medtracker_audit_exporter;')
+  end
+
   it 'bootstraps the deployed runtime role without owner or bypassrls privileges' do
     expect(init_roles_sql).to include('ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;')
     expect(init_roles_sql).to include('GRANT USAGE ON SCHEMA public TO med_tracker_app;')

--- a/spec/migrations/configure_audit_object_lock_exporter_spec.rb
+++ b/spec/migrations/configure_audit_object_lock_exporter_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260709143000_configure_audit_object_lock_exporter')
+
+RSpec.describe ConfigureAuditObjectLockExporter do
+  it 'can read ledger evidence and update delivery state without reading clinical tables' do
+    expect(privilege('audit_ledger_entries', 'SELECT')).to be(true)
+    expect(privilege('audit_export_deliveries', 'UPDATE')).to be(true)
+    expect(privilege('audit_ledger_entries', 'UPDATE')).to be(false)
+    expect(privilege('medications', 'SELECT')).to be(false)
+    expect(privilege('versions', 'SELECT')).to be(false)
+  end
+
+  it 'cannot directly insert or alter signing evidence' do
+    expect(privilege('audit_signing_keys', 'INSERT')).to be(false)
+    expect(privilege('audit_checkpoints', 'INSERT')).to be(false)
+    expect(privilege('audit_checkpoints', 'UPDATE')).to be(false)
+  end
+
+  def privilege(table_name, action)
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT has_table_privilege('med_tracker_audit_exporter', '#{table_name}', '#{action}')
+    SQL
+  end
+end

--- a/spec/migrations/create_tamper_evident_audit_ledger_spec.rb
+++ b/spec/migrations/create_tamper_evident_audit_ledger_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require Rails.root.join('db/migrate/20260709131000_create_tamper_evident_audit_ledger')
+require Rails.root.join('db/migrate/20260709143000_configure_audit_object_lock_exporter')
 
 RSpec.describe CreateTamperEvidentAuditLedger do
   it 'backfills existing evidence into a labelled legacy epoch and rotates to a live head' do
@@ -17,11 +18,20 @@ RSpec.describe CreateTamperEvidentAuditLedger do
 
   def with_rebuilt_ledger
     ActiveRecord::Base.connection.transaction(requires_new: true) do
-      ActiveRecord::Migration.suppress_messages { described_class.new.down }
-      legacy_id = insert_legacy_version
-      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+      legacy_id = rebuild_ledger
       yield legacy_id
       raise ActiveRecord::Rollback
+    end
+  end
+
+  def rebuild_ledger
+    ActiveRecord::Migration.suppress_messages do
+      ConfigureAuditObjectLockExporter.new.down
+      described_class.new.down
+      legacy_id = insert_legacy_version
+      described_class.new.up
+      ConfigureAuditObjectLockExporter.new.up
+      legacy_id
     end
   end
 

--- a/spec/services/audit/checkpoint_signer_spec.rb
+++ b/spec/services/audit/checkpoint_signer_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::CheckpointSigner do
+  fixtures :accounts, :people, :users
+
+  let(:private_key) { OpenSSL::PKey.generate_key('ED25519') }
+  let(:signer) { described_class.new(key_id: 'audit-key-2026-01', private_key_pem: private_key.private_to_pem) }
+
+  it 'records a verifiable signed checkpoint without storing the private key' do
+    event = Audit::Event.record!(household: users(:admin).person.household, event_type: 'audit.checkpoint.test')
+    entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+
+    checkpoint = signer.sign(entry)
+
+    expect(checkpoint).to have_attributes(sequence: entry.sequence, entry_hash: entry.entry_hash,
+                                          signed_at: be_present)
+    expect(checkpoint.audit_signing_key).to have_attributes(key_id: 'audit-key-2026-01', algorithm: 'ed25519')
+    expect(checkpoint.audit_signing_key.attributes.keys).not_to include('private_key')
+    public_key = OpenSSL::PKey.read(private_key.public_to_pem)
+    expect(public_key.verify(nil, checkpoint.signature, signer.payload_for(entry))).to be(true)
+  end
+
+  it 'does not replace an existing signature with another key' do
+    event = Audit::Event.record!(household: users(:admin).person.household, event_type: 'audit.checkpoint.once')
+    entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+    checkpoint = signer.sign(entry)
+    replacement = described_class.new(key_id: 'replacement',
+                                      private_key_pem: OpenSSL::PKey.generate_key('ED25519').private_to_pem)
+
+    expect { replacement.sign(entry) }.to raise_error(described_class::AlreadySigned)
+    expect(checkpoint.reload.audit_signing_key.key_id).to eq('audit-key-2026-01')
+  end
+
+  it 'retains old public keys after rotating to a new signing key' do
+    first_entry = ledger_entry_for('audit.checkpoint.first-key')
+    second_entry = ledger_entry_for('audit.checkpoint.second-key')
+    signer.sign(first_entry)
+    replacement = described_class.new(key_id: 'audit-key-2026-02',
+                                      private_key_pem: OpenSSL::PKey.generate_key('ED25519').private_to_pem)
+
+    replacement.sign(second_entry)
+
+    expect(AuditSigningKey.where(key_id: %w[audit-key-2026-01 audit-key-2026-02]).count).to eq(2)
+  end
+
+  it 'preserves the legacy-baseline label when signing a migration checkpoint' do
+    entry = ledger_entry_for('audit.checkpoint.legacy-label')
+    AuditCheckpoint.create!(
+      household: entry.household, chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+      checkpoint_kind: 'legacy-baseline', sequence: entry.sequence, entry_hash: entry.entry_hash
+    )
+
+    checkpoint = signer.sign(entry)
+
+    expect(checkpoint.checkpoint_kind).to eq('legacy-baseline')
+  end
+
+  def ledger_entry_for(event_type)
+    event = Audit::Event.record!(household: users(:admin).person.household, event_type:)
+    AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+  end
+end

--- a/spec/services/audit/object_lock/configuration_spec.rb
+++ b/spec/services/audit/object_lock/configuration_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ObjectLock::Configuration do
+  subject(:configuration) { described_class.new(environment) }
+
+  let(:environment) do
+    {
+      'AUDIT_WORM_BUCKET' => 'medtracker-audit',
+      'AUDIT_WORM_REGION' => 'eu-west-2',
+      'AUDIT_WORM_EXPECTED_OWNER' => '123456789012',
+      'AUDIT_WORM_RETENTION_MODE' => 'GOVERNANCE',
+      'AUDIT_WORM_SSE' => 'aws:kms',
+      'AUDIT_WORM_KMS_KEY_ID' => 'alias/medtracker-audit'
+    }
+  end
+
+  it 'loads a governance configuration without exposing credentials' do
+    expect(configuration).to have_attributes(
+      bucket: 'medtracker-audit', region: 'eu-west-2', expected_owner: '123456789012',
+      retention_mode: 'GOVERNANCE', server_side_encryption: 'aws:kms'
+    )
+    expect(configuration.to_h.keys).not_to include(:access_key_id, :secret_access_key)
+  end
+
+  it 'rejects compliance retention without recorded governance approval' do
+    environment['AUDIT_WORM_RETENTION_MODE'] = 'COMPLIANCE'
+
+    expect { configuration }.to raise_error(described_class::Invalid, /COMPLIANCE.*approval/)
+  end
+
+  it 'accepts compliance retention only with explicit approval' do
+    environment['AUDIT_WORM_RETENTION_MODE'] = 'COMPLIANCE'
+    environment['AUDIT_WORM_COMPLIANCE_APPROVED'] = 'true'
+
+    expect(configuration.retention_mode).to eq('COMPLIANCE')
+  end
+
+  it 'requires a KMS key for KMS encryption' do
+    environment.delete('AUDIT_WORM_KMS_KEY_ID')
+
+    expect { configuration }.to raise_error(described_class::Invalid, /KMS key/)
+  end
+end

--- a/spec/services/audit/object_lock/delivery_exporter_spec.rb
+++ b/spec/services/audit/object_lock/delivery_exporter_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ObjectLock::DeliveryExporter do
+  fixtures :accounts, :people, :users
+
+  let(:adapter) { instance_double(Audit::ObjectLock::S3Adapter) }
+  let(:exporter) { described_class.new(adapter:) }
+  let(:delivery) do
+    event = Audit::Event.record!(household: users(:admin).person.household, event_type: 'audit.delivery.test')
+    AuditExportDelivery.find_by!(audit_ledger_entry: AuditLedgerEntry.find_by!(source_id: event.id,
+                                                                               source_table: 'security_audit_events'))
+  end
+  let(:result) do
+    Audit::ObjectLock::WriteResult.new(
+      object_key: 'audit/v1/object.json', checksum_sha256: 'checksum', version_id: 'version-1',
+      retention_mode: 'GOVERNANCE', retain_until: 10.years.from_now
+    )
+  end
+
+  it 'marks a successfully persisted object as delivered' do
+    allow(adapter).to receive(:write).with(delivery.audit_ledger_entry).and_return(result)
+
+    expect(exporter.deliver(delivery)).to be(true)
+    expect(delivery.reload).to have_attributes(
+      status: 'delivered', attempts: 1, object_key: 'audit/v1/object.json', checksum_sha256: 'checksum',
+      object_version_id: 'version-1', retention_mode: 'GOVERNANCE'
+    )
+  end
+
+  it 'schedules retryable failures without discarding the delivery' do
+    allow(adapter).to receive(:write).and_raise(Audit::ObjectLock::RetryableError, 'object store unavailable')
+
+    expect(exporter.deliver(delivery)).to be(false)
+    expect(delivery.reload).to have_attributes(status: 'pending', attempts: 1, last_error_code: 'retryable')
+    expect(delivery.next_attempt_at).to be_future
+  end
+
+  it 'marks invalid retention or configuration as failed for operator action' do
+    allow(adapter).to receive(:write).and_raise(Audit::ObjectLock::ConfigurationError, 'wrong retention mode')
+
+    expect(exporter.deliver(delivery)).to be(false)
+    expect(delivery.reload).to have_attributes(status: 'failed', attempts: 1, last_error_code: 'configuration')
+  end
+end

--- a/spec/services/audit/object_lock/runner_spec.rb
+++ b/spec/services/audit/object_lock/runner_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ObjectLock::Runner do
+  let(:adapter) { instance_double(Audit::ObjectLock::S3Adapter, validate!: true) }
+  let(:signer) { instance_double(Audit::CheckpointSigner) }
+  let(:delivery_exporter) { instance_double(Audit::ObjectLock::DeliveryExporter) }
+  let(:records) do
+    { entry: instance_double(AuditLedgerEntry), delivery: instance_double(AuditExportDelivery) }
+  end
+  let(:runner) do
+    described_class.new(
+      adapter:, signer:, delivery_exporter:,
+      checkpoint_entries: -> { [records[:entry]] }, pending_deliveries: -> { [records[:delivery]] }
+    )
+  end
+
+  it 'validates storage before signing checkpoints and draining the outbox' do
+    allow(signer).to receive(:sign).with(records[:entry])
+    allow(delivery_exporter).to receive(:deliver).with(records[:delivery])
+
+    runner.startup!
+    runner.run_once
+
+    expect(adapter).to have_received(:validate!).ordered
+    expect(signer).to have_received(:sign).with(records[:entry]).ordered
+    expect(delivery_exporter).to have_received(:deliver).with(records[:delivery]).ordered
+  end
+
+  it 'continues when a checkpoint was already signed by another exporter' do
+    allow(signer).to receive(:sign).and_raise(Audit::CheckpointSigner::AlreadySigned)
+    allow(delivery_exporter).to receive(:deliver)
+
+    expect { runner.run_once }.not_to raise_error
+    expect(delivery_exporter).to have_received(:deliver).with(records[:delivery])
+  end
+
+  it 'revalidates Object Lock configuration on the scheduled interval' do
+    now = 100
+    scheduled_runner = described_class.new(
+      adapter:, signer:, delivery_exporter:, checkpoint_entries: -> { [] }, pending_deliveries: -> { [] },
+      clock: -> { now }, validation_interval: 300
+    )
+
+    scheduled_runner.startup!
+    now = 401
+    scheduled_runner.run_once
+
+    expect(adapter).to have_received(:validate!).twice
+  end
+end

--- a/spec/services/audit/object_lock/s3_adapter_spec.rb
+++ b/spec/services/audit/object_lock/s3_adapter_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ObjectLock::S3Adapter do
+  fixtures :accounts, :people, :users
+
+  subject(:adapter) { described_class.new(configuration:, client:) }
+
+  let(:configuration) do
+    Audit::ObjectLock::Configuration.new(
+      'AUDIT_WORM_BUCKET' => 'medtracker-audit',
+      'AUDIT_WORM_REGION' => 'eu-west-2',
+      'AUDIT_WORM_EXPECTED_OWNER' => '123456789012',
+      'AUDIT_WORM_RETENTION_MODE' => 'GOVERNANCE',
+      'AUDIT_WORM_SSE' => 'AES256'
+    )
+  end
+  let(:client) { instance_double(Aws::S3::Client) }
+  let(:entry) do
+    event = Audit::Event.record!(household: users(:admin).person.household, event_type: 'audit.export.test')
+    AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+  end
+
+  it 'validates versioning, Object Lock, encryption, and expected ownership' do
+    stub_valid_bucket
+
+    expect { adapter.validate! }.not_to raise_error
+    expect(client).to have_received(:head_bucket)
+      .with(bucket: 'medtracker-audit', expected_bucket_owner: '123456789012')
+  end
+
+  it 'writes a deterministic content-addressed object with retention and a conditional create' do
+    response = instance_double(Aws::S3::Types::PutObjectOutput, version_id: 'version-1')
+    allow(client).to receive(:put_object).and_return(response)
+
+    adapter.write(entry)
+
+    expect(client).to have_received(:put_object) do |attributes|
+      expect(attributes).to include(
+        bucket: 'medtracker-audit', expected_bucket_owner: '123456789012', if_none_match: '*',
+        checksum_algorithm: 'SHA256', object_lock_mode: 'GOVERNANCE', server_side_encryption: 'AES256'
+      )
+      expect(attributes[:key]).to end_with("#{entry.entry_hash.unpack1('H*')}.json")
+      expect(attributes[:body]).to eq(Audit::ObjectLock::RecordSerializer.new(entry).body)
+      expect(attributes[:object_lock_retain_until_date]).to eq(entry.retain_until)
+    end
+  end
+
+  it 'rejects a bucket without Object Lock' do
+    allow(client).to receive(:head_bucket)
+    object_lock = instance_double(Aws::S3::Types::ObjectLockConfiguration, object_lock_enabled: nil)
+    allow(client).to receive_messages(
+      get_bucket_versioning: versioning_response,
+      get_object_lock_configuration: object_lock_response(object_lock)
+    )
+
+    expect { adapter.validate! }.to raise_error(Audit::ObjectLock::ConfigurationError, /Object Lock/)
+  end
+
+  it 'treats a matching conditional-write conflict as an idempotent delivery' do
+    serializer = Audit::ObjectLock::RecordSerializer.new(entry)
+    allow(client).to receive(:put_object)
+      .and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, 'already exists'))
+    allow(client).to receive(:head_object).and_return(
+      instance_double(
+        Aws::S3::Types::HeadObjectOutput,
+        checksum_sha256: serializer.checksum_sha256_base64,
+        metadata: {}, object_lock_retain_until_date: entry.retain_until,
+        object_lock_mode: 'GOVERNANCE', version_id: 'existing-version'
+      )
+    )
+
+    expect(adapter.write(entry).version_id).to eq('existing-version')
+  end
+
+  it 'refuses a conflicting object with the same content-addressed key' do
+    allow(client).to receive(:put_object)
+      .and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, 'already exists'))
+    allow(client).to receive(:head_object).and_return(
+      instance_double(
+        Aws::S3::Types::HeadObjectOutput,
+        checksum_sha256: 'different', metadata: {}, object_lock_retain_until_date: entry.retain_until,
+        object_lock_mode: 'GOVERNANCE', version_id: 'conflicting-version'
+      )
+    )
+
+    expect { adapter.write(entry) }.to raise_error(Audit::ObjectLock::IntegrityError, /checksum/)
+  end
+
+  it 'refuses an existing object with shorter retention' do
+    serializer = Audit::ObjectLock::RecordSerializer.new(entry)
+    allow(client).to receive(:put_object)
+      .and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, 'already exists'))
+    allow(client).to receive(:head_object).and_return(
+      instance_double(
+        Aws::S3::Types::HeadObjectOutput,
+        checksum_sha256: serializer.checksum_sha256_base64,
+        metadata: {}, object_lock_retain_until_date: entry.retain_until - 1.day,
+        object_lock_mode: 'GOVERNANCE', version_id: 'short-retention'
+      )
+    )
+
+    expect { adapter.write(entry) }.to raise_error(Audit::ObjectLock::IntegrityError, /retention is too short/)
+  end
+
+  def stub_valid_bucket
+    object_lock = instance_double(Aws::S3::Types::ObjectLockConfiguration, object_lock_enabled: 'Enabled')
+    allow(client).to receive_messages(
+      head_bucket: instance_double(Aws::S3::Types::HeadBucketOutput),
+      get_bucket_versioning: versioning_response,
+      get_object_lock_configuration: object_lock_response(object_lock),
+      get_bucket_encryption: encryption_response
+    )
+  end
+
+  def versioning_response
+    instance_double(Aws::S3::Types::GetBucketVersioningOutput, status: 'Enabled')
+  end
+
+  def object_lock_response(object_lock)
+    instance_double(
+      Aws::S3::Types::GetObjectLockConfigurationOutput,
+      object_lock_configuration: object_lock
+    )
+  end
+
+  def encryption_response
+    default = instance_double(Aws::S3::Types::ServerSideEncryptionByDefault, sse_algorithm: 'AES256')
+    rule = instance_double(
+      Aws::S3::Types::ServerSideEncryptionRule,
+      apply_server_side_encryption_by_default: default
+    )
+    configuration = instance_double(Aws::S3::Types::ServerSideEncryptionConfiguration, rules: [rule])
+    instance_double(
+      Aws::S3::Types::GetBucketEncryptionOutput,
+      server_side_encryption_configuration: configuration
+    )
+  end
+end

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -11,6 +11,8 @@ module DatabaseRuntimeRoleSetup
     db/migrate/20260630141000_allow_account_linked_person_rls_login_lookup.rb
     db/migrate/20260709131000_create_tamper_evident_audit_ledger.rb
     db/migrate/20260709131100_enforce_audit_ledger_immutability.rb
+    db/migrate/20260709143000_configure_audit_object_lock_exporter.rb
+    db/migrate/20260709143100_enforce_recent_household_row_level_security.rb
   ].freeze
 
   def self.call
@@ -30,6 +32,8 @@ module DatabaseRuntimeRoleSetup
       apply_tenant_database_state
       install_audit_ledger_database_objects
       EnforceAuditLedgerImmutability.new.up
+      install_audit_exporter_database_objects
+      EnforceRecentHouseholdRowLevelSecurity.new.install_policies
     end
   end
 
@@ -48,6 +52,13 @@ module DatabaseRuntimeRoleSetup
     migration.send(:install_ledger_functions)
     migration.send(:install_source_triggers)
     migration.send(:create_household_read_view)
+  end
+
+  def self.install_audit_exporter_database_objects
+    migration = ConfigureAuditObjectLockExporter.new
+    migration.send(:install_exporter_role)
+    migration.send(:install_checkpoint_function)
+    migration.send(:lock_exporter_privileges)
   end
 end
 


### PR DESCRIPTION
## Why this matters

A tamper-evident database ledger can reveal altered history, but a destructive database incident could still remove both the audit event and its proof. This change gives each ledger entry an independently retained copy and signs chain checkpoints so exported evidence can be verified away from MedTracker.

## What changes

- Runs audit export as a separate process with a database role that can read evidence and update delivery receipts, but cannot read clinical tables or change ledger history.
- Writes deterministic, content-addressed JSON to S3-compatible Object Lock with conditional creation, checksums, encryption, retention, and expected-owner checks.
- Retries temporary object-store failures while stopping configuration, checksum, or retention mismatches for operator action.
- Signs chain checkpoints with rotatable Ed25519 keys, stores only public keys, retains older keys, and preserves the honest `legacy-baseline` label.
- Keeps WORM and signing credentials out of the web process and requires explicit approval before compliance retention can be enabled.
- Restores enforced row-level security on six household tables that were added after the original tenancy migration.

## Review order

This is stage 3 of issue #509. It is stacked on #1555, which is stacked on #1552.