### PR TITLE
fix(auth): revoke API credentials on deactivation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,23 @@ class User < ApplicationRecord
   delegate :name, :date_of_birth, :age, to: :person, allow_nil: true
 
   def deactivate!
-    update!(active: false)
+    transaction do
+      update!(active: false)
+      revoke_api_credentials!
+    end
   end
 
   def activate!
     update!(active: true)
+  end
+
+  private
+
+  def revoke_api_credentials!
+    account = person&.account
+    return unless account
+
+    account.api_sessions.active.find_each(&:revoke!)
+    account.api_app_tokens.active.find_each(&:revoke!)
   end
 end

--- a/app/services/auth_token_audit_logger.rb
+++ b/app/services/auth_token_audit_logger.rb
@@ -5,13 +5,15 @@ class AuthTokenAuditLogger
   HASHED_FIELDS = %i[endpoint user_agent].freeze
 
   def record(account:, token_type:, action:, metadata: {}, context: nil)
-    # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
-    Audit::VersionEvent.record!(**version_attrs(account:, token_type:, action:, metadata:, context:))
-    # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
-    security_event_attrs = security_event_attrs(account:, token_type:, action:, metadata:, context:)
-    return if security_event_attrs[:household_id].blank?
-
-    Audit::Event.record!(**security_event_attrs, audit_context: context.to_h)
+    ActiveRecord::Base.transaction(requires_new: true) do
+      # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
+      Audit::VersionEvent.record!(**version_attrs(account:, token_type:, action:, metadata:, context:))
+      # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
+      security_event_attrs = security_event_attrs(account:, token_type:, action:, metadata:, context:)
+      if security_event_attrs[:household_id].present?
+        Audit::Event.record!(**security_event_attrs, audit_context: context.to_h)
+      end
+    end
   rescue StandardError => e
     Rails.logger.error("AuthTokenAuditLogger failed: #{e.class}: #{e.message}")
   end

--- a/spec/requests/deactivated_users_authentication_spec.rb
+++ b/spec/requests/deactivated_users_authentication_spec.rb
@@ -27,4 +27,24 @@ RSpec.describe 'Deactivated user authentication' do
     expect(response).to redirect_to(login_path)
     expect(session[:account_id]).to be_blank
   end
+
+  it 'revokes API credentials when a user is deactivated' do
+    household = ensure_api_household_for(user)
+    membership = household.household_memberships.find_by!(account: account)
+    api_session, = ApiSession.issue_for(account: account, household_membership: membership)
+    api_app_token, raw_token = ApiAppToken.issue_for(
+      account: account,
+      household_membership: membership,
+      name: 'Deactivation regression token'
+    )
+
+    user.deactivate!
+
+    expect(api_session.reload.revoked_at).to be_present
+    expect(api_app_token.reload.revoked_at).to be_present
+
+    get api_v1_auth_households_path, headers: api_auth_headers(raw_token), as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
 end

--- a/spec/requests/deactivated_users_authentication_spec.rb
+++ b/spec/requests/deactivated_users_authentication_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe 'Deactivated user authentication' do
 
     expect(response).to have_http_status(:unauthorized)
   end
+
+  it 'deactivates and revokes API credentials when token audit persistence fails' do
+    household = ensure_api_household_for(user)
+    membership = household.household_memberships.find_by!(account: account)
+    api_session, = ApiSession.issue_for(account: account, household_membership: membership)
+    api_app_token, = ApiAppToken.issue_for(
+      account: account,
+      household_membership: membership,
+      name: 'Audit failure regression token'
+    )
+    allow(Audit::VersionEvent).to receive(:record!) do
+      ActiveRecord::Base.connection.execute('SELECT missing_audit_column FROM users')
+    end
+
+    expect { user.deactivate! }.not_to raise_error
+
+    expect(user.reload).not_to be_active
+    expect(api_session.reload.revoked_at).to be_present
+    expect(api_app_token.reload.revoked_at).to be_present
+  end
 end


### PR DESCRIPTION
Deactivating a user previously left their API sessions and long-lived app tokens active. Those credentials could still reach session-management endpoints while the user was inactive.

Deactivation now revokes active API sessions and app tokens in the same transaction as the user-state change. This closes the stale-credential path and preserves the existing token audit trail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->