### PR TITLE
refactor(auth): reuse login failure count

### DIFF
--- a/app/services/api_login_failure_recorder.rb
+++ b/app/services/api_login_failure_recorder.rb
@@ -23,9 +23,10 @@ class ApiLoginFailureRecorder
 
     account.with_lock do
       failure = AccountLoginFailure.find_or_initialize_by(account: account)
-      failure.number = failure.new_record? ? 1 : failure.number.to_i + 1
+      failure_count = failure.new_record? ? 1 : failure.number.to_i + 1
+      failure.number = failure_count
       failure.save!
-      lock_account! if failure.number >= MAX_INVALID_LOGINS
+      lock_account! if failure_count >= MAX_INVALID_LOGINS
     end
   end
 


### PR DESCRIPTION
## What changed

\`ApiLoginFailureRecorder\` now computes the next failure count once and reuses it for persistence and the lockout threshold check.

## Why this improves maintainability/readability

The counter value being saved and evaluated is explicit, removing a repeated attribute read flagged by RubyCritic.

## How behavior was preserved

New failures still start at one, existing counts still increment once, and account lockout still begins when the saved count reaches the same threshold.

## Verification commands run

- \`task test:preflight\`
- \`task test TEST_FILE=spec/services/api_login_failure_recorder_spec.rb\`
- \`task rubycritic TARGET=app/services/api_login_failure_recorder.rb\`
- \`task rubocop\`
- \`task test\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->