### PR TITLE
feat(observability): export database pool metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'web-push'
 
 # OpenTelemetry for observability [https://opentelemetry.io/docs/languages/ruby/]
 gem 'opentelemetry-api'
+gem 'opentelemetry-metrics-api'
+gem 'opentelemetry-metrics-sdk'
 gem 'opentelemetry-sdk'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -72,6 +74,7 @@ gem 'tailwind_merge'
 group :production, :test do
   # OpenTelemetry for observability [https://opentelemetry.io/docs/languages/ruby/]
   gem 'opentelemetry-exporter-otlp'
+  gem 'opentelemetry-exporter-otlp-metrics'
   gem 'opentelemetry-instrumentation-net_http'
   gem 'opentelemetry-instrumentation-pg'
   gem 'opentelemetry-instrumentation-rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,15 @@ GEM
       opentelemetry-common (~> 0.20)
       opentelemetry-sdk (~> 1.10)
       opentelemetry-semantic_conventions
+    opentelemetry-exporter-otlp-metrics (0.10.0)
+      google-protobuf (>= 3.18, < 5.0)
+      googleapis-common-protos-types (~> 1.3)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-metrics-api (~> 0.2)
+      opentelemetry-metrics-sdk (~> 0.5)
+      opentelemetry-sdk (~> 1.2)
+      opentelemetry-semantic_conventions
     opentelemetry-helpers-sql (0.4.0)
       opentelemetry-api (~> 1.7)
     opentelemetry-helpers-sql-processor (0.5.0)
@@ -435,6 +444,12 @@ GEM
       opentelemetry-instrumentation-active_storage (~> 0.4)
       opentelemetry-instrumentation-active_support (~> 0.11)
       opentelemetry-instrumentation-concurrent_ruby (~> 0.25)
+    opentelemetry-metrics-api (0.6.1)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-metrics-sdk (0.15.0)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-metrics-api (~> 0.2)
+      opentelemetry-sdk (~> 1.2)
     opentelemetry-registry (0.6.1)
       opentelemetry-api (~> 1.1)
     opentelemetry-sdk (1.12.1)
@@ -869,10 +884,13 @@ DEPENDENCIES
   omniauth_openid_connect
   opentelemetry-api
   opentelemetry-exporter-otlp
+  opentelemetry-exporter-otlp-metrics
   opentelemetry-instrumentation-net_http
   opentelemetry-instrumentation-pg
   opentelemetry-instrumentation-rack
   opentelemetry-instrumentation-rails
+  opentelemetry-metrics-api
+  opentelemetry-metrics-sdk
   opentelemetry-sdk
   pagy
   paper_trail

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'opentelemetry-api'
+require 'opentelemetry-metrics-api'
 require 'otel/allowlisted_span_exporter'
 require 'otel/critical_path_sampler'
+require 'otel/database_connection_pool_metrics'
 require 'otel/exception_recorder'
 require 'otel/log_correlation'
 
@@ -39,6 +41,13 @@ module OpenTelemetryConfig
         hash[key.strip] = ''
       end
     end
+  end
+
+  def install_database_pool_metrics
+    meter = OpenTelemetry.meter_provider.meter('medtracker.database_pool')
+    Otel::DatabaseConnectionPoolMetrics.new(pool: ActiveRecord::Base.connection_pool, meter:).install
+    pool_class = ActiveRecord::ConnectionAdapters::ConnectionPool
+    pool_class.prepend(Otel::ConnectionPoolTimeoutInstrumentation) unless pool_class < Otel::ConnectionPoolTimeoutInstrumentation
   end
 
   def trace_sampler(environment: Rails.env, env: ENV)
@@ -106,10 +115,14 @@ module OpenTelemetryConfig
   end
 end
 
+Rails.application.config.after_initialize { OpenTelemetryConfig.install_database_pool_metrics }
+
 if Rails.env.test?
   ENV['OTEL_TRACES_EXPORTER'] = 'none'
+  ENV['OTEL_METRICS_EXPORTER'] = 'none'
 
   require 'opentelemetry/sdk'
+  require 'opentelemetry-metrics-sdk'
   require 'opentelemetry/instrumentation/active_job'
   require 'opentelemetry/instrumentation/active_record'
   require 'opentelemetry/instrumentation/pg'
@@ -148,6 +161,8 @@ if Rails.env.test?
 elsif Rails.env.production? || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].present?
   require 'opentelemetry/sdk'
   require 'opentelemetry/exporter/otlp'
+  require 'opentelemetry-exporter-otlp-metrics'
+  require 'opentelemetry-metrics-sdk'
   require 'opentelemetry/instrumentation/active_job'
   require 'opentelemetry/instrumentation/active_record'
   require 'opentelemetry/instrumentation/net/http'
@@ -213,5 +228,11 @@ elsif Rails.env.production? || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].present?
       'host.name' => Socket.gethostname,
       'process.pid' => Process.pid.to_s
     )
+  end
+
+  if otlp_endpoint.present?
+    metric_exporter = OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter.new
+    metric_reader = OpenTelemetry::SDK::Metrics::Export::PeriodicMetricReader.new(exporter: metric_exporter)
+    OpenTelemetry.meter_provider.add_metric_reader(metric_reader)
   end
 end

--- a/config/observability/database_pool_alerts.yml
+++ b/config/observability/database_pool_alerts.yml
@@ -1,0 +1,24 @@
+groups:
+  - name: medtracker-database-pool
+    rules:
+      - alert: MedTrackerDatabasePoolContention
+        expr: max_over_time(medtracker_db_connection_pool_waiting[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Database work is waiting for a connection
+      - alert: MedTrackerDatabasePoolExhaustion
+        expr: medtracker_db_connection_pool_in_use / medtracker_db_connection_pool_size > 0.9
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Database connection pool utilization is above 90 percent
+      - alert: MedTrackerDatabasePoolCheckoutTimeouts
+        expr: increase(medtracker_db_connection_pool_timeouts_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Database connection checkout timeouts are occurring

--- a/config/observability/database_pool_dashboard.json
+++ b/config/observability/database_pool_dashboard.json
@@ -1,0 +1,44 @@
+{
+  "title": "MedTracker Database Connection Pool",
+  "uid": "medtracker-db-pool",
+  "schemaVersion": 41,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Pool utilization",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "100 * sum(medtracker_db_connection_pool_in_use) / sum(medtracker_db_connection_pool_size)", "legendFormat": "utilization %" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } }
+    },
+    {
+      "id": 2,
+      "title": "Connections by state",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(medtracker_db_connection_pool_size)", "legendFormat": "size" },
+        { "expr": "sum(medtracker_db_connection_pool_in_use)", "legendFormat": "in use" },
+        { "expr": "sum(medtracker_db_connection_pool_idle)", "legendFormat": "idle" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Waiting threads",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(medtracker_db_connection_pool_waiting)", "legendFormat": "waiting" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Checkout timeouts",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(medtracker_db_connection_pool_timeouts_total[5m]))", "legendFormat": "timeouts / second" }
+      ]
+    }
+  ]
+}

--- a/lib/otel/database_connection_pool_metrics.rb
+++ b/lib/otel/database_connection_pool_metrics.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Otel
+  class DatabaseConnectionPoolMetrics
+    GAUGES = {
+      size: ['medtracker.db.connection_pool.size', 'Configured database connection pool capacity'],
+      busy: ['medtracker.db.connection_pool.in_use', 'Database connections currently checked out'],
+      idle: ['medtracker.db.connection_pool.idle', 'Database connections currently idle'],
+      waiting: ['medtracker.db.connection_pool.waiting', 'Threads waiting for a database connection']
+    }.freeze
+    TIMEOUT_METRIC = 'medtracker.db.connection_pool.timeouts'
+
+    class << self
+      attr_accessor :current
+
+      def record_timeout(pool)
+        current&.record_timeout(pool)
+      end
+    end
+
+    def initialize(pool:, meter:)
+      @pool = pool
+      @meter = meter
+    end
+
+    def install
+      install_gauges
+      @timeout_counter = meter.create_counter(
+        TIMEOUT_METRIC,
+        unit: '1',
+        description: 'Database connection checkout timeouts'
+      )
+      self.class.current = self
+      self
+    end
+
+    def record_timeout(timed_out_pool = pool)
+      timeout_counter&.add(1, attributes: pool_attributes(timed_out_pool))
+    end
+
+    private
+
+    attr_reader :meter, :pool, :timeout_counter
+
+    def install_gauges
+      GAUGES.each do |stat_key, (name, description)|
+        meter.create_observable_gauge(
+          name,
+          callback: -> { pool_stat(stat_key) },
+          unit: '1',
+          description:
+        )
+      end
+    end
+
+    def pool_stat(stat_key)
+      pool.stat.fetch(stat_key)
+    rescue StandardError => e
+      Rails.logger.warn("OpenTelemetry database pool metrics unavailable: #{e.class}: #{e.message}")
+      0
+    end
+
+    def pool_attributes(connection_pool)
+      {
+        'db.pool.name' => connection_pool.db_config.name,
+        'db.namespace' => connection_pool.db_config.database.to_s
+      }
+    end
+  end
+
+  module ConnectionPoolTimeoutInstrumentation
+    def checkout(...)
+      super
+    rescue ActiveRecord::ConnectionTimeoutError
+      DatabaseConnectionPoolMetrics.record_timeout(self)
+      raise
+    end
+  end
+end

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(gemfile).to include("gem 'opentelemetry-instrumentation-net_http'")
   end
 
+  it 'includes the OpenTelemetry metrics API, SDK, and OTLP exporter' do
+    expect(gemfile).to include("gem 'opentelemetry-metrics-api'")
+    expect(gemfile).to include("gem 'opentelemetry-metrics-sdk'")
+    expect(gemfile).to include("gem 'opentelemetry-exporter-otlp-metrics'")
+  end
+
   it 'removes unused local test tooling from the bundle' do
     expect(gemfile).not_to include("gem 'parallel_tests'")
     expect(gemfile).not_to include("gem 'rails-controller-testing'")
@@ -116,6 +122,11 @@ RSpec.describe ApplicationHarnessDependencies do
     dependency = gemfile_dependencies.fetch('opentelemetry-sdk')
 
     expect(dependency.groups).to include(:default)
+  end
+
+  it 'keeps the OpenTelemetry metrics API and SDK available to development boot' do
+    expect(gemfile_dependencies.fetch('opentelemetry-metrics-api').groups).to include(:default)
+    expect(gemfile_dependencies.fetch('opentelemetry-metrics-sdk').groups).to include(:default)
   end
 
   it 'copies only required Rails and test paths into the test Docker image' do

--- a/spec/config/observability/database_pool_operations_spec.rb
+++ b/spec/config/observability/database_pool_operations_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module DatabasePoolOperations
+end
+
+RSpec.describe DatabasePoolOperations do
+  let(:dashboard) do
+    JSON.parse(Rails.root.join('config/observability/database_pool_dashboard.json').read)
+  end
+  let(:rules) do
+    path = Rails.root.join('config/observability/database_pool_alerts.yml')
+    YAML.safe_load_file(path).fetch('groups').first.fetch('rules')
+  end
+
+  it 'provides dashboard panels for capacity, utilization, waiting, and timeouts' do
+    expressions = dashboard.fetch('panels').flat_map { |panel| panel.fetch('targets') }.pluck('expr').join(' ')
+
+    expect(expressions).to include('medtracker_db_connection_pool_size')
+    expect(expressions).to include('medtracker_db_connection_pool_in_use')
+    expect(expressions).to include('medtracker_db_connection_pool_idle')
+    expect(expressions).to include('medtracker_db_connection_pool_waiting')
+    expect(expressions).to include('medtracker_db_connection_pool_timeouts_total')
+  end
+
+  it 'alerts only after sustained contention or a checkout timeout' do
+    alerts = rules.index_by { |rule| rule.fetch('alert') }
+
+    expect(alerts.fetch('MedTrackerDatabasePoolContention')).to include('for' => '5m')
+    expect(alerts.fetch('MedTrackerDatabasePoolExhaustion')).to include('for' => '10m')
+    expect(alerts.fetch('MedTrackerDatabasePoolCheckoutTimeouts')).to include('for' => '1m')
+  end
+end

--- a/spec/config/observability/open_telemetry_config_exporter_spec.rb
+++ b/spec/config/observability/open_telemetry_config_exporter_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe OpenTelemetryConfig do
 
       expect(span_processors).to be_empty
     end
+
+    it 'installs database pool timeout instrumentation' do
+      expect(ActiveRecord::ConnectionAdapters::ConnectionPool).to be < Otel::ConnectionPoolTimeoutInstrumentation
+      expect(Otel::DatabaseConnectionPoolMetrics.current).to be_present
+    end
   end
 
   context 'when parsing OTLP headers' do

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Database pool metrics export pipeline' do
+  it 'loads the OTLP metrics exporter used by runtime environments' do
+    require 'opentelemetry-exporter-otlp-metrics'
+
+    expect(OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter).to be_a(Class)
+  end
+
+  it 'uses the OpenTelemetry metrics SDK provider in the test runtime' do
+    expect(OpenTelemetry.meter_provider).to be_a(OpenTelemetry::SDK::Metrics::MeterProvider)
+  end
+
+  it 'installs metrics against the runtime Active Record pool' do
+    pool = ActiveRecord::Base.connection_pool
+    meter = DatabasePoolMetricsTestSupport::Meter.new
+
+    metrics = Otel::DatabaseConnectionPoolMetrics.new(pool:, meter:)
+    metrics.install
+
+    observations = meter.gauges.transform_values(&:observe)
+    expect(observations).to include(
+      'medtracker.db.connection_pool.size' => pool.stat.fetch(:size),
+      'medtracker.db.connection_pool.in_use' => pool.stat.fetch(:busy),
+      'medtracker.db.connection_pool.idle' => pool.stat.fetch(:idle),
+      'medtracker.db.connection_pool.waiting' => pool.stat.fetch(:waiting)
+    )
+  end
+end

--- a/spec/lib/otel/database_connection_pool_metrics_spec.rb
+++ b/spec/lib/otel/database_connection_pool_metrics_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Otel::DatabaseConnectionPoolMetrics do
+  subject(:metrics) { described_class.new(pool:, meter:) }
+
+  let(:meter) { DatabasePoolMetricsTestSupport::Meter.new }
+  let(:db_config) { instance_double(ActiveRecord::DatabaseConfigurations::HashConfig, name: 'primary', database: 'medtracker_test') }
+  let(:pool) do
+    instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size: 10, connections: 7, busy: 4, dead: 0, idle: 3, waiting: 2, checkout_timeout: 5.0 },
+      db_config:
+    )
+  end
+
+  it 'registers the pool gauges and timeout counter with stable names' do
+    metrics.install
+
+    expect(meter.gauges.keys).to contain_exactly(
+      'medtracker.db.connection_pool.size',
+      'medtracker.db.connection_pool.in_use',
+      'medtracker.db.connection_pool.idle',
+      'medtracker.db.connection_pool.waiting'
+    )
+    expect(meter.counters.keys).to contain_exactly('medtracker.db.connection_pool.timeouts')
+  end
+
+  it 'observes current Rails connection pool statistics' do
+    metrics.install
+
+    expect(meter.gauges.transform_values(&:observe)).to eq(
+      'medtracker.db.connection_pool.size' => 10,
+      'medtracker.db.connection_pool.in_use' => 4,
+      'medtracker.db.connection_pool.idle' => 3,
+      'medtracker.db.connection_pool.waiting' => 2
+    )
+  end
+
+  it 'records checkout timeouts with bounded pool metadata' do
+    metrics.install
+
+    metrics.record_timeout(pool)
+
+    expect(meter.counters.fetch('medtracker.db.connection_pool.timeouts').recordings).to eq(
+      [[1, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }]]
+    )
+  end
+
+  it 'records and re-raises connection checkout timeout errors' do
+    timeout_pool_class = Class.new do
+      prepend Otel::ConnectionPoolTimeoutInstrumentation
+
+      def checkout
+        raise ActiveRecord::ConnectionTimeoutError
+      end
+
+      def db_config
+        ActiveRecord::Base.connection_pool.db_config
+      end
+    end
+    metrics.install
+
+    expect { timeout_pool_class.new.checkout }.to raise_error(ActiveRecord::ConnectionTimeoutError)
+    expect(meter.counters.fetch('medtracker.db.connection_pool.timeouts').recordings.size).to eq(1)
+  end
+
+  it 'returns zero from gauge callbacks when pool statistics are unavailable' do
+    allow(pool).to receive(:stat).and_raise(ActiveRecord::ConnectionNotEstablished)
+    allow(Rails.logger).to receive(:warn)
+    metrics.install
+
+    expect(meter.gauges.values.map(&:observe)).to all(eq(0))
+    expect(Rails.logger).to have_received(:warn).with(/database pool metrics unavailable/).at_least(:once)
+  end
+end

--- a/spec/support/database_pool_metrics_test_meter.rb
+++ b/spec/support/database_pool_metrics_test_meter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module DatabasePoolMetricsTestSupport
+  class Metric
+    attr_reader :recordings
+
+    def initialize(callback: nil)
+      @callback = callback
+      @recordings = []
+    end
+
+    def observe
+      @callback.call
+    end
+
+    def add(value, attributes: {})
+      recordings << [value, attributes]
+    end
+  end
+
+  class Meter
+    attr_reader :counters, :gauges
+
+    def initialize
+      @counters = {}
+      @gauges = {}
+    end
+
+    def create_counter(name, **)
+      counters[name] = Metric.new
+    end
+
+    def create_observable_gauge(name, callback:, **)
+      gauges[name] = Metric.new(callback:)
+    end
+  end
+end


### PR DESCRIPTION
Closes #599

Database connection pressure was invisible until requests timed out. This adds OpenTelemetry gauges for pool capacity, checked-out connections, idle connections, and waiting threads, plus a counter for checkout timeouts with bounded database metadata.

The production OTLP pipeline now exports metrics alongside traces. Repository-owned Grafana and Prometheus definitions show pool health over time and alert only on sustained contention, high utilization, or observed checkout timeouts.