### PR TITLE
fix(i18n): restore locale tree parity

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -27,6 +27,14 @@ cy:
           self: Hunan
     errors:
       models:
+        health_event:
+          attributes:
+            ended_on:
+              on_or_after_start_date: rhaid iddo fod ar neu ar ôl y dyddiad dechrau
+        health_event_medication:
+          attributes:
+            medication_id:
+              linked_to_health_event: eisoes wedi'i gysylltu â'r digwyddiad iechyd hwn
         medication:
           attributes:
             barcode:
@@ -43,6 +51,47 @@ cy:
       required: rhaid iddo fodoli
       taken: eisoes wedi'i gymryd
       too_short: yn rhy fyr (yr isafswm yw %{count} nod)
+      linked_to_health_event: eisoes wedi'i gysylltu â'r digwyddiad iechyd hwn
+      on_or_after_start_date: rhaid iddo fod ar neu ar ôl y dyddiad dechrau
+  health_events:
+    created: Cofnodwyd y digwyddiad iechyd.
+    updated: Diweddarwyd y digwyddiad iechyd.
+    deleted: Dilëwyd y digwyddiad iechyd.
+    invalid_medication_link: Dewiswch feddyginiaethau sydd wedi'u neilltuo i'r person hwn yn unig.
+    kinds:
+      illness: Salwch nodedig
+      suspected_side_effect: Sgil-effaith a amheuir
+    severities:
+      mild: Ysgafn
+      moderate: Cymedrol
+      severe: Difrifol
+    actions:
+      record_illness: Cofnodi salwch nodedig
+      record_suspected_side_effect: Cofnodi sgil-effaith a amheuir
+      edit: Golygu
+      delete: Dileu
+      cancel: Canslo
+      save: Cadw
+    index:
+      title: Digwyddiadau iechyd %{person}
+      subtitle: Cofnodwch afiechydon nodedig a sgil-effeithiau a amheuir heb wneud honiadau clinigol.
+      empty: Nid oes digwyddiadau iechyd wedi'u cofnodi eto.
+      ongoing_from: Yn parhau ers %{started_on}
+      date_range: "%{started_on} i %{ended_on}"
+    form:
+      new_title: Cofnodi %{kind}
+      edit_title: Golygu %{kind}
+      subtitle: Cofnodwch ffeithiau a gofnodwyd gan y teulu neu'r gofalwr.
+      title: Teitl
+      started_on: Dyddiad dechrau
+      ended_on: Dyddiad gorffen
+      ongoing: Yn parhau
+      severity: Difrifoldeb
+      no_severity: Heb ei nodi
+      suspected_medications: Meddyginiaethau a amheuir
+      notes: Nodiadau
+      action_taken: Camau a gymerwyd
+      medical_help_sought: Ceisiwyd cymorth meddygol
   app:
     name: MedTracker
   global_search:
@@ -404,6 +453,9 @@ cy:
         all: Pawb
         clear: Clirio
       table:
+        system_access: Mynediad system
+        system_administrator: Gweinyddwr system
+        household_user: Defnyddiwr aelwyd
         activation: Actifadu
         verification: Dilysu
         actions: Gweithredoedd
@@ -568,6 +620,8 @@ cy:
         invitations_title: Gwahoddiadau
         invitations_description: Gwahodd defnyddwyr newydd i ymuno
         manage_people_title: Rheoli pobl
+        household_settings_title: Gosodiadau aelwyd
+        household_settings_description: Ailenwi'r aelwyd hon
         manage_people_description: Gweld a rheoli cofnodion pobl
         audit_trail_title: Llwybr archwilio
         audit_trail_description: Gweld logiau archwilio'r system
@@ -642,6 +696,12 @@ cy:
         platfform.
       update_submit: Diweddaru Rôl
       updated: Rôl aelodaeth wedi'i diweddaru.
+    households:
+      updated: Aelwyd wedi'i chadw
+      title: Gosodiadau aelwyd
+      subtitle: Ailenwch yr aelwyd bresennol a chadwch label yr aelwyd yn adnabyddadwy i bawb sydd â mynediad.
+      name: Enw'r aelwyd
+      save: Cadw'r aelwyd
   platform:
     settings:
       title: Gosodiadau platfform
@@ -649,6 +709,17 @@ cy:
     support_access_sessions:
       created: Mynediad cymorth wedi'i agor.
       ended: Mynediad cymorth wedi dod i ben.
+    users:
+      title: Gweinyddwyr system
+      subtitle: Adolygwch rolau aelwydydd a chaniatáu mynediad gweinyddol ar draws y platfform.
+      settings: Gosodiadau platfform
+      household_role: Rôl aelwyd
+      system_access: Mynediad system
+      system_administrator: Gweinyddwr system
+      household_user: Defnyddiwr aelwyd
+      grant_system_access: Caniatáu mynediad system
+      remove_system_access: Dileu mynediad system
+      updated: Mynediad system wedi'i ddiweddaru
   authentication:
     login_required: Mewngofnodwch i barhau
     privileged_mfa_required:
@@ -891,6 +962,10 @@ cy:
       edit_dosage: Golygu
       mark_as_ordered: Archebu
       mark_as_received: Derbyn
+      order_details: Manylion archeb
+      order_supplier: Cyflenwr
+      order_quantity: Nifer
+      expected_arrival: Cyrraedd disgwyliedig
       refill_inventory: Ail-stocio
       complete_refill: Ail-stocio
       reorder_at_label: Ail-archebu am
@@ -940,9 +1015,9 @@ cy:
       otc_description: Taken as needed without a fixed schedule
     show:
       edit_person: Golygu Person
-      add_schedule: Amserlen
       add_medication: Ychwanegu Meddyginiaeth
       manage_parents: Rheoli rhieni
+      health_events: Digwyddiadau iechyd
       back: Yn ôl
       born: 'Ganwyd:'
       age: 'Oedran:'
@@ -956,10 +1031,6 @@ cy:
       add_first_medication: Ychwanegu Meddyginiaeth Gyntaf
       no_any_medications: Dim meddyginiaethau eto.
       add_first_any_medication: Ychwanegu Meddyginiaeth
-      mark_as_ordered: Archebu
-      mark_as_received: Derbyniwyd
-      refill_inventory: Ail-stocio
-      complete_refill: Ail-stocio
     carer_relationships:
       created: Rhiant neu ofalwr wedi'i aseinio.
       invited: Anfonwyd gwahoddiad gyda'r dibynnydd hwn wedi'i atodi.
@@ -1015,6 +1086,8 @@ cy:
     created: Ychwanegwyd y feddyginiaeth yn llwyddiannus.
     updated: Diweddarwyd y feddyginiaeth yn llwyddiannus.
     deleted: Tynnwyd y feddyginiaeth yn llwyddiannus.
+    paused: Oedwyd y feddyginiaeth.
+    resumed: Ailddechreuwyd y feddyginiaeth.
     medication_taken: Cymerwyd y feddyginiaeth yn llwyddiannus.
     invalid_dose_configured: Dos annilys wedi'i ffurfweddu. Diweddarwch ddos y feddyginiaeth
       cyn cymryd.
@@ -1023,6 +1096,7 @@ cy:
       edit_title: Golygu Meddyginiaeth ar gyfer %{person}
       subtitle: Ychwanegu meddyginiaeth reolaidd neu yn ôl yr angen
     card:
+      paused: Wedi'i oedi
       notes: 'Nodiadau:'
       timing_restrictions: 'Cyfyngiadau Amseru:'
       max_doses_per_day: Uchafswm %{count} dos(au) y dydd
@@ -1034,6 +1108,11 @@ cy:
       give: Rhoi
       out_of_stock: Allan o Stoc
       invalid_dose: Dos Annilys Wedi'i Ffurfweddu
+      actions: Gweithredoedd
+      move_up: Symud i fyny
+      move_down: Symud i lawr
+      pause: Oedi'r feddyginiaeth
+      resume: Ailddechrau'r feddyginiaeth
       move_up_aria_label: Symud meddyginiaeth i fyny
       move_down_aria_label: Symud meddyginiaeth i lawr
       delete_aria_label: Dileu meddyginiaeth
@@ -1139,6 +1218,8 @@ cy:
     created: Crëwyd y presgripsiwn yn llwyddiannus.
     updated: Diweddarwyd y presgripsiwn yn llwyddiannus.
     deleted: Dilëwyd y presgripsiwn yn llwyddiannus.
+    paused: Oedwyd y presgripsiwn.
+    resumed: Ailddechreuwyd y presgripsiwn.
     medication_taken: Cymerwyd y feddyginiaeth yn llwyddiannus.
     invalid_dose_configured: Dos annilys wedi'i ffurfweddu. Diweddarwch ddos y presgripsiwn
       cyn cymryd.
@@ -1147,6 +1228,7 @@ cy:
       edit_title: Golygu Presgripsiwn ar gyfer %{person}
       subtitle: Ychwanegu manylion meddyginiaeth ac amserlen
     card:
+      paused: Wedi'i oedi
       started: 'Dechreuodd:'
       ends: 'Yn gorffen:'
       notes: 'Nodiadau:'
@@ -1161,8 +1243,11 @@ cy:
       delete_aria_label: Dileu meddyginiaeth
       ready_now: Yn Barod Nawr
       waiting: Yn Aros
+      actions: Gweithredoedd
       edit: Golygu
       delete: Dileu
+      pause: Oedi'r presgripsiwn
+      resume: Ailddechrau'r presgripsiwn
       invalid_dose: Dos Annilys Wedi'i Ffurfweddu
       delete_dialog:
         title: Dileu Presgripsiwn
@@ -1307,12 +1392,26 @@ cy:
     json_success: Cofnodwyd cymryd y feddyginiaeth yn llwyddiannus.
     invalid_taken_at: Dewiswch amser dos dilys.
     future_taken_at: Ni all amser y dos fod fwy nag awr yn y dyfodol.
+    paused: 'Methu cymryd meddyginiaeth: wedi''i hoedi'
+    overlapping_prescription_restriction: 'Methu cymryd meddyginiaeth: mae presgripsiwn gweithredol arall ar gyfer y feddyginiaeth hon yn gosod terfyn amser llymach.'
   profiles:
     updated: Diweddarwyd y proffil yn llwyddiannus.
     email_change_requires_verification: Defnyddiwch y llif newid e-bost wedi'i ddilysu
       i ddiweddaru eich e-bost mewngofnodi.
     no_changes: Dim newidiadau i'w cadw.
     profile_update_failed: 'Methwyd â diweddaru''r proffil: %{errors}'
+    api_tokens:
+      title: Tocynnau API
+      description: Creu tocynnau y gellir eu dirymu ar gyfer sgriptiau ac integreiddiadau dibynadwy.
+      created_title: Copïwch y tocyn hwn nawr. Ni chaiff ei ddangos eto.
+      name_label: Enw'r tocyn
+      create: Creu tocyn
+      empty: Dim tocynnau API eto.
+      last_used_at: 'Defnyddiwyd ddiwethaf: %{time}'
+      revoke: Dirymu
+      revoked: Tocyn API wedi'i ddirymu.
+      locked: Mae eich cyfrif wedi'i gloi. Ni ellir newid tocynnau API ar hyn o bryd.
+      mfa_required: Cwblhewch ddilysiad dau ffactor cyn creu tocyn API.
     appearance:
       title: Ymddangosiad
       description: Dewiswch sut mae MedTracker yn edrych ar draws sgriniau wedi'u
@@ -1691,7 +1790,6 @@ cy:
       title: Rhestr Stoc
       left: "%{count} ar ôl"
       order_refills: Archebu ail-lenwadau
-    medication_schedule: Amserlen Meddyginiaeth
     no_active_schedules: Dim presgripsiynau gweithredol wedi'u canfod
     add_schedules_hint: Ychwanegwch bresgripsiynau i'w gweld yma
     dose_taken_at: "%{person} • Cymerwyd am %{time}"
@@ -1793,7 +1891,47 @@ cy:
     updated: Cedwir y gosodiadau hysbysiadau.
     update_failed: Methwyd â chadw'r gosodiadau hysbysiadau.
   reports:
+    invalid_date: Darparwyd fformat dyddiad annilys.
     date_range_too_large: Ni chaiff ystod dyddiadau'r adroddiad fod yn fwy na 180 diwrnod.
+    health_history:
+      title: Adroddiad hanes iechyd MedTracker
+      people: "Pobl: %{people}"
+      no_people: Dim pobl awdurdodedig
+      date_range: "Ystod dyddiadau: %{start_date} i %{end_date}"
+      generated_at: "Cynhyrchwyd: %{timestamp}"
+      empty_section: Dim cofnodion yn yr adran hon.
+      ongoing_from: Yn parhau ers %{started_on}
+      event_date_range: "%{started_on} i %{ended_on}"
+      sources:
+        scheduled: Wedi'i amserlennu
+        as_needed: Yn ôl yr angen/uniongyrchol
+      medication_takes:
+        title: Rhoi meddyginiaethau
+        time: Amser
+        person: Person
+        medication: Meddyginiaeth
+        dose: Dos
+        source: Ffynhonnell
+        location: Lleoliad
+      suspected_side_effects:
+        title: Sgil-effeithiau a amheuir
+      notable_illnesses:
+        title: Afiechydon nodedig
+      events:
+        title: Teitl
+        dates: Dyddiadau
+        severity: Difrifoldeb
+        medications: Meddyginiaethau a amheuir
+        notes: Nodiadau
+        action: Camau a gymerwyd
+      illness_patterns:
+        title: Patrymau salwch a gofnodwyd
+        summary: Cofnodwyd %{count} achos o "%{title}" rhwng %{first} a %{last}. Yr egwyl gyfartalog rhwng dechrau achosion oedd %{interval} diwrnod.
+      disclaimer:
+        title: Ymwadiad
+        entered_information: Mae'r adroddiad hwn yn adlewyrchu gwybodaeth a gofnodwyd yn MedTracker.
+        causation: Nid yw cysylltiadau â sgil-effeithiau a amheuir yn profi achosiaeth.
+        medical_advice: Nid diagnosis yw'r adroddiad hwn ac nid yw'n disodli cyngor meddygol proffesiynol.
     index:
       eyebrow: Dadansoddeg Lles
       title: Adroddiad Iechyd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,15 @@ en:
           self: Self
   errors:
     messages:
+      blank: can't be blank
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      not_a_number: is not a number
+      required: must exist
+      taken: has already been taken
+      too_short: is too short (minimum is %{count} characters)
       linked_to_health_event: has already been linked to this health event
       on_or_after_start_date: must be on or after the start date
   admin:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -27,6 +27,14 @@ es:
           self: Mismo
     errors:
       models:
+        health_event:
+          attributes:
+            ended_on:
+              on_or_after_start_date: debe ser igual o posterior a la fecha de inicio
+        health_event_medication:
+          attributes:
+            medication_id:
+              linked_to_health_event: ya se ha vinculado a este evento de salud
         medication:
           attributes:
             barcode:
@@ -43,6 +51,47 @@ es:
       required: debe existir
       taken: ya está en uso
       too_short: es demasiado corto (mínimo %{count} caracteres)
+      linked_to_health_event: ya se ha vinculado a este evento de salud
+      on_or_after_start_date: debe ser igual o posterior a la fecha de inicio
+  health_events:
+    created: Evento de salud registrado.
+    updated: Evento de salud actualizado.
+    deleted: Evento de salud eliminado.
+    invalid_medication_link: Selecciona solo medicamentos asignados a esta persona.
+    kinds:
+      illness: Enfermedad destacable
+      suspected_side_effect: Posible efecto secundario
+    severities:
+      mild: Leve
+      moderate: Moderado
+      severe: Grave
+    actions:
+      record_illness: Registrar enfermedad destacable
+      record_suspected_side_effect: Registrar posible efecto secundario
+      edit: Editar
+      delete: Eliminar
+      cancel: Cancelar
+      save: Guardar
+    index:
+      title: Eventos de salud de %{person}
+      subtitle: Registra enfermedades destacables y posibles efectos secundarios sin realizar afirmaciones clínicas.
+      empty: Aún no se han registrado eventos de salud.
+      ongoing_from: En curso desde %{started_on}
+      date_range: "%{started_on} a %{ended_on}"
+    form:
+      new_title: Registrar %{kind}
+      edit_title: Editar %{kind}
+      subtitle: Recoge hechos introducidos por la familia o la persona cuidadora.
+      title: Título
+      started_on: Fecha de inicio
+      ended_on: Fecha de finalización
+      ongoing: En curso
+      severity: Gravedad
+      no_severity: Sin especificar
+      suspected_medications: Medicamentos sospechosos
+      notes: Notas
+      action_taken: Medida adoptada
+      medical_help_sought: Se solicitó ayuda médica
   app:
     name: MedTracker
   global_search:
@@ -410,6 +459,9 @@ es:
         all: Todos
         clear: Limpiar
       table:
+        system_access: Acceso al sistema
+        system_administrator: Administrador del sistema
+        household_user: Usuario del hogar
         activation: Activación
         verification: Verificación
         actions: Acciones
@@ -573,6 +625,8 @@ es:
         manage_users_description: Ver y gestionar cuentas de usuario
         invitations_title: Invitaciones
         invitations_description: Invitar a nuevos usuarios a unirse
+        household_settings_title: Configuración del hogar
+        household_settings_description: Cambiar el nombre de este hogar
         manage_people_title: Gestionar personas
         manage_people_description: Ver y gestionar registros de personas
         audit_trail_title: Registro de auditoría
@@ -648,6 +702,12 @@ es:
         de plataforma.
       update_submit: Actualizar rol
       updated: Rol de membresía actualizado.
+    households:
+      updated: Hogar guardado
+      title: Configuración del hogar
+      subtitle: Cambia el nombre del hogar actual y mantenlo reconocible para todas las personas con acceso.
+      name: Nombre del hogar
+      save: Guardar hogar
   platform:
     settings:
       title: Configuración de plataforma
@@ -655,6 +715,17 @@ es:
     support_access_sessions:
       created: Acceso de soporte abierto.
       ended: Acceso de soporte finalizado.
+    users:
+      title: Administradores del sistema
+      subtitle: Revisa los roles del hogar y concede acceso de administración para toda la plataforma.
+      settings: Configuración de la plataforma
+      household_role: Rol del hogar
+      system_access: Acceso al sistema
+      system_administrator: Administrador del sistema
+      household_user: Usuario del hogar
+      grant_system_access: Conceder acceso al sistema
+      remove_system_access: Retirar acceso al sistema
+      updated: Acceso al sistema actualizado
   authentication:
     login_required: Por favor, inicie sesión para continuar
     privileged_mfa_required:
@@ -880,6 +951,10 @@ es:
       nhs_guidance_reviewed_on: Última revisión %{date}
       mark_as_ordered: Pedir
       mark_as_received: Recibido
+      order_details: Detalles del pedido
+      order_supplier: Proveedor
+      order_quantity: Cantidad
+      expected_arrival: Llegada prevista
       refill_inventory: Reabastecer
       complete_refill: Reabastecer
       overview: Resumen
@@ -969,9 +1044,9 @@ es:
       assign_carer: Asignar cuidador
     show:
       edit_person: Editar Persona
-      add_schedule: Agregar Receta
       add_medication: Agregar Medicamento
       manage_parents: Gestionar padres
+      health_events: Eventos de salud
       back: Volver
       born: 'Nacido:'
       age: 'Edad:'
@@ -1018,6 +1093,8 @@ es:
     deleted: Medicamento eliminado correctamente.
     medication_taken: Medicamento tomado correctamente.
     updated: Medicamento actualizado correctamente.
+    paused: Medicamento pausado.
+    resumed: Medicamento reanudado.
     invalid_dose_configured: La dosis configurada no es válida. Actualiza la dosis
       del medicamento antes de tomarlo.
     modal:
@@ -1025,6 +1102,7 @@ es:
       subtitle: Agregar un medicamento rutinario o según necesidad
       edit_title: Editar medicamento para %{person}
     card:
+      paused: En pausa
       notes: 'Notas:'
       timing_restrictions: 'Restricciones de Tiempo:'
       max_doses_per_day: Máximo %{count} dosis(es) por día
@@ -1043,6 +1121,11 @@ es:
       remove_confirmation: "¿Está seguro de que desea eliminar %{medication}? Esta
         acción no se puede deshacer."
       invalid_dose: Dosis configurada no válida
+      actions: Acciones
+      move_up: Subir
+      move_down: Bajar
+      pause: Pausar medicamento
+      resume: Reanudar medicamento
       edit: Editar
     form:
       add_medication: Agregar Medicamento
@@ -1112,6 +1195,8 @@ es:
     created: Receta creada correctamente.
     updated: Receta actualizada correctamente.
     deleted: Receta eliminada correctamente.
+    paused: Receta pausada.
+    resumed: Receta reanudada.
     medication_taken: Medicamento tomado correctamente.
     invalid_dose_configured: La dosis configurada no es válida. Actualiza la dosis
       de la receta antes de tomarla.
@@ -1120,8 +1205,8 @@ es:
       edit_title: Editar Receta para %{person}
       subtitle: Añadir detalles del medicamento y programar
     card:
+      paused: En pausa
       invalid_dose: Dosis configurada no válida
-      invalid_dose_configured: Dosis configurada no válida
       started: 'Iniciado:'
       ends: 'Termina:'
       notes: 'Notas:'
@@ -1136,8 +1221,11 @@ es:
       delete_aria_label: Eliminar medicamento
       ready_now: Listo Ahora
       waiting: Esperando
+      actions: Acciones
       edit: Editar
       delete: Eliminar
+      pause: Pausar receta
+      resume: Reanudar receta
       delete_dialog:
         title: Eliminar Receta
         confirm: "¿Está seguro de que desea eliminar la receta de %{medication}? Esta
@@ -1281,12 +1369,26 @@ es:
     json_success: Toma de medicamento registrada correctamente.
     invalid_taken_at: Elige una hora de dosis válida.
     future_taken_at: La hora de la dosis no puede ser más de una hora en el futuro.
+    paused: 'No se puede tomar el medicamento: está en pausa'
+    overlapping_prescription_restriction: 'No se puede tomar el medicamento: otra receta activa para este medicamento establece un límite de tiempo más estricto.'
   profiles:
     updated: Perfil actualizado correctamente.
     email_change_requires_verification: Usa el flujo verificado de cambio de correo
       para actualizar tu correo de inicio de sesión.
     no_changes: No hay cambios que guardar.
     profile_update_failed: 'Error al actualizar el perfil: %{errors}'
+    api_tokens:
+      title: Tokens de API
+      description: Crea tokens revocables para scripts e integraciones de confianza.
+      created_title: Copia este token ahora. No volverá a mostrarse.
+      name_label: Nombre del token
+      create: Crear token
+      empty: Aún no hay tokens de API.
+      last_used_at: 'Último uso: %{time}'
+      revoke: Revocar
+      revoked: Token de API revocado.
+      locked: Tu cuenta está bloqueada. Los tokens de API no se pueden modificar ahora.
+      mfa_required: Completa la autenticación de dos factores antes de crear un token de API.
     appearance:
       title: Apariencia
       description: Elige cómo se ve MedTracker en pantallas autenticadas y públicas.
@@ -1310,7 +1412,6 @@ es:
         tech_indigo: Índigo Tecnológico
         soft_rose: Rosa Suave
         minty_fresh: Menta Fresca
-        minimalist_monochrome: Minimalista
     close_account:
       title: Cerrar Cuenta
       description: Eliminar permanentemente su cuenta y todos los datos asociados
@@ -1659,7 +1760,6 @@ es:
     as_needed:
       title: Tomar según sea necesario
     todays_schedule: Horario de Hoy
-    medication_schedule: Horario de Medicamentos
     no_active_schedules: No se encontraron prescripciones activas
     add_schedules_hint: Agregue prescripciones para verlas aquí
     dose_taken_at: "%{person} • Tomado a las %{time}"
@@ -1865,7 +1965,47 @@ es:
       cancel: Cancelar
       save: Guardar ajustes
   reports:
+    invalid_date: Se ha proporcionado un formato de fecha no válido.
     date_range_too_large: El intervalo de fechas del informe no puede superar los 180 dias.
+    health_history:
+      title: Informe del historial de salud de MedTracker
+      people: "Personas: %{people}"
+      no_people: No hay personas autorizadas
+      date_range: "Intervalo de fechas: %{start_date} a %{end_date}"
+      generated_at: "Generado: %{timestamp}"
+      empty_section: No hay registros en esta sección.
+      ongoing_from: En curso desde %{started_on}
+      event_date_range: "%{started_on} a %{ended_on}"
+      sources:
+        scheduled: Programado
+        as_needed: Según necesidad/directo
+      medication_takes:
+        title: Administraciones de medicamentos
+        time: Hora
+        person: Persona
+        medication: Medicamento
+        dose: Dosis
+        source: Origen
+        location: Ubicación
+      suspected_side_effects:
+        title: Posibles efectos secundarios
+      notable_illnesses:
+        title: Enfermedades destacables
+      events:
+        title: Título
+        dates: Fechas
+        severity: Gravedad
+        medications: Medicamentos sospechosos
+        notes: Notas
+        action: Medida adoptada
+      illness_patterns:
+        title: Patrones de enfermedad registrados
+        summary: Se registraron %{count} episodios de "%{title}" entre %{first} y %{last}. El intervalo medio entre los inicios de los episodios fue de %{interval} días.
+      disclaimer:
+        title: Aviso
+        entered_information: Este informe refleja la información introducida en MedTracker.
+        causation: Los vínculos con posibles efectos secundarios no demuestran causalidad.
+        medical_advice: Este informe no es un diagnóstico ni sustituye el asesoramiento médico profesional.
     index:
       eyebrow: Análisis de bienestar
       title: Informe de salud

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -27,6 +27,14 @@ ga:
           self: Féin
     errors:
       models:
+        health_event:
+          attributes:
+            ended_on:
+              on_or_after_start_date: caithfidh sé a bheith ar an dáta tosaithe nó ina dhiaidh
+        health_event_medication:
+          attributes:
+            medication_id:
+              linked_to_health_event: ceangailte leis an imeacht sláinte seo cheana
         medication:
           attributes:
             barcode:
@@ -43,6 +51,47 @@ ga:
       required: caithfidh sé a bheith ann
       taken: in úsáid cheana féin
       too_short: ró-ghearr (is é %{count} carachtar an t-íosmhéid)
+      linked_to_health_event: ceangailte leis an imeacht sláinte seo cheana
+      on_or_after_start_date: caithfidh sé a bheith ar an dáta tosaithe nó ina dhiaidh
+  health_events:
+    created: Taifeadadh an t-imeacht sláinte.
+    updated: Nuashonraíodh an t-imeacht sláinte.
+    deleted: Scriosadh an t-imeacht sláinte.
+    invalid_medication_link: Ná roghnaigh ach cógais a sannadh don duine seo.
+    kinds:
+      illness: Tinneas suntasach
+      suspected_side_effect: Fo-iarmhairt amhrasta
+    severities:
+      mild: Éadrom
+      moderate: Measartha
+      severe: Tromchúiseach
+    actions:
+      record_illness: Taifead tinneas suntasach
+      record_suspected_side_effect: Taifead fo-iarmhairt amhrasta
+      edit: Cuir in eagar
+      delete: Scrios
+      cancel: Cealaigh
+      save: Sábháil
+    index:
+      title: Imeachtaí sláinte %{person}
+      subtitle: Taifead tinnis shuntasacha agus fo-iarmhairtí amhrasta gan éilimh chliniciúla a dhéanamh.
+      empty: Níl aon imeachtaí sláinte taifeadta fós.
+      ongoing_from: Ar siúl ó %{started_on}
+      date_range: "%{started_on} go %{ended_on}"
+    form:
+      new_title: Taifead %{kind}
+      edit_title: Cuir %{kind} in eagar
+      subtitle: Taifead fíricí a chuir an teaghlach nó an cúramóir isteach.
+      title: Teideal
+      started_on: Dáta tosaithe
+      ended_on: Dáta deiridh
+      ongoing: Ar siúl
+      severity: Déine
+      no_severity: Gan sonrú
+      suspected_medications: Cógais amhrasta
+      notes: Nótaí
+      action_taken: Gníomh a rinneadh
+      medical_help_sought: Lorgaíodh cabhair leighis
   app:
     name: MedTracker
   global_search:
@@ -187,6 +236,9 @@ ga:
         all: Gach ceann
         clear: Glan
       table:
+        system_access: Rochtain chórais
+        system_administrator: Riarthóir córais
+        household_user: Úsáideoir teaghlaigh
         activation: Gníomhachtú
         verification: Fíorú
         actions: Gníomhartha
@@ -350,6 +402,8 @@ ga:
         manage_users_description: Féach agus bainistigh cuntais úsáideoirí
         invitations_title: Cuirí
         invitations_description: Tabhair cuireadh d'úsáideoirí nua páirt a ghlacadh
+        household_settings_title: Socruithe teaghlaigh
+        household_settings_description: Athainmnigh an teaghlach seo
         manage_people_title: Bainistigh daoine
         manage_people_description: Féach agus bainistigh taifid daoine
         audit_trail_title: Conair iniúchta
@@ -424,6 +478,12 @@ ga:
       owner_rejected: Teastaíonn tacaíocht riarthóra ardáin chun ardú go húinéir.
       update_submit: Nuashonraigh Ról
       updated: Nuashonraíodh ról ballraíochta.
+    households:
+      updated: Sábháladh an teaghlach
+      title: Socruithe teaghlaigh
+      subtitle: Athainmnigh an teaghlach reatha agus coinnigh lipéad an teaghlaigh so-aitheanta do gach duine a bhfuil rochtain aige.
+      name: Ainm an teaghlaigh
+      save: Sábháil an teaghlach
   platform:
     settings:
       title: Socruithe ardáin
@@ -431,6 +491,17 @@ ga:
     support_access_sessions:
       created: Osclaíodh rochtain tacaíochta.
       ended: Cuireadh deireadh le rochtain tacaíochta.
+    users:
+      title: Riarthóirí córais
+      subtitle: Athbhreithnigh róil teaghlaigh agus deonaigh rochtain riaracháin ar fud an ardáin.
+      settings: Socruithe ardáin
+      household_role: Ról teaghlaigh
+      system_access: Rochtain chórais
+      system_administrator: Riarthóir córais
+      household_user: Úsáideoir teaghlaigh
+      grant_system_access: Deonaigh rochtain chórais
+      remove_system_access: Bain rochtain chórais
+      updated: Nuashonraíodh rochtain chórais
   authentication:
     login_required: Logáil isteach le leanúint
     privileged_mfa_required:
@@ -886,6 +957,10 @@ ga:
       edit_dosage: Cuir in Eagar
       mark_as_ordered: Ordaigh
       mark_as_received: Faighte
+      order_details: Sonraí ordaithe
+      order_supplier: Soláthraí
+      order_quantity: Cainníocht
+      expected_arrival: Teacht ionchais
       refill_inventory: Athstocáil
       complete_refill: Athstocáil
       reorder_at_label: Athordaigh Ag
@@ -942,9 +1017,9 @@ ga:
       otc_description: Tógtar de réir mar is gá é gan sceideal seasta
     show:
       edit_person: Cuir Duine in Eagar
-      add_schedule: Cuir Oideas Leigheasanna Leis
       add_medication: Cuir Leigheas Leis
       manage_parents: Bainistigh tuismitheoirí
+      health_events: Imeachtaí sláinte
       back: Ar Ais
       born: 'Rugtha:'
       age: 'Aois:'
@@ -1017,6 +1092,8 @@ ga:
     created: Cuireadh an leigheas leis go rathúil.
     updated: Nuashonraíodh an leigheas go rathúil.
     deleted: Baineadh an leigheas go rathúil.
+    paused: Cuireadh an leigheas ar sos.
+    resumed: Atosaíodh an leigheas.
     medication_taken: Tógadh an leigheas go rathúil.
     invalid_dose_configured: Tá dáileog neamhbhailí cumraithe. Nuashonraigh dáileog
       an leighis sula dtógtar í.
@@ -1025,6 +1102,7 @@ ga:
       edit_title: Cuir Leigheas in Eagar do %{person}
       subtitle: Cuir cógas rialta nó de réir mar is gá leis
     card:
+      paused: Ar sos
       notes: 'Nótaí:'
       timing_restrictions: 'Srianta Ama:'
       max_doses_per_day: Uasmhéid %{count} dáileog in aghaidh an lae
@@ -1036,6 +1114,11 @@ ga:
       give: Tabhair
       out_of_stock: As Stoc
       invalid_dose: Dáileog Neamhbhailí
+      actions: Gníomhartha
+      move_up: Bog suas
+      move_down: Bog síos
+      pause: Cuir an leigheas ar sos
+      resume: Atosaigh an leigheas
       move_up_aria_label: Bog leigheas suas
       move_down_aria_label: Bog leigheas síos
       delete_aria_label: Scrios leigheas
@@ -1112,6 +1195,8 @@ ga:
     created: Cruthaíodh an sceideal go rathúil.
     updated: Nuashonraíodh an sceideal go rathúil.
     deleted: Scriosadh an sceideal go rathúil.
+    paused: Cuireadh an sceideal ar sos.
+    resumed: Atosaíodh an sceideal.
     medication_taken: Tógadh an leigheas go rathúil.
     invalid_dose_configured: Tá dáileog neamhbhailí cumraithe. Nuashonraigh dáileog
       an sceidil sula dtógtar í.
@@ -1120,6 +1205,7 @@ ga:
       edit_title: Cuir Sceideal in Eagar do %{person}
       subtitle: Cuir sonraí leigheas agus sceideal leis
     card:
+      paused: Ar sos
       started: 'Tosaíodh:'
       ends: 'Críochnaíonn:'
       notes: 'Nótaí:'
@@ -1135,8 +1221,11 @@ ga:
       delete_aria_label: Scrios an leigheas
       ready_now: Réidh Anois
       waiting: Ag Fanacht
+      actions: Gníomhartha
       edit: Cuir in Eagar
       delete: Scrios
+      pause: Cuir an sceideal ar sos
+      resume: Atosaigh an sceideal
       delete_dialog:
         title: Scrios Sceideal
         confirm: An bhfuil tú cinnte gur mhaith leat an sceideal %{medication} a scrios?
@@ -1283,12 +1372,26 @@ ga:
     invalid_taken_at: Roghnaigh am dáileoige bailí.
     future_taken_at: Ní féidir am na dáileoige a bheith níos mó ná uair an chloig
       sa todhchaí.
+    paused: 'Ní féidir an leigheas a thógáil: ar sos'
+    overlapping_prescription_restriction: 'Ní féidir an leigheas a thógáil: leagann oideas gníomhach eile don leigheas seo teorainn ama níos déine síos.'
   profiles:
     updated: Nuashonraíodh an phróifíl go rathúil.
     email_change_requires_verification: Úsáid an sreabhadh fíoraithe athraithe ríomhphoist
       chun do ríomhphost sínithe isteach a nuashonrú.
     no_changes: Gan athruithe le sábháil.
     profile_update_failed: 'Theip ar nuashonrú na próifíle: %{errors}'
+    api_tokens:
+      title: Comharthaí API
+      description: Cruthaigh comharthaí inchúlghairthe do scripteanna agus do chomhtháthuithe iontaofa.
+      created_title: Cóipeáil an comhartha seo anois. Ní thaispeánfar arís é.
+      name_label: Ainm an chomhartha
+      create: Cruthaigh comhartha
+      empty: Níl aon chomharthaí API ann fós.
+      last_used_at: 'Úsáideadh go deireanach: %{time}'
+      revoke: Cúlghair
+      revoked: Cúlghaireadh an comhartha API.
+      locked: Tá do chuntas glasáilte. Ní féidir comharthaí API a athrú anois.
+      mfa_required: Críochnú fíordheimhniú dhá fhachtóir sula gcruthaítear comhartha API.
     appearance:
       title: Cuma
       description: Roghnaigh conas a fheictear MedTracker ar scáileáin shínithe isteach
@@ -1312,7 +1415,6 @@ ga:
         tech_indigo: Teicneolaíocht Indigo
         soft_rose: Rós Bog
         minty_fresh: Úr Mionna
-        minimalist_monochrome: Íosmhéideach
     show:
       eyebrow: Socruithe próifíle
       title: Mo Phróifíl
@@ -1538,7 +1640,47 @@ ga:
       review_note: Nóta athbhreithnithe
       save: Sábháil taifead an athbhreithnithe
   reports:
+    invalid_date: Soláthraíodh formáid dáta neamhbhailí.
     date_range_too_large: Ni feidir le raon datai na tuarascola dul thar 180 la.
+    health_history:
+      title: Tuarascáil staire sláinte MedTracker
+      people: "Daoine: %{people}"
+      no_people: Níl aon daoine údaraithe
+      date_range: "Raon dátaí: %{start_date} go %{end_date}"
+      generated_at: "Gineadh: %{timestamp}"
+      empty_section: Níl aon taifid sa rannán seo.
+      ongoing_from: Ar siúl ó %{started_on}
+      event_date_range: "%{started_on} go %{ended_on}"
+      sources:
+        scheduled: Sceidealaithe
+        as_needed: De réir mar is gá/díreach
+      medication_takes:
+        title: Riaracháin leighis
+        time: Am
+        person: Duine
+        medication: Leigheas
+        dose: Dáileog
+        source: Foinse
+        location: Suíomh
+      suspected_side_effects:
+        title: Fo-iarmhairtí amhrasta
+      notable_illnesses:
+        title: Tinnis shuntasacha
+      events:
+        title: Teideal
+        dates: Dátaí
+        severity: Déine
+        medications: Cógais amhrasta
+        notes: Nótaí
+        action: Gníomh a rinneadh
+      illness_patterns:
+        title: Patrúin tinnis taifeadta
+        summary: Taifeadadh %{count} eachtra de "%{title}" idir %{first} agus %{last}. Ba é %{interval} lá an meán-eatramh idir tús na n-eachtraí.
+      disclaimer:
+        title: Séanadh
+        entered_information: Léiríonn an tuarascáil seo faisnéis a cuireadh isteach in MedTracker.
+        causation: Ní chruthaíonn naisc le fo-iarmhairtí amhrasta cúisíocht.
+        medical_advice: Ní diagnóis í an tuarascáil seo agus ní ghlacann sí áit comhairle leighis ghairmiúil.
     index:
       eyebrow: Anailís Folláine
       title: Tuarascáil Sláinte
@@ -1773,7 +1915,6 @@ ga:
       all_family: An Teaghlach Uile
       all_family_initials: TU
       more_people: Tuilleadh daoine
-    medication_schedule: Sceideal Leigheasanna
     as_needed:
       title: Glac de réir mar is gá
     overdue_alert: 'Dul thar am: %{medication} do %{person} (sceidealaithe ag %{time})'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -27,6 +27,14 @@ pt:
           self: Próprio
     errors:
       models:
+        health_event:
+          attributes:
+            ended_on:
+              on_or_after_start_date: deve ser igual ou posterior à data de início
+        health_event_medication:
+          attributes:
+            medication_id:
+              linked_to_health_event: já foi associado a este evento de saúde
         medication:
           attributes:
             barcode:
@@ -43,6 +51,47 @@ pt:
       required: deve existir
       taken: já está em uso
       too_short: é muito curto (mínimo de %{count} caracteres)
+      linked_to_health_event: já foi associado a este evento de saúde
+      on_or_after_start_date: deve ser igual ou posterior à data de início
+  health_events:
+    created: Evento de saúde registado.
+    updated: Evento de saúde atualizado.
+    deleted: Evento de saúde eliminado.
+    invalid_medication_link: Selecione apenas medicamentos atribuídos a esta pessoa.
+    kinds:
+      illness: Doença relevante
+      suspected_side_effect: Suspeita de efeito secundário
+    severities:
+      mild: Ligeira
+      moderate: Moderada
+      severe: Grave
+    actions:
+      record_illness: Registar doença relevante
+      record_suspected_side_effect: Registar suspeita de efeito secundário
+      edit: Editar
+      delete: Eliminar
+      cancel: Cancelar
+      save: Guardar
+    index:
+      title: Eventos de saúde de %{person}
+      subtitle: Registe doenças relevantes e suspeitas de efeitos secundários sem fazer afirmações clínicas.
+      empty: Ainda não existem eventos de saúde registados.
+      ongoing_from: Em curso desde %{started_on}
+      date_range: "%{started_on} a %{ended_on}"
+    form:
+      new_title: Registar %{kind}
+      edit_title: Editar %{kind}
+      subtitle: Registe factos introduzidos pela família ou pelo cuidador.
+      title: Título
+      started_on: Data de início
+      ended_on: Data de fim
+      ongoing: Em curso
+      severity: Gravidade
+      no_severity: Não especificada
+      suspected_medications: Medicamentos suspeitos
+      notes: Notas
+      action_taken: Medida tomada
+      medical_help_sought: Foi procurada ajuda médica
   app:
     name: MedTracker
   global_search:
@@ -411,6 +460,9 @@ pt:
         all: Todos
         clear: Limpar
       table:
+        system_access: Acesso ao sistema
+        system_administrator: Administrador do sistema
+        household_user: Utilizador do agregado
         activation: Ativação
         verification: Verificação
         actions: Ações
@@ -574,6 +626,8 @@ pt:
         manage_users_description: Ver e gerir contas de utilizador
         invitations_title: Convites
         invitations_description: Convidar novos utilizadores a aderir
+        household_settings_title: Definições do agregado
+        household_settings_description: Alterar o nome deste agregado
         manage_people_title: Gerir pessoas
         manage_people_description: Ver e gerir registos de pessoas
         audit_trail_title: Registo de auditoria
@@ -649,6 +703,12 @@ pt:
         da plataforma.
       update_submit: Atualizar função
       updated: Função de associação atualizada.
+    households:
+      updated: Agregado guardado
+      title: Definições do agregado
+      subtitle: Altere o nome do agregado atual e mantenha-o reconhecível para todas as pessoas com acesso.
+      name: Nome do agregado
+      save: Guardar agregado
   platform:
     settings:
       title: Definições da plataforma
@@ -656,6 +716,17 @@ pt:
     support_access_sessions:
       created: Acesso de suporte aberto.
       ended: Acesso de suporte terminado.
+    users:
+      title: Administradores do sistema
+      subtitle: Reveja as funções do agregado e conceda acesso de administração a toda a plataforma.
+      settings: Definições da plataforma
+      household_role: Função no agregado
+      system_access: Acesso ao sistema
+      system_administrator: Administrador do sistema
+      household_user: Utilizador do agregado
+      grant_system_access: Conceder acesso ao sistema
+      remove_system_access: Remover acesso ao sistema
+      updated: Acesso ao sistema atualizado
   authentication:
     login_required: Por favor, inicie sessão para continuar
     privileged_mfa_required:
@@ -897,6 +968,10 @@ pt:
       edit_dosage: Editar
       mark_as_ordered: Encomendar
       mark_as_received: Recebido
+      order_details: Detalhes da encomenda
+      order_supplier: Fornecedor
+      order_quantity: Quantidade
+      expected_arrival: Chegada prevista
       refill_inventory: Reabastecer
       complete_refill: Reabastecer
       reorder_at_label: Reordenar Em
@@ -943,9 +1018,9 @@ pt:
       otc_description: Taken as needed without a fixed schedule
     show:
       edit_person: Editar Pessoa
-      add_schedule: Adicionar Receita
       add_medication: Adicionar Medicamento
       manage_parents: Gerir pais
+      health_events: Eventos de saúde
       back: Voltar
       born: 'Nascido:'
       age: 'Idade:'
@@ -1017,6 +1092,8 @@ pt:
     created: Medicamento adicionado com sucesso.
     updated: Medicamento atualizado com sucesso.
     deleted: Medicamento removido com sucesso.
+    paused: Medicamento pausado.
+    resumed: Medicamento retomado.
     medication_taken: Medicamento tomado com sucesso.
     invalid_dose_configured: Dose inválida configurada. Atualize a dose do medicamento
       antes de administrar.
@@ -1025,6 +1102,7 @@ pt:
       edit_title: Editar Medicamento para %{person}
       subtitle: Adicionar uma medicação de rotina ou conforme necessário
     card:
+      paused: Em pausa
       notes: 'Notas:'
       timing_restrictions: 'Restrições de Tempo:'
       max_doses_per_day: Máximo %{count} dose(s) por dia
@@ -1036,6 +1114,11 @@ pt:
       give: Dar
       out_of_stock: Sem Stock
       invalid_dose: Dose inválida configurada
+      actions: Ações
+      move_up: Mover para cima
+      move_down: Mover para baixo
+      pause: Pausar medicamento
+      resume: Retomar medicamento
       move_up_aria_label: Mover medicamento para cima
       move_down_aria_label: Mover medicamento para baixo
       delete_aria_label: Excluir medicamento
@@ -1112,6 +1195,8 @@ pt:
     created: Receita criada com sucesso.
     updated: Receita atualizada com sucesso.
     deleted: Receita eliminada com sucesso.
+    paused: Receita pausada.
+    resumed: Receita retomada.
     medication_taken: Medicamento tomado com sucesso.
     invalid_dose_configured: Dose inválida configurada. Atualize a dose da receita
       antes de administrar.
@@ -1120,6 +1205,7 @@ pt:
       edit_title: Editar Receita para %{person}
       subtitle: Adicione os detalhes da medicação e da receita
     card:
+      paused: Em pausa
       started: 'Iniciado:'
       ends: 'Termina:'
       notes: 'Notas:'
@@ -1134,8 +1220,11 @@ pt:
       delete_aria_label: Excluir medicamento
       ready_now: Pronto Agora
       waiting: A aguardar
+      actions: Ações
       edit: Editar
       delete: Eliminar
+      pause: Pausar receita
+      resume: Retomar receita
       invalid_dose: Dose inválida configurada
       delete_dialog:
         title: Eliminar Receita
@@ -1280,6 +1369,8 @@ pt:
     json_success: Toma de medicamento registada com sucesso.
     invalid_taken_at: Escolha uma hora de dose válida.
     future_taken_at: A hora da dose não pode ser mais de uma hora no futuro.
+    paused: 'Não é possível tomar o medicamento: está em pausa'
+    overlapping_prescription_restriction: 'Não é possível tomar o medicamento: outra receita ativa para este medicamento define um limite de tempo mais rigoroso.'
   barcode_scanner:
     title: Ler Código de Barras
     start: Iniciar Leitor
@@ -1300,7 +1391,47 @@ pt:
     updated: Definições de notificação guardadas.
     update_failed: Falha ao guardar as definições de notificação.
   reports:
+    invalid_date: Foi fornecido um formato de data inválido.
     date_range_too_large: O intervalo de datas do relatorio nao pode exceder 180 dias.
+    health_history:
+      title: Relatório do historial de saúde do MedTracker
+      people: "Pessoas: %{people}"
+      no_people: Não existem pessoas autorizadas
+      date_range: "Intervalo de datas: %{start_date} a %{end_date}"
+      generated_at: "Gerado: %{timestamp}"
+      empty_section: Não existem registos nesta secção.
+      ongoing_from: Em curso desde %{started_on}
+      event_date_range: "%{started_on} a %{ended_on}"
+      sources:
+        scheduled: Agendado
+        as_needed: Conforme necessário/direto
+      medication_takes:
+        title: Administrações de medicamentos
+        time: Hora
+        person: Pessoa
+        medication: Medicamento
+        dose: Dose
+        source: Origem
+        location: Localização
+      suspected_side_effects:
+        title: Suspeitas de efeitos secundários
+      notable_illnesses:
+        title: Doenças relevantes
+      events:
+        title: Título
+        dates: Datas
+        severity: Gravidade
+        medications: Medicamentos suspeitos
+        notes: Notas
+        action: Medida tomada
+      illness_patterns:
+        title: Padrões de doença registados
+        summary: Foram registados %{count} episódios de "%{title}" entre %{first} e %{last}. O intervalo médio entre o início dos episódios foi de %{interval} dias.
+      disclaimer:
+        title: Aviso
+        entered_information: Este relatório reflete informações introduzidas no MedTracker.
+        causation: As associações a suspeitas de efeitos secundários não estabelecem causalidade.
+        medical_advice: Este relatório não é um diagnóstico nem substitui aconselhamento médico profissional.
     index:
       eyebrow: Análises de Bem-estar
       title: Relatório de Saúde
@@ -1419,6 +1550,18 @@ pt:
       para atualizar o email de início de sessão.
     no_changes: Sem alterações a guardar.
     profile_update_failed: 'Falha ao atualizar perfil: %{errors}'
+    api_tokens:
+      title: Tokens de API
+      description: Crie tokens revogáveis para scripts e integrações de confiança.
+      created_title: Copie este token agora. Não voltará a ser apresentado.
+      name_label: Nome do token
+      create: Criar token
+      empty: Ainda não existem tokens de API.
+      last_used_at: 'Última utilização: %{time}'
+      revoke: Revogar
+      revoked: Token de API revogado.
+      locked: A sua conta está bloqueada. Os tokens de API não podem ser alterados agora.
+      mfa_required: Conclua a autenticação de dois fatores antes de criar um token de API.
     appearance:
       title: Aspeto
       description: Escolha como o MedTracker aparece em ecrãs autenticados e públicos.
@@ -1441,7 +1584,6 @@ pt:
         tech_indigo: Índigo Tecnológico
         soft_rose: Rosa Suave
         minty_fresh: Menta Fresca
-        minimalist_monochrome: Minimalista
     show:
       eyebrow: Definições do perfil
       title: O Meu Perfil
@@ -1886,7 +2028,6 @@ pt:
     overdue_alert: 'Atrasado: %{medication} para %{person} (agendado às %{time})'
     out_of_stock_alert: 'Sem stock: %{medication}. Não é possível registar doses para
       %{person}.'
-    medication_schedule: Horário de Medicamentos
     no_active_schedules: Nenhuma prescrição ativa encontrada
     add_schedules_hint: Adicione prescrições para vê-las aqui
     dose_taken_at: "%{person} • Tomado às %{time}"

--- a/spec/requests/form_validation_feedback_spec.rb
+++ b/spec/requests/form_validation_feedback_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe 'Form inline validation feedback' do
       expect(response.body).to include('ni all fod yn wag')
     end
 
-    it 'falls back to the English validation message when a locale key is missing' do
+    it 'renders the date validation message in Spanish' do
       message = I18n.with_locale(:es) { I18n.t('errors.messages.on_or_after_start_date') }
 
-      expect(message).to eq('must be on or after the start date')
+      expect(message).to eq('debe ser igual o posterior a la fecha de inicio')
     end
   end
 end


### PR DESCRIPTION
The supported locale files had drifted apart across health events, household/platform administration, API tokens, health-history reports, medication controls, and schedules. That meant non-English users could encounter fallback text or missing product vocabulary depending on the screen.

This restores the same translation contract across English, Welsh, Spanish, Irish, and Portuguese while preserving localized validation messages and interpolation variables. The date validation that previously fell back to English in Spanish now has an explicit translation.

Closes #1587