### PR TITLE
fix(people): validate age transitions

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -62,6 +62,7 @@ class Person < ApplicationRecord
                     format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true },
                     uniqueness: { allow_blank: true }
   validate :carer_required_when_lacking_capacity
+  validate :person_type_matches_age
   validate :avatar_must_be_supported_image
   validate :avatar_must_be_smaller_than_five_megabytes
 
@@ -168,6 +169,16 @@ class Person < ApplicationRecord
     return if active_carer_relationship?
 
     errors.add(:base, 'A person without capacity must have at least one carer assigned')
+  end
+
+  def person_type_matches_age
+    return if date_of_birth.blank? || person_type.blank?
+
+    if age < 18 && person_type == 'dependent_adult'
+      errors.add(:person_type, 'must be minor or adult for people under 18')
+    elsif age >= 18 && person_type == 'minor'
+      errors.add(:person_type, 'must be adult or dependent adult for people aged 18 or over')
+    end
   end
 
   def active_carer_relationship?

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -232,6 +232,58 @@ RSpec.describe Person do
     end
   end
 
+  describe 'person type transitions' do
+    it 'rejects a minor type once the person is 18' do
+      person = described_class.new(
+        name: 'Adult Age Minor',
+        date_of_birth: 18.years.ago.to_date,
+        person_type: :minor
+      )
+
+      expect(person).not_to be_valid
+      expect(person.errors[:person_type]).to include('must be adult or dependent adult for people aged 18 or over')
+    end
+
+    it 'rejects a dependent adult type for people under 18' do
+      person = described_class.new(
+        name: 'Minor Age Dependent Adult',
+        date_of_birth: 12.years.ago.to_date,
+        person_type: :dependent_adult
+      )
+
+      expect(person).not_to be_valid
+      expect(person.errors[:person_type]).to include('must be minor or adult for people under 18')
+    end
+
+    it 'allows a minor to transition to adult at 18' do
+      carer = described_class.create!(name: 'Adult Transition Carer', date_of_birth: 40.years.ago.to_date)
+      person = described_class.new(
+        name: 'Transitioning Adult',
+        date_of_birth: 17.years.ago.to_date,
+        person_type: :minor
+      )
+      person.carer_relationships.build(carer: carer, relationship_type: :family_member)
+      person.save!
+
+      expect(person.update(date_of_birth: 18.years.ago.to_date, person_type: :adult)).to be true
+      expect(person).to be_adult
+    end
+
+    it 'allows an adult to transition to dependent adult with a carer' do
+      carer = described_class.create!(name: 'Transition Carer', date_of_birth: 40.years.ago.to_date)
+      person = described_class.create!(
+        name: 'Transitioning Dependent',
+        date_of_birth: 30.years.ago.to_date,
+        person_type: :adult
+      )
+      person.assign_carer!(carer)
+
+      expect(person.update(person_type: :dependent_adult)).to be true
+      expect(person).to be_dependent_adult
+      expect(person.has_capacity).to be false
+    end
+  end
+
   describe '#adult?' do
     it 'returns true for person 18 years or older with adult person_type' do
       adult = described_class.new(

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -216,6 +216,21 @@ RSpec.describe 'People' do
 
         expect(Person.last.household.slug).to eq(default_url_options.fetch(:household_slug))
       end
+
+      it 'rejects a dependent adult type for a person under 18' do
+        expect do
+          post people_path, params: {
+            person: {
+              name: 'Invalid Dependent Adult',
+              date_of_birth: 12.years.ago.to_date,
+              person_type: 'dependent_adult'
+            }
+          }
+        end.not_to change(Person, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('must be minor or adult for people under 18')
+      end
     end
   end
 
@@ -323,6 +338,25 @@ RSpec.describe 'People' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include('target="modal"')
       expect(response.body).to include('person_form')
+    end
+  end
+
+  describe 'PATCH /people/:id person type transitions' do
+    before { sign_in(users(:admin)) }
+
+    it 'requires a minor who has reached 18 to transition type' do
+      person = people(:child_patient)
+
+      patch person_path(person), params: {
+        person: {
+          date_of_birth: 18.years.ago.to_date,
+          person_type: 'minor'
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('must be adult or dependent adult for people aged 18 or over')
+      expect(person.reload.person_type).to eq('minor')
     end
   end
 


### PR DESCRIPTION
People could remain classified as minors after turning 18, or be classified as dependent adults while still under 18. That left age-based behavior and the selected person type disagreeing.

This adds one shared model rule for create and update flows. A minor must move to adult or dependent adult at 18, and dependent adult is rejected below 18. Existing adult classifications for under-18 account records remain compatible, while valid minor-to-adult and adult-to-dependent transitions are covered directly.

Closes #580
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->