### PR TITLE
refactor(ai): reuse validated source URLs

### DIFF
--- a/app/services/ai_medication/suggestion_validator.rb
+++ b/app/services/ai_medication/suggestion_validator.rb
@@ -32,7 +32,8 @@ module AiMedication
     end
 
     def source_valid?(source)
-      source['url'].present? && source['title'].present? && allowlist.allowed?(source['url'])
+      url = source['url']
+      url.present? && source['title'].present? && allowlist.allowed?(url)
     end
 
     def valid_dose?(dose)
@@ -45,11 +46,13 @@ module AiMedication
     end
 
     def dose_evidence_valid?(evidence)
-      evidence.is_a?(Hash) &&
-        evidence['url'].present? &&
+      return false unless evidence.is_a?(Hash)
+
+      url = evidence['url']
+      url.present? &&
         evidence['title'].present? &&
         evidence['text'].present? &&
-        allowlist.allowed?(evidence['url'])
+        allowlist.allowed?(url)
     end
 
     def positive_number?(value)


### PR DESCRIPTION
## What changed

\`AiMedication::SuggestionValidator\` now reads each source or dose-evidence URL once and reuses that value for presence and allowlist validation.

## Why this improves maintainability/readability

The validation flow now makes the URL under review explicit and removes two repeated hash lookups flagged by RubyCritic.

## How behavior was preserved

The same string-keyed URL values still go through the same presence checks and trusted-source allowlist. Invalid evidence types still return false before any hash access, and source titles, evidence titles, and evidence text retain the same validation order.

## Verification commands run

- \`task test:preflight\`
- \`task test TEST_FILE=spec/services/ai_medication/suggestion_validator_spec.rb\`
- \`task rubycritic TARGET=app/services/ai_medication/suggestion_validator.rb\`
- \`task rubocop\`
- \`task test\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->