### PR TITLE
fix(people): enforce dependent capacity

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -151,7 +151,6 @@ class Person < ApplicationRecord
 
   def set_capacity_from_person_type
     return unless minor? || dependent_adult?
-    return unless active_carer_relationship?
 
     self.has_capacity = false
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -775,7 +775,7 @@ RSpec.describe Person do
       expect(adult.has_capacity).to be true
     end
 
-    it 'does not force has_capacity for minors without a carer (self-signup)' do
+    it 'auto-sets has_capacity to false for minors without a carer' do
       minor = described_class.new(
         name: 'Self-Signup Minor',
         date_of_birth: 10.years.ago,
@@ -784,7 +784,19 @@ RSpec.describe Person do
       )
       minor.valid?
 
-      expect(minor.has_capacity).to be true
+      expect(minor.has_capacity).to be false
+    end
+
+    it 'auto-sets has_capacity to false for dependent adults without a carer' do
+      dependent = described_class.new(
+        name: 'Unassigned Dependent',
+        date_of_birth: 70.years.ago,
+        person_type: :dependent_adult,
+        has_capacity: true
+      )
+      dependent.valid?
+
+      expect(dependent.has_capacity).to be false
     end
   end
 

--- a/spec/requests/api/v1/people_controller_spec.rb
+++ b/spec/requests/api/v1/people_controller_spec.rb
@@ -56,24 +56,37 @@ RSpec.describe Api::V1::PeopleController do
       household = user.person.household
       other_household = Household.create!(name: 'Other API Household', slug: 'other-api-household')
 
-      granted_person = Person.create!(
+      household_carer = people(:jane)
+      other_household_carer = Person.create!(
+        household: other_household,
+        name: 'Other Household Carer',
+        date_of_birth: 40.years.ago.to_date,
+        person_type: :adult
+      )
+      granted_person = Person.new(
         household: household,
         name: 'Granted Alex',
         date_of_birth: 8.years.ago.to_date,
         person_type: :minor
       )
-      hidden_person = Person.create!(
+      granted_person.carer_relationships.build(carer: household_carer, relationship_type: :parent)
+      granted_person.save!
+      hidden_person = Person.new(
         household: household,
         name: 'Hidden Alex',
         date_of_birth: 9.years.ago.to_date,
         person_type: :minor
       )
-      other_household_person = Person.create!(
+      hidden_person.carer_relationships.build(carer: household_carer, relationship_type: :parent)
+      hidden_person.save!
+      other_household_person = Person.new(
         household: other_household,
         name: 'Other Alex',
         date_of_birth: 10.years.ago.to_date,
         person_type: :minor
       )
+      other_household_person.carer_relationships.build(carer: other_household_carer, relationship_type: :parent)
+      other_household_person.save!
       membership = household.household_memberships.find_or_initialize_by(account: account).tap do |record|
         record.person = people(:jane)
         record.role = :owner

--- a/spec/requests/dosages_wizard_spec.rb
+++ b/spec/requests/dosages_wizard_spec.rb
@@ -297,13 +297,14 @@ RSpec.describe 'Medication wizard dose option follow-up' do
     sign_in(users(:admin))
     household = Household.find_by!(slug: default_request_household_slug)
     membership = household.household_memberships.find_by!(account: users(:admin).person.account)
-    dependent = Person.create!(
+    dependent = Person.new(
       name: 'Dependent Adult Patient',
       date_of_birth: 50.years.ago.to_date,
       person_type: :dependent_adult,
-      has_capacity: true,
       household: household
     )
+    dependent.carer_relationships.build(carer: users(:admin).person, relationship_type: :guardian)
+    dependent.save!
     household.person_access_grants.create!(
       household_membership: membership,
       person: dependent,

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -207,19 +207,14 @@ RSpec.describe 'Invitations' do
   end
 
   def create_dependent(household:, name:, carer:)
-    dependent = Person.create!(
+    dependent = Person.new(
       household: household,
       name: name,
       date_of_birth: 8.years.ago.to_date,
-      person_type: :minor,
-      has_capacity: true
+      person_type: :minor
     )
-    CarerRelationship.create!(
-      carer: carer,
-      patient: dependent,
-      relationship_type: :parent
-    )
-    dependent.update!(has_capacity: false)
+    dependent.carer_relationships.build(carer: carer, relationship_type: :parent)
+    dependent.save!
     dependent
   end
 end

--- a/spec/services/admin/dashboard_metrics_query_spec.rb
+++ b/spec/services/admin/dashboard_metrics_query_spec.rb
@@ -64,7 +64,10 @@ RSpec.describe Admin::DashboardMetricsQuery do
       HouseholdInvitation.delete_all
       NhsDmdImport.delete_all
       PaperTrail::Version.delete_all
-      Person.find_each { |person| person.update!(has_capacity: true) }
+      Person.adult.find_each { |person| person.update!(has_capacity: true) }
+      household.people.needing_carer_assignment.find_each do |person|
+        person.carer_relationships.create!(carer: people(:jane), relationship_type: :guardian)
+      end
     end
 
     it 'returns pending and expired invitation counts' do


### PR DESCRIPTION
Minors and dependent adults could retain has_capacity=true when they had no carer relationship, leaving the model in a state that conflicts with the person-type contract.\n\nThis makes person type authoritative: validating either dependent type always clears capacity. Test setup now creates realistic carer relationships instead of relying on an invalid capacity combination.\n\nCloses #588