### PR TITLE
fix(dev): isolate Docker test preflight by worktree

### DIFF
--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -11,7 +11,7 @@ vars:
   COMPOSE_PROJECT:
     sh: |
       base=$(basename "$PWD")
-      hash=$(git rev-parse --path-format=absolute --git-common-dir | git hash-object --stdin | cut -c1-8)
+      hash=$(pwd -P | git hash-object --stdin | cut -c1-8)
       printf '%s-%s\n' "$base" "$hash"
   GIT_COMMON_DIR:
     sh: git rev-parse --path-format=absolute --git-common-dir

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -2,6 +2,15 @@
 version: "3"
 
 tasks:
+  preflight:
+    desc: Verify Docker and the test image with a lightweight spec
+    summary: |
+      Verify Docker is available, the test image exists, and a focused spec runs.
+      Usage: task test:preflight
+      Usage: task test:preflight TEST_FILE=spec/path/to/spec.rb
+    cmds:
+      - './scripts/test_preflight.fish {{ .TEST_FILE | default "spec/config/taskfiles_spec.rb" }}'
+
   build:
     desc: Build test Docker images
     summary: |

--- a/agents.md
+++ b/agents.md
@@ -73,6 +73,7 @@ Use `task` for everything. Never run `docker compose`, `bin/dev`, or `bundle exe
 | What | Command |
 |---|---|
 | Run tests | `task test` |
+| Test Docker preflight | `task test:preflight` |
 | Lint | `task rubocop` |
 | Start dev server | `task dev:up` |
 | Build dev images | `task dev:build` |
@@ -98,6 +99,8 @@ Use `task` for everything. Never run `docker compose`, `bin/dev`, or `bundle exe
 - Do not use Docker Compose watch; the bind mount and Rails reloader already provide live updates.
 
 ## Testing
+
+Run `task test:preflight` before implementation work. If it reports that Docker is unavailable or the test image is missing, fix that specific prerequisite. Use GitHub CI as the verification authority only when local Docker remains unavailable.
 
 - Write RSpec tests in `_spec.rb` files using Rails/RSpec conventions.
 - Test public APIs and observable behavior, not implementation details.

--- a/scripts/test_preflight.fish
+++ b/scripts/test_preflight.fish
@@ -1,0 +1,20 @@
+#!/usr/bin/env fish
+
+set test_file $argv[1]
+
+if not docker info >/dev/null 2>&1
+    echo 'Docker is unavailable. Start Docker, then rerun task test:preflight.' >&2
+    exit 10
+end
+
+if not docker image inspect med-tracker-web-test >/dev/null 2>&1
+    echo 'Test image med-tracker-web-test is missing. Run task test:build, then rerun task test:preflight.' >&2
+    exit 11
+end
+
+if not task test TEST_FILE=$test_file
+    echo "Test preflight spec failed: $test_file" >&2
+    exit 12
+end
+
+echo "Test preflight passed: $test_file"

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -36,8 +36,21 @@ RSpec.describe 'Taskfiles' do
   it 'uses a worktree-specific Docker Compose project name' do
     compose_project = internal_taskfile.dig('vars', 'COMPOSE_PROJECT', 'sh')
 
-    expect(compose_project).to include('git rev-parse --path-format=absolute --git-common-dir')
+    expect(compose_project).to include('pwd -P')
     expect(compose_project).to include('git hash-object --stdin')
+  end
+
+  it 'defines a Docker test preflight with distinct failure messages' do
+    commands = test_taskfile.dig('tasks', 'preflight', 'cmds')
+
+    expect(commands).to include(
+      './scripts/test_preflight.fish {{ .TEST_FILE | default "spec/config/taskfiles_spec.rb" }}'
+    )
+    expect(test_preflight_script).to include(
+      'Docker is unavailable',
+      'Test image med-tracker-web-test is missing',
+      'Test preflight spec failed'
+    )
   end
 
   it 'serializes Docker Compose runs within each worktree environment' do
@@ -107,5 +120,9 @@ RSpec.describe 'Taskfiles' do
 
   def compose_lock_script
     Rails.root.join('scripts/with_compose_lock.rb').read
+  end
+
+  def test_preflight_script
+    Rails.root.join('scripts/test_preflight.fish').read
   end
 end


### PR DESCRIPTION
Docker-backed test runs from separate worktrees were sharing the same Compose project, so one agent could recreate another agent’s database and migration containers. That made the supposed preflight fail intermittently before a spec even started.

This change derives the Compose project from the actual worktree path, giving every worktree its own containers, network, and volumes while retaining the existing per-environment lock. It also adds `task test:preflight`, which clearly distinguishes an unavailable Docker daemon, a missing test image, and a failing smoke spec, and documents when GitHub CI should be used as the fallback.

Closes #1476