### PR TITLE
fix(dev): install health-check client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ USER ruby
 
 FROM gem_builder AS development
 
+USER root
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
+  && apt-get clean
+
+USER ruby
+
 ENV RAILS_ENV=development \
   NODE_ENV=development \
   BUNDLE_WITHOUT="test:production:tools" \

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -106,6 +106,12 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(development_stage).not_to include('COPY --chown=ruby:ruby . .')
   end
 
+  it 'installs the health-check client in the development Docker image' do
+    development_stage = docker_stage('development')
+
+    expect(development_stage).to include('apt-get install -y --no-install-recommends curl')
+  end
+
   it 'keeps the OpenTelemetry SDK available to development boot' do
     dependency = gemfile_dependencies.fetch('opentelemetry-sdk')
 


### PR DESCRIPTION
`task dev:up` could start Rails successfully but still fail because the development image did not contain the `curl` client used by the inherited Docker health check.

This installs `curl` only in the development image stage and adds a regression check for that image contract. Production behavior remains unchanged, and a clean rebuild now reaches `web-dev` healthy with `task dev:up` exiting successfully.

The focused Docker contract spec and RuboCop pass. The full suite was attempted but entered an unrelated test-database fixture failure cascade while disabling referential integrity (`PG::ObjectInUse`).

Fixes #1573