### PR TITLE
fix(admin): restore large user pagination

### DIFF
--- a/app/components/admin/users/pagination.rb
+++ b/app/components/admin/users/pagination.rb
@@ -125,7 +125,7 @@ module Components
         end
 
         def render_page_numbers
-          pagy_obj.series.each do |item|
+          page_series.each do |item|
             case item
             when Integer
               Link(
@@ -140,6 +140,30 @@ module Components
               span(class: gap_class) { '…' }
             end
           end
+        end
+
+        def page_series
+          return page_range(1) if pagy_obj.pages <= 7
+
+          start_page = (pagy_obj.page - 3).clamp(1, pagy_obj.pages - 6)
+          series = (start_page...(start_page + 7)).to_a
+          series[0] = 1
+          series[-1] = pagy_obj.pages
+          add_series_gaps(series)
+          series.map { |page| page_item(page) }
+        end
+
+        def page_range(start_page)
+          (start_page..pagy_obj.pages).map { |page| page_item(page) }
+        end
+
+        def add_series_gaps(series)
+          series[1] = :gap unless series[1] == 2
+          series[-2] = :gap unless series[-2] == pagy_obj.pages - 1
+        end
+
+        def page_item(page)
+          page == pagy_obj.page ? page.to_s : page
         end
 
         def page_url(page)

--- a/spec/requests/admin_users_index_performance_spec.rb
+++ b/spec/requests/admin_users_index_performance_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin users index performance' do
+  fixtures :accounts, :people, :users
+
+  let(:admin) { users(:admin) }
+  let(:household) { households(:fixture_household) }
+  let(:performance_budget_seconds) { 0.5 }
+
+  before do
+    sign_in(admin)
+    create_users(100)
+  end
+
+  it 'loads within the performance budget with more than 100 users' do
+    get admin_users_path
+
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    get admin_users_path
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+
+    expect(response).to have_http_status(:ok)
+    expect(User.count).to be > 100
+    expect(elapsed).to be < performance_budget_seconds
+  end
+
+  def create_users(count)
+    count.times { |index| create_user(index) }
+  end
+
+  def create_user(index)
+    account = Account.create!(
+      email: "performance.user.#{index}@example.com",
+      password_hash: accounts(:admin).password_hash,
+      status: :verified
+    )
+    person = Person.create!(account: account, household: household, name: "Performance User #{index}",
+                            date_of_birth: 30.years.ago.to_date)
+    household.household_memberships.create!(account: account, person: person, role: :member, status: :active)
+    User.create!(person: person, email_address: account.email, password_digest: admin.password_digest)
+  end
+end


### PR DESCRIPTION
The admin user list stopped rendering as soon as enough users existed for a second page. Its custom pagination called a Pagy method that is now protected, so the 100-user performance target could not be reached at all.

This keeps the existing Material pagination UI while deriving its page series from Pagy public state. It also adds a real request-level guardrail that creates more than 100 users, warms the endpoint, and requires the rendered response to complete within 500ms. The existing bulk-loading and zero-query rendering protections continue to cover the N+1 side of the budget.

Closes #579
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->