### PR TITLE
refactor(admin): extract user lifecycle services

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,32 +36,14 @@ module Admin
       @user = User.new(user_params)
       authorize @user
 
-      unless create_membership_role_valid?
-        respond_to do |format|
+      respond_to do |format|
+        if provision_user.success?
+          format.html { redirect_to admin_users_path, notice: t('users.created') }
+          format.turbo_stream { render_users_index_turbo(t('users.created')) }
+        else
           format.html { render_user_form_with_errors }
           format.turbo_stream { render_user_form_with_errors }
         end
-        return
-      end
-
-      if account_already_exists?
-        respond_to do |format|
-          format.html { render_user_form_with_errors }
-          format.turbo_stream { render_user_form_with_errors }
-        end
-        return
-      end
-
-      create_user_with_account!
-      respond_to do |format|
-        format.html { redirect_to admin_users_path, notice: t('users.created') }
-        format.turbo_stream { render_users_index_turbo(t('users.created')) }
-      end
-    rescue ActiveRecord::RecordInvalid => e
-      handle_record_invalid_error(e)
-      respond_to do |format|
-        format.html { render_user_form_with_errors }
-        format.turbo_stream { render_user_form_with_errors }
       end
     end
 
@@ -83,76 +65,19 @@ module Admin
     def destroy
       @user = policy_scope(User).find(params.expect(:id))
       authorize @user
-
-      respond_to do |format|
-        if @user == current_user
-          format.html { redirect_to admin_users_path, alert: t('users.cannot_deactivate_self') }
-          format.turbo_stream do
-            flash.now[:alert] = t('users.cannot_deactivate_self')
-            render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert])),
-                   status: :unprocessable_content
-          end
-        elsif owner_deactivation_blocked?
-          format.html { redirect_to admin_users_path, alert: t('users.owner_deactivation_rejected') }
-          format.turbo_stream do
-            flash.now[:alert] = t('users.owner_deactivation_rejected')
-            render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert])),
-                   status: :unprocessable_content
-          end
-        else
-          @user.deactivate!
-          format.html { redirect_to admin_users_path, notice: t('users.deactivated') }
-          format.turbo_stream do
-            flash.now[:notice] = t('users.deactivated')
-            render turbo_stream: user_row_streams(@user)
-          end
-        end
-      end
+      respond_to_user_lifecycle(run_user_lifecycle(:deactivate))
     end
 
     def activate
       @user = policy_scope(User).find(params.expect(:id))
       authorize @user
-
-      @user.activate!
-      respond_to do |format|
-        format.html { redirect_to admin_users_path, notice: t('users.activated') }
-        format.turbo_stream do
-          flash.now[:notice] = t('users.activated')
-          render turbo_stream: user_row_streams(@user)
-        end
-      end
+      respond_to_user_lifecycle(run_user_lifecycle(:activate))
     end
 
     def verify
       @user = policy_scope(User).find(params.expect(:id))
       authorize @user
-
-      account = @user.person&.account
-      unless account
-        respond_to do |format|
-          format.html { redirect_to admin_users_path, alert: t('admin.users.missing_account') }
-          format.turbo_stream do
-            flash.now[:alert] = t('admin.users.missing_account')
-            render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert])),
-                   status: :unprocessable_content
-          end
-        end
-        return
-      end
-
-      ActiveRecord::Base.transaction do
-        account.update!(status: :verified)
-        AccountVerificationKey.where(account_id: account.id).delete_all
-      end
-
-      respond_to do |format|
-        format.html { redirect_to admin_users_path, notice: t('users.verified') }
-        format.turbo_stream do
-          flash.now[:notice] = t('users.verified')
-          render turbo_stream: user_row_streams(@user)
-        end
-      end
+      respond_to_user_lifecycle(run_user_lifecycle(:verify))
     end
 
     private
@@ -166,58 +91,17 @@ module Admin
         dependent_assignment_scope.where(person_type: %i[minor dependent_adult], has_capacity: false).order(:name).to_a
     end
 
-    def account_already_exists?
-      return false unless Account.exists?(email: @user.email_address)
-
-      @user.errors.add(:email_address, :taken)
-      true
-    end
-
-    def create_membership_role_valid?
-      requested_role = @user.membership_role.presence || 'member'
-      return true if ::Admin::MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
-
-      @user.errors.add(:membership_role, create_membership_role_error(requested_role))
-      false
-    end
-
-    def create_membership_role_error(requested_role)
-      if requested_role == ::Admin::MembershipRoleUpdater::OWNER_ROLE
-        t('admin.membership_roles.owner_rejected')
-      else
-        t('admin.membership_roles.invalid_role')
-      end
-    end
-
-    def create_user_with_account!
-      ActiveRecord::Base.transaction do
-        account = Account.create!(
-          email: @user.email_address,
-          password_hash: BCrypt::Password.create(params[:user][:password]),
-          status: :verified
-        )
-        @user.person.account = account
-        @user.person.household ||= admin_target_household
-        @user.save!
-        membership = create_household_membership_for(account, @user.person)
-        grant_person_access(membership, @user.person, :manage, :self)
-        assign_dependents(membership)
-      end
+    def provision_user
+      Admin::UserProvisioner.new(
+        user: @user,
+        password: params.dig(:user, :password),
+        household: admin_target_household,
+        actor_membership: admin_target_membership
+      ).call
     end
 
     def update_user_profile
-      ActiveRecord::Base.transaction do
-        @user.update(user_update_params)
-      end
-    end
-
-    def handle_record_invalid_error(exception)
-      @user ||= User.new(user_params)
-      return unless exception.record.is_a?(Account) && exception.record.errors[:email].any?
-
-      exception.record.errors[:email].each do |error|
-        @user.errors.add(:email_address, error)
-      end
+      @user.update(user_update_params)
     end
 
     def render_user_form_with_errors
@@ -300,20 +184,6 @@ module Admin
       )
     end
 
-    def assign_dependents(membership = nil)
-      return if carer_relationship_type.blank?
-
-      relationships = DependentRelationshipAssigner.new(
-        carer: @user.person,
-        dependent_ids: @user.dependent_ids,
-        relationship_type: carer_relationship_type,
-        scope: dependent_assignment_scope
-      ).call
-      relationships.each do |relationship|
-        grant_person_access(membership, relationship.patient, dependent_access_level, dependent_relationship_type)
-      end
-    end
-
     def admin_target_household
       current_household || default_household_for_urls
     end
@@ -322,51 +192,14 @@ module Admin
       current_membership || current_account&.active_household_membership_for(admin_target_household)
     end
 
-    def owner_deactivation_blocked?
-      !owner_governance.can_deactivate_owner_user?(existing_household_membership_for(@user))
-    end
-
-    def owner_governance
-      @owner_governance ||= Admin::OwnerGovernance.new(
+    def run_user_lifecycle(action)
+      Admin::UserLifecycleUpdater.new(
+        user: @user,
+        action: action,
+        actor: current_user,
         household: admin_target_household,
         actor_membership: admin_target_membership
-      )
-    end
-
-    def existing_household_membership_for(user)
-      account = user.person&.account
-      return unless admin_target_household && account
-
-      admin_target_household.household_memberships.active.find_by(account: account)
-    end
-
-    def create_household_membership_for(account, person)
-      return unless admin_target_household
-
-      admin_target_household.household_memberships.create!(
-        account: account,
-        person: person,
-        role: membership_role,
-        status: :active
-      )
-    end
-
-    def household_membership_for(user)
-      return unless admin_target_household
-
-      membership = admin_target_household.household_memberships.active.find_or_initialize_by(account: user.person.account)
-      membership.person = user.person
-      membership.role = membership_role
-      membership.status = :active
-      membership.save!
-      membership
-    end
-
-    def membership_role
-      requested_role = @user.membership_role.presence
-      return requested_role if ::Admin::MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
-
-      :member
+      ).call
     end
 
     def dependent_assignment_scope
@@ -375,43 +208,27 @@ module Admin
       Person.where(household: admin_target_household)
     end
 
-    def grant_person_access(membership, person, access_level, relationship_type)
-      return unless admin_target_household && membership && person&.household_id == admin_target_household.id
-
-      grant = admin_target_household.person_access_grants.find_or_initialize_by(
-        household_membership: membership,
-        person: person
-      )
-      grant.access_level = access_level
-      grant.relationship_type = relationship_type
-      grant.granted_by_membership ||= admin_target_membership || membership
-      grant.revoked_at = nil
-      grant.save!
-    end
-
-    def dependent_access_level
-      requested_level = @user.dependent_access_level.presence
-      return requested_level if PersonAccessGrant.access_levels.key?(requested_level)
-
-      dependent_relationship_type == 'parent' ? :manage : :record
-    end
-
-    def dependent_relationship_type
-      requested_type = @user.dependent_relationship_type.presence
-      return requested_type if PersonAccessGrant.relationship_types.key?(requested_type) && requested_type != 'self'
-
-      :professional
-    end
-
-    def carer_relationship_type
-      case dependent_relationship_type.to_s
-      when 'parent'
-        'parent'
-      when 'family_member'
-        'family_member'
-      else
-        'professional_carer'
+    def respond_to_user_lifecycle(result)
+      respond_to do |format|
+        if result.success?
+          format.html { redirect_to admin_users_path, notice: result.message }
+          format.turbo_stream { render_user_lifecycle_success(result.message) }
+        else
+          format.html { redirect_to admin_users_path, alert: result.message }
+          format.turbo_stream { render_user_lifecycle_failure(result.message) }
+        end
       end
+    end
+
+    def render_user_lifecycle_success(message)
+      flash.now[:notice] = message
+      render turbo_stream: user_row_streams(@user)
+    end
+
+    def render_user_lifecycle_failure(message)
+      flash.now[:alert] = message
+      render turbo_stream: turbo_stream.update('flash', Components::Layouts::Flash.new(alert: flash[:alert])),
+             status: :unprocessable_content
     end
 
     def user_row_streams(user)

--- a/app/services/admin/user_lifecycle_updater.rb
+++ b/app/services/admin/user_lifecycle_updater.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Admin
+  class UserLifecycleUpdater
+    Result = Data.define(:success?, :message)
+
+    def initialize(user:, action:, actor:, household:, actor_membership:)
+      @user = user
+      @action = action.to_sym
+      @actor = actor
+      @household = household
+      @actor_membership = actor_membership
+    end
+
+    def call
+      case action
+      when :activate
+        activate
+      when :deactivate
+        deactivate
+      when :verify
+        verify
+      else
+        raise ArgumentError, "Unsupported user lifecycle action: #{action}"
+      end
+    end
+
+    private
+
+    attr_reader :user, :action, :actor, :household, :actor_membership
+
+    def activate
+      user.activate!
+      success('users.activated')
+    end
+
+    def deactivate
+      return failure('users.cannot_deactivate_self') if user == actor
+      return failure('users.owner_deactivation_rejected') if owner_deactivation_blocked?
+
+      user.deactivate!
+      success('users.deactivated')
+    end
+
+    def verify
+      account = user.person&.account
+      return failure('admin.users.missing_account') unless account
+
+      ActiveRecord::Base.transaction do
+        account.update!(status: :verified)
+        AccountVerificationKey.where(account_id: account.id).delete_all
+      end
+      success('users.verified')
+    end
+
+    def owner_deactivation_blocked?
+      !owner_governance.can_deactivate_owner_user?(target_membership)
+    end
+
+    def owner_governance
+      @owner_governance ||= OwnerGovernance.new(
+        household: household,
+        actor_membership: actor_membership
+      )
+    end
+
+    def target_membership
+      account = user.person&.account
+      return unless household && account
+
+      household.household_memberships.active.find_by(account: account)
+    end
+
+    def success(key)
+      Result.new(true, I18n.t(key))
+    end
+
+    def failure(key)
+      Result.new(false, I18n.t(key))
+    end
+  end
+end

--- a/app/services/admin/user_provisioner.rb
+++ b/app/services/admin/user_provisioner.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Admin
+  class UserProvisioner
+    Result = Data.define(:success?, :user, :error)
+
+    def initialize(user:, password:, household:, actor_membership:)
+      @user = user
+      @password = password
+      @household = household
+      @actor_membership = actor_membership
+    end
+
+    def call
+      error = validation_error
+      return Result.new(false, user, error) if error
+
+      persist_user!
+      Result.new(true, user, nil)
+    rescue ActiveRecord::RecordInvalid => e
+      copy_account_email_errors(e.record)
+      Result.new(false, user, :invalid_record)
+    end
+
+    private
+
+    attr_reader :user, :password, :household, :actor_membership
+
+    def validation_error
+      return :invalid_membership_role unless membership_role_valid?
+
+      :duplicate_account if account_already_exists?
+    end
+
+    def membership_role_valid?
+      return true if MembershipRoleUpdater::ALLOWED_ROLES.include?(membership_role)
+
+      user.errors.add(:membership_role, membership_role_error)
+      false
+    end
+
+    def membership_role_error
+      key = if membership_role == MembershipRoleUpdater::OWNER_ROLE
+              'admin.membership_roles.owner_rejected'
+            else
+              'admin.membership_roles.invalid_role'
+            end
+      I18n.t(key)
+    end
+
+    def account_already_exists?
+      return false unless Account.exists?(email: user.email_address)
+
+      user.errors.add(:email_address, :taken)
+      true
+    end
+
+    def persist_user!
+      ActiveRecord::Base.transaction do
+        account = create_account!
+        save_user!(account)
+        membership = create_membership!(account)
+        grant_person_access!(membership, user.person, :manage, :self)
+        assign_dependents!(membership)
+      end
+    end
+
+    def create_account!
+      Account.create!(
+        email: user.email_address,
+        password_hash: BCrypt::Password.create(password),
+        status: :verified
+      )
+    end
+
+    def save_user!(account)
+      user.person.account = account
+      user.person.household ||= household
+      user.save!
+    end
+
+    def create_membership!(account)
+      return unless household
+
+      household.household_memberships.create!(
+        account: account,
+        person: user.person,
+        role: membership_role,
+        status: :active
+      )
+    end
+
+    def assign_dependents!(membership)
+      return if carer_relationship_type.blank?
+
+      relationships = DependentRelationshipAssigner.new(
+        carer: user.person,
+        dependent_ids: user.dependent_ids,
+        relationship_type: carer_relationship_type,
+        scope: dependent_assignment_scope
+      ).call
+      relationships.each do |relationship|
+        grant_person_access!(membership, relationship.patient, dependent_access_level, dependent_relationship_type)
+      end
+    end
+
+    def dependent_assignment_scope
+      return Person.none unless household
+
+      Person.where(household: household)
+    end
+
+    def grant_person_access!(membership, person, access_level, relationship_type)
+      return unless household && membership && person&.household_id == household.id
+
+      grant = household.person_access_grants.find_or_initialize_by(
+        household_membership: membership,
+        person: person
+      )
+      grant.access_level = access_level
+      grant.relationship_type = relationship_type
+      grant.granted_by_membership ||= actor_membership || membership
+      grant.revoked_at = nil
+      grant.save!
+    end
+
+    def membership_role
+      requested_role = user.membership_role.presence
+      return requested_role if MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
+
+      requested_role || 'member'
+    end
+
+    def dependent_access_level
+      requested_level = user.dependent_access_level.presence
+      return requested_level if PersonAccessGrant.access_levels.key?(requested_level)
+
+      dependent_relationship_type == 'parent' ? :manage : :record
+    end
+
+    def dependent_relationship_type
+      requested_type = user.dependent_relationship_type.presence
+      return requested_type if PersonAccessGrant.relationship_types.key?(requested_type) && requested_type != 'self'
+
+      :professional
+    end
+
+    def carer_relationship_type
+      case dependent_relationship_type.to_s
+      when 'parent'
+        'parent'
+      when 'family_member'
+        'family_member'
+      else
+        'professional_carer'
+      end
+    end
+
+    def copy_account_email_errors(record)
+      return unless record.is_a?(Account) && record.errors[:email].any?
+
+      record.errors[:email].each do |error|
+        user.errors.add(:email_address, error)
+      end
+    end
+  end
+end

--- a/spec/services/admin/user_lifecycle_updater_spec.rb
+++ b/spec/services/admin/user_lifecycle_updater_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UserLifecycleUpdater do
+  fixtures :accounts, :households, :people, :users
+
+  before { FixtureHouseholdSetup.apply! }
+
+  let(:household) { households(:fixture_household) }
+  let(:actor) { users(:admin) }
+  let(:actor_membership) do
+    household.household_memberships.find_by!(account: actor.person.account)
+  end
+
+  def update_lifecycle(user, action, actor_user: actor, membership: actor_membership)
+    described_class.new(
+      user: user,
+      action: action,
+      actor: actor_user,
+      household: household,
+      actor_membership: membership
+    ).call
+  end
+
+  it 'activates an inactive user' do
+    user = users(:jane)
+    user.deactivate!
+
+    result = update_lifecycle(user, :activate)
+
+    expect(result).to have_attributes(success?: true, message: I18n.t('users.activated'))
+    expect(user.reload).to be_active
+  end
+
+  it 'deactivates an active member' do
+    user = users(:jane)
+
+    result = update_lifecycle(user, :deactivate)
+
+    expect(result).to have_attributes(success?: true, message: I18n.t('users.deactivated'))
+    expect(user.reload).not_to be_active
+  end
+
+  it 'rejects self-deactivation' do
+    result = update_lifecycle(actor, :deactivate)
+
+    expect(result).to have_attributes(success?: false, message: I18n.t('users.cannot_deactivate_self'))
+    expect(actor.reload).to be_active
+  end
+
+  it 'rejects owner deactivation by a household administrator' do
+    owner = users(:parent)
+    administrator = users(:jane)
+    assign_role(owner, :owner)
+    administrator_membership = assign_role(administrator, :administrator)
+
+    result = update_lifecycle(
+      owner,
+      :deactivate,
+      actor_user: administrator,
+      membership: administrator_membership
+    )
+
+    expect(result).to have_attributes(
+      success?: false,
+      message: I18n.t('users.owner_deactivation_rejected')
+    )
+    expect(owner.reload).to be_active
+  end
+
+  it 'verifies the linked account and removes verification keys' do
+    user = users(:jane)
+    account = user.person.account
+    account.update!(status: :unverified)
+    AccountVerificationKey.create!(account_id: account.id, key: 'verification-key')
+
+    result = update_lifecycle(user, :verify)
+
+    expect(result).to have_attributes(success?: true, message: I18n.t('users.verified'))
+    expect(account.reload).to be_verified
+    expect(AccountVerificationKey.where(account_id: account.id)).to be_empty
+  end
+
+  it 'rejects verification when the user has no linked account' do
+    person = Person.create!(
+      household: household,
+      name: 'Accountless User',
+      date_of_birth: '1990-01-01'
+    )
+    user = User.create!(person: person, email_address: 'accountless@example.test')
+
+    result = update_lifecycle(user, :verify)
+
+    expect(result).to have_attributes(
+      success?: false,
+      message: I18n.t('admin.users.missing_account')
+    )
+  end
+
+  def assign_role(user, role)
+    household.household_memberships.find_by!(account: user.person.account).tap do |membership|
+      membership.update!(role: role)
+    end
+  end
+end

--- a/spec/services/admin/user_provisioner_spec.rb
+++ b/spec/services/admin/user_provisioner_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UserProvisioner do
+  fixtures :accounts, :households, :people, :users, :carer_relationships
+
+  subject(:result) do
+    described_class.new(
+      user: user,
+      password: user.password,
+      household: household,
+      actor_membership: actor_membership
+    ).call
+  end
+
+  before { FixtureHouseholdSetup.apply! }
+
+  let(:household) { households(:fixture_household) }
+  let(:actor_membership) do
+    household.household_memberships.find_by!(account: users(:admin).person.account)
+  end
+  let(:dependent) { people(:child_patient) }
+  let(:user) do
+    User.new(
+      email_address: 'provisioned.user@example.test',
+      password: 'SecureP@ssword123!',
+      password_confirmation: 'SecureP@ssword123!',
+      membership_role: 'administrator',
+      dependent_access_level: 'manage',
+      dependent_relationship_type: 'parent',
+      dependent_ids: [dependent.id],
+      person_attributes: {
+        name: 'Provisioned User',
+        date_of_birth: '1990-01-01'
+      }
+    )
+  end
+
+  it 'creates the account, membership, self grant, and dependant grant atomically' do
+    expect { result }
+      .to change(Account, :count).by(1)
+      .and change(User, :count).by(1)
+      .and change(HouseholdMembership, :count).by(1)
+      .and change(PersonAccessGrant, :count).by(2)
+      .and change(CarerRelationship, :count).by(1)
+
+    expect(result).to have_attributes(success?: true, error: nil, user: user)
+  end
+
+  it 'connects the new account to its household access records' do
+    result
+
+    account = Account.find_by!(email: user.email_address)
+    membership = household.household_memberships.find_by!(account: account)
+    expect(account).to be_verified
+    expect(user.reload.person).to have_attributes(account: account, household: household)
+    expect(membership).to have_attributes(person: user.person, role: 'administrator', status: 'active')
+    expect(grant_for(membership, user.person))
+      .to have_attributes(access_level: 'manage', relationship_type: 'self')
+    expect(grant_for(membership, dependent))
+      .to have_attributes(access_level: 'manage', relationship_type: 'parent')
+  end
+
+  it 'rejects duplicate accounts without writing partial records' do
+    user.email_address = users(:jane).email_address
+
+    expect { result }.not_to(
+      change { [Account.count, User.count, HouseholdMembership.count, PersonAccessGrant.count] }
+    )
+
+    expect(result).to have_attributes(success?: false, error: :duplicate_account, user: user)
+    expect(user.errors[:email_address]).to include('has already been taken')
+  end
+
+  it 'rejects owner membership creation without writing partial records' do
+    user.membership_role = 'owner'
+
+    expect { result }.not_to(
+      change { [Account.count, User.count, HouseholdMembership.count, PersonAccessGrant.count] }
+    )
+
+    expect(result).to have_attributes(success?: false, error: :invalid_membership_role, user: user)
+    expect(user.errors[:membership_role]).to include(
+      I18n.t('admin.membership_roles.owner_rejected')
+    )
+  end
+
+  def grant_for(membership, person)
+    household.person_access_grants.find_by!(household_membership: membership, person: person)
+  end
+end

--- a/spec/services/medication_reminder_eligibility_query_spec.rb
+++ b/spec/services/medication_reminder_eligibility_query_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe MedicationReminderEligibilityQuery do
   let(:now) { Time.zone.local(2026, 6, 9, 10, 0, 0) }
   let(:today) { now.to_date }
 
+  before { travel_to(now) }
+
   def build_query(scheduled_time: nil)
     described_class.new(person: person, scheduled_time: scheduled_time, now: now)
   end


### PR DESCRIPTION
## Summary

- moves account creation, membership setup, self access, and dependant grants into one transactional provisioning service
- moves activation, deactivation governance, and verification-key cleanup behind one lifecycle result contract
- reduces Admin::UsersController from 427 lines and 40 methods to 244 lines and 29 methods while preserving HTML and Turbo behavior
- adds direct service coverage for duplicate accounts, invalid roles, grants, self-deactivation, owner protection, activation, and verification

## Dependency

This PR is stacked on #1561, which fixes the date-expiring reminder spec discovered by the mandatory full-suite run. The final stacked suite is green with 3,997 examples. RubyCritic produced its controller report but exits during SimpleCov shutdown because of the existing #1550 defect.

Closes #1549