### PR TITLE
fix(i18n): complete review translations

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -761,17 +761,17 @@ cy:
         directions: Cyfarwyddiadau
         warnings: Rhybuddion
       review_prompt_summary:
-        one: "%{count} medication review prompt (%{risk_level})"
-        other: "%{count} medication review prompts (%{risk_level})"
+        one: "%{count} eitem adolygu meddyginiaeth (%{risk_level})"
+        other: "%{count} eitem adolygu meddyginiaeth (%{risk_level})"
       review_prompt_filtered:
         one: 1 eitem adolygu llai hyderus wedi'i chuddio i leihau sŵn
         other: "%{count} eitem adolygu llai hyderus wedi'u cuddio i leihau sŵn"
-      review_prompt_details_button: View Review Prompt Details
-      review_prompt_details: Review Prompt Details
-      review_prompt_risk_level: Risk level
-      review_prompt_source: Evidence source
-      review_prompt_checked_on: Evidence checked on
-      review_prompt_description: Review with a practitioner
+      review_prompt_details_button: Gweld manylion yr eitem adolygu
+      review_prompt_details: Manylion yr eitem adolygu
+      review_prompt_risk_level: Lefel risg
+      review_prompt_source: Ffynhonnell y dystiolaeth
+      review_prompt_checked_on: Gwiriwyd y dystiolaeth ar
+      review_prompt_description: Adolygu gydag ymarferydd
       update_stock: Diweddaru stoc
       confirm_restock: Cadarnhewch eich bod am ychwanegu %{quantity} uned at %{medication}.
       confirm_restock_without_quantity: Cadarnhewch faint o unedau rydych am eu hychwanegu
@@ -1481,11 +1481,39 @@ cy:
     hidden_count:
       one: 1 eitem adolygu llai hyderus wedi'i chuddio i leihau sŵn
       other: "%{count} eitem adolygu llai hyderus wedi'u cuddio i leihau sŵn"
+    included_count:
+      one: 1 eitem adolygu llai hyderus wedi'i chynnwys
+      other: "%{count} eitem adolygu llai hyderus wedi'u cynnwys"
     show_hidden: Dangos eitemau wedi'u hidlo
     hide_hidden: Cuddio eitemau wedi'u hidlo
     empty_title: Dim adolygiadau meddyginiaeth i'w dangos
     empty_description: Nid oes unrhyw bâr tystiolaeth a adolygwyd yn cyfateb i'r meddyginiaethau gweithredol yng nghofnodion yr aelwyd a ddewiswyd.
     review_reason: Mae tystiolaeth gyhoeddus y label yn awgrymu y gallai fod yn werth adolygu'r cyfuniad hwn gyda fferyllydd, nyrs, meddyg teulu neu ragnodydd.
+    view_evidence: Gweld y dystiolaeth
+    summaries:
+      contraindicated: Mae label y feddyginiaeth yn argymell gofal ychwanegol pan gymerir y rhain gyda'i gilydd.
+      avoid: Mae label y feddyginiaeth yn argymell gofal ychwanegol pan gymerir y rhain gyda'i gilydd.
+      monitor_or_adjust: Mae label y feddyginiaeth yn argymell monitro neu addasu'r driniaeth pan gymerir y rhain gyda'i gilydd.
+      possible_or_caution: Mae label y feddyginiaeth yn disgrifio pryder posibl pan gymerir y rhain gyda'i gilydd.
+      unclassified: Mae label y feddyginiaeth yn enwi'r meddyginiaethau hyn gyda'i gilydd ond nid yw'n rhoi cyfarwyddyd clir.
+    filters:
+      priority: Blaenoriaeth
+      include_filtered: Cynnwys eitemau wedi'u hidlo
+      apply: Defnyddio hidlwyr
+      review_statuses:
+        needs_review: Angen adolygiad
+        reviewed: Wedi'u hadolygu
+        all: Pob un
+      priorities:
+        all: Pob un
+        discuss_soon: Trafod yn fuan
+        ask_when_convenient: Gofyn pan fo'n gyfleus
+        low_confidence: Hyder isel
+      short_priorities:
+        all: Pob un
+        discuss_soon: Yn fuan
+        ask_when_convenient: Cyfleus
+        low_confidence: Hyder isel
     evidence_excerpt: Tystiolaeth gyhoeddus y label
     checked_on: Gwiriwyd y dystiolaeth ar %{date}
     confidence: Hyder cyfateb %{value}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -769,17 +769,17 @@ es:
         directions: Instrucciones
         warnings: Advertencias
       review_prompt_summary:
-        one: "%{count} medication review prompt (%{risk_level})"
-        other: "%{count} medication review prompts (%{risk_level})"
+        one: "%{count} indicación de revisión de medicamentos (%{risk_level})"
+        other: "%{count} indicaciones de revisión de medicamentos (%{risk_level})"
       review_prompt_filtered:
         one: 1 elemento de revisión de menor confianza oculto para reducir el ruido
         other: "%{count} elementos de revisión de menor confianza ocultos para reducir el ruido"
-      review_prompt_details_button: View Review Prompt Details
-      review_prompt_details: Review Prompt Details
-      review_prompt_risk_level: Risk level
-      review_prompt_source: Evidence source
-      review_prompt_checked_on: Evidence checked on
-      review_prompt_description: Review with a practitioner
+      review_prompt_details_button: Ver detalles de la revisión
+      review_prompt_details: Detalles de la revisión
+      review_prompt_risk_level: Nivel de riesgo
+      review_prompt_source: Fuente de la evidencia
+      review_prompt_checked_on: Evidencia consultada el
+      review_prompt_description: Revisar con un profesional
       update_stock: Actualizar stock
       confirm_restock: Confirme que desea añadir %{quantity} unidades a %{medication}.
       confirm_restock_without_quantity: Confirme cuántas unidades desea añadir a
@@ -1459,11 +1459,39 @@ es:
     hidden_count:
       one: 1 elemento de revisión de menor confianza oculto para reducir el ruido
       other: "%{count} elementos de revisión de menor confianza ocultos para reducir el ruido"
+    included_count:
+      one: 1 elemento de revisión de menor confianza incluido
+      other: "%{count} elementos de revisión de menor confianza incluidos"
     show_hidden: Mostrar elementos filtrados
     hide_hidden: Ocultar elementos filtrados
     empty_title: No hay revisiones de medicamentos que mostrar
     empty_description: Ningún par de evidencias revisado coincide con los medicamentos activos de los registros del hogar seleccionado.
     review_reason: La evidencia pública de las etiquetas sugiere que puede ser útil revisar esta combinación con un farmacéutico, enfermero, médico de cabecera o prescriptor.
+    view_evidence: Ver evidencia
+    summaries:
+      contraindicated: La etiqueta del medicamento recomienda extremar la precaución al tomar estos medicamentos juntos.
+      avoid: La etiqueta del medicamento recomienda extremar la precaución al tomar estos medicamentos juntos.
+      monitor_or_adjust: La etiqueta del medicamento recomienda supervisar o ajustar el tratamiento al tomar estos medicamentos juntos.
+      possible_or_caution: La etiqueta del medicamento describe un posible motivo de preocupación al tomar estos medicamentos juntos.
+      unclassified: La etiqueta del medicamento menciona estos medicamentos juntos, pero no proporciona una indicación clara.
+    filters:
+      priority: Prioridad
+      include_filtered: Incluir elementos filtrados
+      apply: Aplicar filtros
+      review_statuses:
+        needs_review: Pendientes de revisión
+        reviewed: Revisados
+        all: Todos
+      priorities:
+        all: Todas
+        discuss_soon: Consultar pronto
+        ask_when_convenient: Consultar cuando sea conveniente
+        low_confidence: Confianza baja
+      short_priorities:
+        all: Todas
+        discuss_soon: Pronto
+        ask_when_convenient: Cuando convenga
+        low_confidence: Confianza baja
     evidence_excerpt: Evidencia pública de la etiqueta
     checked_on: Evidencia consultada el %{date}
     confidence: Confianza de coincidencia %{value}

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -764,17 +764,17 @@ ga:
         directions: Treoracha
         warnings: Rabhaidh
       review_prompt_summary:
-        one: "%{count} medication review prompt (%{risk_level})"
-        other: "%{count} medication review prompts (%{risk_level})"
+        one: "%{count} mhír athbhreithnithe cógais (%{risk_level})"
+        other: "%{count} mír athbhreithnithe cógais (%{risk_level})"
       review_prompt_filtered:
         one: 1 mhír athbhreithnithe ar mhuinín níos ísle i bhfolach chun torann a laghdú
         other: "%{count} mír athbhreithnithe ar mhuinín níos ísle i bhfolach chun torann a laghdú"
-      review_prompt_details_button: View Review Prompt Details
-      review_prompt_details: Review Prompt Details
-      review_prompt_risk_level: Risk level
-      review_prompt_source: Evidence source
-      review_prompt_checked_on: Evidence checked on
-      review_prompt_description: Review with a practitioner
+      review_prompt_details_button: Féach ar shonraí na míre athbhreithnithe
+      review_prompt_details: Sonraí na míre athbhreithnithe
+      review_prompt_risk_level: Leibhéal riosca
+      review_prompt_source: Foinse na fianaise
+      review_prompt_checked_on: Fianaise seiceáilte ar
+      review_prompt_description: Athbhreithnigh le cleachtóir
       update_stock: Nuashonraigh stoc
       confirm_restock: Deimhnigh gur mian leat %{quantity} aonad a chur le %{medication}.
       confirm_restock_without_quantity: Deimhnigh cé mhéad aonad is mian leat a chur
@@ -1459,11 +1459,39 @@ ga:
     hidden_count:
       one: 1 mhír athbhreithnithe ar mhuinín níos ísle i bhfolach chun torann a laghdú
       other: "%{count} mír athbhreithnithe ar mhuinín níos ísle i bhfolach chun torann a laghdú"
+    included_count:
+      one: 1 mhír athbhreithnithe ar mhuinín níos ísle san áireamh
+      other: "%{count} mír athbhreithnithe ar mhuinín níos ísle san áireamh"
     show_hidden: Taispeáin míreanna scagtha
     hide_hidden: Folaigh míreanna scagtha
     empty_title: Níl aon athbhreithniú cógas le taispeáint
     empty_description: Ní mheaitseálann aon phéire fianaise athbhreithnithe na cógais ghníomhacha sna taifid teaghlaigh roghnaithe.
     review_reason: Tugann fianaise phoiblí lipéid le fios gur fiú an teaglaim seo a athbhreithniú le cógaiseoir, altra, dochtúir teaghlaigh nó oideasóir.
+    view_evidence: Féach ar an bhfianaise
+    summaries:
+      contraindicated: Molann lipéad an chógais cúram breise nuair a thógtar iad seo le chéile.
+      avoid: Molann lipéad an chógais cúram breise nuair a thógtar iad seo le chéile.
+      monitor_or_adjust: Molann lipéad an chógais monatóireacht nó coigeartú a dhéanamh ar an gcóireáil nuair a thógtar iad seo le chéile.
+      possible_or_caution: Déanann lipéad an chógais cur síos ar ábhar imní féideartha nuair a thógtar iad seo le chéile.
+      unclassified: Ainmníonn lipéad an chógais na cógais seo le chéile ach ní thugann sé treoir shoiléir.
+    filters:
+      priority: Tosaíocht
+      include_filtered: Cuir míreanna scagtha san áireamh
+      apply: Cuir scagairí i bhfeidhm
+      review_statuses:
+        needs_review: Athbhreithniú de dhíth
+        reviewed: Athbhreithnithe
+        all: Gach ceann
+      priorities:
+        all: Gach ceann
+        discuss_soon: Pléigh go luath
+        ask_when_convenient: Fiafraigh nuair atá sé áisiúil
+        low_confidence: Muinín íseal
+      short_priorities:
+        all: Gach ceann
+        discuss_soon: Go luath
+        ask_when_convenient: Áisiúil
+        low_confidence: Muinín íseal
     evidence_excerpt: Fianaise phoiblí lipéid
     checked_on: Fianaise seiceáilte ar %{date}
     confidence: Muinín mheaitseála %{value}

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -767,17 +767,17 @@ pt:
         directions: Instruções
         warnings: Avisos
       review_prompt_summary:
-        one: "%{count} medication review prompt (%{risk_level})"
-        other: "%{count} medication review prompts (%{risk_level})"
+        one: "%{count} indicação de revisão de medicamentos (%{risk_level})"
+        other: "%{count} indicações de revisão de medicamentos (%{risk_level})"
       review_prompt_filtered:
         one: 1 item de revisão de menor confiança ocultado para reduzir o ruído
         other: "%{count} itens de revisão de menor confiança ocultados para reduzir o ruído"
-      review_prompt_details_button: View Review Prompt Details
-      review_prompt_details: Review Prompt Details
-      review_prompt_risk_level: Risk level
-      review_prompt_source: Evidence source
-      review_prompt_checked_on: Evidence checked on
-      review_prompt_description: Review with a practitioner
+      review_prompt_details_button: Ver detalhes da revisão
+      review_prompt_details: Detalhes da revisão
+      review_prompt_risk_level: Nível de risco
+      review_prompt_source: Fonte da evidência
+      review_prompt_checked_on: Evidência verificada em
+      review_prompt_description: Rever com um profissional
       update_stock: Atualizar stock
       confirm_restock: Confirme que pretende adicionar %{quantity} unidades a %{medication}.
       confirm_restock_without_quantity: Confirme quantas unidades pretende adicionar
@@ -1588,11 +1588,39 @@ pt:
     hidden_count:
       one: 1 item de revisão de menor confiança ocultado para reduzir o ruído
       other: "%{count} itens de revisão de menor confiança ocultados para reduzir o ruído"
+    included_count:
+      one: 1 item de revisão de menor confiança incluído
+      other: "%{count} itens de revisão de menor confiança incluídos"
     show_hidden: Mostrar itens filtrados
     hide_hidden: Ocultar itens filtrados
     empty_title: Não há revisões de medicamentos para mostrar
     empty_description: Nenhum par de evidências revisto corresponde aos medicamentos ativos nos registos do agregado selecionado.
     review_reason: A evidência pública do rótulo sugere que esta combinação pode merecer revisão com um farmacêutico, enfermeiro, médico de família ou prescritor.
+    view_evidence: Ver evidência
+    summaries:
+      contraindicated: O rótulo do medicamento recomenda cuidados adicionais quando estes medicamentos são tomados em conjunto.
+      avoid: O rótulo do medicamento recomenda cuidados adicionais quando estes medicamentos são tomados em conjunto.
+      monitor_or_adjust: O rótulo do medicamento recomenda a monitorização ou o ajuste do tratamento quando estes medicamentos são tomados em conjunto.
+      possible_or_caution: O rótulo do medicamento descreve uma possível preocupação quando estes medicamentos são tomados em conjunto.
+      unclassified: O rótulo do medicamento menciona estes medicamentos em conjunto, mas não fornece uma instrução clara.
+    filters:
+      priority: Prioridade
+      include_filtered: Incluir itens filtrados
+      apply: Aplicar filtros
+      review_statuses:
+        needs_review: Precisam de revisão
+        reviewed: Revistos
+        all: Todos
+      priorities:
+        all: Todas
+        discuss_soon: Falar em breve
+        ask_when_convenient: Perguntar quando for conveniente
+        low_confidence: Confiança baixa
+      short_priorities:
+        all: Todas
+        discuss_soon: Em breve
+        ask_when_convenient: Quando for conveniente
+        low_confidence: Confiança baixa
     evidence_excerpt: Evidência pública do rótulo
     checked_on: Evidência verificada em %{date}
     confidence: Confiança de correspondência %{value}


### PR DESCRIPTION
The medicine-review interface added in #1586 was only partially translated outside English. Several finder labels still displayed English text, while the lower-confidence count, evidence summaries, and filter controls were missing entirely from Welsh, Spanish, Irish, and Portuguese.

This change translates those remaining labels and gives all five locales the same medication-review node structure, including plural branches and interpolation variables. Users selecting any supported locale now receive the complete review and filtering vocabulary instead of mixed-language or fallback UI.

The audit also found older repository-wide locale drift outside this feature. That broader cleanup is tracked separately in #1587 so this change stays limited to the medicine-review interface.