### PR TITLE
feat(storage): enforce durable production uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,8 @@ RUN apt-get update \
 
 USER ruby
 
+RUN mkdir -p /app/storage
+
 ENV RAILS_ENV=production \
   NODE_ENV=production \
   BUNDLE_WITHOUT="development:test:tools" \

--- a/Taskfiles/prod.yml
+++ b/Taskfiles/prod.yml
@@ -89,6 +89,23 @@ tasks:
           ENVIRONMENT: prod
           COMMAND: 'rails runner ''load Rails.root.join("db/seeds/seed_users.rb")'''
 
+  verify-storage-restore:
+    desc: Verify a restored production attachment and its stored blob
+    summary: |
+      Verify that an Active Storage attachment restored in PostgreSQL has a
+      readable, checksum-valid object on the mounted production volume.
+      Uses the owner-capable database role because the isolated recovery check
+      must select a restored attachment before tenant context is established.
+      Usage: task prod:verify-storage-restore
+      Usage: task prod:verify-storage-restore ATTACHMENT_ID=123
+    vars:
+      attachment_id: '{{ .ATTACHMENT_ID | default "" }}'
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner ATTACHMENT_ID="{{ .attachment_id }}" rails med_tracker:storage:verify_restore'
+
   import-dmd-barcodes:
     desc: Import NHS dm+d GTIN barcode mappings from CSV
     summary: |

--- a/app/services/storage/restore_verifier.rb
+++ b/app/services/storage/restore_verifier.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Storage
+  class RestoreVerifier
+    class VerificationError < StandardError; end
+
+    Result = Data.define(:attachment_id, :blob_id, :byte_size)
+
+    def self.call(attachment_id: nil)
+      new(attachment_id: attachment_id).call
+    end
+
+    def initialize(attachment_id: nil)
+      @attachment_id = attachment_id
+    end
+
+    def call
+      attachment = restored_attachment
+      blob = attachment.blob
+      verify_stored_object!(blob)
+
+      Result.new(
+        attachment_id: attachment.id,
+        blob_id: blob.id,
+        byte_size: blob.byte_size
+      )
+    rescue ActiveStorage::IntegrityError
+      raise VerificationError, 'The restored object checksum does not match its database record'
+    end
+
+    private
+
+    attr_reader :attachment_id
+
+    def restored_attachment
+      attachment = if attachment_id.present?
+                     ActiveStorage::Attachment.find_by(id: attachment_id)
+                   else
+                     ActiveStorage::Attachment.order(:id).first
+                   end
+      return attachment if attachment
+
+      raise VerificationError, 'No attachment was found in the restored database'
+    end
+
+    def verify_stored_object!(blob)
+      unless blob.service.exist?(blob.key)
+        raise VerificationError, 'The restored attachment record exists but its stored object is missing'
+      end
+
+      blob.open { |file| file.read(1) }
+    end
+  end
+end

--- a/compose.yaml
+++ b/compose.yaml
@@ -229,6 +229,8 @@ services:
     environment: &rails_env_prod
       RAILS_ENV: production
       APP_URL: ${APP_URL:-http://localhost}
+      ACTIVE_STORAGE_SERVICE: ${ACTIVE_STORAGE_SERVICE:-persistent}
+      ACTIVE_STORAGE_ROOT: ${ACTIVE_STORAGE_ROOT:-/app/storage}
       DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker
       DATABASE_ROLE: ${MIGRATION_DATABASE_ROLE:-med_tracker_owner}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-local-prod-testing-only-not-for-real-use}

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -36,6 +36,9 @@ env:
   secret:
     - RAILS_MASTER_KEY
   clear:
+    ACTIVE_STORAGE_SERVICE: persistent
+    ACTIVE_STORAGE_ROOT: /app/storage
+
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
@@ -65,7 +68,7 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "med_tracker_storage:/rails/storage"
+  - "med_tracker_storage:/app/storage"
 
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/integer/time'
+require Rails.root.join('lib/production_storage')
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -24,7 +25,8 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  storage = ProductionStorage.resolve
+  config.active_storage.service = storage.service
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+persistent:
+  service: Disk
+  root: <%= ENV.fetch("ACTIVE_STORAGE_ROOT", "/app/storage") %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/docs/adrs/0008-production-upload-storage.md
+++ b/docs/adrs/0008-production-upload-storage.md
@@ -1,0 +1,64 @@
+# ADR 0008: Production Upload Storage
+
+- Status: Accepted
+- Date: 2026-07-10
+
+## Context
+
+Active Storage previously selected the development-oriented `local` service in
+production. Docker Compose happened to mount a named volume at `/app/storage`,
+while the hosted Kubernetes deployment used a 5 Gi Longhorn `ReadWriteOnce`
+claim. Rails did not distinguish that durable mount from the writable directory
+inside an application image, so a missing mount could silently accept uploads
+that disappeared with the pod.
+
+The hosted deployment already has one web replica, uses the `Recreate` strategy,
+and cannot mount its `ReadWriteOnce` claim from multiple nodes. That topology is
+deliberately single-node.
+
+## Decision
+
+Production uses the `persistent` Active Storage disk service rooted at
+`ACTIVE_STORAGE_ROOT`, which defaults to `/app/storage`.
+`ACTIVE_STORAGE_SERVICE` may select only `persistent`. At runtime the application
+verifies that the root is absolute, exists, is writable, and is listed as a mount
+point by the Linux kernel. Production boot fails when any check fails. Asset
+compilation with `SECRET_KEY_BASE_DUMMY=1` skips only the runtime mount check.
+
+The deployment contract is:
+
+- one web replica;
+- a `ReadWriteOnce` persistent volume;
+- `Recreate` deployment strategy;
+- coordinated backups of PostgreSQL Active Storage records and `/app/storage`;
+- encrypted off-cluster retention and regular isolated restore tests.
+
+Horizontal web scaling is not supported by this storage contract. Scaling web
+replicas requires either an RWX storage service with demonstrated cross-node
+semantics or a migration to object storage before replicas are increased.
+
+## Rejected Alternative: Object Storage
+
+Object storage is a strong future choice for portable, horizontally scaled
+deployments, but adopting it now would add an S3 provider dependency, secrets,
+bucket lifecycle policy, and a live blob migration while the deployed topology
+remains single-replica. That operational expansion is not needed to make the
+current Longhorn-backed service durable and fail closed.
+
+Object storage remains the preferred migration path when horizontal scaling or
+cross-cluster portability becomes a requirement. Rails mirror services can be
+used during that migration, followed by a verified copy and service cutover.
+
+## Consequences
+
+Uploads cannot be accepted when the production volume is absent or mounted at
+the wrong path. Compose, Kamal, and hosted Kubernetes must all mount the same
+root. Operators must back up the database and blob volume as one recovery set.
+Deployments remain single-replica until the storage decision changes.
+
+## Related Documents
+
+- `docs/operations/upload-storage-backup-and-restore.md`
+- `config/storage.yml`
+- `config/environments/production.rb`
+- GitHub issue #1551

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ ensuring medications are given on time and safely.
   `medtracker` CLI and `medtracker-mcp` stdio server over `/api/v1`.
 - [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
 - [External App Integration Contract](adrs/0007-external-app-integration-contract.md): choose `/api/v1`, `/mcp`, or FHIR R4 by client audience.
+- [Production Upload Storage](adrs/0008-production-upload-storage.md): understand the single-node persistent-volume decision and scaling boundary.
+- [Upload Storage Backup and Restore](operations/upload-storage-backup-and-restore.md): back up and verify database records with stored blobs.
 - [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.
 
 ---

--- a/docs/operations/upload-storage-backup-and-restore.md
+++ b/docs/operations/upload-storage-backup-and-restore.md
@@ -1,0 +1,71 @@
+# Upload Storage Backup and Restore
+
+Production uploads use a deliberately single-node persistent disk mounted at
+`/app/storage`. Rails refuses to boot when this path is not a real mount point.
+The hosted Kubernetes contract is a Longhorn `ReadWriteOnce` claim with a
+`Recreate` deployment. Do not increase web replicas under this contract.
+
+## Recovery Set
+
+Every recoverable backup must contain both parts from the same recovery point:
+
+1. PostgreSQL, including `active_storage_attachments`,
+   `active_storage_blobs`, and `active_storage_variant_records`.
+2. Every object below `/app/storage`.
+
+The self-service MedTracker ZIP export is not an upload backup and does not
+replace this recovery set.
+
+Pause writes or use storage and database snapshots whose recovery timestamps
+are coordinated. Encrypt backups in transit and at rest, keep a copy outside the
+application cluster, and restrict access to the same operators who can restore
+production health data.
+
+The minimum retention contract is 35 daily backups and 12 monthly backups for
+both parts of the recovery set. Provider snapshot retention may exceed this,
+but shorter retention requires a documented risk decision and data-retention
+review.
+
+## Backup Checklist
+
+1. Record the app image tag, schema migration version, database recovery point,
+   persistent-volume snapshot identifier, timestamp, and operator.
+2. Create the PostgreSQL backup and Longhorn volume snapshot at a coordinated
+   recovery point.
+3. Copy or replicate both encrypted backups off cluster.
+4. Confirm both artifacts are readable and covered by the same retention label.
+5. Schedule the isolated restore test; a snapshot is not verified until it has
+   been restored and checked.
+
+## Isolated Restore
+
+1. Create an isolated database and persistent volume with no production routes.
+2. Restore PostgreSQL and `/app/storage` from the same recorded recovery set.
+3. Mount the restored volume at `/app/storage`.
+4. Run migrations with the owner-capable database role.
+5. Start the app with `ACTIVE_STORAGE_SERVICE=persistent` and
+   `ACTIVE_STORAGE_ROOT=/app/storage`.
+6. Choose a restored attachment id and run:
+
+```fish
+task prod:verify-storage-restore ATTACHMENT_ID=123
+```
+
+The check fails if the database attachment is missing, its object key does not
+exist on the restored volume, or Active Storage detects a checksum mismatch.
+The command prints only attachment id, blob id, and byte size; it does not print
+filenames or upload contents.
+
+7. Verify the attachment through its authorized household route and confirm a
+   user outside that household cannot retrieve it.
+8. Record the recovery point, attachment id, image tag, duration, tester, and
+   result. Destroy the isolated environment after evidence is retained.
+
+## Migration and Scaling
+
+Before horizontal scaling, choose an RWX volume with tested multi-node behavior
+or migrate blobs to object storage. For object storage, configure provider
+credentials outside Git, apply bucket encryption, versioning, lifecycle, and
+access policies, copy every existing key, verify database checksums against the
+destination, and only then change the selected service. Keep the source volume
+read-only until the rollback window expires.

--- a/lib/production_storage.rb
+++ b/lib/production_storage.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ProductionStorage
+  class ConfigurationError < StandardError; end
+
+  Configuration = Data.define(:service, :root)
+
+  SERVICE = 'persistent'
+  DEFAULT_ROOT = '/app/storage'
+  DEFAULT_MOUNTINFO_PATH = '/proc/self/mountinfo'
+
+  def self.resolve(environment: ENV, mountinfo_path: Pathname(DEFAULT_MOUNTINFO_PATH))
+    service = service_name(environment)
+    root = storage_root(environment)
+    validate_mount!(root, mountinfo_path) unless asset_compilation?(environment)
+
+    Configuration.new(service: service.to_sym, root: root)
+  rescue Errno::ENOENT, Errno::EACCES => e
+    raise ConfigurationError, "Unable to validate ACTIVE_STORAGE_ROOT: #{e.message}"
+  end
+
+  def self.service_name(environment)
+    service = environment.fetch('ACTIVE_STORAGE_SERVICE', SERVICE)
+    unless service == SERVICE
+      raise ConfigurationError, "ACTIVE_STORAGE_SERVICE must be #{SERVICE.inspect} in production"
+    end
+
+    service
+  end
+  private_class_method :service_name
+
+  def self.storage_root(environment)
+    root = Pathname(environment.fetch('ACTIVE_STORAGE_ROOT', DEFAULT_ROOT)).cleanpath
+    raise ConfigurationError, 'ACTIVE_STORAGE_ROOT must be an absolute path' unless root.absolute?
+    raise ConfigurationError, 'ACTIVE_STORAGE_ROOT must name an existing directory' unless root.directory?
+    raise ConfigurationError, 'ACTIVE_STORAGE_ROOT must be writable' unless root.writable?
+
+    root.realpath
+  end
+  private_class_method :storage_root
+
+  def self.asset_compilation?(environment)
+    environment['SECRET_KEY_BASE_DUMMY'] == '1'
+  end
+  private_class_method :asset_compilation?
+
+  def self.validate_mount!(root, mountinfo_path)
+    mounted = mountinfo_path.each_line.any? do |line|
+      mount_path = line.split.fetch(4)
+      Pathname(unescape_mount_path(mount_path)).cleanpath == root
+    end
+    return if mounted
+
+    raise ConfigurationError, 'ACTIVE_STORAGE_ROOT must be a mounted persistent volume'
+  end
+  private_class_method :validate_mount!
+
+  def self.unescape_mount_path(path)
+    path.gsub(/\\([0-7]{3})/) { Regexp.last_match(1).to_i(8).chr }
+  end
+  private_class_method :unescape_mount_path
+end

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :med_tracker do
+  namespace :storage do
+    desc 'Verify an attachment restored from the database and persistent storage backup'
+    task verify_restore: :environment do
+      result = Storage::RestoreVerifier.call(attachment_id: ENV['ATTACHMENT_ID'].presence)
+      puts "Storage restore verified: attachment_id=#{result.attachment_id} " \
+           "blob_id=#{result.blob_id} byte_size=#{result.byte_size}"
+    rescue Storage::RestoreVerifier::VerificationError => e
+      abort "Storage restore verification failed: #{e.message}"
+    end
+  end
+end

--- a/spec/lib/production_storage_documentation_spec.rb
+++ b/spec/lib/production_storage_documentation_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProductionStorage, '.documentation' do
+  let(:adr) { Rails.root.join('docs/adrs/0008-production-upload-storage.md').read }
+  let(:runbook) { Rails.root.join('docs/operations/upload-storage-backup-and-restore.md').read }
+  let(:compose) { Rails.root.join('compose.yaml').read }
+  let(:deploy) { Rails.root.join('config/deploy.yml').read }
+
+  it 'records the accepted single-node persistent-volume decision' do
+    expect(adr).to include('Status: Accepted')
+    expect(adr).to include('ReadWriteOnce')
+    expect(adr).to include('Recreate')
+    expect(adr).to include('Horizontal web scaling is not supported')
+    expect(adr).to include('Object storage')
+  end
+
+  it 'documents coordinated database and blob backups with retention' do
+    expect(runbook).to include('active_storage_attachments')
+    expect(runbook).to include('active_storage_blobs')
+    expect(runbook).to include('/app/storage')
+    expect(runbook).to include('35 daily backups')
+    expect(runbook).to include('12 monthly backups')
+  end
+
+  it 'documents and exposes the restored-attachment smoke check' do
+    expect(runbook).to include('task prod:verify-storage-restore')
+    expect(runbook).to include('ATTACHMENT_ID=')
+    expect(runbook).to include('isolated')
+  end
+
+  it 'keeps production compose storage selection and mount explicit' do
+    expect(compose).to include('ACTIVE_STORAGE_SERVICE: ${ACTIVE_STORAGE_SERVICE:-persistent}')
+    expect(compose).to include('ACTIVE_STORAGE_ROOT: ${ACTIVE_STORAGE_ROOT:-/app/storage}')
+    expect(compose).to include('medtracker_prod_storage:/app/storage')
+  end
+
+  it 'aligns the deployment template with the production storage contract' do
+    expect(deploy).to include('ACTIVE_STORAGE_SERVICE: persistent')
+    expect(deploy).to include('ACTIVE_STORAGE_ROOT: /app/storage')
+    expect(deploy).to include('med_tracker_storage:/app/storage')
+  end
+
+  it 'creates the production storage root as the unprivileged runtime user' do
+    dockerfile = Rails.root.join('Dockerfile').read
+    app_stage = dockerfile.split("FROM base AS app\n", 2).last
+
+    expect(app_stage).to include("USER ruby\n\nRUN mkdir -p /app/storage")
+  end
+
+  it 'uses the validated production service while preserving local test services' do
+    production = Rails.root.join('config/environments/production.rb').read
+    storage = Rails.root.join('config/storage.yml').read
+
+    expect(production).to include('ProductionStorage.resolve')
+    expect(storage).to include("persistent:\n  service: Disk")
+    expect(storage).to include("test:\n  service: Disk")
+    expect(storage).to include("local:\n  service: Disk")
+  end
+end

--- a/spec/lib/production_storage_spec.rb
+++ b/spec/lib/production_storage_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/production_storage')
+
+RSpec.describe ProductionStorage do
+  def resolve(root:, service: 'persistent', mounted: true, dummy: false)
+    mountinfo = Tempfile.new('mountinfo')
+    mountinfo.write("36 25 0:32 / #{root} rw,relatime - ext4 /dev/test rw\n") if mounted
+    mountinfo.close
+
+    environment = {
+      'ACTIVE_STORAGE_SERVICE' => service,
+      'ACTIVE_STORAGE_ROOT' => root.to_s
+    }
+    environment['SECRET_KEY_BASE_DUMMY'] = '1' if dummy
+
+    described_class.resolve(environment: environment, mountinfo_path: Pathname(mountinfo.path))
+  ensure
+    mountinfo&.unlink
+  end
+
+  it 'selects the mounted persistent disk service' do
+    Dir.mktmpdir do |directory|
+      configuration = resolve(root: Pathname(directory))
+
+      expect(configuration.service).to eq(:persistent)
+      expect(configuration.root).to eq(Pathname(directory).realpath)
+    end
+  end
+
+  it 'rejects unsupported production services' do
+    Dir.mktmpdir do |directory|
+      expect { resolve(root: Pathname(directory), service: 'local') }
+        .to raise_error(described_class::ConfigurationError, /ACTIVE_STORAGE_SERVICE/)
+    end
+  end
+
+  it 'rejects a relative storage root' do
+    expect { resolve(root: Pathname('storage')) }
+      .to raise_error(described_class::ConfigurationError, /absolute/)
+  end
+
+  it 'rejects a missing storage root' do
+    root = Pathname(Dir.tmpdir).join("missing-storage-#{SecureRandom.hex(6)}")
+
+    expect { resolve(root: root) }
+      .to raise_error(described_class::ConfigurationError, /directory/)
+  end
+
+  it 'rejects a directory that is not a mounted volume' do
+    Dir.mktmpdir do |directory|
+      expect { resolve(root: Pathname(directory), mounted: false) }
+        .to raise_error(described_class::ConfigurationError, /mounted persistent volume/)
+    end
+  end
+
+  it 'allows production asset compilation without a runtime volume' do
+    Dir.mktmpdir do |directory|
+      configuration = resolve(root: Pathname(directory), mounted: false, dummy: true)
+
+      expect(configuration.service).to eq(:persistent)
+    end
+  end
+end

--- a/spec/services/storage/restore_verifier_spec.rb
+++ b/spec/services/storage/restore_verifier_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Storage::RestoreVerifier do
+  subject(:verification) { described_class.call(attachment_id: attachment.id) }
+
+  let(:person) { create(:person) }
+  let(:attachment) { person.avatar.attachment }
+
+  before do
+    person.avatar.attach(io: StringIO.new('restored avatar'), filename: 'avatar.png', content_type: 'image/png')
+  end
+
+  after do
+    person.avatar.purge
+  end
+
+  it 'verifies that the restored blob exists and matches its stored checksum' do
+    result = verification
+
+    expect(result.attachment_id).to eq(attachment.id)
+    expect(result.blob_id).to eq(attachment.blob_id)
+    expect(result.byte_size).to eq('restored avatar'.bytesize)
+  end
+
+  it 'rejects a database attachment whose stored object is missing' do
+    allow(attachment.blob.service).to receive(:exist?).with(attachment.blob.key).and_return(false)
+
+    expect { verification }
+      .to raise_error(described_class::VerificationError, /stored object is missing/)
+  end
+
+  it 'rejects a restored object that fails the Active Storage integrity check' do
+    allow(ActiveStorage::Attachment).to receive(:find_by).with(id: attachment.id).and_return(attachment)
+    allow(attachment.blob).to receive(:open).and_raise(ActiveStorage::IntegrityError)
+
+    expect { verification }
+      .to raise_error(described_class::VerificationError, /checksum/)
+  end
+
+  it 'requires an attachment from the restored database' do
+    expect { described_class.call(attachment_id: 'missing') }
+      .to raise_error(described_class::VerificationError, /attachment/)
+  end
+end

--- a/spec/tasks/rake/task_storage_verify_restore_spec.rb
+++ b/spec/tasks/rake/task_storage_verify_restore_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe Rake::Task do
+  let(:task_name) { 'med_tracker:storage:verify_restore' }
+  let(:task) { described_class[task_name] }
+
+  before do
+    Rails.application.load_tasks unless described_class.task_defined?(task_name)
+    task.reenable
+  end
+
+  around do |example|
+    previous_attachment_id = ENV.fetch('ATTACHMENT_ID', nil)
+    example.run
+  ensure
+    ENV['ATTACHMENT_ID'] = previous_attachment_id
+  end
+
+  it 'reports the restored attachment and blob without health data' do
+    ENV['ATTACHMENT_ID'] = '42'
+    result = Storage::RestoreVerifier::Result.new(attachment_id: 42, blob_id: 84, byte_size: 512)
+    allow(Storage::RestoreVerifier).to receive(:call).with(attachment_id: '42').and_return(result)
+
+    expect { task.invoke }
+      .to output("Storage restore verified: attachment_id=42 blob_id=84 byte_size=512\n").to_stdout
+  end
+
+  it 'fails the smoke check when verification fails' do
+    ENV['ATTACHMENT_ID'] = nil
+    allow(Storage::RestoreVerifier).to receive(:call)
+      .with(attachment_id: nil)
+      .and_raise(Storage::RestoreVerifier::VerificationError, 'No attachment found')
+
+    expect { task.invoke }.to raise_error(SystemExit)
+      .and output(/Storage restore verification failed: No attachment found/).to_stderr
+  end
+end


### PR DESCRIPTION
## Summary

Production uploads could silently fall back to container-local storage when the expected volume was absent or misconfigured. That risks losing medication-related files whenever the container is replaced.

This change makes the existing single-node storage contract explicit:

- production starts only with the supported persistent disk service and a mounted, writable `/app/storage`
- the final image prepares the mount point with application-user ownership, so a fresh volume works without privileged startup logic
- Compose and Kamal use the same path and service settings
- a restore verifier checks the restored database record, object presence, and checksum without printing health data
- an ADR and operations runbook document coordinated database/file backups, retention, restore drills, and the boundary before horizontal scaling

The current deployment remains intentionally single-replica with a ReadWriteOnce volume and Recreate strategy. Moving to multiple application replicas requires object storage or a shared filesystem rather than weakening this startup guard.

This PR is stacked on #1568, which is stacked on #1566 and #1561. Review only the final commit for this issue.

Closes #1551