### PR TITLE
fix(security): generate request CSP nonces

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -30,11 +30,11 @@ Rails.application.configure do
     policy.worker_src  :self
   end
 
-  # Generate session nonces for permitted importmap and inline scripts.
+  # Generate request nonces for permitted importmap and inline scripts.
   # Note: style-src is intentionally excluded from nonce directives because
   # Turbo injects inline styles at runtime (progress bar, drive transitions)
   # without access to the nonce, causing CSP violations.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy in development

--- a/spec/requests/login_layout_spec.rb
+++ b/spec/requests/login_layout_spec.rb
@@ -3,6 +3,32 @@
 require 'rails_helper'
 
 RSpec.describe 'Login layout' do
+  it 'uses one non-empty CSP nonce across the anonymous response' do
+    get login_path
+
+    document = response.parsed_body
+    nonce = document.at_css('meta[name="csp-nonce"]')['content']
+    activation_script = document.css('script[nonce]').find do |script|
+      script.text.include?('applyLoginIllustrations')
+    end
+
+    expect(nonce).to be_present
+    expect(response.headers.fetch('Content-Security-Policy')).to include("'nonce-#{nonce}'")
+    expect(activation_script['nonce']).to eq(nonce)
+  end
+
+  it 'generates a new CSP nonce for each anonymous request' do
+    get login_path
+    first_nonce = response.parsed_body.at_css('meta[name="csp-nonce"]')['content']
+
+    get login_path
+    second_nonce = response.parsed_body.at_css('meta[name="csp-nonce"]')['content']
+
+    expect(first_nonce).to be_present
+    expect(second_nonce).to be_present
+    expect(second_nonce).not_to eq(first_nonce)
+  end
+
   it 'renders without the global mobile navigation chrome' do
     get login_path
 


### PR DESCRIPTION
## Summary

A first anonymous login request did not yet have a session id, so the CSP nonce generator returned an empty string. Rails then emitted an invalid `nonce-` source and the browser blocked the inline login-illustration activation script. Hosted environments enforce that policy rather than merely reporting it.

- generate a cryptographically random 16-byte nonce for every request using the Rails-supported CSP contract
- prove the CSP header, meta tag, and inline activation script share the same non-empty nonce
- prove consecutive anonymous requests receive different nonces
- keep nonce authorization limited to `script-src`, without adding `unsafe-inline` or exposing session identifiers

Browser verification now reports zero console errors and confirms the optimized login illustration initializes normally. Brakeman reports no security warnings.

This PR is stacked on #1564 because that Lighthouse/browser audit exposed the defect. Review only the final commit for this issue.

Closes #1570