### PR TITLE
feat(audit): verify and export evidence

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,6 +20,8 @@ includes:
     taskfile: Taskfiles/docs.yml
   worktree:
     taskfile: Taskfiles/worktree.yml
+  audit:
+    taskfile: Taskfiles/audit.yml
 
 tasks:
   default:

--- a/Taskfiles/audit.yml
+++ b/Taskfiles/audit.yml
@@ -1,0 +1,30 @@
+---
+version: "3"
+
+tasks:
+  verify:
+    desc: Verify the audit database ledger and optional Object Lock evidence
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          SERVICE: audit-verifier-prod
+          COMMAND: rails audit:verify
+
+  export:
+    desc: Export signed native audit evidence and optional FHIR R4 AuditEvent resources
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          SERVICE: audit-verifier-prod
+          COMMAND: rails audit:export
+
+  monitor:
+    desc: Emit the PHI-safe audit delivery backlog status
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          SERVICE: audit-verifier-prod
+          COMMAND: rails audit:monitor

--- a/app/services/audit/backlog_monitor.rb
+++ b/app/services/audit/backlog_monitor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Audit
+  class BacklogMonitor
+    Result = Data.define(:severity, :pending_count, :oldest_age_seconds)
+    WARNING_AGE = 5.minutes
+    CRITICAL_AGE = 1.hour
+
+    def initialize(deliveries: AuditExportDelivery.pending, now: Time.current)
+      @deliveries = deliveries
+      @now = now
+    end
+
+    def call
+      ages = deliveries.map { |delivery| [(now - delivery.created_at).to_i, 0].max }
+      result = Result.new(severity: severity(ages.max.to_i), pending_count: ages.size,
+                          oldest_age_seconds: ages.max.to_i)
+      ActiveSupport::Notifications.instrument('audit_delivery_backlog.med_tracker', notification_payload(result))
+      result
+    end
+
+    private
+
+    attr_reader :deliveries, :now
+
+    def severity(age)
+      return 'critical' if age >= CRITICAL_AGE
+      return 'warning' if age >= WARNING_AGE
+
+      'healthy'
+    end
+
+    def notification_payload(result)
+      {
+        severity: result.severity, pending_count: result.pending_count,
+        oldest_age_seconds: result.oldest_age_seconds,
+        warning_threshold_seconds: WARNING_AGE.to_i, critical_threshold_seconds: CRITICAL_AGE.to_i
+      }
+    end
+  end
+end

--- a/app/services/audit/entry_filter.rb
+++ b/app/services/audit/entry_filter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Audit
+  class EntryFilter
+    class Invalid < StandardError; end
+
+    def initialize(environment, relation: AuditLedgerEntry.all)
+      @environment = environment
+      @relation = relation
+    end
+
+    def call
+      filtered = relation
+      filtered = filtered.where(household_id: integer_filter('HOUSEHOLD_ID')) if value?('HOUSEHOLD_ID')
+      filtered = filtered.where(occurred_at: time_filter('FROM')..) if value?('FROM')
+      filtered = filtered.where(occurred_at: ..time_filter('TO')) if value?('TO')
+      filtered
+    end
+
+    def time_filtered?
+      value?('FROM') || value?('TO')
+    end
+
+    private
+
+    attr_reader :environment, :relation
+
+    def value?(name)
+      environment[name].present?
+    end
+
+    def integer_filter(name)
+      Integer(environment.fetch(name), 10)
+    rescue ArgumentError
+      raise Invalid, "invalid #{name}"
+    end
+
+    def time_filter(name)
+      Time.iso8601(environment.fetch(name))
+    rescue ArgumentError
+      raise Invalid, "invalid #{name}"
+    end
+  end
+end

--- a/app/services/audit/evidence_exporter.rb
+++ b/app/services/audit/evidence_exporter.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+
+module Audit
+  class EvidenceExporter
+    Result = Data.define(:native_path, :manifest_path, :fhir_path)
+
+    def initialize(entries:, output_directory:, manifest_signer:, **options)
+      @entries_source = entries
+      @output_directory = Pathname(output_directory)
+      @manifest_signer = manifest_signer
+      @household_id = options[:household_id]
+      @fhir = options.fetch(:fhir, false)
+      @clock = options.fetch(:clock, -> { Time.current })
+    end
+
+    def call
+      FileUtils.mkdir_p(output_directory)
+      write_native
+      write_fhir if fhir
+      write_manifest
+      record_export_event
+      Result.new(native_path:, manifest_path:, fhir_path: fhir ? fhir_path : nil)
+    end
+
+    private
+
+    attr_reader :entries_source, :output_directory, :manifest_signer, :household_id, :fhir, :clock
+
+    def entries
+      @entries ||= entries_source.reorder(:chain_key, :chain_epoch, :sequence).to_a
+    end
+
+    def record_export_event
+      Audit::Event.record!(
+        household_id:, event_type: 'audit.evidence.exported',
+        metadata: { outcome: 'success', format: fhir ? 'native-and-fhir-r4' : 'native' }
+      )
+    end
+
+    def write_native
+      body = entries.map { |entry| Audit::ObjectLock::RecordSerializer.new(entry).body }.join("\n")
+      body += "\n" if body.present?
+      File.binwrite(native_path, body)
+    end
+
+    def write_fhir
+      bundle = {
+        resourceType: 'Bundle', type: 'collection', timestamp: generated_at,
+        entry: entries.map do |entry|
+          resource = FhirAuditEventMapper.new(entry).to_h
+          { fullUrl: "urn:uuid:#{resource[:id]}", resource: }
+        end
+      }
+      File.binwrite(fhir_path, ManifestSigner.canonical_json(bundle))
+    end
+
+    def write_manifest
+      unsigned = {
+        schema_version: 1, generated_at:, household_id:,
+        files: exported_files.to_h { |path| [path.basename.to_s, file_description(path)] },
+        chains: chain_descriptions
+      }.compact
+      File.binwrite(manifest_path, ManifestSigner.canonical_json(manifest_signer.sign(unsigned)))
+    end
+
+    def exported_files
+      [native_path, (fhir_path if fhir)].compact
+    end
+
+    def file_description(path)
+      { sha256: Digest::SHA256.file(path).hexdigest, bytes: path.size }
+    end
+
+    def chain_descriptions
+      entries.group_by { |entry| [entry.chain_key, entry.chain_epoch] }.map do |(chain_key, epoch), values|
+        tail = values.max_by(&:sequence)
+        { chain_key:, epoch:, final_sequence: tail.sequence, final_hash: tail.entry_hash.unpack1('H*') }
+      end
+    end
+
+    def generated_at
+      @generated_at ||= clock.call.utc.iso8601(6)
+    end
+
+    def native_path
+      output_directory.join('audit.ndjson')
+    end
+
+    def fhir_path
+      output_directory.join('fhir-audit-events.json')
+    end
+
+    def manifest_path
+      output_directory.join('manifest.json')
+    end
+  end
+end

--- a/app/services/audit/fhir_audit_event_mapper.rb
+++ b/app/services/audit/fhir_audit_event_mapper.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'cgi'
+
+module Audit
+  class FhirAuditEventMapper
+    TYPE_SYSTEM = 'http://dicom.nema.org/resources/ontology/DCM'
+    SUBTYPE_SYSTEM = 'https://medtracker.app/fhir/CodeSystem/audit-event-type'
+    ROLE_SYSTEM = 'https://medtracker.app/fhir/CodeSystem/household-role'
+
+    def initialize(entry)
+      @envelope = entry.envelope
+    end
+
+    def to_h
+      {
+        resourceType: 'AuditEvent', id: envelope['event_id'],
+        type: { system: TYPE_SYSTEM, code: '110100', display: 'Application Activity' },
+        subtype: [{ system: SUBTYPE_SYSTEM, code: envelope['event_type'] }],
+        action: action, recorded: envelope['occurred_at'], outcome: outcome,
+        agent: [agent], source:, entity: [entity]
+      }.compact
+    end
+
+    private
+
+    attr_reader :envelope
+
+    def action
+      event_type = envelope['event_type'].to_s
+      return 'C' if event_type.match?(/create|record|login|start/)
+      return 'R' if event_type.match?(/read|view|access|export/)
+      return 'U' if event_type.match?(/update|change|rotate|restock|take/)
+      return 'D' if event_type.match?(/delete|destroy|revoke|logout/)
+
+      'E'
+    end
+
+    def outcome
+      envelope['outcome'].to_s == 'success' ? '0' : '8'
+    end
+
+    def agent
+      agent = envelope.fetch('agent', {})
+      {
+        who: { identifier: { system: 'https://medtracker.app/identifier/account', value: agent['account_id'].to_s } },
+        requestor: agent['account_id'].present?,
+        role: agent_role(agent['role']),
+        policy: policy_uris,
+        network: network
+      }.compact
+    end
+
+    def agent_role(role)
+      return if role.blank?
+
+      [{ coding: [{ system: ROLE_SYSTEM, code: role }] }]
+    end
+
+    def policy_uris
+      policy = envelope.fetch('policy', {})
+      return if policy.values.compact.empty?
+
+      value = [policy['class'], policy['query']].compact.join('/')
+      ["https://medtracker.app/policy/#{CGI.escape(value)}"]
+    end
+
+    def network
+      address = envelope.dig('request', 'ip')
+      { address:, type: '2' } if address.present?
+    end
+
+    def source
+      {
+        observer: {
+          identifier: { system: 'https://medtracker.app/identifier/audit-source', value: 'medtracker' }
+        },
+        type: [{ system: 'http://terminology.hl7.org/CodeSystem/security-source-type', code: '4' }]
+      }
+    end
+
+    def entity
+      source = envelope.fetch('source', {})
+      {
+        what: {
+          identifier: {
+            system: 'https://medtracker.app/identifier/audit-source-row',
+            value: [source['table'], source['id']].compact.join('/')
+          }
+        },
+        name: envelope.dig('entity', 'type')
+      }.compact
+    end
+  end
+end

--- a/app/services/audit/manifest_signer.rb
+++ b/app/services/audit/manifest_signer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+require 'openssl'
+
+module Audit
+  class ManifestSigner
+    def self.canonical_json(value)
+      JSON.generate(deep_sort(value))
+    end
+
+    def self.deep_sort(value)
+      case value
+      when Hash then value.to_h { |key, child| [key.to_s, deep_sort(child)] }.sort.to_h
+      when Array then value.map { |child| deep_sort(child) }
+      else value
+      end
+    end
+
+    def initialize(key_id:, private_key_pem:)
+      @key_id = key_id
+      @private_key = OpenSSL::PKey.read(private_key_pem)
+      raise ArgumentError, 'manifest signing key must be Ed25519' unless private_key.oid == 'ED25519'
+    end
+
+    def sign(manifest)
+      signature = private_key.sign(nil, self.class.canonical_json(manifest))
+      manifest.merge(
+        signing: {
+          key_id:, algorithm: 'ed25519', public_key: Base64.strict_encode64(private_key.public_to_der),
+          signature: Base64.strict_encode64(signature)
+        }
+      )
+    end
+
+    private
+
+    attr_reader :key_id, :private_key
+  end
+end

--- a/app/services/audit/object_lock/s3_adapter.rb
+++ b/app/services/audit/object_lock/s3_adapter.rb
@@ -37,9 +37,36 @@ module Audit
         raise RetryableError, "audit Object Lock write failed: #{e.class.name}"
       end
 
+      def verify(record, delivery:)
+        serializer = RecordSerializer.new(record)
+        validate_delivery_receipt!(serializer, delivery)
+        response = delivered_object_head(serializer, delivery)
+        validate_delivered_object!(response, serializer, delivery)
+        validate_single_version!(serializer)
+        true
+      rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
+        raise IntegrityError, 'audit object is missing'
+      rescue Aws::S3::Errors::ServiceError => e
+        raise RetryableError, "audit Object Lock verification failed: #{e.class.name}"
+      end
+
       private
 
       attr_reader :configuration, :client
+
+      def delivered_object_head(serializer, delivery)
+        client.head_object(
+          bucket:, key: serializer.object_key, version_id: delivery.object_version_id,
+          expected_bucket_owner:, checksum_mode: 'ENABLED'
+        )
+      end
+
+      def validate_delivered_object!(response, serializer, delivery)
+        validate_existing_checksum!(response, serializer)
+        validate_retention_until!(response, [serializer.retain_until, delivery.retain_until].compact.max)
+        validate_retention_mode!(response, delivery.retention_mode)
+        validate_object_version!(response, delivery)
+      end
 
       def bucket
         configuration.bucket
@@ -110,13 +137,17 @@ module Audit
       end
 
       def validate_existing_retention!(response, serializer)
-        return if retention_covers?(response, serializer)
+        return if retention_covers?(response, serializer.retain_until)
 
         raise IntegrityError, 'existing audit object retention is too short'
       end
 
       def validate_existing_mode!(response)
-        return if response.object_lock_mode == configuration.retention_mode
+        validate_retention_mode!(response, configuration.retention_mode)
+      end
+
+      def validate_retention_mode!(response, expected_mode)
+        return if response.object_lock_mode == expected_mode
 
         raise IntegrityError, 'existing audit object retention mode does not match'
       end
@@ -126,8 +157,42 @@ module Audit
           response.metadata['content-sha256'] == serializer.checksum_sha256
       end
 
-      def retention_covers?(response, serializer)
-        response.object_lock_retain_until_date && response.object_lock_retain_until_date >= serializer.retain_until
+      def retention_covers?(response, retain_until)
+        response.object_lock_retain_until_date && response.object_lock_retain_until_date >= retain_until
+      end
+
+      def validate_delivery_receipt!(serializer, delivery)
+        return if matching_receipt?(serializer, delivery) && complete_receipt?(delivery)
+
+        raise IntegrityError, 'audit delivery receipt does not match the expected object'
+      end
+
+      def matching_receipt?(serializer, delivery)
+        delivery.object_key == serializer.object_key && delivery.checksum_sha256 == serializer.checksum_sha256
+      end
+
+      def complete_receipt?(delivery)
+        delivery.object_version_id.present? && delivery.retention_mode.present? && delivery.retain_until.present?
+      end
+
+      def validate_retention_until!(response, retain_until)
+        return if retention_covers?(response, retain_until)
+
+        raise IntegrityError, 'existing audit object retention is too short'
+      end
+
+      def validate_object_version!(response, delivery)
+        return if response.version_id == delivery.object_version_id
+
+        raise IntegrityError, 'audit object version does not match its delivery receipt'
+      end
+
+      def validate_single_version!(serializer)
+        response = client.list_object_versions(bucket:, prefix: serializer.object_key, expected_bucket_owner:)
+        versions = response.versions.select { |version| version.key == serializer.object_key }
+        return if versions.one?
+
+        raise IntegrityError, 'audit object has missing or duplicate versions'
       end
 
       def result(serializer, version_id)

--- a/app/services/audit/verification/command.rb
+++ b/app/services/audit/verification/command.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Audit
+  module Verification
+    class Command
+      SCOPES = %w[database worm combined].freeze
+
+      def initialize(environment: ENV, output: $stdout, error_output: $stderr, database_verifier: nil,
+                     worm_verifier: nil)
+        @environment = environment
+        @output = output
+        @error_output = error_output
+        @database_verifier = database_verifier
+        @worm_verifier = worm_verifier
+      end
+
+      def call
+        result = verification_result
+        render(result)
+        result.exit_code
+      rescue ConfigurationError, Audit::EntryFilter::Invalid => e
+        error_output.puts("audit verification could not run: #{e.message}")
+        2
+      rescue StandardError => e
+        error_output.puts("audit verification could not run: #{e.class.name}")
+        2
+      end
+
+      private
+
+      attr_reader :environment, :output, :error_output, :database_verifier, :worm_verifier
+
+      def verification_result
+        raise ConfigurationError, "unsupported scope: #{scope}" unless SCOPES.include?(scope)
+
+        case scope
+        when 'database' then resolved_database_verifier.call
+        when 'worm' then resolved_worm_verifier.call
+        else combine(resolved_database_verifier.call, resolved_worm_verifier.call)
+        end
+      end
+
+      def resolved_database_verifier
+        database_verifier || DatabaseVerifier.new(entries: entry_filter.call,
+                                                  verify_heads: !entry_filter.time_filtered?)
+      end
+
+      def resolved_worm_verifier
+        worm_verifier || raise(ConfigurationError, 'WORM verification is not configured')
+      end
+
+      def entry_filter
+        @entry_filter ||= Audit::EntryFilter.new(environment)
+      end
+
+      def scope
+        @scope ||= environment.fetch('SCOPE', 'database').downcase
+      end
+
+      def combine(database_result, worm_result)
+        Result.new(
+          scope: 'combined',
+          checked_entries: database_result.checked_entries,
+          checked_checkpoints: database_result.checked_checkpoints,
+          checked_objects: worm_result.checked_objects,
+          issues: database_result.issues + worm_result.issues
+        )
+      end
+
+      def render(result)
+        environment.fetch('FORMAT', 'human') == 'json' ? render_json(result) : render_human(result)
+      end
+
+      def render_json(result)
+        output.puts(JSON.generate(result.to_h))
+      end
+
+      def render_human(result)
+        output.puts("Audit verification: #{result.valid? ? 'VALID' : 'INVALID'}")
+        output.puts(result_summary(result))
+        result.issues.each { |issue| output.puts("#{issue.code}: #{issue.message}") }
+      end
+
+      def result_summary(result)
+        "Entries: #{result.checked_entries}; checkpoints: #{result.checked_checkpoints}; " \
+          "objects: #{result.checked_objects}"
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/database_verifier.rb
+++ b/app/services/audit/verification/database_verifier.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'json'
+require 'openssl'
+
+module Audit
+  module Verification
+    class DatabaseVerifier
+      SOURCE_TABLES = %w[security_audit_events versions].freeze
+      HASH_DOMAIN = 'medtracker.audit.ledger.v1'
+      CHECKPOINT_DOMAIN = 'medtracker.audit.checkpoint.v1'
+      SEPARATOR = "\u001F"
+      SECURITY_EVENT_SOURCE_SQL = <<~SQL.squish.freeze
+        SELECT (to_jsonb(source_row.*) - 'updated_at')::text
+        FROM security_audit_events source_row
+        WHERE source_row.id = $1
+      SQL
+      VERSION_SOURCE_SQL = <<~SQL.squish.freeze
+        SELECT (to_jsonb(source_row.*) - 'updated_at')::text
+        FROM versions source_row
+        WHERE source_row.id = $1
+      SQL
+
+      def initialize(entries: AuditLedgerEntry.all, verify_heads: true)
+        @entries_source = entries
+        @verify_heads = verify_heads
+        @issues = []
+      end
+
+      def call
+        verify_entries
+        verify_chain_heads if verify_heads
+        checked_checkpoints = verify_checkpoints
+        Result.new(
+          scope: 'database', checked_entries: entries.size, checked_checkpoints:,
+          checked_objects: 0, issues: sorted_issues
+        )
+      end
+
+      private
+
+      attr_reader :entries_source, :issues, :verify_heads
+
+      def entries
+        @entries ||= entries_source.to_a.sort_by { |entry| [entry.chain_key, entry.chain_epoch, entry.sequence] }
+      end
+
+      def verify_entries
+        entries.group_by { |entry| [entry.chain_key, entry.chain_epoch] }.each_value do |chain_entries|
+          verify_chain_entries(chain_entries)
+        end
+      end
+
+      def verify_chain_entries(chain_entries)
+        chain_entries.each_with_index do |entry, index|
+          predecessor = index.zero? ? stored_predecessor(entry) : chain_entries[index - 1]
+          verify_sequence(entry, predecessor)
+          verify_previous_hash(entry, predecessor)
+          verify_canonical_payload(entry)
+          verify_entry_hash(entry)
+          verify_source_payload(entry)
+        end
+      end
+
+      def stored_predecessor(entry)
+        return if entry.sequence == 1
+
+        AuditLedgerEntry.find_by(
+          chain_key: entry.chain_key, chain_epoch: entry.chain_epoch, sequence: entry.sequence - 1
+        )
+      end
+
+      def verify_sequence(entry, predecessor)
+        expected = predecessor ? predecessor.sequence + 1 : 1
+        add_issue('sequence_gap', 'ledger sequence is missing or duplicated', entry) unless entry.sequence == expected
+      end
+
+      def verify_previous_hash(entry, predecessor)
+        expected = predecessor&.entry_hash
+        return if entry.previous_hash == expected
+
+        add_issue('previous_hash_mismatch', 'ledger previous hash does not match',
+                  entry)
+      end
+
+      def verify_canonical_payload(entry)
+        parsed = JSON.parse(entry.canonical_payload)
+        unless parsed == entry.envelope
+          add_issue('canonical_payload_mismatch', 'canonical payload does not match its envelope',
+                    entry)
+        end
+      rescue JSON::ParserError
+        add_issue('canonical_payload_invalid', 'canonical payload is not valid JSON', entry)
+      end
+
+      def verify_entry_hash(entry)
+        calculated = Digest::SHA256.digest(hash_input(entry))
+        return if calculated == entry.entry_hash
+
+        add_issue('entry_hash_mismatch', 'ledger entry hash does not match its payload',
+                  entry)
+      end
+
+      def hash_input(entry)
+        prefix = [HASH_DOMAIN, entry.chain_key, entry.chain_epoch, entry.sequence].join(SEPARATOR) + SEPARATOR
+        prefix.b + (entry.previous_hash || ''.b) + entry.canonical_payload
+      end
+
+      def verify_source_payload(entry)
+        unless SOURCE_TABLES.include?(entry.source_table)
+          add_issue('source_table_unknown', 'ledger source table is not supported', entry)
+          return
+        end
+
+        current_payload = source_payload(entry)
+        code = current_payload ? 'source_payload_mismatch' : 'source_row_missing'
+        message = current_payload ? 'source row no longer matches the ledger' : 'source row is missing'
+        add_issue(code, message, entry) unless current_payload == entry.source_payload
+      end
+
+      def source_payload(entry)
+        sql = case entry.source_table
+              when 'versions' then VERSION_SOURCE_SQL
+              when 'security_audit_events' then SECURITY_EVENT_SOURCE_SQL
+              end
+        value = connection.select_value(sql, 'Audit source', [source_id_bind(entry.source_id)])
+        JSON.parse(value) if value
+      end
+
+      def source_id_bind(source_id)
+        ActiveRecord::Relation::QueryAttribute.new('source_id', source_id, ActiveRecord::Type::Integer.new)
+      end
+
+      def verify_chain_heads
+        relevant_chain_heads.each { |head| verify_chain_head(head) }
+      end
+
+      def relevant_chain_heads
+        heads = AuditChainHead.all.to_a
+        return heads if entries.empty?
+
+        chain_keys = entries.map(&:chain_key).uniq
+        heads.select { |head| chain_keys.include?(head.chain_key) }
+      end
+
+      def verify_chain_head(head)
+        tail = chain_tail(head)
+        return if head_matches?(head, tail)
+
+        add_issue('chain_head_mismatch', 'chain head does not match the retained tail', tail, head.chain_key,
+                  head.last_sequence)
+      end
+
+      def chain_tail(head)
+        entries.select do |entry|
+          entry.chain_key == head.chain_key && entry.chain_epoch == head.chain_epoch
+        end.max_by(&:sequence)
+      end
+
+      def head_matches?(head, tail)
+        return head.last_sequence.zero? && head.last_hash.nil? unless tail
+
+        head.last_sequence == tail.sequence && head.last_hash == tail.entry_hash
+      end
+
+      def verify_checkpoints
+        checkpoints = checkpoints_for_entries
+        checkpoints.each { |checkpoint| verify_checkpoint(checkpoint) }
+        checkpoints.size
+      end
+
+      def checkpoints_for_entries
+        keys = entries.to_h { |entry| [[entry.chain_key, entry.chain_epoch, entry.sequence], true] }
+        AuditCheckpoint.includes(:audit_signing_key).select do |checkpoint|
+          keys.key?([checkpoint.chain_key, checkpoint.chain_epoch, checkpoint.sequence])
+        end
+      end
+
+      def verify_checkpoint(checkpoint)
+        verify_checkpoint_entry(checkpoint)
+        return unless checkpoint_signed?(checkpoint)
+
+        verify_checkpoint_signature(checkpoint)
+      end
+
+      def verify_checkpoint_entry(checkpoint)
+        entry = checkpoint_entry(checkpoint)
+        return if entry&.entry_hash == checkpoint.entry_hash
+
+        add_checkpoint_issue('checkpoint_entry_mismatch', 'checkpoint does not identify a retained entry', checkpoint)
+      end
+
+      def checkpoint_entry(checkpoint)
+        entries.find do |candidate|
+          candidate.chain_key == checkpoint.chain_key && candidate.chain_epoch == checkpoint.chain_epoch &&
+            candidate.sequence == checkpoint.sequence
+        end
+      end
+
+      def checkpoint_signed?(checkpoint)
+        return true if checkpoint.signature.present? && checkpoint.audit_signing_key && checkpoint.signed_at
+
+        add_checkpoint_issue('checkpoint_unsigned', 'checkpoint has no verifiable signature', checkpoint)
+        false
+      end
+
+      def verify_checkpoint_signature(checkpoint)
+        public_key = OpenSSL::PKey.read(checkpoint.audit_signing_key.public_key)
+        return if public_key.verify(nil, checkpoint.signature, checkpoint_payload(checkpoint))
+
+        add_checkpoint_issue('checkpoint_signature_invalid', 'checkpoint signature is invalid', checkpoint)
+      rescue OpenSSL::PKey::PKeyError
+        add_checkpoint_issue('checkpoint_signature_invalid', 'checkpoint signature is invalid', checkpoint)
+      end
+
+      def checkpoint_payload(checkpoint)
+        [
+          CHECKPOINT_DOMAIN, checkpoint.audit_signing_key.key_id, checkpoint.chain_key,
+          checkpoint.chain_epoch, checkpoint.sequence, checkpoint.entry_hash.unpack1('H*'),
+          checkpoint.signed_at.utc.iso8601(6)
+        ].join(SEPARATOR)
+      end
+
+      def add_checkpoint_issue(code, message, checkpoint)
+        issues << Issue.new(code:, message:, chain_key: checkpoint.chain_key, sequence: checkpoint.sequence)
+      end
+
+      def add_issue(code, message, entry = nil, chain_key = nil, sequence = nil)
+        issues << Issue.new(
+          code:, message:, chain_key: chain_key || entry&.chain_key, sequence: sequence || entry&.sequence
+        )
+      end
+
+      def sorted_issues
+        issues.sort_by { |issue| [issue.chain_key.to_s, issue.sequence.to_i, issue.code] }
+      end
+
+      def connection
+        ActiveRecord::Base.connection
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/result.rb
+++ b/app/services/audit/verification/result.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class ConfigurationError < StandardError; end
+
+    Issue = Data.define(:code, :message, :chain_key, :sequence) do
+      def to_h
+        { code:, message:, chain_key:, sequence: }.compact
+      end
+    end
+
+    Result = Data.define(:scope, :checked_entries, :checked_checkpoints, :checked_objects, :issues) do
+      def valid?
+        issues.empty?
+      end
+
+      def exit_code
+        valid? ? 0 : 1
+      end
+
+      def issue_codes
+        issues.map(&:code)
+      end
+
+      def to_h
+        {
+          scope:, valid: valid?, exit_code:, checked_entries:, checked_checkpoints:,
+          checked_objects:, issues: issues.map(&:to_h)
+        }
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/worm_verifier.rb
+++ b/app/services/audit/verification/worm_verifier.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class WormVerifier
+      def initialize(adapter:, records: nil, deliveries: AuditExportDelivery.all)
+        @records = records || default_records
+        @deliveries = deliveries
+        @adapter = adapter
+        @issues = []
+        @checked_objects = 0
+      end
+
+      def call
+        delivery_by_record = deliveries.to_a.index_by(&:export_record)
+        records.to_a.each { |record| verify_record(record, delivery_by_record[record]) }
+        Result.new(
+          scope: 'worm', checked_entries: 0, checked_checkpoints: 0,
+          checked_objects:, issues: sorted_issues
+        )
+      end
+
+      private
+
+      attr_reader :records, :deliveries, :adapter, :issues, :checked_objects
+
+      def default_records
+        AuditLedgerEntry.all.to_a + AuditCheckpoint.where.not(signature: nil).to_a
+      end
+
+      def verify_record(record, delivery)
+        unless delivery
+          add_issue('worm_delivery_missing', 'audit record has no delivery receipt', record)
+          return
+        end
+        unless delivery.delivered?
+          code = delivery.failed? ? 'worm_delivery_failed' : 'worm_delivery_pending'
+          add_issue(code, 'audit record has not been retained in Object Lock', record)
+          return
+        end
+
+        adapter.verify(record, delivery:)
+        @checked_objects += 1
+      rescue Audit::ObjectLock::IntegrityError => e
+        add_issue('worm_object_invalid', e.message, record)
+      end
+
+      def add_issue(code, message, record)
+        issues << Issue.new(code:, message:, chain_key: record.chain_key, sequence: record.sequence)
+      end
+
+      def sorted_issues
+        issues.sort_by { |issue| [issue.chain_key.to_s, issue.sequence.to_i, issue.code] }
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/worm_verifier_factory.rb
+++ b/app/services/audit/verification/worm_verifier_factory.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class WormVerifierFactory
+      def initialize(environment = ENV)
+        @environment = environment
+      end
+
+      def call
+        WormVerifier.new(records: selected_records, adapter: validated_adapter)
+      rescue Audit::EntryFilter::Invalid, Audit::ObjectLock::Configuration::Invalid => e
+        raise ConfigurationError, e.message
+      end
+
+      private
+
+      attr_reader :environment
+
+      def selected_records
+        entries + signed_checkpoints
+      end
+
+      def entries
+        @entries ||= Audit::EntryFilter.new(environment).call.to_a
+      end
+
+      def signed_checkpoints
+        keys = entries.to_h { |entry| [[entry.chain_key, entry.chain_epoch, entry.sequence], true] }
+        AuditCheckpoint.where.not(signature: nil).select do |checkpoint|
+          keys.key?([checkpoint.chain_key, checkpoint.chain_epoch, checkpoint.sequence])
+        end
+      end
+
+      def validated_adapter
+        configuration = Audit::ObjectLock::Configuration.new(environment)
+        Audit::ObjectLock::S3Adapter.new(configuration:).tap(&:validate!)
+      end
+    end
+  end
+end

--- a/app/services/medication_reminder_eligibility_query.rb
+++ b/app/services/medication_reminder_eligibility_query.rb
@@ -38,14 +38,18 @@ class MedicationReminderEligibilityQuery
     @schedules ||= if person.schedules.loaded?
                      loaded_active_schedules
                    else
-                     person.schedules.active.includes(:medication, :medication_takes).to_a
+                     active_schedules_for_today.includes(:medication, :medication_takes).to_a
                    end
   end
 
   def loaded_active_schedules
-    person.schedules.select(&:active?).tap do |schedules|
+    person.schedules.select { |schedule| schedule.active_on?(today) }.tap do |schedules|
       ActiveRecord::Associations::Preloader.new(records: schedules, associations: %i[medication medication_takes]).call
     end
+  end
+
+  def active_schedules_for_today
+    person.schedules.where(active: true).where('start_date <= ? AND end_date >= ?', today, today)
   end
 
   def person_medications

--- a/compose.yaml
+++ b/compose.yaml
@@ -307,6 +307,53 @@ services:
     healthcheck:
       disable: true
 
+  audit-verifier-prod:
+    extends:
+      file: compose/base.yml
+      service: rails
+    profiles: [audit]
+    networks: [prod]
+    build:
+      target: app
+    depends_on:
+      db-prod:
+        condition: service_healthy
+      migrate-prod:
+        condition: service_completed_successfully
+    environment:
+      RAILS_ENV: production
+      DATABASE_URL: postgresql://medtracker_audit_verifier:local_audit_verifier_only@db-prod:5432/medtracker
+      DATABASE_ROLE: med_tracker_audit_verifier
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-local-prod-testing-only-not-for-real-use}
+      APP_URL: ${APP_URL:-http://localhost}
+      SCOPE: ${SCOPE:-database}
+      FORMAT: ${FORMAT:-human}
+      HOUSEHOLD_ID: ${HOUSEHOLD_ID:-}
+      FROM: ${FROM:-}
+      TO: ${TO:-}
+      OUTPUT: ${OUTPUT:-tmp/audit-exports/latest}
+      FHIR: ${FHIR:-false}
+      AUDIT_WORM_BUCKET: ${AUDIT_WORM_BUCKET:-}
+      AUDIT_WORM_REGION: ${AUDIT_WORM_REGION:-eu-west-2}
+      AUDIT_WORM_EXPECTED_OWNER: ${AUDIT_WORM_EXPECTED_OWNER:-}
+      AUDIT_WORM_RETENTION_MODE: ${AUDIT_WORM_RETENTION_MODE:-GOVERNANCE}
+      AUDIT_WORM_COMPLIANCE_APPROVED: ${AUDIT_WORM_COMPLIANCE_APPROVED:-false}
+      AUDIT_WORM_SSE: ${AUDIT_WORM_SSE:-aws:kms}
+      AUDIT_WORM_KMS_KEY_ID: ${AUDIT_WORM_KMS_KEY_ID:-}
+      AUDIT_WORM_ENDPOINT: ${AUDIT_WORM_ENDPOINT:-}
+      AUDIT_WORM_FORCE_PATH_STYLE: ${AUDIT_WORM_FORCE_PATH_STYLE:-false}
+      AUDIT_MANIFEST_SIGNING_KEY_ID: ${AUDIT_MANIFEST_SIGNING_KEY_ID:-}
+      AUDIT_MANIFEST_SIGNING_PRIVATE_KEY: ${AUDIT_MANIFEST_SIGNING_PRIVATE_KEY:-}
+      AUDIT_MANIFEST_SIGNING_PRIVATE_KEY_FILE: ${AUDIT_MANIFEST_SIGNING_PRIVATE_KEY_FILE:-}
+      AWS_ACCESS_KEY_ID: ${AUDIT_VERIFY_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AUDIT_VERIFY_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AUDIT_VERIFY_SESSION_TOKEN:-}
+    ports: []
+    volumes:
+      - ./tmp/audit-exports:/app/tmp/audit-exports
+    healthcheck:
+      disable: true
+
 networks:
   dev:
   test:

--- a/compose/init-roles.sql
+++ b/compose/init-roles.sql
@@ -15,6 +15,14 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_audit_exporter') THEN
     CREATE ROLE medtracker_audit_exporter LOGIN PASSWORD 'local_audit_exporter_only';
   END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_audit_verifier') THEN
+    CREATE ROLE med_tracker_audit_verifier NOLOGIN NOSUPERUSER NOBYPASSRLS;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_audit_verifier') THEN
+    CREATE ROLE medtracker_audit_verifier LOGIN PASSWORD 'local_audit_verifier_only';
+  END IF;
 END
 $$;
 
@@ -22,15 +30,19 @@ ALTER ROLE med_tracker_owner NOLOGIN;
 ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE med_tracker_audit_exporter NOLOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE medtracker_audit_exporter LOGIN NOSUPERUSER NOBYPASSRLS;
+ALTER ROLE med_tracker_audit_verifier NOLOGIN NOSUPERUSER NOBYPASSRLS;
+ALTER ROLE medtracker_audit_verifier LOGIN NOSUPERUSER NOBYPASSRLS;
 
 GRANT med_tracker_owner TO medtracker;
 GRANT med_tracker_app TO medtracker;
 GRANT med_tracker_audit_exporter TO medtracker_audit_exporter;
+GRANT med_tracker_audit_verifier TO medtracker_audit_verifier;
 
 ALTER DATABASE medtracker OWNER TO med_tracker_owner;
 ALTER SCHEMA public OWNER TO med_tracker_owner;
 
 GRANT CONNECT ON DATABASE medtracker TO med_tracker_owner, med_tracker_app;
 GRANT CONNECT ON DATABASE medtracker TO med_tracker_audit_exporter;
+GRANT CONNECT ON DATABASE medtracker TO med_tracker_audit_verifier;
 GRANT USAGE, CREATE ON SCHEMA public TO med_tracker_owner;
 GRANT USAGE ON SCHEMA public TO med_tracker_app;

--- a/db/migrate/20260709150000_configure_audit_verifier_role.rb
+++ b/db/migrate/20260709150000_configure_audit_verifier_role.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class ConfigureAuditVerifierRole < ActiveRecord::Migration[8.1]
+  VERIFIER_ROLE = 'med_tracker_audit_verifier'
+  AUDIT_TABLES = %w[
+    audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
+  ].freeze
+
+  def up
+    install_verifier_role
+    lock_verifier_privileges
+  end
+
+  def down
+    revoke_verifier_privileges
+  end
+
+  def install_verifier_role
+    return if role_exists?(VERIFIER_ROLE)
+
+    raise ActiveRecord::IrreversibleMigration, verifier_bootstrap_message unless can_create_roles?
+
+    execute "CREATE ROLE #{VERIFIER_ROLE} NOLOGIN NOSUPERUSER NOBYPASSRLS;"
+  end
+
+  def lock_verifier_privileges
+    revoke_verifier_privileges
+    audit_objects = (AUDIT_TABLES + %w[versions security_audit_events]).join(', ')
+    execute "GRANT USAGE ON SCHEMA public TO #{VERIFIER_ROLE};"
+    execute "GRANT SELECT ON TABLE #{audit_objects} TO #{VERIFIER_ROLE};"
+    execute "GRANT INSERT ON TABLE security_audit_events TO #{VERIFIER_ROLE};"
+    execute "GRANT USAGE, SELECT ON SEQUENCE security_audit_events_id_seq TO #{VERIFIER_ROLE};"
+  end
+
+  def revoke_verifier_privileges
+    audit_objects = (AUDIT_TABLES + %w[versions security_audit_events]).join(', ')
+    execute "REVOKE ALL PRIVILEGES ON TABLE #{audit_objects} FROM #{VERIFIER_ROLE};"
+    execute "REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM #{VERIFIER_ROLE};" if superuser?
+    execute "REVOKE USAGE ON SCHEMA public FROM #{VERIFIER_ROLE};"
+  end
+
+  private
+
+  def role_exists?(role_name)
+    select_value("SELECT COUNT(*) FROM pg_roles WHERE rolname = #{quote(role_name)}").to_i.positive?
+  end
+
+  def can_create_roles?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper OR rolcreaterole, false)
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
+  end
+
+  def superuser?
+    select_value(<<~SQL.squish)
+      SELECT COALESCE(rolsuper, false)
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
+  end
+
+  def verifier_bootstrap_message
+    'Database role med_tracker_audit_verifier is missing. Create it as NOLOGIN, NOSUPERUSER, NOBYPASSRLS before migrating.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_143100) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -1,139 +1,82 @@
-# Audit Trail Documentation
+# Audit Evidence
 
-## Overview
+## What the system records
 
-MedTracker uses [PaperTrail](https://github.com/paper-trail-gem/paper_trail) to maintain a complete audit trail of all changes to critical data models. This ensures compliance with UK healthcare regulations and provides accountability for all system actions.
+MedTracker records two audit sources:
 
-## Audited Models
+- `versions` contains PaperTrail create, update, and destroy evidence, including `object_changes`.
+- `security_audit_events` contains authentication, authorization, support access, import/export, API, MCP, and other security events.
 
-The following models have audit trail enabled:
+Both sources use the same versioned envelope. It identifies the event, outcome, time, household, affected entity, actor account/user/membership, active role, permissions version, authentication method, opaque session reference, request and trace identifiers, IP address, Pundit policy/query, support session, source row, redacted metadata, and retention decision. Secrets, bearer tokens, cookies, passwords, OIDC tokens, and raw session identifiers are not permitted in the envelope.
 
-- **User**: Track user account changes (excluding password fields for security)
-- **Person**: Track patient/carer demographic changes
-- **CarerRelationship**: Track carer assignments and removals
-- **Medication**: Track changes to medication definitions and stock
-- **MedicationTake**: Track all medication doses (critical for patient safety)
+The web and API controllers establish and clear the request context explicitly. Background work is identified as system activity; it is not represented as user-authorized activity.
 
-## Security Audit Events
+## Integrity boundary
 
-Security-sensitive operational events are stored in `security_audit_events`.
-MCP requests write `event_type: mcp.request` with the request ID, IP address,
-household, actor account, actor membership, JSON-RPC method, outcome, and HTTP
-status. Raw bearer tokens are not stored.
+PostgreSQL `SECURITY DEFINER` triggers append both source tables to `audit_ledger_entries` in the same transaction. Each household has an independent chain; events without a household use the global chain. Every entry binds the chain epoch, sequence, previous hash, canonical envelope, source payload, hash/schema versions, and retention decision into a SHA-256 hash.
 
-## Accessing Audit Logs
+The runtime application role can insert source events but cannot update or delete source or ledger rows. Household administrators read a tenant-filtered view. The audit exporter and verifier use separate database roles and credentials:
 
-- **URL**: `/admin/audit_logs`
-- **Access**: Administrators only (enforced by `AuditLogPolicy`)
-- **Features**:
-  - Filter by record type (User, Person, etc.)
-  - Filter by event type (create, update, destroy)
-  - View complete change history with timestamps
-  - See who made changes and from which IP address
-  - View previous state of records before changes
-  - Read-only interface (no editing or deletion of audit logs)
+- `med_tracker_audit_exporter` reads ledger/checkpoint data, signs checkpoints through a one-way database function, and updates delivery receipts. It cannot read source or clinical tables or modify ledger history.
+- `med_tracker_audit_verifier` reads source and ledger evidence and may insert the audit event describing an export. It cannot read clinical tables or alter existing source, ledger, checkpoint, or delivery rows.
 
-## Technical Details
+Database-owner access remains a break-glass capability. PostgreSQL cannot independently audit a malicious database owner who controls the database and its logs. Every owner-level audit-table operation therefore requires an incident or approved change record in a separate system.
 
-### Database Schema
+## Existing history
 
-Audit logs are stored in the `versions` table with the following key fields:
+Rows that existed when the ledger was installed are chained in a distinct `legacy-baseline` epoch. A signed baseline manifest proves the bytes exported at that point and detects later changes. It does not prove that pre-migration history was complete or unmodified before the baseline. Documentation and exports must retain that label.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `item_type` | string | Model class name (e.g., "User", "Person") |
-| `item_id` | bigint | ID of the record that changed |
-| `event` | string | Type of change: "create", "update", or "destroy" |
-| `whodunnit` | string | User ID who made the change |
-| `ip` | string | IP address of the request |
-| `object` | text | YAML snapshot of record state before change |
-| `created_at` | datetime | When the change occurred |
+## Object Lock evidence
 
-### Configuration
+The exporter writes one deterministic, content-addressed JSON object per ledger entry and signed checkpoint to an S3-compatible Object Lock bucket. Uploads use conditional creation, SHA-256 checksums, server-side encryption, expected-owner checks, versioning, and retention metadata. Matching conditional-write conflicts are accepted only after the existing object, checksum, version, mode, and retention are verified.
 
-See `config/initializers/paper_trail.rb` for:
+Temporary storage failures leave the transactional outbox pending for retry. Configuration, checksum, duplicate-version, and retention failures stop automatic retry and require operator action. The web process has no signing key or WORM credential.
 
-- Permitted YAML classes for safe deserialization
-- Default tracking options (create, update, destroy)
-- Global PaperTrail settings
+Governance mode is the default. `COMPLIANCE` mode requires `AUDIT_WORM_COMPLIANCE_APPROVED=true` after records-governance approval because its retention cannot be shortened. Object Lock configuration and permission validation is repeated while the exporter runs.
 
-### User Tracking
+## Verification
 
-The `ApplicationController` sets the audit context:
+Run:
 
-```ruby
-def user_for_paper_trail
-  current_user&.id
-end
-
-def info_for_paper_trail
-  { ip: request.remote_ip }
-end
+```fish
+task audit:verify
 ```
 
-This ensures every change is attributed to a specific user and IP address.
+Inputs are supplied as environment variables:
 
-### Adding Audit Trail to New Models
+| Variable | Values |
+|---|---|
+| `SCOPE` | `database`, `worm`, or `combined` |
+| `FORMAT` | `human` or `json` |
+| `HOUSEHOLD_ID` | Optional numeric household filter |
+| `FROM` / `TO` | Optional ISO 8601 time bounds |
 
-To enable audit tracking on a new model:
+Exit status `0` means all selected evidence is valid, `1` means an integrity failure was found, and `2` means verification could not run because of configuration or runtime failure.
 
-```ruby
-class YourModel < ApplicationRecord
-  has_paper_trail
-  
-  # Optional: exclude sensitive fields
-  # has_paper_trail ignore: %i[password_field secret_field]
-  
-  # Optional: track only specific events
-  # has_paper_trail on: %i[create destroy]
-end
+Database verification checks source-row equality, canonical payload parsing, sequence continuity, every previous-hash link, recomputed entry hashes, live chain heads, checkpoint targets, Ed25519 signatures, and retained public keys. WORM verification checks delivery completeness, object key/checksum/version, retention mode/date, missing objects, and duplicate versions.
+
+Time-bounded verification validates selected entries and their predecessor links but does not compare a filtered range with the current chain head. Scheduled full verification is still required to detect tail truncation.
+
+## Export
+
+Run:
+
+```fish
+task audit:export
 ```
 
-## Compliance & Regulatory Requirements
+Set `OUTPUT`, optional `HOUSEHOLD_ID`, `FROM`, `TO`, and `FHIR=true` as required. The export contains deterministic native NDJSON and a signed manifest. `FHIR=true` also writes a FHIR R4 `Bundle` of `AuditEvent` resources. The native envelope remains authoritative for integrity; FHIR is an interoperability representation. FHIR defines AuditEvent as a security log and advises servers not to support update/delete because that compromises audit integrity: <https://hl7.org/fhir/R4/auditevent.html>.
 
-This audit trail supports compliance with:
+Creating an export is itself written to `security_audit_events` without recording output paths or clinical content.
 
-- **UK GDPR Article 32**: Security of processing - maintaining records of data access and changes
-- **DCB0129**: Clinical Risk Management - tracking medication and patient data changes
-- **DCB0160**: Clinical Safety - audit trail for safety-critical operations
-- **NHS Data Security and Protection Toolkit**: Evidence of access controls and audit logging
+## Retention
 
-## Data Retention
+Retention policy `clinical-security-v1` applies a ten-year default floor to clinical/security audit evidence. A related record schedule, legal hold, inquiry, litigation requirement, or approved local policy may require longer retention. This is a floor, not a universal claim that every record must be destroyed after ten years or kept forever.
 
-Audit logs are retained **indefinitely** for regulatory compliance and legal requirements. The `versions` table should be monitored for growth and may require archival strategies for long-term deployments.
+Reaching `retain_until` makes evidence eligible for records-governance review. MedTracker does not automatically destroy expired audit evidence. A future governed disposal process must verify eligibility and legal holds and create an immutable destruction manifest.
 
-## Performance Considerations
+The policy must be approved by the deploying organisation's records manager and DPO before production retention is locked. NHS records guidance applies different schedules to different records, requires appraisal at the end of the minimum period, and warns against unjustified continued retention: <https://transform.england.nhs.uk/media/documents/NHSX_Records_Management_CoP_V7.pdf>.
 
-- Audit logs are written synchronously with each database change
-- The `versions` table will grow continuously - plan for database growth
-- Queries are optimized with indexes on `item_type`, `item_id`, and `created_at`
-- Consider archiving old audit logs (>7 years) to separate storage if needed
+## Limits
 
-## Security
-
-- **Read-only**: Audit logs cannot be edited or deleted through the UI
-- **Administrator access only**: Only users with `administrator` role can view audit logs
-- **IP tracking**: All changes include the originating IP address
-- **Password exclusion**: Password fields are never stored in audit logs
-- **Rate limiting**: To prevent abuse and DoS attacks on sensitive audit data:
-  - 100 requests per minute per IP address
-  - 200 requests per minute per authenticated user
-  - Violations are logged for monitoring
-
-## Testing
-
-Audit trail functionality is tested in:
-
-- `spec/models/*_spec.rb` - Model-level versioning tests
-- `spec/policies/audit_log_policy_spec.rb` - Authorization tests
-- `spec/components/admin/audit_logs/*_spec.rb` - UI component tests
-
-## Future Enhancements
-
-Potential improvements for consideration:
-
-1. **Export functionality**: Allow administrators to export audit logs as CSV/JSON
-2. **Advanced search**: Full-text search across change data
-3. **Diff view**: Visual comparison of before/after states
-4. **Alerts**: Notify administrators of suspicious patterns
-5. **Retention policies**: Automated archival of old logs
+These controls provide stronger technical evidence; they do not by themselves create UK GDPR, DSPT, DTAC, DCB0129, DCB0160, or other regulatory compliance. Governance, operating procedures, supplier controls, clinical safety work, and deployment-specific approval remain required.

--- a/docs/compliance/audit-retention-policy.md
+++ b/docs/compliance/audit-retention-policy.md
@@ -1,0 +1,31 @@
+# Audit Evidence Retention Policy
+
+Policy version: `clinical-security-v1`
+
+Status: technical default awaiting deployment-specific records-manager and DPO approval.
+
+## Schedule
+
+The default minimum retention period for clinical/security audit evidence is ten years from the recorded event. Evidence inherits a longer period when the related clinical record, contract, statutory inquiry, litigation requirement, or approved local schedule requires it.
+
+Every ledger envelope stores the policy version and calculated `retain_until`. Later policy changes create a new version; they do not rewrite past decisions.
+
+## End-of-period review
+
+`retain_until` means eligible for review, not automatic deletion. The reviewer must confirm the governing record category, current law/policy, open incidents, inquiries, litigation, complaints, and legal holds. Continued retention needs a reason and review date.
+
+No automated disposal is enabled. A future disposal workflow must produce an immutable manifest identifying the approved scope, policy, approvers, time, and resulting Object Lock/database disposition.
+
+## Legal holds
+
+When a hold is issued:
+
+1. Record its authority, scope, owner, start date, and review date in the organisation's records system.
+2. Stop disposal for every matching chain/export.
+3. Extend Object Lock retention where required; never shorten existing retention.
+4. Record the change/incident reference in the signed evidence manifest.
+5. Require records-manager or legal approval to release the hold.
+
+Database-owner changes made to implement a hold require a separate external change record.
+
+Reference: [NHS Records Management Code of Practice 2021](https://transform.england.nhs.uk/media/documents/NHSX_Records_Management_CoP_V7.pdf).

--- a/docs/compliance/dcb0129-audit-evidence.md
+++ b/docs/compliance/dcb0129-audit-evidence.md
@@ -1,0 +1,17 @@
+# Clinical Safety Evidence: Audit Ledger
+
+This record supplies technical evidence for the clinical safety case. It does not declare DCB0129 or DCB0160 compliance.
+
+## Hazard contribution
+
+| Hazard | Potential harm | Control/evidence | Remaining dependency |
+|---|---|---|---|
+| Medication history is altered without detection | Investigation uses false dose/stock history | Synchronous source trigger, per-household hash chain, immutable runtime grants, verifier corruption cases | Database-owner oversight and operational verification |
+| Actor or authority cannot be reconstructed | Unsafe action cannot be attributed or reviewed | Versioned envelope records actor, role, permission version, auth method, policy/query, request and support context | Identity-provider and deployment logs must be retained |
+| Audit evidence disappears during outage/restore | Safety incident cannot be reconstructed | Transactional outbox, Object Lock copy, signed checkpoints, restore-divergence procedure | WORM backlog alerts and tested recovery |
+| Pre-migration evidence is treated as trustworthy | Incorrect historical assurance | `legacy-baseline` epoch and signed baseline limitation | Reviewers must preserve the label in reports |
+| Audit failure blocks or silently loses clinical work | Missed medication workflow or missing evidence | Local ledger is synchronous/fail-closed; WORM delivery is asynchronous and monitored | Capacity and failure-mode review before launch |
+
+The Clinical Safety Officer must link these controls to the hazard log, verify operating evidence, and assess new failure modes from storage, signing-key, and verifier dependencies.
+
+NHS England is reviewing DCB0129 and DCB0160. The safety case owner must track the replacement/revised standard and update this evidence: <https://digital.nhs.uk/data-and-information/information-standards/governance/latest-activity/standards-and-collections/review-of-digital-clinical-safety-standards-dcb0129-and-dcb0160>.

--- a/docs/compliance/dpia-audit-evidence.md
+++ b/docs/compliance/dpia-audit-evidence.md
@@ -1,0 +1,26 @@
+# DPIA Addendum: Audit Evidence
+
+This addendum is an input to a deployment DPIA, not a completed DPIA or legal approval.
+
+## Processing
+
+The audit envelope processes identifiers, roles, authorization decisions, request context, IP addresses, affected-record identifiers, and redacted event metadata. Native exports can contain historical source payloads and therefore require the same or stronger protection as the underlying health data.
+
+## Purpose and necessity
+
+The purposes are patient-safety investigation, security monitoring, access accountability, incident response, support-access oversight, records management, and evidence of control operation. Ordinary HTML page views are excluded to reduce unnecessary collection.
+
+## Risks and controls
+
+| Risk | Control | Residual decision |
+|---|---|---|
+| Tokens or credentials enter logs | Shared redaction, opaque session references, credential type/record IDs only | Review new event metadata before release |
+| Household evidence leaks | Per-household chains, tenant-filtered admin view, dedicated verifier/exporter roles | Restrict exported files and WORM read access |
+| History is changed or deleted | Immutable runtime grants, chained hashes, signed checkpoints, Object Lock copies | Database-owner activity needs external oversight |
+| Excessive retention | Versioned schedule and `retain_until`; no indefinite claim | Records manager/DPO approve production policy |
+| Existing history is overstated | Distinct `legacy-baseline` epoch and explicit limitation | Preserve baseline wording in reports |
+| Export creates another PHI copy | Signed manifest, audited export, controlled output path | Deployment must define transfer and deletion handling |
+
+## Required approval
+
+The deploying controller must document lawful basis, access roles, retention schedule, WORM provider/region, international transfers, data-subject handling, processor terms, incident contacts, and records-manager/DPO approval before production use.

--- a/docs/monetization-strategy.md
+++ b/docs/monetization-strategy.md
@@ -32,7 +32,7 @@ Monetize high-quality clinical data and labor-saving automations.
 
 ### Pillar D: Hardened Security Modules
 Features required for "High-Assurance" clinical use.
-*   **Forensic Audit Logs:** Tamper-evident log chaining, WORM (Write Once Read Many) storage support, and 10-year immutable retention.
+*   **Forensic Audit Logs:** Tamper-evident log chaining, WORM (Write Once Read Many) storage support, and policy-based retention with governed legal holds and disposal review.
 *   **SSO/OIDC Integration:** Custom enterprise identity provider mapping.
 
 ---

--- a/docs/operations/audit-evidence-runbook.md
+++ b/docs/operations/audit-evidence-runbook.md
@@ -1,0 +1,53 @@
+# Audit Evidence Operations
+
+## Production gate
+
+Do not enable WORM delivery until the records manager/DPO has approved the retention schedule, the bucket is versioned with Object Lock at creation time, encryption and expected owner are confirmed, governance mode has been exercised, and the exporter/verifier credentials have been proven unable to delete objects, shorten retention, bypass governance, read clinical tables, or modify ledger history. Record a representative concurrent-write load test and a ten-year database/object-store capacity estimate using measured event volume and payload sizes before approval.
+
+Compliance mode requires a separate records-governance change approval and `AUDIT_WORM_COMPLIANCE_APPROVED=true`.
+
+The capacity record must include peak audited writes per second, p95 insert latency, daily event count, average and p95 ledger/object bytes, index and backup overhead, replication, checkpoint/export overhead, forecast assumptions, safety margin, estimated cost, and the date when the estimate must be reviewed. Do not infer production capacity from the six-thread serialization regression spec.
+
+## Schedule
+
+- Run `SCOPE=database FORMAT=json task audit:verify` as a full daily check.
+- Run `SCOPE=worm FORMAT=json task audit:verify` on a rotating object sample daily and all objects at least monthly.
+- Run `task audit:monitor` at least once per minute.
+- Alert when the oldest pending delivery reaches five minutes; page at one hour.
+- Keep command output and alerts free of household, person, medication, event, and source identifiers.
+
+## Baseline
+
+Immediately after migration, sign every `legacy-baseline` checkpoint and export the native evidence and manifest to Object Lock. Record the manifest checksum, object version, public key ID, deployment version, migration time, and external change reference. State that integrity is proven from the baseline onward only.
+
+## Signing-key rotation
+
+1. Generate Ed25519 key material in the approved key-management system.
+2. Configure the new key ID/private key only in the exporter or one-off verifier process.
+3. Produce and verify a checkpoint with the new key.
+4. Retire the old private key from active use.
+5. Retain every old public key and signed checkpoint indefinitely while dependent evidence exists.
+6. Record the rotation in the external change system and export the resulting checkpoint.
+
+## Backlog response
+
+At five minutes, check exporter health, credentials, bucket owner/versioning/Object Lock/encryption, and delivery error codes. At one hour, page incident response. Do not discard rows, reset attempts, weaken retention, overwrite objects, or grant the exporter broader database access. Configuration/integrity failures require human resolution; temporary failures remain pending with bounded retry.
+
+## Integrity incident
+
+1. Stop affected exporter/verifier credentials without stopping local ledger writes.
+2. Preserve database snapshots, WORM versions, public keys, manifests, app/deployment logs, and request/trace IDs.
+3. Run combined JSON verification and store the unchanged output in the incident record.
+4. Identify the first invalid chain/sequence without exporting unrelated household data.
+5. Treat checksum, duplicate-version, retention, missing-object, source mismatch, and tail-truncation findings as evidence incidents.
+6. Do not repair or re-chain history in place. Recovery creates a new documented epoch/checkpoint after evidence preservation and approval.
+
+## Restore and disaster recovery
+
+After restoring PostgreSQL, run full database verification before enabling traffic. Compare every restored chain head and checkpoint with the latest signed WORM evidence. A backup that is internally valid but behind WORM is a restore-divergence incident; replay through an approved recovery process rather than deleting external evidence.
+
+Record backup identifier, database/app version, restore point, verifier version, manifest/checkpoint IDs, result, operator, and incident/change reference. Test restore and divergence handling at least quarterly.
+
+## Legal hold and disposal
+
+Follow [the retention policy](../compliance/audit-retention-policy.md). Holds are controlled in the external records system and may extend but never shorten WORM retention. There is no automatic audit-evidence disposal. Database-owner actions require an external incident/change record.

--- a/docs/operations/hosted-private-beta-runbook.md
+++ b/docs/operations/hosted-private-beta-runbook.md
@@ -18,6 +18,10 @@ Before onboarding another household, verify:
 - Invite-only registration is pinned by environment or platform-admin policy.
 - Backup and Restore test evidence exists for the current deployment.
 - Support access is only available through the audited Platform admin flow.
+- The audit exporter and verifier use dedicated credentials and cannot read clinical tables or mutate ledger history.
+- A signed `legacy-baseline` manifest has been retained outside PostgreSQL with its limitation recorded.
+- Full database and WORM verification pass; no delivery is older than five minutes.
+- The records manager/DPO has approved the versioned retention schedule and Object Lock mode.
 
 ## Tenant/RLS foundation verification
 
@@ -131,6 +135,8 @@ policy unless an explicit retention hold exists.
 4. Verify RLS default-denies without tenant context.
 5. Verify each restored household can only see its own people, medicines, schedules, notifications, audit rows, and attachments.
 6. Record restore date, backup identifier, app image/tag, migration version, tester, and outcome.
+7. Run combined audit verification and compare restored chain heads with signed WORM checkpoints.
+8. Treat a valid but older database chain as restore divergence; do not delete newer WORM evidence.
 
 ## Incident response
 
@@ -139,3 +145,4 @@ policy unless an explicit retention hold exists.
 3. Export a tenant-scoped evidence bundle for investigation.
 4. Patch and verify in an isolated environment.
 5. Re-run the go/no-go checklist before re-enabling affected access.
+6. Preserve signed manifests, public keys, Object Lock versions, delivery receipts, and verifier JSON output.

--- a/docs/uk-regulatory-compliance-plan.md
+++ b/docs/uk-regulatory-compliance-plan.md
@@ -73,6 +73,8 @@ MedTracker’s compliance posture depends primarily on its intended use. The pla
 
 ## 6. Clinical safety and human factors (DCB0129/0160)
 
+DCB0129 and DCB0160 remain applicable, but NHS England is actively reviewing them. The clinical safety case must track the revised or replacement standard and must not treat the current audit implementation as compliance on its own.
+
 - Appoint a Clinical Safety Officer (CSO) for manufacturer and for each deploying organisation.
 - Create a Safety Case and Hazard Log; use ISO 14971 risk management.
 - Human factors: implement the “five rights” prompts, clear error states, and confirmation flows.

--- a/lib/tasks/audit.rake
+++ b/lib/tasks/audit.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+namespace :audit do
+  desc 'Verify audit evidence with SCOPE=database|worm|combined and FORMAT=human|json'
+  task verify: :environment do
+    scope = ENV.fetch('SCOPE', 'database').downcase
+    worm_verifier = Audit::Verification::WormVerifierFactory.new.call if %w[worm combined].include?(scope)
+    status = Audit::Verification::Command.new(worm_verifier:).call
+    exit(status) unless status.zero?
+  end
+
+  desc 'Export native NDJSON, a signed manifest, and optional FHIR R4 AuditEvent resources'
+  task export: :environment do
+    filter = Audit::EntryFilter.new(ENV.to_h)
+    signer = Audit::ManifestSigner.new(
+      key_id: ENV.fetch('AUDIT_MANIFEST_SIGNING_KEY_ID'),
+      private_key_pem: audit_manifest_private_key
+    )
+    result = Audit::EvidenceExporter.new(
+      entries: filter.call, output_directory: ENV.fetch('OUTPUT', 'tmp/audit-exports/latest'),
+      manifest_signer: signer, household_id: ENV['HOUSEHOLD_ID'].presence&.to_i,
+      fhir: ActiveModel::Type::Boolean.new.cast(ENV.fetch('FHIR', nil))
+    ).call
+    puts({ native: result.native_path.to_s, manifest: result.manifest_path.to_s,
+           fhir: result.fhir_path&.to_s }.compact.to_json)
+  rescue KeyError, Audit::EntryFilter::Invalid, ArgumentError => e
+    warn("audit export could not run: #{e.message}")
+    exit(2)
+  end
+
+  desc 'Emit aggregate audit-delivery backlog status'
+  task monitor: :environment do
+    result = Audit::BacklogMonitor.new.call
+    puts({ severity: result.severity, pending_count: result.pending_count,
+           oldest_age_seconds: result.oldest_age_seconds }.to_json)
+    exit(1) if result.severity == 'critical'
+  end
+
+  def audit_manifest_private_key
+    path = ENV.fetch('AUDIT_MANIFEST_SIGNING_PRIVATE_KEY_FILE', nil)
+    return File.binread(path) if path.present?
+
+    ENV.fetch('AUDIT_MANIFEST_SIGNING_PRIVATE_KEY')
+  end
+end

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe YAML do
     expect(init_roles_sql).not_to include('GRANT med_tracker_owner TO medtracker_audit_exporter;')
   end
 
+  it 'runs audit verification without web, exporter, owner, or clinical database privileges', :aggregate_failures do
+    verifier = compose_config.dig('services', 'audit-verifier-prod')
+
+    expect(verifier.dig('environment', 'DATABASE_ROLE')).to eq('med_tracker_audit_verifier')
+    expect(verifier.dig('environment', 'DATABASE_URL')).to include('medtracker_audit_verifier:')
+    expect(verifier['environment']).to include('SCOPE', 'FORMAT', 'HOUSEHOLD_ID', 'FROM', 'TO')
+    expect(init_roles_sql).to include('GRANT med_tracker_audit_verifier TO medtracker_audit_verifier;')
+    expect(init_roles_sql).not_to include('GRANT med_tracker_owner TO medtracker_audit_verifier;')
+    expect(init_roles_sql).not_to include('GRANT med_tracker_app TO medtracker_audit_verifier;')
+  end
+
   it 'bootstraps the deployed runtime role without owner or bypassrls privileges' do
     expect(init_roles_sql).to include('ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;')
     expect(init_roles_sql).to include('GRANT USAGE ON SCHEMA public TO med_tracker_app;')

--- a/spec/migrations/configure_audit_verifier_role_spec.rb
+++ b/spec/migrations/configure_audit_verifier_role_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260709150000_configure_audit_verifier_role')
+
+RSpec.describe ConfigureAuditVerifierRole do
+  it 'can read audit evidence and record exports without reading clinical tables' do
+    expect(privilege('audit_ledger_entries', 'SELECT')).to be(true)
+    expect(privilege('security_audit_events', 'SELECT')).to be(true)
+    expect(privilege('security_audit_events', 'INSERT')).to be(true)
+    expect(privilege('versions', 'SELECT')).to be(true)
+    expect(privilege('medications', 'SELECT')).to be(false)
+  end
+
+  it 'cannot alter source, ledger, checkpoint, or delivery history' do
+    expect(privilege('security_audit_events', 'UPDATE')).to be(false)
+    expect(privilege('versions', 'DELETE')).to be(false)
+    expect(privilege('audit_ledger_entries', 'UPDATE')).to be(false)
+    expect(privilege('audit_checkpoints', 'INSERT')).to be(false)
+    expect(privilege('audit_export_deliveries', 'UPDATE')).to be(false)
+  end
+
+  it 'revokes verifier access when rolled back' do
+    migration = described_class.new
+
+    migration.down
+
+    expect(privilege('audit_ledger_entries', 'SELECT')).to be(false)
+    expect(privilege('security_audit_events', 'INSERT')).to be(false)
+  ensure
+    migration&.lock_verifier_privileges
+  end
+
+  def privilege(table_name, action)
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT has_table_privilege('med_tracker_audit_verifier', '#{table_name}', '#{action}')
+    SQL
+  end
+end

--- a/spec/services/audit/backlog_monitor_spec.rb
+++ b/spec/services/audit/backlog_monitor_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::BacklogMonitor do
+  it 'emits only aggregate warning and critical backlog data' do
+    now = Time.iso8601('2026-07-09T13:00:00Z')
+    deliveries = [
+      instance_double(AuditExportDelivery, created_at: now - 10.minutes),
+      instance_double(AuditExportDelivery, created_at: now - 70.minutes)
+    ]
+    events, subscription = capture_notifications
+
+    result = described_class.new(deliveries:, now:).call
+
+    expect(result).to have_attributes(severity: 'critical', pending_count: 2, oldest_age_seconds: 4200)
+    expect(events).to contain_exactly(
+      severity: 'critical', pending_count: 2, oldest_age_seconds: 4200,
+      warning_threshold_seconds: 300, critical_threshold_seconds: 3600
+    )
+    expect(events.first.keys).not_to include(:household_id, :source_id, :event_type)
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+  end
+
+  it 'reports healthy when the outbox has no overdue entries' do
+    now = Time.iso8601('2026-07-09T13:00:00Z')
+    delivery = instance_double(AuditExportDelivery, created_at: now - 1.minute)
+
+    result = described_class.new(deliveries: [delivery], now:).call
+
+    expect(result.severity).to eq('healthy')
+  end
+
+  def capture_notifications
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe('audit_delivery_backlog.med_tracker') do |event|
+      events << event.payload
+    end
+    [events, subscription]
+  end
+end

--- a/spec/services/audit/entry_filter_spec.rb
+++ b/spec/services/audit/entry_filter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::EntryFilter do
+  it 'filters by household and inclusive ISO 8601 time bounds' do
+    relation = instance_double(ActiveRecord::Relation)
+    household_relation = instance_double(ActiveRecord::Relation)
+    from_relation = instance_double(ActiveRecord::Relation)
+    from = Time.iso8601('2026-07-01T00:00:00Z')
+    to = Time.iso8601('2026-07-02T00:00:00Z')
+    allow(relation).to receive(:where).with(household_id: 42).and_return(household_relation)
+    allow(household_relation).to receive(:where).with(occurred_at: from..).and_return(from_relation)
+    allow(from_relation).to receive(:where).with(occurred_at: ..to).and_return(:filtered)
+
+    result = described_class.new(
+      { 'HOUSEHOLD_ID' => '42', 'FROM' => from.iso8601, 'TO' => to.iso8601 }, relation:
+    ).call
+
+    expect(result).to eq(:filtered)
+  end
+
+  it 'rejects invalid household and time filters' do
+    expect do
+      described_class.new({ 'HOUSEHOLD_ID' => 'not-an-id' }).call
+    end.to raise_error(described_class::Invalid, 'invalid HOUSEHOLD_ID')
+
+    expect do
+      described_class.new({ 'FROM' => 'yesterday' }).call
+    end.to raise_error(described_class::Invalid, 'invalid FROM')
+  end
+end

--- a/spec/services/audit/evidence_exporter_spec.rb
+++ b/spec/services/audit/evidence_exporter_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'tmpdir'
+
+RSpec.describe Audit::EvidenceExporter do
+  fixtures :accounts, :people, :users
+
+  let(:household) { users(:admin).person.household }
+  let(:manifest_signer) do
+    private_key = OpenSSL::PKey.generate_key('ED25519')
+    Audit::ManifestSigner.new(key_id: 'export-key-2026-01', private_key_pem: private_key.private_to_pem)
+  end
+  let(:directory) { Pathname(Dir.mktmpdir('audit-export')) }
+  let(:result) do
+    described_class.new(
+      entries: AuditLedgerEntry.where(household:), output_directory: directory,
+      manifest_signer:, household_id: household.id, fhir: true,
+      clock: -> { Time.iso8601('2026-07-09T12:30:00Z') }
+    ).call
+  end
+  let(:manifest) { JSON.parse(File.binread(result.manifest_path)) }
+
+  before { Audit::Event.record!(household:, event_type: 'audit.export.subject', metadata: { outcome: 'success' }) }
+
+  after { FileUtils.remove_entry(directory) if directory.exist? }
+
+  it 'writes deterministic native evidence and audits the export' do
+    native_lines = File.readlines(result.native_path, chomp: true).map { |line| JSON.parse(line) }
+
+    expect(native_lines).not_to be_empty
+    expect(native_lines).to all(include('evidence_type' => 'ledger_entry'))
+    expect(SecurityAuditEvent.where(event_type: 'audit.evidence.exported', household:)).to exist
+  end
+
+  it 'does not record a successful export when evidence cannot be written' do
+    allow(File).to receive(:binwrite).and_raise(Errno::ENOSPC)
+
+    expect { result }.to raise_error(Errno::ENOSPC)
+    expect(SecurityAuditEvent.where(event_type: 'audit.evidence.exported', household:)).not_to exist
+  end
+
+  it 'writes a signed manifest for the native evidence' do
+    expect(manifest.dig('files', 'audit.ndjson', 'sha256')).to eq(Digest::SHA256.file(result.native_path).hexdigest)
+    expect(manifest.dig('signing', 'key_id')).to eq('export-key-2026-01')
+    expect(manifest_signature_valid?(manifest)).to be(true)
+  end
+
+  it 'optionally writes a FHIR R4 AuditEvent bundle' do
+    bundle = JSON.parse(File.binread(result.fhir_path))
+
+    expect(bundle).to include('resourceType' => 'Bundle', 'type' => 'collection')
+    expect(bundle.fetch('entry')).to all(satisfy { |item| item.dig('resource', 'resourceType') == 'AuditEvent' })
+  end
+
+  private
+
+  def manifest_signature_valid?(manifest)
+    signing = manifest.fetch('signing')
+    unsigned = manifest.except('signing')
+    public_key = OpenSSL::PKey.read(Base64.strict_decode64(signing.fetch('public_key')))
+    public_key.verify(
+      nil, Base64.strict_decode64(signing.fetch('signature')),
+      Audit::ManifestSigner.canonical_json(unsigned)
+    )
+  end
+end

--- a/spec/services/audit/fhir_audit_event_mapper_spec.rb
+++ b/spec/services/audit/fhir_audit_event_mapper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::FhirAuditEventMapper do
+  let(:entry) do
+    instance_double(
+      AuditLedgerEntry,
+      envelope: {
+        'event_id' => 'aaf4883c-a035-4ff0-a96d-df2f4a3597a0',
+        'event_type' => 'medication.read', 'outcome' => 'success',
+        'occurred_at' => '2026-07-09T12:00:00.000000Z',
+        'agent' => { 'account_id' => 42, 'role' => 'administrator' },
+        'policy' => { 'class' => 'MedicationPolicy', 'query' => 'show?' },
+        'request' => { 'ip' => '192.0.2.10' },
+        'source' => { 'table' => 'versions', 'id' => 9 },
+        'entity' => { 'type' => 'Medication', 'id' => 7 }
+      }
+    )
+  end
+
+  it 'maps the native envelope to a valid-shaped FHIR R4 AuditEvent' do
+    resource = described_class.new(entry).to_h
+
+    expect(resource).to include(
+      resourceType: 'AuditEvent', id: 'aaf4883c-a035-4ff0-a96d-df2f4a3597a0',
+      action: 'R', recorded: '2026-07-09T12:00:00.000000Z', outcome: '0',
+      type: hash_including(code: '110100'),
+      source: hash_including(observer: hash_including(identifier: hash_including(value: 'medtracker')))
+    )
+    expect(resource.dig(:agent, 0, :requestor)).to be(true)
+    expect(resource.dig(:agent, 0, :role, 0, :coding, 0, :code)).to eq('administrator')
+    expect(resource.dig(:entity, 0, :what, :identifier, :value)).to eq('versions/9')
+  end
+end

--- a/spec/services/audit/object_lock/s3_adapter_spec.rb
+++ b/spec/services/audit/object_lock/s3_adapter_spec.rb
@@ -104,6 +104,31 @@ RSpec.describe Audit::ObjectLock::S3Adapter do
     expect { adapter.write(entry) }.to raise_error(Audit::ObjectLock::IntegrityError, /retention is too short/)
   end
 
+  it 'verifies the exact delivered object version' do
+    serializer = Audit::ObjectLock::RecordSerializer.new(entry)
+    delivery = delivery_for(serializer)
+    allow(client).to receive_messages(
+      head_object: valid_head(serializer, version_id: 'version-1'),
+      list_object_versions: instance_double(
+        Aws::S3::Types::ListObjectVersionsOutput, versions: [object_version(serializer, 'version-1')]
+      )
+    )
+
+    expect(adapter.verify(entry, delivery:)).to be(true)
+  end
+
+  it 'rejects duplicate object versions' do
+    serializer = Audit::ObjectLock::RecordSerializer.new(entry)
+    delivery = delivery_for(serializer)
+    versions = [object_version(serializer, 'version-1'), object_version(serializer, 'version-2')]
+    allow(client).to receive_messages(
+      head_object: valid_head(serializer, version_id: 'version-1'),
+      list_object_versions: instance_double(Aws::S3::Types::ListObjectVersionsOutput, versions:)
+    )
+
+    expect { adapter.verify(entry, delivery:) }.to raise_error(Audit::ObjectLock::IntegrityError, /duplicate/)
+  end
+
   def stub_valid_bucket
     object_lock = instance_double(Aws::S3::Types::ObjectLockConfiguration, object_lock_enabled: 'Enabled')
     allow(client).to receive_messages(
@@ -136,5 +161,26 @@ RSpec.describe Audit::ObjectLock::S3Adapter do
       Aws::S3::Types::GetBucketEncryptionOutput,
       server_side_encryption_configuration: configuration
     )
+  end
+
+  def valid_head(serializer, version_id:)
+    instance_double(
+      Aws::S3::Types::HeadObjectOutput,
+      checksum_sha256: serializer.checksum_sha256_base64,
+      metadata: {}, object_lock_retain_until_date: entry.retain_until,
+      object_lock_mode: 'GOVERNANCE', version_id:
+    )
+  end
+
+  def delivery_for(serializer)
+    instance_double(
+      AuditExportDelivery,
+      object_key: serializer.object_key, checksum_sha256: serializer.checksum_sha256,
+      object_version_id: 'version-1', retention_mode: 'GOVERNANCE', retain_until: entry.retain_until
+    )
+  end
+
+  def object_version(serializer, version_id)
+    instance_double(Aws::S3::Types::ObjectVersion, key: serializer.object_key, version_id:)
   end
 end

--- a/spec/services/audit/verification/command_spec.rb
+++ b/spec/services/audit/verification/command_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Verification::Command do
+  let(:output) { StringIO.new }
+  let(:error_output) { StringIO.new }
+
+  it 'emits stable JSON and returns zero for valid evidence' do
+    result = Audit::Verification::Result.new(scope: 'database', checked_entries: 2, checked_checkpoints: 1,
+                                             checked_objects: 0, issues: [])
+    verifier = instance_double(Audit::Verification::DatabaseVerifier, call: result)
+
+    exit_code = described_class.new(environment: { 'FORMAT' => 'json', 'SCOPE' => 'database' },
+                                    output:, error_output:, database_verifier: verifier).call
+
+    expect(exit_code).to eq(0)
+    expect(JSON.parse(output.string)).to eq(
+      'scope' => 'database', 'valid' => true, 'exit_code' => 0,
+      'checked_entries' => 2, 'checked_checkpoints' => 1, 'checked_objects' => 0, 'issues' => []
+    )
+  end
+
+  it 'returns one for integrity failures' do
+    issue = Audit::Verification::Issue.new(code: 'entry_hash_mismatch', message: 'entry hash differs',
+                                           chain_key: 'global', sequence: 1)
+    result = Audit::Verification::Result.new(scope: 'database', checked_entries: 1, checked_checkpoints: 0,
+                                             checked_objects: 0, issues: [issue])
+    verifier = instance_double(Audit::Verification::DatabaseVerifier, call: result)
+
+    exit_code = described_class.new(environment: { 'FORMAT' => 'json' }, output:, error_output:,
+                                    database_verifier: verifier).call
+
+    expect(exit_code).to eq(1)
+    expect(JSON.parse(output.string).fetch('issues').first.fetch('code')).to eq('entry_hash_mismatch')
+  end
+
+  it 'returns two with PHI-safe output for invalid configuration or runtime failure' do
+    verifier = instance_double(Audit::Verification::DatabaseVerifier)
+    allow(verifier).to receive(:call).and_raise(Audit::Verification::ConfigurationError, 'invalid FROM')
+
+    exit_code = described_class.new(environment: {}, output:, error_output:, database_verifier: verifier).call
+
+    expect(exit_code).to eq(2)
+    expect(error_output.string).to include('audit verification could not run: invalid FROM')
+  end
+end

--- a/spec/services/audit/verification/database_verifier_spec.rb
+++ b/spec/services/audit/verification/database_verifier_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Verification::DatabaseVerifier do
+  fixtures :accounts, :people, :users
+
+  let(:household) { users(:admin).person.household }
+
+  it 'validates source rows, canonical payloads, hash links, chain heads, and signed checkpoints' do
+    first = ledger_entry_for('audit.verify.first')
+    second = ledger_entry_for('audit.verify.second')
+    signer.sign(second)
+
+    result = described_class.new(entries: AuditLedgerEntry.where(id: [first.id, second.id])).call
+
+    expect(result).to be_valid
+    expect(result.checked_entries).to eq(2)
+    expect(result.checked_checkpoints).to eq(1)
+  end
+
+  it 'reports a modified entry hash' do
+    entry = ledger_entry_for('audit.verify.hash')
+    execute("UPDATE audit_ledger_entries SET entry_hash = decode('#{'00' * 32}', 'hex') WHERE id = #{entry.id}")
+
+    result = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+
+    expect(result.issue_codes).to include('entry_hash_mismatch', 'chain_head_mismatch')
+    expect(result.exit_code).to eq(1)
+  end
+
+  it 'reports source-row divergence' do
+    entry = ledger_entry_for('audit.verify.source')
+    execute("UPDATE security_audit_events SET event_type = 'audit.verify.changed' WHERE id = #{entry.source_id}")
+
+    result = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+
+    expect(result.issue_codes).to include('source_payload_mismatch')
+  end
+
+  it 'reports missing or duplicated sequence positions' do
+    first = ledger_entry_for('audit.verify.sequence.first')
+    second = ledger_entry_for('audit.verify.sequence.second')
+    missing = second.dup
+    missing.sequence += 2
+    duplicate = second.dup
+    duplicate.sequence = first.sequence
+
+    missing_result = described_class.new(entries: [missing], verify_heads: false).call
+    duplicated = described_class.new(entries: [first, duplicate], verify_heads: false).call
+
+    expect(missing_result.issue_codes).to include('sequence_gap')
+    expect(duplicated.issue_codes).to include('sequence_gap')
+  end
+
+  it 'validates independent household chains together' do
+    first = ledger_entry_for('audit.verify.mixed.first')
+    other_household = Household.create!(name: 'Independent verifier household')
+    event = Audit::Event.record!(household: other_household, event_type: 'audit.verify.mixed.second',
+                                 metadata: { outcome: 'success' })
+    second = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+
+    result = described_class.new(entries: [second, first]).call
+
+    expect(result).to be_valid
+  end
+
+  it 'reports a deleted chain tail instead of accepting the shortened ledger' do
+    entry = ledger_entry_for('audit.verify.truncated')
+    execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
+    execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
+
+    result = described_class.new(entries: AuditLedgerEntry.none).call
+
+    expect(result.issue_codes).to include('chain_head_mismatch')
+  end
+
+  it 'reports unsigned and invalid checkpoint evidence' do
+    entry = ledger_entry_for('audit.verify.checkpoint')
+    checkpoint = AuditCheckpoint.create!(
+      household:, chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+      checkpoint_kind: 'periodic', sequence: entry.sequence, entry_hash: entry.entry_hash
+    )
+
+    unsigned = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    expect(unsigned.issue_codes).to include('checkpoint_unsigned')
+
+    signer.sign(entry)
+    execute("UPDATE audit_checkpoints SET signature = decode('00', 'hex') WHERE id = #{checkpoint.id}")
+    invalid = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    expect(invalid.issue_codes).to include('checkpoint_signature_invalid')
+  end
+
+  private
+
+  def signer
+    @signer ||= Audit::CheckpointSigner.new(
+      key_id: 'verification-key', private_key_pem: OpenSSL::PKey.generate_key('ED25519').private_to_pem
+    )
+  end
+
+  def ledger_entry_for(event_type)
+    event = Audit::Event.record!(household:, event_type:, metadata: { outcome: 'success' })
+    AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+  end
+
+  def execute(sql)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/spec/services/audit/verification/worm_verifier_factory_spec.rb
+++ b/spec/services/audit/verification/worm_verifier_factory_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Verification::WormVerifierFactory do
+  let(:adapter) { instance_double(Audit::ObjectLock::S3Adapter, validate!: true) }
+  let(:configuration) { instance_double(Audit::ObjectLock::Configuration) }
+
+  it 'validates Object Lock before building a verifier for the filtered records' do
+    allow(Audit::ObjectLock::Configuration).to receive(:new).and_return(configuration)
+    allow(Audit::ObjectLock::S3Adapter).to receive(:new).with(configuration:).and_return(adapter)
+
+    verifier = described_class.new({}).call
+
+    expect(adapter).to have_received(:validate!)
+    expect(verifier).to be_a(Audit::Verification::WormVerifier)
+  end
+
+  it 'reports invalid filters as configuration failures' do
+    expect do
+      described_class.new('HOUSEHOLD_ID' => 'invalid').call
+    end.to raise_error(Audit::Verification::ConfigurationError, 'invalid HOUSEHOLD_ID')
+  end
+end

--- a/spec/services/audit/verification/worm_verifier_spec.rb
+++ b/spec/services/audit/verification/worm_verifier_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Verification::WormVerifier do
+  let(:adapter) { instance_double(Audit::ObjectLock::S3Adapter) }
+  let(:record) { instance_double(AuditLedgerEntry, chain_key: 'global', sequence: 1) }
+  let(:delivery) do
+    instance_double(AuditExportDelivery, delivered?: true, pending?: false, failed?: false,
+                                         export_record: record)
+  end
+
+  it 'validates every delivered object and returns a valid result' do
+    allow(adapter).to receive(:verify).with(record, delivery:).and_return(true)
+
+    result = described_class.new(records: [record], deliveries: [delivery], adapter:).call
+
+    expect(result).to be_valid
+    expect(result.checked_objects).to eq(1)
+  end
+
+  it 'reports missing outbox rows and undelivered evidence' do
+    pending = instance_double(AuditExportDelivery, delivered?: false, pending?: true, failed?: false,
+                                                   export_record: record)
+
+    missing = described_class.new(records: [record], deliveries: [], adapter:).call
+    undelivered = described_class.new(records: [record], deliveries: [pending], adapter:).call
+
+    expect(missing.issue_codes).to include('worm_delivery_missing')
+    expect(undelivered.issue_codes).to include('worm_delivery_pending')
+  end
+
+  it 'reports remote checksum, version, retention, or duplicate divergence' do
+    allow(adapter).to receive(:verify)
+      .and_raise(Audit::ObjectLock::IntegrityError, 'existing audit object checksum does not match')
+
+    result = described_class.new(records: [record], deliveries: [delivery], adapter:).call
+
+    expect(result.issue_codes).to include('worm_object_invalid')
+    expect(result.issues.first.message).to eq('existing audit object checksum does not match')
+  end
+
+  it 'treats object-store availability failures as runtime errors' do
+    allow(adapter).to receive(:verify).and_raise(Audit::ObjectLock::RetryableError, 'unavailable')
+
+    expect do
+      described_class.new(records: [record], deliveries: [delivery], adapter:).call
+    end.to raise_error(Audit::ObjectLock::RetryableError)
+  end
+end

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -13,6 +13,7 @@ module DatabaseRuntimeRoleSetup
     db/migrate/20260709131100_enforce_audit_ledger_immutability.rb
     db/migrate/20260709143000_configure_audit_object_lock_exporter.rb
     db/migrate/20260709143100_enforce_recent_household_row_level_security.rb
+    db/migrate/20260709150000_configure_audit_verifier_role.rb
   ].freeze
 
   def self.call
@@ -34,6 +35,7 @@ module DatabaseRuntimeRoleSetup
       EnforceAuditLedgerImmutability.new.up
       install_audit_exporter_database_objects
       EnforceRecentHouseholdRowLevelSecurity.new.install_policies
+      install_audit_verifier_database_objects
     end
   end
 
@@ -59,6 +61,12 @@ module DatabaseRuntimeRoleSetup
     migration.send(:install_exporter_role)
     migration.send(:install_checkpoint_function)
     migration.send(:lock_exporter_privileges)
+  end
+
+  def self.install_audit_verifier_database_objects
+    migration = ConfigureAuditVerifierRole.new
+    migration.install_verifier_role
+    migration.lock_verifier_privileges
   end
 end
 


### PR DESCRIPTION
## Why

A tamper-evident ledger only helps if operators can independently prove that it is intact and safely provide evidence during an investigation. The earlier stages created the audit contract, database chain, signed checkpoints, and Object Lock delivery; this final stage makes those controls usable and reviewable in day-to-day operations.

## What changes

- Adds one verification command for database evidence, Object Lock copies, or both, with stable human and JSON results and distinct integrity/configuration exit codes.
- Detects changed or missing source rows, broken or truncated chains, invalid checkpoints, missing deliveries, checksum/version/retention mismatches, and duplicate remote objects.
- Exports deterministic native evidence with a signed manifest and an optional FHIR R4 AuditEvent bundle. Every export is itself audited.
- Runs verification and export through a dedicated database role that can read audit evidence and record the export, but cannot read clinical tables or alter audit history.
- Adds delivery backlog monitoring plus honest retention, DPIA, clinical-safety, incident, restore, legal-hold, and production-gate guidance.
- Fixes reminder eligibility so an injected evaluation time is used consistently instead of being mixed with the server clock.

This completes the fourth implementation stage for #509. It strengthens evidence and operations without claiming that the software alone creates regulatory compliance.