### PR TITLE
feat(fhir): add SMART third-party authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'stimulus-rails'
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem 'bcrypt'
 # Authentication framework [https://rodauth.jeremyevans.net/]
+gem 'rodauth-oauth', '~> 1.6'
 gem 'rodauth-rails'
 # Required for Rodauth to use ActiveRecord's database connection
 gem 'sequel-activerecord_connection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -595,6 +595,9 @@ GEM
       sequel (>= 4)
     rodauth-model (0.5.0)
       rodauth (~> 2.28)
+    rodauth-oauth (1.6.4)
+      base64
+      rodauth (~> 2.0)
     rodauth-omniauth (0.6.2)
       omniauth (~> 2.0)
       rodauth (~> 2.36)
@@ -884,6 +887,7 @@ DEPENDENCIES
   pundit-matchers
   rack-attack
   rails (>= 8.0)
+  rodauth-oauth (~> 1.6)
   rodauth-omniauth
   rodauth-rails
   rotp

--- a/app/controllers/api/fhir/r4/base_controller.rb
+++ b/app/controllers/api/fhir/r4/base_controller.rb
@@ -8,8 +8,54 @@ module Api
         SUPPORTED_FORMATS = ['json', FHIR_JSON].freeze
 
         before_action :ensure_fhir_format
+        before_action :ensure_smart_scope
 
         private
+
+        def policy_scope(scope, policy_scope_class: nil)
+          resolved = super
+          return resolved unless current_api_session.is_a?(OauthGrant) && current_api_session.patient_scoped?
+
+          smart_patient_scope(resolved)
+        end
+
+        def ensure_smart_scope
+          return unless current_api_session.is_a?(OauthGrant)
+          return if controller_name == 'metadata'
+          return if current_api_session.allows_fhir_read?(controller_name.classify)
+
+          render_forbidden
+        end
+
+        def smart_patient_scope(scope)
+          person_id = current_api_session.person_id
+          case scope.klass.name
+          when 'Person'
+            scope.where(id: person_id)
+          when 'Schedule', 'PersonMedication'
+            scope.where(person_id: person_id)
+          when 'MedicationTake'
+            smart_medication_take_scope(scope, person_id)
+          when 'Medication'
+            smart_medication_scope(scope, person_id)
+          else
+            scope.none
+          end
+        end
+
+        def smart_medication_take_scope(scope, person_id)
+          scope.left_outer_joins(:schedule, :person_medication)
+               .where(schedules: { person_id: person_id })
+               .or(scope.left_outer_joins(:schedule, :person_medication)
+                        .where(person_medications: { person_id: person_id }))
+        end
+
+        def smart_medication_scope(scope, person_id)
+          scope.left_outer_joins(:schedules, :person_medications)
+               .where(schedules: { person_id: person_id })
+               .or(scope.left_outer_joins(:schedules, :person_medications)
+                        .where(person_medications: { person_id: person_id })).distinct
+        end
 
         def render_fhir_collection(scope, serializer, search: {})
           searched = apply_fhir_search(scope, search)

--- a/app/controllers/api/fhir/r4/metadata_controller.rb
+++ b/app/controllers/api/fhir/r4/metadata_controller.rb
@@ -12,11 +12,28 @@ module Api
             kind: 'instance',
             fhirVersion: '4.0.1',
             format: ['json', FHIR_JSON],
-            rest: [{ mode: 'server', resource: resources }]
+            rest: [{ mode: 'server', security: smart_security, resource: resources }]
           }, content_type: FHIR_JSON
         end
 
         private
+
+        def smart_security
+          {
+            service: [{
+              coding: [{
+                system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
+                code: 'SMART-on-FHIR'
+              }]
+            }],
+            extension: [{
+              url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
+              extension: %w[authorize token revoke].map do |endpoint|
+                { url: endpoint, valueUri: "#{request.base_url}/#{endpoint}" }
+              end
+            }]
+          }
+        end
 
         def resources
           [

--- a/app/controllers/api/fhir/r4/smart_configuration_controller.rb
+++ b/app/controllers/api/fhir/r4/smart_configuration_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  module Fhir
+    module R4
+      class SmartConfigurationController < ActionController::API
+        def show
+          render json: {
+            authorization_endpoint: endpoint('/authorize'),
+            token_endpoint: endpoint('/token'),
+            revocation_endpoint: endpoint('/revoke'),
+            capabilities: %w[launch-standalone client-public permission-v2],
+            code_challenge_methods_supported: ['S256'],
+            grant_types_supported: %w[authorization_code refresh_token],
+            response_types_supported: ['code'],
+            token_endpoint_auth_methods_supported: %w[none client_secret_basic client_secret_post],
+            scopes_supported: scopes_supported
+          }
+        end
+
+        private
+
+        def endpoint(path)
+          "#{request.base_url}#{path}"
+        end
+
+        def scopes_supported
+          %w[
+            launch/patient
+            offline_access
+            online_access
+            patient/*.rs
+            patient/Patient.rs
+            patient/Medication.rs
+            patient/MedicationRequest.rs
+            patient/MedicationStatement.rs
+            patient/MedicationAdministration.rs
+            user/*.rs
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -60,6 +60,7 @@ module Api
       def valid_session?
         return false if @current_api_session.blank? || @current_api_session.revoked_at.present?
         return @current_api_session.access_expires_at.future? if @current_api_session.is_a?(ApiSession)
+        return @current_api_session.active_for_membership? if @current_api_session.is_a?(OauthGrant)
 
         @current_api_session.is_a?(ApiAppToken)
       end
@@ -133,7 +134,8 @@ module Api
 
       def lookup_api_credential
         token = bearer_token
-        ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token)
+        ApiSession.lookup_by_access_token(token) || ApiAppToken.lookup_by_token(token) ||
+          OauthGrant.lookup_by_access_token(token)
       end
 
       def render_collection(scope, serializer:, includes: nil)

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -12,7 +12,17 @@ class RodauthMain < Rodauth::Rails::Auth
            :reset_password, :change_password, :change_login, :verify_login_change,
            :close_account, :omniauth,
            :otp, :recovery_codes,
-           :webauthn, :webauthn_login, :webauthn_autofill
+           :webauthn, :webauthn_login, :webauthn_autofill,
+           :oauth_pkce, :oauth_token_revocation
+
+    oauth_application_scopes OauthApplication::SUPPORTED_SCOPES
+    oauth_access_token_expires_in 15.minutes.to_i
+    oauth_refresh_token_expires_in 30.days.to_i
+    oauth_refresh_token_protection_policy 'rotation'
+    oauth_grants_token_hash_column :token_hash
+    oauth_grants_refresh_token_hash_column :refresh_token_hash
+    oauth_applications_client_secret_hash_column :client_secret_hash
+    oauth_token_endpoint_auth_methods_supported %w[none client_secret_basic client_secret_post]
 
     # See the Rodauth documentation for the list of available config options:
     # http://rodauth.jeremyevans.net/documentation.html
@@ -98,6 +108,61 @@ class RodauthMain < Rodauth::Rails::Auth
       super(password) && password_complex_enough?(password)
     end
     auth_class_eval do
+      public :password_hash
+
+      def resource_owner_params
+        membership = Account.find(account_id).first_active_household_membership
+        super.merge(
+          household_membership_id: membership.id,
+          person_id: membership.person_id,
+          permissions_version: membership.permissions_version,
+          created_at: Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def authorize_page_lead(name:)
+        membership = Account.find(account_id).first_active_household_membership
+        household_name = ERB::Util.html_escape(membership.household.name)
+        person_name = ERB::Util.html_escape(membership.person.name)
+        "#{super} for #{household_name} / #{person_name}"
+      end
+
+      def create_oauth_grant(create_params = {})
+        code = super
+        record_smart_oauth_event('smart_oauth.consent_granted', create_params.merge(resource_owner_params))
+        code
+      end
+
+      def revoke_oauth_grant
+        grant = super
+        record_smart_oauth_event('smart_oauth.token_revoked', grant)
+        grant
+      end
+
+      def record_smart_oauth_event(event_type, grant)
+        membership = HouseholdMembership.find(grant.fetch(:household_membership_id))
+        Audit::Event.record!(
+          household_id: membership.household_id,
+          actor_account_id: membership.account_id,
+          actor_membership_id: membership.id,
+          event_type: event_type,
+          request_id: rails_controller_instance&.request&.request_id,
+          ip: request.ip,
+          metadata: smart_oauth_audit_metadata(grant, membership)
+        )
+      end
+
+      def smart_oauth_audit_metadata(grant, membership)
+        {
+          oauth_application_id: oauth_application.fetch(oauth_applications_id_column),
+          account_id: membership.account_id,
+          household_membership_id: membership.id,
+          person_id: grant[:person_id] || membership.person_id,
+          scopes: grant[oauth_grants_scopes_column] || scopes.join(oauth_scope_separator)
+        }
+      end
+
       def audit_auth_token(token_type, action, metadata = {})
         audit_account = Account.find_by(id: account_id)
         return unless audit_account

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class OauthApplication < ApplicationRecord
+  SUPPORTED_SCOPES = %w[
+    launch/patient
+    offline_access
+    online_access
+    patient/*.rs
+    patient/Patient.rs
+    patient/Medication.rs
+    patient/MedicationRequest.rs
+    patient/MedicationStatement.rs
+    patient/MedicationAdministration.rs
+    user/*.rs
+  ].freeze
+
+  belongs_to :account, optional: true
+  has_many :oauth_grants, dependent: :destroy
+
+  validates :name, :client_id, :redirect_uri, :scopes, presence: true
+  validate :redirect_uri_uses_https
+  validate :scopes_are_supported
+
+  private
+
+  def redirect_uri_uses_https
+    redirect_uri.to_s.split.each do |value|
+      uri = URI.parse(value)
+      errors.add(:redirect_uri, 'must use HTTPS') unless uri.is_a?(URI::HTTPS) && uri.host.present?
+    rescue URI::InvalidURIError
+      errors.add(:redirect_uri, 'must be a valid HTTPS URI')
+    end
+  end
+
+  def scopes_are_supported
+    unsupported = scopes.to_s.split - SUPPORTED_SCOPES
+    errors.add(:scopes, "include unsupported values: #{unsupported.join(', ')}") if unsupported.any?
+  end
+end

--- a/app/models/oauth_grant.rb
+++ b/app/models/oauth_grant.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class OauthGrant < ApplicationRecord
+  self.inheritance_column = nil
+
+  belongs_to :account
+  belongs_to :oauth_application
+  belongs_to :household_membership
+  belongs_to :person
+
+  scope :active, -> { where(revoked_at: nil).where(expires_in: Time.current..) }
+
+  class << self
+    def lookup_by_access_token(token)
+      active.find_by(token_hash: digest(token))
+    end
+
+    def digest(token)
+      Base64.urlsafe_encode64(Digest::SHA256.digest(token.to_s))
+    end
+  end
+
+  def active_for_membership?
+    household_membership&.active? && permissions_version == household_membership.permissions_version
+  end
+
+  def touch_last_used!
+    update!(last_used_at: Time.current)
+  end
+
+  def allows_fhir_read?(resource_type)
+    granted_scopes = scopes.to_s.split
+    granted_scopes.include?('patient/*.rs') || granted_scopes.include?('user/*.rs') ||
+      granted_scopes.include?("patient/#{resource_type}.rs") || granted_scopes.include?("user/#{resource_type}.rs")
+  end
+
+  def patient_scoped?
+    scopes.to_s.split.any? { |scope| scope.start_with?('patient/') }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     scope 'fhir/R4', module: 'fhir/r4', as: :fhir_r4 do
+      get '.well-known/smart-configuration', to: 'smart_configuration#show'
       get :metadata, to: 'metadata#show'
       get 'Patient', to: 'patients#index'
       get 'Patient/:id', to: 'patients#show'

--- a/db/migrate/20260710210701_create_rodauth_oauth.rb
+++ b/db/migrate/20260710210701_create_rodauth_oauth.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CreateRodauthOauth < ActiveRecord::Migration[8.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.references :account, foreign_key: true
+      t.string :name, null: false
+      t.string :redirect_uri, null: false
+      t.string :client_id, null: false, index: { unique: true }
+      t.string :client_secret
+      t.string :client_secret_hash
+      t.string :scopes, null: false
+      t.timestamps
+    end
+
+    create_table :oauth_grants do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :household_membership, null: false, foreign_key: true
+      t.references :person, null: false, foreign_key: true
+      t.references :oauth_application, null: false, foreign_key: true
+      t.string :type
+      t.string :code
+      t.string :token, index: { unique: true }
+      t.string :token_hash, index: { unique: true }
+      t.string :refresh_token, index: { unique: true }
+      t.string :refresh_token_hash, index: { unique: true }
+      t.datetime :expires_in, null: false
+      t.string :redirect_uri
+      t.datetime :revoked_at
+      t.string :scopes, null: false
+      t.string :access_type, null: false, default: 'offline'
+      t.string :code_challenge
+      t.string :code_challenge_method
+      t.integer :permissions_version, null: false
+      t.datetime :last_used_at
+      t.timestamps
+
+      t.index %i[oauth_application_id code], unique: true
+    end
+  end
+end

--- a/docs/adrs/0007-external-app-integration-contract.md
+++ b/docs/adrs/0007-external-app-integration-contract.md
@@ -92,21 +92,21 @@ person-level authorization.
 
 ## SMART on FHIR
 
-SMART on FHIR is deferred.
+MedTracker supports the SMART App Launch authorization-code flow for registered
+third-party clients. Public clients use PKCE with `S256`; confidential clients
+may use HTTP Basic or posted client credentials. Consent binds the grant to the
+signed-in account's active household membership and person, and FHIR reads must
+pass both the SMART resource scope and the existing policy scope.
 
-MedTracker supports FHIR R4 resource responses, but it does not yet support the
-full SMART app launch profile. Specifically, it does not currently provide:
+The discovery document is available at
+`/api/fhir/R4/.well-known/smart-configuration`. The FHIR `CapabilityStatement`
+advertises the authorization, token, and revocation endpoints. MedTracker does
+not advertise EHR launch because only standalone launch is implemented.
 
-- third-party app registration and redirect URI governance;
-- SMART launch context;
-- SMART scopes and consent;
-- external OAuth authorization-code issuance;
-- third-party refresh-token lifecycle;
-- `.well-known/smart-configuration` metadata.
-
-The FHIR `CapabilityStatement` should describe implemented FHIR resource
-behavior only. It must not imply SMART support until the SMART-specific contract
-is implemented and tested.
+Access tokens expire after 15 minutes. Refresh tokens expire after 30 days and
+rotate on use. Revoking either credential revokes the complete grant. Stored
+credentials are SHA-256 digests; raw authorization codes and tokens are not
+written to security audit metadata.
 
 ## Rejected Alternatives
 

--- a/docs/api/smart-on-fhir.md
+++ b/docs/api/smart-on-fhir.md
@@ -1,0 +1,42 @@
+# SMART on FHIR
+
+MedTracker exposes a SMART App Launch 2.x standalone authorization flow for
+registered third-party healthcare applications. It is separate from the
+first-party `/api/v1` API, CLI credentials, and hosted MCP access.
+
+## Discovery and registration
+
+Read the server contract from
+`/api/fhir/R4/.well-known/smart-configuration`. A registered client has an exact
+HTTPS redirect URI, a client identifier, approved SMART scopes, and optionally
+a confidential client secret. Redirect URIs are compared exactly; wildcard and
+HTTP callback URIs are rejected.
+
+## Authorization
+
+Start at `/authorize` with `response_type=code`, the registered `client_id` and
+`redirect_uri`, requested scopes, state, and an `S256` PKCE challenge. The
+consent page shows the client, requested scopes, household, and person. The
+grant records the membership permissions version, so membership revocation or a
+permission change invalidates existing access.
+
+Exchange the code at `/token` with its PKCE verifier. Access tokens last 15
+minutes. Refresh tokens last 30 days and rotate whenever they are used. Revoke a
+grant through `/revoke`.
+
+## Scope and policy enforcement
+
+Supported read scopes use SMART v2 syntax, including `patient/*.rs` and
+resource-specific forms such as `patient/MedicationRequest.rs`. `user/*.rs` is
+also available. A SMART scope never replaces MedTracker authorization: FHIR
+queries remain restricted by the bound household membership, person grants,
+account state, and Pundit policy scopes.
+
+## Security and audit behavior
+
+Access and refresh tokens are stored only as SHA-256 digests. Consent and
+revocation audit events identify the client, account, membership, person, and
+scopes without recording authorization codes, token material, or FHIR payloads.
+Exact redirect matching, single-use authorization codes, PKCE, rotating refresh
+tokens, membership-version checks, and account lockout checks limit replay and
+scope escalation.

--- a/docs/security/smart-on-fhir-security-review.md
+++ b/docs/security/smart-on-fhir-security-review.md
@@ -1,0 +1,36 @@
+# SMART on FHIR security review
+
+This review covers third-party SMART authorization only. First-party `/api/v1`,
+CLI, and MCP credentials retain their existing authentication paths.
+
+## Controls
+
+- Tokens: access and refresh credentials are random, short-lived, and stored as
+  SHA-256 digests. Confidential client secrets use password hashes. Raw token
+  values exist only in authorization responses.
+- Redirects: every registered callback is an exact HTTPS URI. Authorization
+  rejects any URI that is not in the client registration.
+- PKCE and replay: public clients must use `S256`. Authorization codes are
+  single-use, bound to the redirect URI and verifier, and expire before access
+  tokens are issued.
+- Scope escalation: requested scopes must be a subset of the registered client
+  scopes. FHIR controllers check the SMART resource scope and then apply the
+  existing household and person policy scope.
+- Tenant context: grants bind account, household membership, person, and the
+  membership permissions version. Inactive or changed memberships, locked
+  accounts, inactive users, expired grants, and revoked grants fail closed.
+- Refresh and revocation: refresh tokens rotate on use and expire after 30
+  days. Revocation invalidates the complete grant, including its access and
+  refresh credentials.
+- Audit and logs: consent and revocation events record client, account,
+  membership, person, and scopes. Codes, token material, and FHIR payloads are
+  excluded and the shared audit redactor remains active.
+
+## Residual boundaries
+
+Only standalone launch is advertised. EHR launch context, dynamic client
+registration, write scopes, bulk data, and OpenID Connect identity scopes are
+not implemented and do not appear in discovery metadata. OAuth grant lookup
+must occur before tenant context is known, so the grant table is not protected
+by household RLS; every accepted grant is immediately checked against its
+bound active membership and permissions version before tenant context is set.

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -56,6 +56,8 @@ class SchemaInventory
     native_device_tokens
     nhs_dmd_barcodes
     nhs_dmd_imports
+    oauth_applications
+    oauth_grants
     platform_admins
     push_subscriptions
     support_access_sessions

--- a/spec/lib/rodauth_main_spec.rb
+++ b/spec/lib/rodauth_main_spec.rb
@@ -5,6 +5,26 @@ require 'rails_helper'
 RSpec.describe RodauthMain do
   fixtures :people
 
+  describe 'SMART OAuth provider' do
+    subject(:auth) { RodauthApp.rodauth.allocate }
+
+    it 'requires PKCE and publishes the supported SMART scopes' do
+      expect(auth.oauth_require_pkce).to be true
+      expect(auth.oauth_application_scopes).to include('launch/patient', 'patient/*.rs', 'offline_access')
+    end
+
+    it 'uses short access tokens, rotating refresh tokens, and a thirty day refresh lifetime' do
+      expect(auth.oauth_access_token_expires_in).to eq(15.minutes)
+      expect(auth.oauth_refresh_token_expires_in).to eq(30.days)
+      expect(auth.oauth_refresh_token_protection_policy).to eq('rotation')
+      expect(auth.oauth_applications_client_secret_hash_column).to eq(:client_secret_hash)
+    end
+
+    it 'exposes authorization, token, and revocation routes' do
+      expect(auth).to respond_to(:authorize_path, :token_path, :revoke_path)
+    end
+  end
+
   describe '#set_redirect_error_flash' do
     it 'does not set flash for the routine login-required redirect' do
       auth = RodauthApp.rodauth.allocate

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OauthApplication do
+  subject(:application) do
+    described_class.new(
+      name: 'SMART client',
+      client_id: 'smart-client',
+      redirect_uri: 'https://client.example/callback',
+      scopes: 'launch/patient patient/*.rs offline_access'
+    )
+  end
+
+  it 'accepts a registered HTTPS redirect URI and supported SMART scopes' do
+    expect(application).to be_valid
+  end
+
+  it 'rejects redirect URIs that were not registered with HTTPS' do
+    application.redirect_uri = 'http://client.example/callback'
+
+    expect(application).not_to be_valid
+  end
+
+  it 'accepts multiple exact HTTPS redirect URIs' do
+    application.redirect_uri = 'https://client.example/callback https://client.example/secondary-callback'
+
+    expect(application).to be_valid
+  end
+
+  it 'rejects a registration when any redirect URI is not HTTPS' do
+    application.redirect_uri = 'https://client.example/callback http://client.example/secondary-callback'
+
+    expect(application).not_to be_valid
+  end
+
+  it 'rejects scopes outside the supported SMART contract' do
+    application.scopes = 'patient/*.cruds'
+
+    expect(application).not_to be_valid
+  end
+end

--- a/spec/requests/api/fhir/r4_spec.rb
+++ b/spec/requests/api/fhir/r4_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe 'FHIR R4 API' do
     )
     patient = fhir_json.dig('rest', 0, 'resource').find { |resource| resource.fetch('type') == 'Patient' }
     expect(patient.fetch('searchParam').pluck('name')).to include('_id', 'name', 'birthdate')
+    expect(fhir_json.dig('rest', 0, 'security', 'service', 0, 'coding', 0)).to include(
+      'code' => 'SMART-on-FHIR'
+    )
   end
 
   it 'searches and reads patients with household scoping' do

--- a/spec/requests/api/fhir/smart_access_spec.rb
+++ b/spec/requests/api/fhir/smart_access_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SMART FHIR access' do
+  fixtures :accounts, :people, :users
+
+  let(:smart_context) do
+    person = users(:jane).person
+    account = person.account
+    membership = person.household.household_memberships.find_or_create_by!(
+      account: account,
+      person: person
+    ).tap do |record|
+      record.update!(role: :member, status: :active)
+    end
+    access_grant = person.household.person_access_grants.find_or_initialize_by(
+      household_membership: membership,
+      person: person,
+      revoked_at: nil
+    )
+    access_grant.update!(
+      access_level: :manage,
+      relationship_type: :self,
+      granted_by_membership: membership
+    )
+    raw_token = 'smart-access-token'
+    oauth_application = OauthApplication.create!(
+      name: 'SMART FHIR client',
+      client_id: SecureRandom.uuid,
+      redirect_uri: 'https://client.example/callback',
+      scopes: 'patient/Patient.rs patient/Medication.rs'
+    )
+    grant = OauthGrant.create!(
+      account: account,
+      oauth_application: oauth_application,
+      household_membership: membership,
+      person: person,
+      permissions_version: membership.permissions_version,
+      token_hash: OauthGrant.digest(raw_token),
+      expires_in: 15.minutes.from_now,
+      scopes: 'patient/Patient.rs'
+    )
+
+    { person: person, account: account, membership: membership, raw_token: raw_token, grant: grant }
+  end
+
+  it 'accepts a valid patient read scope' do
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('"resourceType":"Patient"', "\"id\":\"#{person.portable_id}\"")
+  end
+
+  it 'rejects a token without the requested resource scope' do
+    get '/api/fhir/R4/Medication', headers: smart_headers
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'rejects revoked grants' do
+    grant.update!(revoked_at: Time.current)
+
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects grants after their membership permissions change' do
+    membership.update!(permissions_version: membership.permissions_version + 1)
+
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects grants after their membership is revoked' do
+    membership.update!(status: :revoked)
+
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects grants for locked accounts' do
+    allow(ApiAuthState).to receive(:locked_out?).with(account).and_return(true)
+
+    get "/api/fhir/R4/Patient/#{person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'does not expose a patient from another household' do
+    other_household = Household.create!(name: 'Other SMART household')
+    other_person = other_household.people.create!(
+      name: 'Other SMART patient',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+
+    get "/api/fhir/R4/Patient/#{other_person.portable_id}", headers: smart_headers
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  def smart_headers
+    { 'Authorization' => "Bearer #{smart_context.fetch(:raw_token)}" }
+  end
+
+  def person = smart_context.fetch(:person)
+  def account = smart_context.fetch(:account)
+  def membership = smart_context.fetch(:membership)
+  def grant = smart_context.fetch(:grant)
+end

--- a/spec/requests/api/fhir/smart_configuration_spec.rb
+++ b/spec/requests/api/fhir/smart_configuration_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SMART on FHIR discovery' do
+  it 'publishes the supported authorization contract without authentication' do
+    get '/api/fhir/R4/.well-known/smart-configuration'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('application/json')
+    expect(response.parsed_body).to include(
+      'authorization_endpoint' => end_with('/authorize'),
+      'token_endpoint' => end_with('/token'),
+      'revocation_endpoint' => end_with('/revoke'),
+      'code_challenge_methods_supported' => ['S256'],
+      'capabilities' => include('launch-standalone', 'client-public')
+    )
+  end
+end

--- a/spec/requests/smart_oauth_authorization_spec.rb
+++ b/spec/requests/smart_oauth_authorization_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SMART OAuth authorization' do
+  fixtures :accounts, :people, :users
+
+  let(:user) { users(:jane) }
+  let(:membership) do
+    user.person.household.household_memberships.find_or_create_by!(
+      account: user.person.account,
+      person: user.person
+    ).tap do |record|
+      record.update!(role: :member, status: :active)
+    end
+  end
+  let(:code_verifier) { 'smart-code-verifier-with-more-than-forty-three-characters' }
+  let!(:oauth_application) do
+    OauthApplication.create!(
+      name: 'Trusted SMART client',
+      client_id: 'smart-client',
+      redirect_uri: 'https://client.example/callback',
+      scopes: 'launch/patient patient/*.rs offline_access'
+    )
+  end
+  let(:authorization_params) do
+    {
+      response_type: 'code',
+      client_id: oauth_application.client_id,
+      redirect_uri: oauth_application.redirect_uri,
+      scope: oauth_application.scopes,
+      state: 'opaque-state',
+      code_challenge: Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false),
+      code_challenge_method: 'S256'
+    }
+  end
+
+  before do
+    membership
+    sign_in user
+  end
+
+  it 'renders consent for a registered redirect URI and valid PKCE challenge' do
+    get '/authorize', params: authorization_params
+
+    expect(response).to have_http_status(:ok), response.body
+    expect(response.body).to include(
+      oauth_application.name,
+      'patient/*.rs',
+      user.person.household.name,
+      user.person.name
+    )
+  end
+
+  it 'exchanges an authorization code with PKCE and stores only token digests' do
+    payload = issue_tokens
+    grant = OauthGrant.order(:id).last
+    audit_event = SecurityAuditEvent.find_by!(event_type: 'smart_oauth.consent_granted')
+    expect(response).to have_http_status(:ok)
+    expect(payload).to include('access_token', 'refresh_token')
+    expect(grant).to have_attributes(
+      household_membership_id: membership.id,
+      person_id: user.person.id,
+      permissions_version: membership.permissions_version,
+      scopes: oauth_application.scopes,
+      token: nil,
+      refresh_token: nil
+    )
+    expect(grant.token_hash).to eq(OauthGrant.digest(payload.fetch('access_token')))
+    expect(audit_event.metadata).to include(
+      'oauth_application_id' => oauth_application.id,
+      'household_membership_id' => membership.id,
+      'person_id' => user.person.id,
+      'scopes' => oauth_application.scopes
+    )
+    expect(audit_event.metadata.keys).not_to include('token', 'refresh_token', 'code')
+  end
+
+  it 'rotates refresh tokens and revokes the resulting grant' do
+    payload = issue_tokens
+
+    post '/token', params: {
+      grant_type: 'refresh_token',
+      client_id: oauth_application.client_id,
+      refresh_token: payload.fetch('refresh_token')
+    }, as: :json
+
+    refreshed = response.parsed_body
+    expect(response).to have_http_status(:ok), response.body
+    expect(refreshed.fetch('refresh_token')).not_to eq(payload.fetch('refresh_token'))
+
+    post '/logout'
+    post '/revoke', params: {
+      client_id: oauth_application.client_id,
+      token: refreshed.fetch('access_token'),
+      token_type_hint: 'access_token'
+    }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(OauthGrant.order(:id).last.revoked_at).to be_present
+    expect(SecurityAuditEvent.find_by!(event_type: 'smart_oauth.token_revoked').metadata.keys)
+      .not_to include('token', 'refresh_token', 'code')
+  end
+
+  it 'rejects an unregistered redirect URI' do
+    get '/authorize', params: authorization_params.merge(redirect_uri: 'https://attacker.example/callback')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Invalid or missing 'redirect_uri'")
+    expect(response.headers['Location']).to be_nil
+  end
+
+  it 'rejects authorization without PKCE' do
+    get '/authorize', params: authorization_params.except(:code_challenge, :code_challenge_method)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(
+      'action="https://client.example/callback"',
+      'name="error" value="invalid_request"',
+      'name="error_description" value="code challenge required"'
+    )
+  end
+
+  it 'rejects a code exchange without the PKCE verifier' do
+    post '/authorize', params: authorization_params.merge(scope: oauth_application.scopes.split)
+    code = response.parsed_body.at_css('input[name="code"]')['value']
+
+    post '/token', params: {
+      grant_type: 'authorization_code',
+      client_id: oauth_application.client_id,
+      redirect_uri: oauth_application.redirect_uri,
+      code: code
+    }, as: :json
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body).to include('error' => 'invalid_request')
+  end
+
+  it 'provides a denied-consent response preserving state' do
+    get '/authorize', params: authorization_params
+
+    denial_url = response.parsed_body.at_css('a.btn-outline-danger')['href']
+    expect(denial_url).to include('error=access_denied', 'state=opaque-state')
+  end
+
+  def issue_tokens
+    post '/token', params: {
+      grant_type: 'authorization_code',
+      client_id: oauth_application.client_id,
+      redirect_uri: oauth_application.redirect_uri,
+      code: authorization_code,
+      code_verifier: code_verifier
+    }, as: :json
+
+    response.parsed_body
+  end
+
+  def authorization_code
+    post '/authorize', params: authorization_params.merge(scope: oauth_application.scopes.split)
+    response.parsed_body.at_css('input[name="code"]')['value']
+  end
+end


### PR DESCRIPTION
External healthcare apps can now use a standard SMART authorization-code flow instead of MedTracker first-party API credentials.

This adds exact HTTPS client registration, S256 PKCE consent, household/person-bound grants, rotating refresh tokens, revocation, SMART discovery, and truthful CapabilityStatement security metadata. FHIR reads must pass both the granted SMART resource scope and MedTracker existing household/person policy scope, so a SMART token cannot widen access.

Access and refresh tokens are stored only as SHA-256 digests, confidential client secrets use password hashes, and consent/revocation audit events omit codes, tokens, and clinical payloads. The ADR, integration guide, and security review describe the supported standalone-launch boundary and explicitly exclude unimplemented EHR launch, dynamic registration, write, bulk-data, and OIDC identity features.

Manual browser capture remains blocked by the shared development-container problem tracked in #1573; the consent HTML and complete authorization flow are covered at the request boundary.

Closes #1534