### PR TITLE
refactor(ai): reuse source response body

### DIFF
--- a/app/services/ai_medication/source_page_client.rb
+++ b/app/services/ai_medication/source_page_client.rb
@@ -22,10 +22,11 @@ module AiMedication
       response = perform_request(uri)
       raise "Source returned #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
+      body = response.body
       SourcePage.new(
         url: url,
-        title: title_from(response.body),
-        text: text_from(response.body)
+        title: title_from(body),
+        text: text_from(body)
       )
     rescue URI::InvalidURIError, *NETWORK_ERRORS => e
       raise "Source fetch failed: #{e.message}"


### PR DESCRIPTION
## What changed

`AiMedication::SourcePageClient#fetch` now reads a successful HTTP response body once and reuses that value for title and plain-text extraction.

## Why this improves maintainability

The parsing inputs are now explicit and consistent, removing a duplicated response lookup that RubyCritic flagged and making the data flow through the method easier to follow.

## How behavior was preserved

The same response body is passed to the existing `title_from` and `text_from` helpers. URL handling, HTTP status errors, network error handling, title extraction, tag stripping, and text truncation are unchanged.

## Verification commands run

- `task test:preflight`
- `task test TEST_FILE=spec/services/ai_medication/source_page_client_spec.rb`
- `task rubycritic TARGET=app/services/ai_medication/source_page_client.rb`
- `task rubocop`
- `task test`

The full suite was rerun after rebasing onto current `origin/main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->