### PR TITLE
test(reminders): freeze eligibility scenarios

### DIFF
--- a/spec/services/medication_reminder_eligibility_query_spec.rb
+++ b/spec/services/medication_reminder_eligibility_query_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe MedicationReminderEligibilityQuery do
   let(:now) { Time.zone.local(2026, 6, 9, 10, 0, 0) }
   let(:today) { now.to_date }
 
+  before { travel_to(now) }
+
   def build_query(scheduled_time: nil)
     described_class.new(person: person, scheduled_time: scheduled_time, now: now)
   end


### PR DESCRIPTION
## Summary

- freezes reminder eligibility examples at the scenario time they already declare
- keeps schedule active scopes and query inputs on the same deterministic clock
- prevents the suite from expiring as the real calendar advances

Closes #1560