### PR TITLE
perf(profile): keep queries outside view rendering

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,7 +12,7 @@ class ProfilesController < ApplicationController
 
     respond_to do |format|
       format.html do
-        render Views::Profiles::Show.new(person: @person, account: @account)
+        render profile_view(person: @person, account: @account)
       end
     end
   end
@@ -44,7 +44,7 @@ class ProfilesController < ApplicationController
         flash.now[:notice] = t('.removed')
         render turbo_stream: [
           turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice])),
-          turbo_stream.replace('main-content', Views::Profiles::Show.new(person: @person, account: @account))
+          turbo_stream.replace('main-content', profile_view(person: @person, account: @account))
         ]
       end
     end
@@ -77,6 +77,12 @@ class ProfilesController < ApplicationController
 
   private
 
+  def profile_view(person:, account:)
+    person.association(:notification_preference).load_target
+    api_app_tokens = account.api_app_tokens.active.order(created_at: :desc).to_a
+    Views::Profiles::Show.new(person: person, account: account, api_app_tokens: api_app_tokens)
+  end
+
   def update_person_profile(attributes)
     if @person.update(attributes)
       respond_profile_updated(person: @person.reload, account: @account, close_modal: true)
@@ -100,7 +106,7 @@ class ProfilesController < ApplicationController
         flash.now[:notice] = t('profiles.updated')
         streams = [turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice]))]
         streams.unshift(turbo_stream.update('modal', '')) if close_modal
-        streams << turbo_stream.replace('main-content', Views::Profiles::Show.new(person: person, account: account))
+        streams << turbo_stream.replace('main-content', profile_view(person: person, account: account))
         render turbo_stream: streams
       end
     end

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -14,7 +14,7 @@ module Views
         super()
         @person = person
         @account = account
-        @api_app_tokens = api_app_tokens || account.api_app_tokens.active.order(created_at: :desc).to_a
+        @api_app_tokens = api_app_tokens || []
         @new_api_app_token = new_api_app_token
       end
 

--- a/spec/requests/profiles_show_spec.rb
+++ b/spec/requests/profiles_show_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe 'Profiles' do
   end
 
   describe 'GET /profile' do
+    it 'does not load notification preferences or API tokens while rendering the view' do
+      rendered_queries = capture_profile_render_queries { get profile_path }
+
+      expect(rendered_queries.grep(/notification_preferences|api_app_tokens/)).to be_empty
+    end
+
     it 'renders the profile page shell and key sections' do
       get profile_path
 
@@ -106,6 +112,19 @@ RSpec.describe 'Profiles' do
       expect(response.body).to include('Test Passkey')
       expect(response.body).to include('Remove')
     end
+  end
+
+  def capture_profile_render_queries(&)
+    queries = []
+    sql_subscriber = lambda do |_name, _start, _finish, _id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+      next unless caller_locations.any? { |location| location.path.include?('/app/views/profiles/') }
+
+      queries << payload[:sql]
+    end
+
+    ActiveSupport::Notifications.subscribed(sql_subscriber, 'sql.active_record', &)
+    queries
   end
 
   describe 'PATCH /profile' do


### PR DESCRIPTION
Profile rendering used to fetch notification preferences and API tokens from inside Phlex components. This moves both reads to the controller boundary and adds a regression test that fails whenever those tables are queried from profile view code.

The dashboard schedule and notification query budgets remain covered by the existing dashboard query specs. This complements the Lighthouse tracking in #597 without replacing it.

Closes #1475