### PR TITLE
fix(observability): trace background jobs

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -110,6 +110,7 @@ if Rails.env.test?
   ENV['OTEL_TRACES_EXPORTER'] = 'none'
 
   require 'opentelemetry/sdk'
+  require 'opentelemetry/instrumentation/active_job'
   require 'opentelemetry/instrumentation/active_record'
   require 'opentelemetry/instrumentation/pg'
   require 'opentelemetry/instrumentation/rack'
@@ -120,6 +121,11 @@ if Rails.env.test?
     c.service_version = 'test'
 
     c.use('OpenTelemetry::Instrumentation::Rails')
+    c.use(
+      'OpenTelemetry::Instrumentation::ActiveJob',
+      propagation_style: :link,
+      span_naming: :job_class
+    )
     c.use('OpenTelemetry::Instrumentation::ActiveRecord')
     c.use(
       'OpenTelemetry::Instrumentation::Rack',
@@ -142,6 +148,7 @@ if Rails.env.test?
 elsif Rails.env.production? || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].present?
   require 'opentelemetry/sdk'
   require 'opentelemetry/exporter/otlp'
+  require 'opentelemetry/instrumentation/active_job'
   require 'opentelemetry/instrumentation/active_record'
   require 'opentelemetry/instrumentation/net/http'
   require 'opentelemetry/instrumentation/pg'
@@ -178,6 +185,11 @@ elsif Rails.env.production? || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].present?
     end
 
     c.use('OpenTelemetry::Instrumentation::Rails')
+    c.use(
+      'OpenTelemetry::Instrumentation::ActiveJob',
+      propagation_style: :link,
+      span_naming: :job_class
+    )
     c.use('OpenTelemetry::Instrumentation::ActiveRecord')
     c.use(
       'OpenTelemetry::Instrumentation::Rack',

--- a/spec/features/observability/active_job_trace_continuity_spec.rb
+++ b/spec/features/observability/active_job_trace_continuity_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Active Job trace continuity' do
+  include ActiveJob::TestHelper
+
+  let(:tracer) { OpenTelemetry.tracer_provider.tracer('medtracker-active-job-trace-spec') }
+  let(:span_processor) { OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter) }
+  let(:exporter) do
+    Class.new do
+      attr_reader :finished_spans
+
+      def initialize
+        @finished_spans = []
+      end
+
+      def export(span_data, timeout: nil)
+        @finished_spans.concat(span_data)
+        @timeout = timeout
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+
+      def force_flush(timeout: nil)
+        @timeout = timeout
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+
+      def shutdown(timeout: nil)
+        @timeout = timeout
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+    end.new
+  end
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    OpenTelemetry.tracer_provider.add_span_processor(span_processor)
+
+    example.run
+  ensure
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActiveJob::Base.queue_adapter = original_adapter
+    OpenTelemetry.tracer_provider.instance_variable_get(:@span_processors).delete(span_processor)
+  end
+
+  it 'links a performed job to the trace that enqueued it' do
+    stub_const('TraceContinuityJob', Class.new(ApplicationJob) do
+      def perform; end
+    end)
+    request_trace_id = nil
+
+    tracer.in_span('request') do |span|
+      request_trace_id = span.context.trace_id
+      TraceContinuityJob.perform_later
+    end
+    perform_enqueued_jobs
+
+    expect(process_span.links.map { |link| link.span_context.trace_id }).to include(request_trace_id)
+  end
+
+  it 'records an escaped job failure on the consumer span' do
+    stub_const('FailingTraceJob', Class.new(ApplicationJob) do
+      def perform
+        raise 'job failure'
+      end
+    end)
+
+    tracer.in_span('request') { FailingTraceJob.perform_later }
+
+    expect { perform_enqueued_jobs }.to raise_error(RuntimeError, 'job failure')
+    expect(process_span.status.code).to eq(OpenTelemetry::Trace::Status::ERROR)
+    expect(process_span.events.map(&:name)).to include('exception')
+  end
+
+  def process_span
+    exporter.finished_spans.find { |span| span.name.end_with?(' process') }
+  end
+end

--- a/spec/features/observability/otlp_exporter_spec.rb
+++ b/spec/features/observability/otlp_exporter_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe 'OTEL-011: OTLP exporter configuration' do
       expect(instrumentation.installed?).to be(true)
     end
 
+    it 'enables Active Job instrumentation with linked trace propagation' do
+      instrumentation = OpenTelemetry::Instrumentation::ActiveJob::Instrumentation.instance
+
+      expect(instrumentation).to be_installed
+      expect(instrumentation.instance_variable_get(:@config)).to include(
+        propagation_style: :link,
+        span_naming: :job_class
+      )
+    end
+
     it 'enables Rack instrumentation with untraced endpoints' do
       instrumentation = OpenTelemetry::Instrumentation::Rack::Instrumentation.instance
       expect(instrumentation).not_to be_nil


### PR DESCRIPTION
Background-job tracing was present as a dependency but never enabled, so Solid Queue work could not be connected to the request that scheduled it.

This enables the Active Job instrumentation explicitly. Enqueue and processing spans now use the job class name, while processing traces link back to the originating request without forcing long-lived request traces to stay open. Escaped job failures are recorded on the consumer span.

The integration coverage runs a serialized job through the real Active Job hooks and proves both trace linkage and failure recording.

Closes #612.