### PR TITLE
test(jobs): guard Active Job framework API names

### DIFF
--- a/spec/architecture/job_framework_api_collisions_spec.rb
+++ b/spec/architecture/job_framework_api_collisions_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Active Job framework API collisions' do
+  it 'keeps private application job helpers away from the framework public API' do
+    collisions = ApplicationJob.descendants.to_h do |job_class|
+      [job_class.name, collisions_for(job_class)]
+    end.compact_blank
+
+    expect(collisions).to be_empty
+  end
+
+  it 'detects a private helper that shadows a framework accessor' do
+    shadowing_job = Class.new(ApplicationJob) do
+      private
+
+      def scheduled_at; end
+    end
+
+    expect(collisions_for(shadowing_job)).to contain_exactly(:scheduled_at)
+  end
+
+  def collisions_for(job_class)
+    job_class.private_instance_methods(false) & ActiveJob::Base.public_instance_methods
+  end
+end


### PR DESCRIPTION
Private helpers in application jobs can silently replace public Active Job methods such as `scheduled_at`, changing serialization or runtime behavior without an obvious failure.

This adds an architecture guard that compares every application job’s private helpers with the Rails 8.1 public job API. It also proves the guard itself by defining a deliberately shadowing test job and detecting the collision, while confirming the current notification jobs are clean.

Closes #1477