### PR TITLE
feat(barcodes): add deterministic resolution contract

### DIFF
--- a/app/services/barcode_catalog/resolver.rb
+++ b/app/services/barcode_catalog/resolver.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module BarcodeCatalog
+  class Resolver
+    Result = Data.define(:status, :barcode, :match, :source, :error) do
+      def resolved?
+        status == :resolved
+      end
+
+      def error?
+        status == :error
+      end
+    end
+
+    def initialize(lookup: Lookup.new)
+      @lookup = lookup
+    end
+
+    def call(value)
+      barcode = NhsDmdBarcode.normalize_gtin(value)
+      return outcome(:invalid, barcode:, error: 'invalid_barcode') unless NhsDmd::BarcodeLookup.barcode_query?(barcode)
+
+      match = lookup.lookup(barcode)
+      return outcome(:not_found, barcode:) unless match
+
+      outcome(:resolved, barcode:, match:, source: match[:source])
+    rescue StandardError => e
+      Rails.logger.error("BarcodeCatalog::Resolver failed: #{e.class}: #{e.message}")
+      outcome(:error, barcode:, error: 'barcode_resolution_failed')
+    end
+
+    private
+
+    attr_reader :lookup
+
+    def outcome(status, barcode:, match: nil, source: nil, error: nil)
+      Result.new(status:, barcode:, match:, source:, error:)
+    end
+  end
+end

--- a/app/services/medication_finder_search_responder.rb
+++ b/app/services/medication_finder_search_responder.rb
@@ -28,9 +28,8 @@ class MedicationFinderSearchResponder
 
   def successful_response(query:, result:, form:, strength:, permissions:)
     normalized_form = NhsDmd::DosageFormFilter.normalize(form)
-    results = NhsDmd::DosageFormFilter.filter(result.results, form)
     normalized_strength = NhsDmd::StrengthFilter.normalize(strength)
-    results = NhsDmd::StrengthFilter.filter(results, strength)
+    results = filtered_results(result.results, form:, strength:)
 
     Result.new(
       body: {
@@ -54,9 +53,14 @@ class MedicationFinderSearchResponder
   end
 
   def barcode_resolution(result)
-    return unless result.barcode.present?
+    return if result.barcode.blank?
 
     { status: 'resolved', source: result.barcode_source }
+  end
+
+  def filtered_results(results, form:, strength:)
+    results = NhsDmd::DosageFormFilter.filter(results, form)
+    NhsDmd::StrengthFilter.filter(results, strength)
   end
 
   def result_payload(search_result, barcode)

--- a/app/services/medication_finder_search_responder.rb
+++ b/app/services/medication_finder_search_responder.rb
@@ -37,6 +37,7 @@ class MedicationFinderSearchResponder
         results: results.map { |search_result| result_payload(search_result, result.barcode) },
         query: result.resolved_query.presence || query,
         barcode: result.barcode,
+        barcode_resolution: barcode_resolution(result),
         form: normalized_form,
         strength: normalized_strength,
         permissions: permissions
@@ -50,6 +51,12 @@ class MedicationFinderSearchResponder
       body: { results: [], error: 'Medication search is temporarily unavailable.' },
       status: :service_unavailable
     )
+  end
+
+  def barcode_resolution(result)
+    return unless result.barcode.present?
+
+    { status: 'resolved', source: result.barcode_source }
   end
 
   def result_payload(search_result, barcode)

--- a/app/services/nhs_dmd/search.rb
+++ b/app/services/nhs_dmd/search.rb
@@ -2,7 +2,7 @@
 
 module NhsDmd
   class Search # rubocop:disable Metrics/ClassLength
-    Result = Struct.new(:results, :error, :resolved_query, :barcode, keyword_init: true) do
+    Result = Struct.new(:results, :error, :resolved_query, :barcode, :barcode_source, keyword_init: true) do
       def success?
         error.nil?
       end
@@ -13,7 +13,7 @@ module NhsDmd
                    open_food_facts_search: OpenFoodFacts::Search.new,
                    audit_logger: ExternalLookup::AuditLogger.new)
       @client = client
-      @barcode_lookup = barcode_lookup
+      @barcode_resolver = BarcodeCatalog::Resolver.new(lookup: barcode_lookup)
       @open_food_facts_lookup = open_food_facts_lookup
       @open_food_facts_search = open_food_facts_search
       @audit_logger = audit_logger
@@ -46,10 +46,13 @@ module NhsDmd
     end
 
     def local_barcode_result(query)
-      barcode_match = @barcode_lookup.lookup(query)
-      return nil unless barcode_match
+      return nil unless BarcodeLookup.barcode_query?(query)
 
-      barcode_result(query, barcode_match)
+      resolution = @barcode_resolver.call(query)
+      return failed_result(resolution.error) if resolution.error?
+      return nil unless resolution.resolved?
+
+      barcode_result(query, resolution.match, source: resolution.source)
     end
 
     def remote_result(query)
@@ -155,14 +158,15 @@ module NhsDmd
       }
     end
 
-    def barcode_result(query, barcode_match)
+    def barcode_result(query, barcode_match, source: barcode_match[:source])
       translated_query = barcode_match[:display]
 
       Result.new(
         results: build_results(barcode_items(translated_query, barcode_match)),
         error: nil,
         resolved_query: translated_query,
-        barcode: NhsDmdBarcode.normalize_gtin(query)
+        barcode: NhsDmdBarcode.normalize_gtin(query),
+        barcode_source: source
       )
     end
 
@@ -261,7 +265,12 @@ module NhsDmd
       results = nhs_items(query)
       return nil if results.empty?
 
-      Result.new(results: build_results(results), error: nil, barcode: NhsDmdBarcode.normalize_gtin(query))
+      Result.new(
+        results: build_results(results),
+        error: nil,
+        barcode: NhsDmdBarcode.normalize_gtin(query),
+        barcode_source: 'nhs_dmd_api'
+      )
     end
 
     def dedupe_items(items)

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -278,6 +278,10 @@ RSpec.describe 'GET /medication-finder/search' do
         )
         expect(response.parsed_body['query']).to eq('Laxido Orange oral powder sachets (Galen Ltd)')
         expect(response.parsed_body['barcode']).to eq('5016298210989')
+        expect(response.parsed_body['barcode_resolution']).to eq(
+          'status' => 'resolved',
+          'source' => 'nhs_dmd'
+        )
       end
     end
 

--- a/spec/services/barcode_catalog/lookup_spec.rb
+++ b/spec/services/barcode_catalog/lookup_spec.rb
@@ -206,5 +206,11 @@ RSpec.describe BarcodeCatalog::Lookup do
         display: 'Ibuprofen 400mg tablets (Tesco Stores Ltd)'
       )
     end
+
+    it 'returns source metadata for every successful adapter outcome' do
+      create_external_entry
+
+      expect(lookup.lookup(gtin)).to include(source: a_string_matching(/\S/))
+    end
   end
 end

--- a/spec/services/barcode_catalog/resolver_spec.rb
+++ b/spec/services/barcode_catalog/resolver_spec.rb
@@ -15,12 +15,15 @@ RSpec.describe BarcodeCatalog::Resolver do
 
     result = resolver.call(' 5016-2982-10989 ')
 
-    expect(result).to have_attributes(
+    expect(result.to_h).to eq(
       status: :resolved,
       barcode: '5016298210989',
       source: 'nhs_dmd',
       error: nil,
-      match: a_hash_including(display: 'Laxido Orange oral powder sachets')
+      match: {
+        display: 'Laxido Orange oral powder sachets',
+        source: 'nhs_dmd'
+      }
     )
   end
 

--- a/spec/services/barcode_catalog/resolver_spec.rb
+++ b/spec/services/barcode_catalog/resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BarcodeCatalog::Resolver do
 
   let(:lookup) { instance_double(BarcodeCatalog::Lookup, lookup: nil) }
 
-  it 'returns a resolved outcome with normalized barcode and source metadata' do
+  it 'returns a resolved outcome with normalized barcode and source metadata', :aggregate_failures do
     allow(lookup).to receive(:lookup).with('5016298210989').and_return(
       display: 'Laxido Orange oral powder sachets',
       source: 'nhs_dmd'

--- a/spec/services/barcode_catalog/resolver_spec.rb
+++ b/spec/services/barcode_catalog/resolver_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BarcodeCatalog::Resolver do
+  subject(:resolver) { described_class.new(lookup: lookup) }
+
+  let(:lookup) { instance_double(BarcodeCatalog::Lookup, lookup: nil) }
+
+  it 'returns a resolved outcome with normalized barcode and source metadata' do
+    allow(lookup).to receive(:lookup).with('5016298210989').and_return(
+      display: 'Laxido Orange oral powder sachets',
+      source: 'nhs_dmd'
+    )
+
+    result = resolver.call(' 5016-2982-10989 ')
+
+    expect(result).to have_attributes(
+      status: :resolved,
+      barcode: '5016298210989',
+      source: 'nhs_dmd',
+      error: nil
+    )
+    expect(result.match).to include(display: 'Laxido Orange oral powder sachets')
+  end
+
+  it 'returns a not-found outcome for a valid unmapped barcode' do
+    allow(lookup).to receive(:lookup).with('5016298210989').and_return(nil)
+
+    expect(resolver.call('5016298210989')).to have_attributes(
+      status: :not_found,
+      barcode: '5016298210989',
+      match: nil,
+      source: nil,
+      error: nil
+    )
+  end
+
+  it 'returns an invalid outcome without invoking adapters' do
+    expect(resolver.call('not-a-barcode')).to have_attributes(
+      status: :invalid,
+      barcode: '',
+      match: nil,
+      source: nil,
+      error: 'invalid_barcode'
+    )
+    expect(lookup).not_to have_received(:lookup)
+  end
+
+  it 'returns a UI-safe error outcome when an adapter raises' do
+    allow(lookup).to receive(:lookup).and_raise(Net::ReadTimeout, 'upstream details')
+    allow(Rails.logger).to receive(:error)
+
+    result = resolver.call('5016298210989')
+
+    expect(result).to have_attributes(
+      status: :error,
+      barcode: '5016298210989',
+      match: nil,
+      source: nil,
+      error: 'barcode_resolution_failed'
+    )
+    expect(Rails.logger).to have_received(:error).with(/BarcodeCatalog::Resolver failed: Net::ReadTimeout/)
+  end
+end

--- a/spec/services/barcode_catalog/resolver_spec.rb
+++ b/spec/services/barcode_catalog/resolver_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BarcodeCatalog::Resolver do
   it 'returns a not-found outcome for a valid unmapped barcode' do
     allow(lookup).to receive(:lookup).with('5016298210989').and_return(nil)
 
-    expect(resolver.call('5016298210989')).to have_attributes(
+    expect(resolver.call('5016298210989').to_h).to eq(
       status: :not_found,
       barcode: '5016298210989',
       match: nil,
@@ -40,7 +40,7 @@ RSpec.describe BarcodeCatalog::Resolver do
   end
 
   it 'returns an invalid outcome without invoking adapters' do
-    expect(resolver.call('not-a-barcode')).to have_attributes(
+    expect(resolver.call('not-a-barcode').to_h).to eq(
       status: :invalid,
       barcode: '',
       match: nil,
@@ -56,7 +56,7 @@ RSpec.describe BarcodeCatalog::Resolver do
 
     result = resolver.call('5016298210989')
 
-    expect(result).to have_attributes(
+    expect(result.to_h).to eq(
       status: :error,
       barcode: '5016298210989',
       match: nil,

--- a/spec/services/barcode_catalog/resolver_spec.rb
+++ b/spec/services/barcode_catalog/resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BarcodeCatalog::Resolver do
 
   let(:lookup) { instance_double(BarcodeCatalog::Lookup, lookup: nil) }
 
-  it 'returns a resolved outcome with normalized barcode and source metadata', :aggregate_failures do
+  it 'returns a resolved outcome with normalized barcode and source metadata' do
     allow(lookup).to receive(:lookup).with('5016298210989').and_return(
       display: 'Laxido Orange oral powder sachets',
       source: 'nhs_dmd'
@@ -19,9 +19,9 @@ RSpec.describe BarcodeCatalog::Resolver do
       status: :resolved,
       barcode: '5016298210989',
       source: 'nhs_dmd',
-      error: nil
+      error: nil,
+      match: a_hash_including(display: 'Laxido Orange oral powder sachets')
     )
-    expect(result.match).to include(display: 'Laxido Orange oral powder sachets')
   end
 
   it 'returns a not-found outcome for a valid unmapped barcode' do

--- a/spec/services/medication_finder_search_responder_spec.rb
+++ b/spec/services/medication_finder_search_responder_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe MedicationFinderSearchResponder do
     end
   end
 
-  def successful_nhs_result(results: [], resolved_query: nil, barcode: nil)
+  def successful_nhs_result(results: [], resolved_query: nil, barcode: nil, barcode_source: nil)
     instance_double(
       NhsDmd::Search::Result,
       success?: true,
       results: results,
       resolved_query: resolved_query,
-      barcode: barcode
+      barcode: barcode,
+      barcode_source: barcode_source
     )
   end
 
@@ -129,12 +130,18 @@ RSpec.describe MedicationFinderSearchResponder do
       end
 
       it 'includes barcode from the search result' do
-        barcoded = successful_nhs_result(results: [], resolved_query: nil, barcode: '5000168511017')
+        barcoded = successful_nhs_result(
+          results: [],
+          resolved_query: nil,
+          barcode: '5000168511017',
+          barcode_source: 'nhs_dmd'
+        )
         allow(search).to receive(:call).and_return(barcoded)
 
         result = responder.call(query: '5000168511017')
 
         expect(result.body[:barcode]).to eq('5000168511017')
+        expect(result.body[:barcode_resolution]).to eq(status: 'resolved', source: 'nhs_dmd')
       end
 
       it 'includes permissions in the response body' do

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe NhsDmd::Search do
           code: '13629411000001105',
           display: 'Laxido Orange oral powder sachets (Galen Ltd)',
           system: 'https://dmd.nhs.uk',
-          concept_class: 'AMPP'
+          concept_class: 'AMPP',
+          source: 'nhs_dmd'
         }
         translated_results = [
           {
@@ -118,6 +119,7 @@ RSpec.describe NhsDmd::Search do
         expect(result).to be_success
         expect(result.resolved_query).to eq('Laxido Orange oral powder sachets (Galen Ltd)')
         expect(result.barcode).to eq('5016298210989')
+        expect(result.barcode_source).to eq('nhs_dmd')
         expect(result.results.map(&:to_h)).to contain_exactly(
           a_hash_including(
             code: '13629411000001105',

--- a/spec/services/nhs_dmd/search_spec.rb
+++ b/spec/services/nhs_dmd/search_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe NhsDmd::Search do
       it 'translates the barcode into a searchable dm+d query while preserving the scanned barcode' do
         result = search.call('5016298210989')
 
-        expect(result).to be_success
         expect(result.resolved_query).to eq('Laxido Orange oral powder sachets (Galen Ltd)')
         expect(result.barcode).to eq('5016298210989')
         expect(result.barcode_source).to eq('nhs_dmd')

--- a/spec/system/barcode_scanner_spec.rb
+++ b/spec/system/barcode_scanner_spec.rb
@@ -216,5 +216,24 @@ RSpec.describe 'BarcodeScanner' do
       expect(page.evaluate_script('window.__barcodeScannerGetCamerasCalls')).to eq(2)
       expect(page).to have_no_button('Start Scanner')
     end
+
+    it 'resolves a decoded barcode and continues into medication lookup' do
+      NhsDmdBarcode.create!(
+        gtin: '05016298210989',
+        code: '13629411000001105',
+        display: 'Laxido Orange oral powder sachets (Galen Ltd)',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'AMPP'
+      )
+      visit medication_finder_path
+
+      within '[data-testid="barcode-scanner"]' do
+        fill_in 'manual-barcode', with: '5016298210989'
+        click_button 'Submit'
+      end
+
+      expect(page).to have_text('Laxido Orange oral powder sachets')
+      expect(page).to have_text('5016298210989')
+    end
   end
 end


### PR DESCRIPTION
Closes #602

Barcode scans previously flowed directly into a chain of catalogue lookups, so callers could not distinguish invalid input, a genuine miss, or an adapter failure. This introduces one resolution contract with normalized values, deterministic outcomes, safe error codes, and source metadata.

Medication Finder now carries the resolution source into its JSON response, while the scanner path is covered from manual/camera-equivalent decode through a rendered lookup result.