### PR TITLE
refactor(audit): reuse oldest backlog age

### DIFF
--- a/app/services/audit/backlog_monitor.rb
+++ b/app/services/audit/backlog_monitor.rb
@@ -13,8 +13,9 @@ module Audit
 
     def call
       ages = deliveries.map { |delivery| [(now - delivery.created_at).to_i, 0].max }
-      result = Result.new(severity: severity(ages.max.to_i), pending_count: ages.size,
-                          oldest_age_seconds: ages.max.to_i)
+      oldest_age_seconds = ages.max.to_i
+      result = Result.new(severity: severity(oldest_age_seconds), pending_count: ages.size,
+                          oldest_age_seconds: oldest_age_seconds)
       ActiveSupport::Notifications.instrument('audit_delivery_backlog.med_tracker', notification_payload(result))
       result
     end


### PR DESCRIPTION
## What changed

\`Audit::BacklogMonitor\` now calculates the oldest backlog age once and reuses it for severity classification and the result payload.

## Why this improves maintainability/readability

The aggregate value has one clear name and source, removing duplicate \`ages.max.to_i\` calls flagged by RubyCritic.

## How behavior was preserved

The same maximum non-negative delivery age still determines both severity and \`oldest_age_seconds\`; an empty backlog still resolves to zero.

## Verification commands run

- \`task test TEST_FILE=spec/services/audit/backlog_monitor_spec.rb\`
- \`task rubycritic TARGET=app/services/audit/backlog_monitor.rb\`
- \`task rubocop\`
- \`task test\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->