### PR TITLE
fix(build): provide asset compilation URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN bundle install
 
 COPY --chown=ruby:ruby . .
 
-RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
+RUN APP_URL=https://assets-build.invalid SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
 
 ENTRYPOINT ["/app/bin/docker-entrypoint-web"]
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -228,6 +228,7 @@ services:
         condition: service_healthy
     environment: &rails_env_prod
       RAILS_ENV: production
+      APP_URL: ${APP_URL:-http://localhost}
       DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker
       DATABASE_ROLE: ${MIGRATION_DATABASE_ROLE:-med_tracker_owner}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-local-prod-testing-only-not-for-real-use}

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(app_stage).not_to include('APP_URL=')
   end
 
+  it 'provides an overridable URL to the production-style Compose environment' do
+    expect(compose_yaml).to include('APP_URL: ${APP_URL:-http://localhost}')
+  end
+
   it 'keeps Debian package installs out of the shared Docker base stage' do
     base_stage = docker_stage('base')
 

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(dockerfile).to include('BUNDLE_WITH')
   end
 
+  it 'limits the dummy application URL to production asset compilation' do
+    assets_stage = docker_stage('assets')
+    app_stage = docker_stage('app')
+
+    expect(assets_stage).to include(
+      'RUN APP_URL=https://assets-build.invalid SECRET_KEY_BASE_DUMMY=1 rails assets:precompile'
+    )
+    expect(app_stage).not_to include('APP_URL=')
+  end
+
   it 'keeps Debian package installs out of the shared Docker base stage' do
     base_stage = docker_stage('base')
 

--- a/spec/services/medication_reminder_eligibility_query_spec.rb
+++ b/spec/services/medication_reminder_eligibility_query_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe MedicationReminderEligibilityQuery do
   let(:now) { Time.zone.local(2026, 6, 9, 10, 0, 0) }
   let(:today) { now.to_date }
 
+  before { travel_to(now) }
+
   def build_query(scheduled_time: nil)
     described_class.new(person: person, scheduled_time: scheduled_time, now: now)
   end


### PR DESCRIPTION
## Summary

Production asset compilation loaded the same fail-closed configuration as a real application boot, but the Docker assets stage supplied only a dummy secret. That made every production image build fail before the final image existed.

- supply a reserved `.invalid` application URL only on the asset-precompilation instruction
- keep `APP_URL` out of the assets-stage and final-image environment declarations
- lock the scope down with the existing Docker harness contract

The dummy URL is safe for compilation because no server is started and `.invalid` cannot resolve. Real production processes still receive no baked-in `APP_URL`, so the existing runtime `ENV.fetch` remains fail closed.

`task prod:build` now completes. This PR is stacked on #1561 so the full suite includes the separately isolated deterministic reminder-clock fix.

Closes #1565
