### PR TITLE
fix(a11y): standardize icon-only controls

### DIFF
--- a/app/components/global_search/palette.rb
+++ b/app/components/global_search/palette.rb
@@ -63,7 +63,7 @@ module Components
               aria: { label: t('global_search.close') },
               data: { action: 'global-search#close' }
             ) do
-              render Icons::X.new(size: 20)
+              render Icons::X.new(size: 20, aria_hidden: 'true')
             end
           end
         end

--- a/app/components/layouts/mobile_menu.rb
+++ b/app/components/layouts/mobile_menu.rb
@@ -60,8 +60,7 @@ module Components
           data_action: 'click->ruby-ui--sheet-content#close',
           aria: { label: t('layouts.mobile_menu.close_menu') }
         ) do
-          render Icons::X.new(size: 22)
-          span(class: 'sr-only') { t('layouts.mobile_menu.close_menu') }
+          render Icons::X.new(size: 22, aria_hidden: 'true')
         end
       end
 

--- a/app/components/layouts/mobile_rail.rb
+++ b/app/components/layouts/mobile_rail.rb
@@ -50,7 +50,7 @@ module Components
                         'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface'
                       end}"
           ) do
-            render item[:icon].new(size: 24)
+            render item[:icon].new(size: 24, aria_hidden: 'true')
           end
         end
       end

--- a/app/components/layouts/navigation.rb
+++ b/app/components/layouts/navigation.rb
@@ -64,7 +64,7 @@ module Components
             aria: { label: t('global_search.open'), expanded: 'false', controls: 'global_search_panel' },
             data: { action: 'global-search#open', global_search_target: 'trigger' }
           ) do
-            render Icons::Search.new(size: 22)
+            render Icons::Search.new(size: 22, aria_hidden: 'true')
           end
         end
 

--- a/app/components/locations/index_view.rb
+++ b/app/components/locations/index_view.rb
@@ -132,7 +132,7 @@ module Components
                    'bg-card hover:bg-tertiary-container text-on-surface-variant',
             aria_label: t('locations.index.edit', default: 'Edit location')
           ) do
-            render Icons::Pencil.new(size: 16)
+            render Icons::Pencil.new(size: 16, aria_hidden: 'true')
           end
           render_delete_dialog(location)
         end
@@ -145,7 +145,7 @@ module Components
                       class: 'text-on-surface-variant ' \
                              'hover:text-destructive hover:bg-destructive/5',
                       aria_label: t('locations.index.delete', default: 'Delete location')) do
-              render Icons::Trash.new(size: 18)
+              render Icons::Trash.new(size: 18, aria_hidden: 'true')
             end
           end
           AlertDialogContent(class: 'rounded-[2rem] border-none shadow-2xl') do

--- a/app/components/locations/show_view.rb
+++ b/app/components/locations/show_view.rb
@@ -181,7 +181,7 @@ module Components
                      'hover:text-destructive',
               aria_label: t('locations.show.remove_member.aria_label', default: 'Remove member')
             ) do
-              render Icons::X.new(size: 14)
+              render Icons::X.new(size: 14, aria_hidden: 'true')
             end
           end
 
@@ -218,7 +218,7 @@ module Components
                 class: 'text-on-surface-variant hover:text-primary h-8 w-8 p-0 flex items-center justify-center',
                 aria_label: t('locations.show.edit_details', default: 'Edit location details')
               ) do
-                render Icons::Pencil.new(size: 16)
+                render Icons::Pencil.new(size: 16, aria_hidden: 'true')
               end
             end
           end
@@ -241,7 +241,7 @@ module Components
                      'hover:text-primary hover:bg-primary/5',
               aria_label: t('locations.show.add_member.aria_label', default: 'Add member')
             ) do
-              render Icons::Plus.new(size: 16)
+              render Icons::Plus.new(size: 16, aria_hidden: 'true')
             end
           end
 

--- a/app/components/medications/list_item_component.rb
+++ b/app/components/medications/list_item_component.rb
@@ -108,7 +108,7 @@ module Components
               data: { turbo_frame: '_top' },
               aria_label: t('medications.index.edit', default: 'Edit medication')
             ) do
-              render Icons::Pencil.new(size: 16)
+              render Icons::Pencil.new(size: 16, aria_hidden: 'true')
             end
           end
           if can_refill
@@ -138,7 +138,7 @@ module Components
                       class: 'rounded-shape-full w-11 h-11 p-0 text-on-surface-variant ' \
                              'hover:text-destructive hover:bg-destructive/5',
                       aria_label: t('medications.index.delete', default: 'Delete medication')) do
-              render Icons::Trash.new(size: 18)
+              render Icons::Trash.new(size: 18, aria_hidden: 'true')
             end
           end
           AlertDialogContent(class: 'rounded-[2rem] border-none shadow-2xl') do

--- a/app/components/medications/wizard/modal_wrapper.rb
+++ b/app/components/medications/wizard/modal_wrapper.rb
@@ -23,7 +23,7 @@ module Components
               href: medications_path,
               class: 'fixed inset-0 z-50 bg-foreground/10 backdrop-blur-[1.5px]',
               data: { turbo_frame: '_top' },
-              aria_label: 'Close'
+              aria: { label: I18n.t('ruby_ui.common.close') }
             )
 
             div(
@@ -39,10 +39,9 @@ module Components
                        'bg-surface-container-highest/90 text-on-surface-variant ' \
                        'shadow-elevation-1 transition-all hover:bg-secondary-container ' \
                        'hover:text-on-secondary-container',
-                aria_label: 'Close'
+                aria: { label: I18n.t('ruby_ui.common.close') }
               ) do
-                render Icons::X.new(size: 18)
-                span(class: 'sr-only') { 'Close' }
+                render Icons::X.new(size: 18, aria_hidden: 'true')
               end
 
               div(class: 'p-8') do

--- a/app/components/medications/wizard/slide_over_wrapper.rb
+++ b/app/components/medications/wizard/slide_over_wrapper.rb
@@ -23,7 +23,7 @@ module Components
               href: medications_path,
               class: 'fixed inset-0 z-50 bg-foreground/10 backdrop-blur-[1.5px]',
               data: { turbo_frame: '_top' },
-              aria_label: 'Close'
+              aria: { label: I18n.t('ruby_ui.common.close') }
             )
 
             # Slide-over panel
@@ -56,10 +56,10 @@ module Components
                    'rounded-shape-full border border-outline-variant/30 ' \
                    'bg-surface-container-highest/90 text-on-surface-variant ' \
                    'shadow-elevation-1 transition-all hover:bg-secondary-container hover:text-on-secondary-container',
-            data: { turbo_frame: '_top' }
+            data: { turbo_frame: '_top' },
+            aria: { label: I18n.t('ruby_ui.common.close') }
           ) do
-            render Icons::X.new(size: 18)
-            span(class: 'sr-only') { 'Close' }
+            render Icons::X.new(size: 18, aria_hidden: 'true')
           end
         end
 

--- a/app/components/reports/filter_form.rb
+++ b/app/components/reports/filter_form.rb
@@ -22,7 +22,7 @@ module Components
             class: 'rounded-xl shadow-elevation-1',
             'aria-label': translate('apply_filters_aria_label')
           ) do
-            render Icons::ChevronRight.new(size: 20)
+            render Icons::ChevronRight.new(size: 20, aria_hidden: 'true')
           end
         end
       end

--- a/app/components/ruby_ui/calendar/calendar_next.rb
+++ b/app/components/ruby_ui/calendar/calendar_next.rb
@@ -11,7 +11,7 @@ module RubyUI
     private
 
     def icon
-      render ::Components::Icons::ChevronRight.new(size: 16)
+      render ::Components::Icons::ChevronRight.new(size: 16, aria_hidden: 'true')
     end
 
     def default_attrs

--- a/app/components/ruby_ui/calendar/calendar_prev.rb
+++ b/app/components/ruby_ui/calendar/calendar_prev.rb
@@ -11,7 +11,7 @@ module RubyUI
     private
 
     def icon
-      render ::Components::Icons::ChevronLeft.new(size: 16)
+      render ::Components::Icons::ChevronLeft.new(size: 16, aria_hidden: 'true')
     end
 
     def default_attrs

--- a/app/components/ruby_ui/dialog/dialog_content.rb
+++ b/app/components/ruby_ui/dialog/dialog_content.rb
@@ -44,10 +44,10 @@ module RubyUI
       button(
         type: 'button',
         class: 'absolute end-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-tertiary-container data-[state=open]:text-on-surface-variant',
-        data_action: 'click->ruby-ui--dialog#dismiss'
+        data_action: 'click->ruby-ui--dialog#dismiss',
+        aria: { label: I18n.t('ruby_ui.common.close') }
       ) do
-        render ::Components::Icons::X.new(size: 16)
-        span(class: 'sr-only') { I18n.t('ruby_ui.common.close') }
+        render ::Components::Icons::X.new(size: 16, aria_hidden: 'true')
       end
     end
 

--- a/app/components/ruby_ui/sheet/sheet_content.rb
+++ b/app/components/ruby_ui/sheet/sheet_content.rb
@@ -38,10 +38,10 @@ module RubyUI
       button(
         type: 'button',
         class: 'absolute end-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-tertiary-container data-[state=open]:text-on-surface-variant',
-        data_action: 'click->ruby-ui--sheet-content#close'
+        data_action: 'click->ruby-ui--sheet-content#close',
+        aria: { label: I18n.t('ruby_ui.common.close') }
       ) do
-        render ::Components::Icons::X.new(size: 16)
-        span(class: 'sr-only') { I18n.t('ruby_ui.common.close') }
+        render ::Components::Icons::X.new(size: 16, aria_hidden: 'true')
       end
     end
 

--- a/app/views/rodauth/add_recovery_codes.rb
+++ b/app/views/rodauth/add_recovery_codes.rb
@@ -76,10 +76,10 @@ module Views
         button(
           type: 'button',
           class: 'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-surface-container-highest text-primary transition-all hover:scale-105 active:scale-95',
-          title: t('rodauth.views.add_recovery_codes.copy_to_clipboard'),
+          aria: { label: t('rodauth.views.add_recovery_codes.copy_to_clipboard') },
           data: { action: 'click->clipboard#copy', clipboard_text_param: recovery_code }
         ) do
-          render Icons::Copy.new(size: 18)
+          render Icons::Copy.new(size: 18, aria_hidden: 'true')
         end
       end
 

--- a/app/views/rodauth/otp_setup.rb
+++ b/app/views/rodauth/otp_setup.rb
@@ -78,10 +78,10 @@ module Views
         button(
           type: 'button',
           class: 'p-2.5 rounded-xl bg-surface-container-highest text-primary transition-all hover:scale-110 active:scale-95',
-          title: t('rodauth.views.otp_setup.copy_to_clipboard'),
+          aria: { label: t('rodauth.views.otp_setup.copy_to_clipboard') },
           data: { action: 'click->clipboard#copy', clipboard_text_param: text }
         ) do
-          render Icons::Copy.new(size: 18)
+          render Icons::Copy.new(size: 18, aria_hidden: 'true')
         end
       end
 

--- a/spec/components/global_search/palette_spec.rb
+++ b/spec/components/global_search/palette_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::GlobalSearch::Palette, type: :component do
+  it 'hides the close icon from the labelled close button' do
+    rendered = render_inline(described_class.new)
+    close_button = rendered.at_css('button[aria-label="Close search"]')
+
+    expect(close_button).to be_present
+    expect(close_button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+end

--- a/spec/components/layouts/mobile_menu_spec.rb
+++ b/spec/components/layouts/mobile_menu_spec.rb
@@ -80,8 +80,11 @@ RSpec.describe Components::Layouts::MobileMenu, type: :component do
     it 'renders close button with aria-label' do
       rendered = render_inline(described_class.new)
 
-      close_button = rendered.css('button[aria-label="Close menu"]')
+      close_button = rendered.at_css('button[aria-label="Close menu"]')
+
       expect(close_button).to be_present
+      expect(close_button.at_css('svg[aria-hidden="true"]')).to be_present
+      expect(close_button.css('.sr-only')).to be_empty
     end
 
     it 'renders close button with 44px minimum touch target' do
@@ -90,12 +93,6 @@ RSpec.describe Components::Layouts::MobileMenu, type: :component do
       close_button = rendered.css('button[aria-label="Close menu"]').first
       expect(close_button['class']).to include('min-h-[44px]')
       expect(close_button['class']).to include('min-w-[44px]')
-    end
-
-    it 'renders sr-only text for close button' do
-      rendered = render_inline(described_class.new)
-
-      expect(rendered.css('.sr-only').map(&:text)).to include('Close menu')
     end
   end
 

--- a/spec/components/layouts/mobile_rail_spec.rb
+++ b/spec/components/layouts/mobile_rail_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Components::Layouts::MobileRail, type: :component do
     Nokogiri::HTML::DocumentFragment.parse(html)
   end
 
-  it 'renders icon-only navigation with aria labels and no logout action' do
+  it 'renders icon-only navigation with aria labels and no logout action', :aggregate_failures do
     rendered = render_rail(user: admin_user)
 
     expect(rendered.css('aside[data-testid="mobile-rail"]')).to be_present
@@ -34,6 +34,7 @@ RSpec.describe Components::Layouts::MobileRail, type: :component do
     expect(rendered.css('a[aria-label="Inventory"]')).to be_present
     expect(rendered.css('a[aria-label="Profile"]')).to be_present
     expect(rendered.css('button[aria-label="Sign Out"]')).to be_empty
+    expect(rendered.css('a[aria-label] svg')).to all(satisfy { |icon| icon['aria-hidden'] == 'true' })
   end
 
   it 'renders the inventory item with the inventory icon' do

--- a/spec/components/layouts/navigation_spec.rb
+++ b/spec/components/layouts/navigation_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Components::Layouts::Navigation, type: :component do
+  fixtures :users
+
   describe 'i18n translations' do
     it 'renders navigation with default locale translations' do
       component = described_class.new(current_user: nil)
@@ -22,6 +24,17 @@ RSpec.describe Components::Layouts::Navigation, type: :component do
       rendered = render_inline(component)
 
       expect(rendered.to_html).to include('nav__brand-link text-foreground')
+    end
+  end
+
+  describe 'accessibility' do
+    it 'hides the search icon from the labelled search button' do
+      rendered = render_inline(described_class.new(current_user: users(:admin)))
+
+      search_button = rendered.at_css(%(button[aria-label="#{I18n.t('global_search.open')}"]))
+
+      expect(search_button).to be_present
+      expect(search_button.at_css('svg[aria-hidden="true"]')).to be_present
     end
   end
 end

--- a/spec/components/locations/index_view_spec.rb
+++ b/spec/components/locations/index_view_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Components::Locations::IndexView, type: :component do
     expect(action_classes.flatten).not_to include('h-10')
   end
 
+  it 'hides icons inside labelled location action controls', :aggregate_failures do
+    rendered = render_inline(described_class.new(locations: [locations(:home)]))
+
+    edit_link = rendered.at_css('a[aria-label="Edit location"]')
+    delete_button = rendered.at_css('button[aria-label="Delete location"]')
+
+    expect(edit_link.at_css('svg[aria-hidden="true"]')).to be_present
+    expect(delete_button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+
   def include_touch_target_class
     satisfy { |classes| classes.include?('min-h-11') || classes.include?('min-h-[44px]') }
   end

--- a/spec/components/locations/show_view_spec.rb
+++ b/spec/components/locations/show_view_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe Components::Locations::ShowView, type: :component do
     expect(rendered.text).not_to include('Foreign Location Candidate')
   end
 
+  it 'hides icons inside labelled location controls', :aggregate_failures do
+    person = create(:person, name: 'Location Member')
+    create(:location_membership, location: location, person: person)
+
+    rendered = render_location(available_people: [], update_allowed: true)
+
+    expect(rendered.at_css('button[aria-label="Remove member"] svg[aria-hidden="true"]')).to be_present
+    expect(rendered.at_css('a[aria-label="Edit location details"] svg[aria-hidden="true"]')).to be_present
+    expect(rendered.at_css('button[aria-label="Add member"] svg[aria-hidden="true"]')).to be_present
+  end
+
   def render_location(available_people: [], update_allowed: false)
     vc = view_context
     policy_stub = Struct.new(:update?, :refill?).new(update_allowed, false)

--- a/spec/components/medications/list_item_component_spec.rb
+++ b/spec/components/medications/list_item_component_spec.rb
@@ -94,4 +94,13 @@ RSpec.describe Components::Medications::ListItemComponent, type: :component do
     expect(fill['style']).to start_with('transform: translateX(')
     expect(rendered.css('progress.supply-progress')).to be_empty
   end
+
+  it 'hides icons inside labelled medication action controls', :aggregate_failures do
+    medication = medications(:paracetamol)
+
+    rendered = render_inline(described_class.new(medication: medication, can_update: true, can_destroy: true))
+
+    expect(rendered.at_css('a[aria-label="Edit medication"] svg[aria-hidden="true"]')).to be_present
+    expect(rendered.at_css('button[aria-label="Delete medication"] svg[aria-hidden="true"]')).to be_present
+  end
 end

--- a/spec/components/medications/wizard/modal_wrapper_spec.rb
+++ b/spec/components/medications/wizard/modal_wrapper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Medications::Wizard::ModalWrapper, type: :component do
+  fixtures :locations, :medications, :people
+
+  [
+    described_class,
+    Components::Medications::Wizard::SlideOverWrapper
+  ].each do |wrapper_class|
+    it "translates and de-duplicates close controls in #{wrapper_class.name.demodulize}" do
+      rendered = I18n.with_locale(:cy) do
+        render_inline(
+          wrapper_class.new(
+            medication: medications(:paracetamol),
+            locations: [locations(:home)],
+            people: [people(:john)]
+          )
+        )
+      end
+      close_links = rendered.css('a[aria-label="Cau"]')
+
+      expect(close_links.size).to eq(2)
+      expect(close_links.css('svg[aria-hidden="true"]')).to be_present
+      expect(close_links.css('.sr-only')).to be_empty
+    end
+  end
+end

--- a/spec/components/reports/filter_form_spec.rb
+++ b/spec/components/reports/filter_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Reports::FilterForm, type: :component do
+  it 'hides the icon from the labelled apply filters button' do
+    rendered = render_inline(
+      described_class.new(
+        action_path: '/reports',
+        people: [],
+        selected_person_id: nil,
+        start_date: nil,
+        end_date: nil
+      )
+    )
+    apply_button = rendered.at_css(%(button[aria-label="#{I18n.t('reports.index.apply_filters_aria_label')}"]))
+
+    expect(apply_button).to be_present
+    expect(apply_button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+end

--- a/spec/components/ruby_ui/calendar_prev_spec.rb
+++ b/spec/components/ruby_ui/calendar_prev_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RubyUI::CalendarPrev, type: :component do
+  it 'hides the previous month icon from its labelled button' do
+    rendered = render_inline(described_class.new)
+    button = rendered.at_css(%(button[aria-label="#{I18n.t('ruby_ui.calendar.previous_month')}"]))
+
+    expect(button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+
+  it 'hides the next month icon from its labelled button' do
+    rendered = render_inline(RubyUI::CalendarNext.new)
+    button = rendered.at_css(%(button[aria-label="#{I18n.t('ruby_ui.calendar.next_month')}"]))
+
+    expect(button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+end

--- a/spec/components/ruby_ui/dialog_content_spec.rb
+++ b/spec/components/ruby_ui/dialog_content_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe RubyUI::DialogContent, type: :component do
     expect(html).not_to include('bg-white')
     expect(html).not_to include('bg-background/80')
   end
+
+  it 'names the close button and hides redundant close content' do
+    rendered = render_inline(described_class.new(size: :md) { 'Dialog body' })
+    close_button = rendered.at_css(%(button[aria-label="#{I18n.t('ruby_ui.common.close')}"]))
+
+    expect(close_button).to be_present
+    expect(close_button.at_css('svg[aria-hidden="true"]')).to be_present
+    expect(close_button.css('.sr-only')).to be_empty
+  end
 end

--- a/spec/components/ruby_ui/sheet_content_spec.rb
+++ b/spec/components/ruby_ui/sheet_content_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe RubyUI::SheetContent, type: :component do
+  let(:close_button_component) do
+    Class.new(described_class) do
+      def view_template
+        close_button
+      end
+    end
+  end
+
   it 'uses token-driven shell surfaces for the drawer' do
     rendered = render_inline(described_class.new(side: :right) { 'Sheet body' })
     html = rendered.to_html
@@ -11,5 +19,14 @@ RSpec.describe RubyUI::SheetContent, type: :component do
     expect(html).to include('backdrop-blur-[1.5px]')
     expect(html).to include('bg-popover')
     expect(html).not_to include('bg-slate-950/12')
+  end
+
+  it 'names the close button and hides redundant close content' do
+    rendered = render_inline(close_button_component.new)
+    close_button = rendered.at_css(%(button[aria-label="#{I18n.t('ruby_ui.common.close')}"]))
+
+    expect(close_button).to be_present
+    expect(close_button.at_css('svg[aria-hidden="true"]')).to be_present
+    expect(close_button.css('.sr-only')).to be_empty
   end
 end

--- a/spec/components/views/rodauth/add_recovery_codes_spec.rb
+++ b/spec/components/views/rodauth/add_recovery_codes_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe Views::Rodauth::AddRecoveryCodes, type: :component do
     expect(rendered.text).to include('Store these codes somewhere safe.')
   end
 
+  it 'gives copy buttons an accessible name and hides their icons' do
+    rodauth = recovery_codes_auth(can_add: true, codes: ['alpha-code'])
+    allow(controller).to receive_messages(rodauth: rodauth, form_authenticity_token: 'token')
+
+    rendered = render_inline(described_class.new)
+    copy_button = rendered.at_css('button[aria-label="Copy to clipboard"]')
+
+    expect(copy_button).to be_present
+    expect(copy_button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+
   def recovery_codes_auth(can_add:, codes:, button: 'View Authentication Recovery Codes')
     RodauthApp.rodauth.allocate.tap do |rodauth|
       allow(rodauth).to receive_messages(

--- a/spec/components/views/rodauth/otp_setup_spec.rb
+++ b/spec/components/views/rodauth/otp_setup_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Views::Rodauth::OtpSetup, type: :component do
+  let(:rodauth) do
+    RodauthApp.rodauth.allocate.tap do |instance|
+      allow(instance).to receive_messages(
+        otp_qr_code: '<svg></svg>',
+        otp_user_key: 'secret-key',
+        otp_provisioning_uri: 'otpauth://totp/MedTracker',
+        otp_setup_path: '/otp-setup',
+        otp_setup_param: 'otp-secret',
+        otp_setup_raw_param: 'otp-raw',
+        otp_key: 'raw-secret',
+        otp_keys_use_hmac?: false,
+        otp_auth_param: 'otp'
+      )
+    end
+  end
+
+  before do
+    allow(controller).to receive_messages(rodauth: rodauth, form_authenticity_token: 'token')
+  end
+
+  it 'gives the copy button an accessible name and hides its icon' do
+    rendered = render_inline(described_class.new)
+    copy_button = rendered.at_css('button[aria-label="Copy to clipboard"]')
+
+    expect(copy_button).to be_present
+    expect(copy_button.at_css('svg[aria-hidden="true"]')).to be_present
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,8 @@
 
 require 'capybara/rspec'
 
+Capybara.enable_aria_label = true
+
 # Performance-optimized browser args for CI and local testing
 PLAYWRIGHT_BROWSER_ARGS = [
   '--disable-blink-features=AutomationControlled',

--- a/spec/system/medications/add_schedule_workflow_spec.rb
+++ b/spec/system/medications/add_schedule_workflow_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Inventory add schedule workflow', :browser do
 
     expect(page).to have_text('Who is this medication for?')
 
-    click_on 'Close'
+    click_button I18n.t('ruby_ui.common.close')
 
     expect(page).to have_current_path(medications_path)
     expect(page).to have_text('Inventory')

--- a/spec/system/people_spec.rb
+++ b/spec/system/people_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'People' do
 
       expect(page).to have_text('How is this medication taken?')
 
-      click_button 'Close'
+      click_button I18n.t('ruby_ui.common.close')
 
       expect(page).to have_current_path(people_path)
       expect(page).to have_text('People')


### PR DESCRIPTION
Icon-only controls now follow one accessible-name contract across navigation, search, location and medication actions, report filters, calendar navigation, authentication copy actions, dialogs, sheets, and medication workflows.

The interactive element owns the translated accessible name, while decorative SVGs are hidden from assistive technology. Redundant nested screen-reader text and title-only naming have been removed, and wizard close controls now use the existing translated close label instead of hardcoded English.

Capybara is configured to resolve controls by `aria-label`, so browser tests interact with these controls by their accessible names and catch regressions without depending on DOM structure.

This prevents duplicate or noisy screen-reader announcements, restores the two broken cancel-flow system tests, and keeps the visual presentation unchanged.