### PR TITLE
refactor(api): reuse MFA verification time

### DIFF
--- a/app/services/api/fresh_privileged_action.rb
+++ b/app/services/api/fresh_privileged_action.rb
@@ -11,6 +11,7 @@ module Api
     def satisfied?
       return false unless credential.is_a?(ApiSession)
       return false unless credential.oidc_mfa_verified?
+
       mfa_verified_at = credential.mfa_verified_at
       return false if mfa_verified_at.blank?
 

--- a/app/services/api/fresh_privileged_action.rb
+++ b/app/services/api/fresh_privileged_action.rb
@@ -11,9 +11,10 @@ module Api
     def satisfied?
       return false unless credential.is_a?(ApiSession)
       return false unless credential.oidc_mfa_verified?
-      return false if credential.mfa_verified_at.blank?
+      mfa_verified_at = credential.mfa_verified_at
+      return false if mfa_verified_at.blank?
 
-      credential.mfa_verified_at >= TTL.ago
+      mfa_verified_at >= TTL.ago
     end
 
     private


### PR DESCRIPTION
## What changed

`Api::FreshPrivilegedAction` now reads the session MFA verification timestamp once and reuses it for blank and freshness checks.

## Why this improves maintainability/readability

The timestamp under validation is explicit, removing the duplicate credential lookup flagged by RubyCritic.

## How behaviour was preserved

Non-API credentials, sessions without OIDC MFA, blank timestamps, stale timestamps, and fresh timestamps all retain their existing outcomes.

## Verification commands run

- `task test TEST_FILE=spec/services/api/fresh_privileged_action_spec.rb`
- `task rubycritic TARGET=app/services/api/fresh_privileged_action.rb`
- `task rubocop`
- `task test\` (after rebasing onto current `origin/main`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->