### PR TITLE
fix(i18n): translate validation messages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module MedTracker
     # in config/environments, which are processed later.
     #
     config.time_zone = ENV.fetch('TZ', 'UTC')
+    config.i18n.fallbacks = true
     config.active_storage.draw_routes = false
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -32,6 +32,17 @@ cy:
             barcode:
               invalid: rhaid iddo fod yn GTIN 13 neu 14 digid
               taken: eisoes wedi'i gysylltu â meddyginiaeth arall yn y rhestr
+  errors:
+    messages:
+      blank: ni all fod yn wag
+      greater_than: rhaid bod yn fwy na %{count}
+      greater_than_or_equal_to: rhaid bod yn fwy na neu'n hafal i %{count}
+      inclusion: nid yw wedi'i gynnwys yn y rhestr
+      invalid: yn annilys
+      not_a_number: nid yw'n rhif
+      required: rhaid iddo fodoli
+      taken: eisoes wedi'i gymryd
+      too_short: yn rhy fyr (yr isafswm yw %{count} nod)
   app:
     name: MedTracker
   global_search:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,6 +32,17 @@ es:
             barcode:
               invalid: debe ser un GTIN de 13 o 14 dígitos
               taken: ya está vinculado a otro medicamento en el inventario
+  errors:
+    messages:
+      blank: no puede estar en blanco
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor o igual que %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      not_a_number: no es un número
+      required: debe existir
+      taken: ya está en uso
+      too_short: es demasiado corto (mínimo %{count} caracteres)
   app:
     name: MedTracker
   global_search:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -32,6 +32,17 @@ ga:
             barcode:
               invalid: caithfidh sé a bheith ina GTIN 13 nó 14 digit
               taken: ceangailte cheana le cógas eile sa stórliosta
+  errors:
+    messages:
+      blank: ní féidir a bheith folamh
+      greater_than: ní mór a bheith níos mó ná %{count}
+      greater_than_or_equal_to: ní mór a bheith níos mó ná nó cothrom le %{count}
+      inclusion: níl sé san áireamh sa liosta
+      invalid: neamhbhailí
+      not_a_number: ní uimhir é
+      required: caithfidh sé a bheith ann
+      taken: in úsáid cheana féin
+      too_short: ró-ghearr (is é %{count} carachtar an t-íosmhéid)
   app:
     name: MedTracker
   global_search:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -32,6 +32,17 @@ pt:
             barcode:
               invalid: deve ser um GTIN de 13 ou 14 dígitos
               taken: já está vinculado a outro medicamento no inventário
+  errors:
+    messages:
+      blank: não pode ficar em branco
+      greater_than: deve ser maior que %{count}
+      greater_than_or_equal_to: deve ser maior ou igual a %{count}
+      inclusion: não está incluído na lista
+      invalid: não é válido
+      not_a_number: não é um número
+      required: deve existir
+      taken: já está em uso
+      too_short: é muito curto (mínimo de %{count} caracteres)
   app:
     name: MedTracker
   global_search:

--- a/spec/requests/form_validation_feedback_spec.rb
+++ b/spec/requests/form_validation_feedback_spec.rb
@@ -55,5 +55,31 @@ RSpec.describe 'Form inline validation feedback' do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('must be greater than 0')
     end
+
+    it 'renders validation messages in Spanish' do
+      I18n.with_locale(:es) do
+        post medications_path,
+             params: { medication: { name: '', description: 'Prueba', dose_amount: 10, dose_unit: 'mg' } }
+      end
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('no puede estar en blanco')
+    end
+
+    it 'renders validation messages in Welsh' do
+      I18n.with_locale(:cy) do
+        post medications_path,
+             params: { medication: { name: '', description: 'Prawf', dose_amount: 10, dose_unit: 'mg' } }
+      end
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('ni all fod yn wag')
+    end
+
+    it 'falls back to the English validation message when a locale key is missing' do
+      message = I18n.with_locale(:es) { I18n.t('errors.messages.on_or_after_start_date') }
+
+      expect(message).to eq('must be on or after the start date')
+    end
   end
 end


### PR DESCRIPTION
Validation feedback was localized around the form, but Rails model errors still fell through to missing-translation text outside English. This adds the generic validation messages used by MedTracker in Welsh, Spanish, Irish, and Portuguese, and makes missing locale keys fall back consistently to English.

The request-level regression coverage proves two non-English form responses and the fallback path, preventing localized forms from silently regressing to broken error copy.

Closes #617.