### PR TITLE
fix(deploy): separate migrations from seeds

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -222,7 +222,7 @@ services:
       service: rails
     profiles: [prod]
     networks: [prod]
-    command: bin/rails db:prepare
+    command: bin/rails db:migrate
     depends_on:
       db-prod:
         condition: service_healthy

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(compose_yaml).to include('APP_URL: ${APP_URL:-http://localhost}')
   end
 
+  it 'migrates a new production database without loading tenant seeds' do
+    production_services = compose_yaml.split('  # === Production (profile: prod) ===', 2).last
+    migrate_service = production_services.split("  migrate-prod:\n", 2).last.split("  web-prod:\n", 2).first
+
+    expect(migrate_service).to include('command: bin/rails db:migrate')
+    expect(migrate_service).not_to include('db:prepare')
+    expect(compose_yaml.scan('command: bin/rails db:prepare').size).to eq(2)
+  end
+
   it 'keeps Debian package installs out of the shared Docker base stage' do
     base_stage = docker_stage('base')
 


### PR DESCRIPTION
## Summary

A brand-new production database took the `db:prepare` path, which automatically loaded development-oriented seeds after migration. Tenant RLS correctly rejected those unscoped seed inserts, leaving the production-style stack unable to initialize.

- run the production migration container with `db:migrate` so it changes schema only
- keep development and test on `db:prepare`
- lock the separation down in the Docker harness contract

Tenant and administrator creation remains available through the existing explicit bootstrap and invitation tasks. A fresh production volume now migrates successfully and reaches a healthy web container without loading `db/seeds.rb`.

This PR is stacked on #1566 because that PR repairs production image and local Compose URL configuration first.

Closes #1567
