### PR TITLE
fix(auth): audit passkey verification

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -424,6 +424,12 @@ class RodauthMain < Rodauth::Rails::Auth
     after_two_factor_authentication do
       set_session_value(:privileged_action_mfa_verified_at, Time.current.to_i)
     end
+    before_webauthn_auth do
+      audit_auth_token('webauthn_verification', 'succeeded', outcome: 'success')
+    end
+    after_webauthn_auth_failure do
+      audit_auth_token('webauthn_verification', 'failed', outcome: 'failure')
+    end
     before_otp_setup_route do
       # Allow OTP setup if user has no 2FA methods configured yet
       # Only require 2FA auth if they already have a method set up

--- a/app/services/auth_token_audit_logger.rb
+++ b/app/services/auth_token_audit_logger.rb
@@ -66,6 +66,7 @@ class AuthTokenAuditLogger
     hashed_metadata(data).merge(device_name_metadata(data))
                          .merge(optional_value(data, :platform))
                          .merge(optional_value(data, :credential_nickname))
+                         .merge(optional_value(data, :outcome))
                          .merge(expires_at_metadata(data))
   end
 

--- a/spec/lib/rodauth_main_spec.rb
+++ b/spec/lib/rodauth_main_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe RodauthMain do
     end
   end
 
+  describe 'WebAuthn verification auditing' do
+    let(:auth) { RodauthApp.rodauth.allocate }
+
+    before { allow(auth).to receive(:audit_auth_token) }
+
+    it 'records successful user verification' do
+      auth.send(:before_webauthn_auth)
+
+      expect(auth).to have_received(:audit_auth_token).with(
+        'webauthn_verification', 'succeeded', outcome: 'success'
+      )
+    end
+
+    it 'records failed user verification' do
+      auth.send(:after_webauthn_auth_failure)
+
+      expect(auth).to have_received(:audit_auth_token).with(
+        'webauthn_verification', 'failed', outcome: 'failure'
+      )
+    end
+  end
+
   describe 'Zitadel professional title helpers' do
     it 'returns an empty role list when Zitadel roles are absent' do
       auth = RodauthApp.rodauth.allocate

--- a/spec/services/auth_token_audit_logger_spec.rb
+++ b/spec/services/auth_token_audit_logger_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe AuthTokenAuditLogger do
       expect(version.request_id).to eq('req-explicit')
     end
 
+    it 'stores a bounded verification outcome' do
+      audit_logger.record(
+        account: account,
+        token_type: 'webauthn_verification',
+        action: 'failed',
+        metadata: { outcome: 'failure' }
+      )
+
+      expect(version_data['outcome']).to eq('failure')
+    end
+
     it 'does not raise when called without PaperTrail request context' do
       PaperTrail.request.whodunnit = nil
       PaperTrail.request.controller_info = {}


### PR DESCRIPTION
Sensitive MFA-management actions already require a fresh passkey ceremony, and MedTracker already asks the authenticator for required user verification. The missing evidence was the outcome of that ceremony: successful and rejected server-side assertions were not represented in the security audit trail.

This records bounded WebAuthn verification success/failure events through the existing redacted token-audit path. Each event keeps the existing actor, household, request, and IP attribution without storing credential IDs, keys, assertions, or other token material. Client-side cancellation still leaves protected data unchanged, while invalid assertions that reach the server now produce a failure event.

Closes #564
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->