### PR TITLE
fix(administration): preserve dose history

### DIFF
--- a/app/controllers/api/v1/sync/batches_controller.rb
+++ b/app/controllers/api/v1/sync/batches_controller.rb
@@ -50,6 +50,7 @@ module Api
         def delete_record(operation, index)
           record = find_batch_record(operation)
           authorize record, :destroy?
+          ensure_deletable!(record, index)
           portable_id = record.portable_id
           record_type = record.class.name
           record.destroy!
@@ -64,6 +65,13 @@ module Api
             metadata: { record_type: record_type }
           )
           { index: index, action: 'delete', record_type: record_type, record_portable_id: portable_id }
+        end
+
+        def ensure_deletable!(record, index)
+          return unless record.is_a?(Medication)
+          return unless MedicationAdministrationHistory.exists_for?(record)
+
+          raise BatchError, "operation #{index} delete conflicts with retained administration history"
         end
 
         def find_batch_record(operation)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -65,15 +65,25 @@ class LocationsController < ApplicationController
 
   def destroy
     authorize @location
+    destroy_location
+  end
+
+  private
+
+  def destroy_location
+    if MedicationAdministrationHistory.exists_for?(@location)
+      @location.errors.add(:base, 'Location cannot be deleted while administration history exists')
+      return render_destroy_failure
+    end
+
     location_id = @location.id
-    @location.destroy
+    return render_destroy_failure unless @location.destroy
+
     respond_to do |format|
       format.html { redirect_to locations_url, notice: t('locations.deleted') }
       format.turbo_stream { render_destroy_stream(location_id) }
     end
   end
-
-  private
 
   def set_location
     @location = locations_query.find(id: params.expect(:id))
@@ -142,6 +152,20 @@ class LocationsController < ApplicationController
       turbo_stream.remove(tenant_dom_target("location_show_#{location_id}")),
       turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
     ]
+  end
+
+  def render_destroy_failure
+    message = @location.errors.full_messages.to_sentence.presence || 'Location could not be deleted'
+    respond_to do |format|
+      format.html { redirect_to @location, alert: message, status: :see_other }
+      format.turbo_stream do
+        flash.now[:alert] = message
+        render turbo_stream: turbo_stream.update(
+          'flash',
+          Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert])
+        ), status: :unprocessable_content
+      end
+    end
   end
 
   def render_error(form)

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -211,9 +211,15 @@ class MedicationsController < ApplicationController
   end
 
   def destroy_medication
+    if MedicationAdministrationHistory.exists_for?(@medication)
+      @medication.errors.add(:base, 'Medication cannot be deleted while administration history exists')
+      return render_destroy_failure
+    end
+
     medication_id = @medication.id
-    @medication.destroy
-    render_destroy_success(medication_id)
+    return render_destroy_success(medication_id) if @medication.destroy
+
+    render_destroy_failure
   end
 
   def render_destroy_success(medication_id)
@@ -232,6 +238,20 @@ class MedicationsController < ApplicationController
       turbo_stream.remove(tenant_dom_target("medication_show_#{medication_id}")),
       turbo_stream.update('flash', Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]))
     ]
+  end
+
+  def render_destroy_failure
+    message = @medication.errors.full_messages.to_sentence.presence || 'Medication could not be deleted'
+    respond_to do |format|
+      format.html { redirect_to @medication, alert: message, status: :see_other }
+      format.turbo_stream do
+        flash.now[:alert] = message
+        render turbo_stream: turbo_stream.update(
+          'flash',
+          Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert])
+        ), status: :unprocessable_content
+      end
+    end
   end
 
   def build_medication_from_request

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -119,12 +119,7 @@ class PeopleController < ApplicationController
   # DELETE /people/1 or /people/1.json
   def destroy
     authorize @person
-    @person.destroy!
-
-    respond_to do |format|
-      format.html { redirect_to people_path, status: :see_other, notice: t('people.deleted') }
-      format.json { head :no_content }
-    end
+    destroy_person
   end
 
   def add_medication
@@ -140,6 +135,20 @@ class PeopleController < ApplicationController
   end
 
   private
+
+  def destroy_person
+    if MedicationAdministrationHistory.exists_for?(@person)
+      @person.errors.add(:base, 'Person cannot be deleted while administration history exists')
+      return render_destroy_failure
+    end
+
+    return render_destroy_failure unless @person.destroy
+
+    respond_to do |format|
+      format.html { redirect_to people_path, status: :see_other, notice: t('people.deleted') }
+      format.json { head :no_content }
+    end
+  end
 
   def set_person
     @person = policy_scope(Person).find(params.expect(:id))
@@ -182,5 +191,20 @@ class PeopleController < ApplicationController
 
   def auto_assign_created_person_carer_relationship?
     current_membership&.person.present? && (@person.minor? || @person.dependent_adult?)
+  end
+
+  def render_destroy_failure
+    message = @person.errors.full_messages.to_sentence.presence || 'Person could not be deleted'
+    respond_to do |format|
+      format.html { redirect_to @person, alert: message, status: :see_other }
+      format.turbo_stream do
+        flash.now[:alert] = message
+        render turbo_stream: turbo_stream.update(
+          'flash',
+          Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert])
+        ), status: :unprocessable_content
+      end
+      format.json { render json: @person.errors, status: :unprocessable_content }
+    end
   end
 end

--- a/app/controllers/person_medications_controller.rb
+++ b/app/controllers/person_medications_controller.rb
@@ -52,7 +52,7 @@ class PersonMedicationsController < ApplicationController
 
   def destroy
     authorize @person_medication
-    @person_medication.destroy
+    @person_medication.retire!
     render_person_medication_destroy_success
   end
 
@@ -93,7 +93,7 @@ class PersonMedicationsController < ApplicationController
   end
 
   def set_person_medication
-    @person_medication = @person.person_medications.find(params.expect(:id))
+    @person_medication = @person.person_medications.current.find(params.expect(:id))
   end
 
   def prepare_new_person_medication

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -72,7 +72,7 @@ class SchedulesController < ApplicationController
 
   def destroy
     authorize @schedule
-    @schedule.destroy
+    @schedule.retire!
     render_schedule_destroy_success
   end
 

--- a/app/models/concerns/retirable_administration_source.rb
+++ b/app/models/concerns/retirable_administration_source.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RetirableAdministrationSource
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :medication_takes, dependent: :restrict_with_error
+    scope :current, -> { where(retired_at: nil) }
+  end
+
+  def retire! = update!(retired_at: Time.current, active: false)
+end

--- a/app/models/medication_take.rb
+++ b/app/models/medication_take.rb
@@ -38,6 +38,16 @@ class MedicationTake < ApplicationRecord
   after_create :decrement_medication_stock, unless: :skip_stock_mutation
   after_commit :publish_low_stock_threshold_reached, on: :create
 
+  def readonly?
+    persisted? || super
+  end
+
+  def delete
+    raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if persisted?
+
+    super
+  end
+
   # Delegate to get the source (schedule or person_medication)
   def dose_source
     MedicationDoseSource.for(self)

--- a/app/models/person_medication.rb
+++ b/app/models/person_medication.rb
@@ -8,13 +8,12 @@ class PersonMedication < ApplicationRecord
   include TimingRestrictions
   include HouseholdAssignable
   include Pausable
+  include RetirableAdministrationSource
 
   belongs_to :household, optional: true
   belongs_to :person
   belongs_to :medication
   belongs_to :source_dosage_option, class_name: 'MedicationDosageOption', optional: true
-  has_many :medication_takes, dependent: :destroy
-
   enum :dose_cycle, { daily: 0, weekly: 1, monthly: 2 }, prefix: :dose
   enum :administration_kind, { routine: 0, as_needed: 1 }
 
@@ -23,7 +22,7 @@ class PersonMedication < ApplicationRecord
   # @see docs/audit-trail.md
   has_paper_trail
 
-  scope :active, -> { where(active: true) }
+  scope :active, -> { current.where(active: true) }
   scope :ordered, -> { order(:position, :id) }
 
   before_validation :assign_household
@@ -31,7 +30,9 @@ class PersonMedication < ApplicationRecord
   before_validation :clear_routine_default_interval
   before_validation :assign_position, on: :create
 
-  validates :person_id, uniqueness: { scope: :medication_id }
+  validates :person_id,
+            uniqueness: { scope: :medication_id, conditions: -> { where(retired_at: nil) } },
+            if: -> { retired_at.nil? }
   validates :dose_amount, presence: true, numericality: { greater_than: 0 },
                           unless: :legacy_record_without_resolvable_dose?
   validates :dose_unit, presence: true, inclusion: { in: Medication::DOSAGE_UNITS },

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -7,6 +7,7 @@ class Schedule < ApplicationRecord
   include ScheduleDoseAvailability
   include HouseholdAssignable
   include Pausable
+  include RetirableAdministrationSource
 
   WEEKDAY_INDEXES = Date::DAYNAMES.each_with_index.with_object({}) do |(name, index), indexes|
     indexes[name.downcase] = index
@@ -32,9 +33,7 @@ class Schedule < ApplicationRecord
     tapering: 5, every_other_day: 6
   }, prefix: :schedule_type
 
-  has_many :medication_takes, dependent: :destroy
-
-  scope :active, -> { where(active: true).where('start_date <= ? AND end_date >= ?', Time.zone.today, Time.zone.today) }
+  scope :active, -> { current.where(active: true).where(start_date: ..Date.current, end_date: Date.current..) }
 
   validates :start_date, :end_date, presence: true
   validates :dose_amount, presence: true, numericality: { greater_than: 0 }

--- a/app/policies/person_medication_policy.rb
+++ b/app/policies/person_medication_policy.rb
@@ -58,7 +58,7 @@ class PersonMedicationPolicy < ApplicationPolicy
     def household_person_medication_scope
       return scope.none unless active_membership?
 
-      scope.where(household: household, person_id: granted_person_ids_for(:view))
+      scope.current.where(household: household, person_id: granted_person_ids_for(:view))
     end
   end
 end

--- a/app/policies/schedule_policy.rb
+++ b/app/policies/schedule_policy.rb
@@ -55,7 +55,7 @@ class SchedulePolicy < ApplicationPolicy
     def household_schedule_scope
       return scope.none unless active_membership?
 
-      scope.where(household: household, person_id: granted_person_ids_for(:view))
+      scope.current.where(household: household, person_id: granted_person_ids_for(:view))
     end
   end
 end

--- a/app/services/medication_administration_history.rb
+++ b/app/services/medication_administration_history.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class MedicationAdministrationHistory
+  def self.exists_for?(record) = new(record).exists?
+
+  def initialize(record)
+    @record = record
+  end
+
+  def exists?
+    schedules, person_medications = administration_sources
+    scheduled_takes = MedicationTake.where(schedule_id: schedules.select(:id))
+    ad_hoc_takes = MedicationTake.where(person_medication_id: person_medications.select(:id))
+    scheduled_takes.or(ad_hoc_takes).exists?
+  end
+
+  private
+
+  attr_reader :record
+
+  def administration_sources
+    case record
+    when Medication, Person
+      [record.schedules, record.person_medications]
+    when Location
+      medication_ids = record.medications.select(:id)
+      [Schedule.where(medication_id: medication_ids), PersonMedication.where(medication_id: medication_ids)]
+    else
+      raise ArgumentError, "Unsupported administration history owner: #{record.class}"
+    end
+  end
+end

--- a/app/services/person_show_query.rb
+++ b/app/services/person_show_query.rb
@@ -10,8 +10,8 @@ class PersonShowQuery
   end
 
   def call
-    schedules = person.schedules.includes(:medication)
-    person_medications = person.person_medications.includes(:medication).ordered
+    schedules = person.schedules.current.includes(:medication)
+    person_medications = person.person_medications.current.includes(:medication).ordered
 
     Result.new(
       person: person,

--- a/app/services/portable_data/export_event_record_serializer.rb
+++ b/app/services/portable_data/export_event_record_serializer.rb
@@ -34,7 +34,7 @@ module PortableData
 
     def medication_take_event(take)
       {
-        taken_at: take.taken_at&.iso8601,
+        taken_at: take.taken_at&.iso8601(6),
         dose_amount: take.dose_amount,
         dose_unit: take.dose_unit
       }

--- a/app/services/portable_data/export_record_serializer.rb
+++ b/app/services/portable_data/export_record_serializer.rb
@@ -149,6 +149,7 @@ module PortableData
       {
         portable_id: schedule.portable_id,
         source_dosage_option_portable_id: schedule.source_dosage_option&.portable_id,
+        retired_at: schedule.retired_at&.iso8601,
         updated_at: schedule.updated_at.iso8601
       }
     end
@@ -192,6 +193,7 @@ module PortableData
       {
         portable_id: person_medication.portable_id,
         source_dosage_option_portable_id: person_medication.source_dosage_option&.portable_id,
+        retired_at: person_medication.retired_at&.iso8601,
         updated_at: person_medication.updated_at.iso8601
       }
     end
@@ -222,9 +224,7 @@ module PortableData
       }
     end
 
-    def event_medication_take_payload(take)
-      event_record_serializer.medication_take_payload(take)
-    end
+    def event_medication_take_payload(take) = event_record_serializer.medication_take_payload(take)
 
     def event_notification_preference_payload(preference)
       event_record_serializer.notification_preference_payload(preference)

--- a/app/services/portable_data/import_writer.rb
+++ b/app/services/portable_data/import_writer.rb
@@ -215,7 +215,7 @@ module PortableData
     end
 
     def schedule_timing_attributes(row)
-      {
+      attributes = {
         schedule_type: row[:schedule_type].presence || :daily,
         schedule_config: row[:schedule_config] || {},
         start_date: row[:start_date],
@@ -223,6 +223,8 @@ module PortableData
         active: row.fetch(:active, true),
         notes: row[:notes]
       }
+      attributes[:retired_at] = row[:retired_at] if row.key?(:retired_at)
+      attributes
     end
   end
 end

--- a/app/services/portable_data/import_writer_medication_takes.rb
+++ b/app/services/portable_data/import_writer_medication_takes.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PortableData
+  module ImportWriterMedicationTakes
+    def import_medication_takes
+      records(:medication_takes).each do |row|
+        take = find_or_initialize(MedicationTake, row)
+        attributes = medication_take_attributes(row)
+        verify_immutable_medication_take!(take, attributes, row) if take.persisted?
+        next if take.persisted?
+
+        take.skip_stock_mutation = true
+        take.assign_attributes(attributes)
+        take.save!
+      end
+    end
+
+    def verify_immutable_medication_take!(take, attributes, row)
+      expected = MedicationTake.new(attributes).attributes.slice(*immutable_medication_take_columns)
+      actual = take.attributes.slice(*immutable_medication_take_columns)
+      return if actual == expected
+
+      raise Importer::Error, "immutable medication take #{row.fetch(:portable_id)} conflicts with the imported record"
+    end
+
+    def immutable_medication_take_columns
+      %w[
+        client_uuid schedule_id person_medication_id taken_at dose_amount dose_unit
+        taken_from_medication_id taken_from_location_id
+      ]
+    end
+
+    def medication_take_attributes(row)
+      medication_take_source_attributes(row).merge(medication_take_event_attributes(row))
+                                            .merge(medication_take_inventory_attributes(row))
+    end
+
+    def medication_take_source_attributes(row)
+      source_type = row.fetch(:source_type)
+      source = source_record(source_type, row.fetch(:source_portable_id))
+
+      {
+        schedule: source_type == 'schedule' ? source : nil,
+        person_medication: source_type == 'person_medication' ? source : nil
+      }
+    end
+
+    def medication_take_event_attributes(row)
+      {
+        client_uuid: row[:client_uuid],
+        taken_at: row[:taken_at],
+        dose_amount: row[:dose_amount],
+        dose_unit: row[:dose_unit]
+      }
+    end
+
+    def medication_take_inventory_attributes(row)
+      {
+        taken_from_medication: medication_by_portable_id(row[:taken_from_medication_portable_id]),
+        taken_from_location: location_by_portable_id(row[:taken_from_location_portable_id])
+      }
+    end
+  end
+end

--- a/app/services/portable_data/import_writer_person_medications.rb
+++ b/app/services/portable_data/import_writer_person_medications.rb
@@ -40,6 +40,7 @@ module PortableData
         notes: row[:notes]
       }
       attributes[:position] = row[:position] if row.key?(:position) && !row[:position].nil?
+      attributes[:retired_at] = row[:retired_at] if row.key?(:retired_at)
       attributes
     end
   end

--- a/app/services/portable_data/import_writer_records.rb
+++ b/app/services/portable_data/import_writer_records.rb
@@ -2,45 +2,7 @@
 
 module PortableData
   module ImportWriterRecords
-    def import_medication_takes
-      records(:medication_takes).each do |row|
-        take = find_or_initialize(MedicationTake, row)
-        take.skip_stock_mutation = true
-        take.assign_attributes(medication_take_attributes(row))
-        take.save!
-      end
-    end
-
-    def medication_take_attributes(row)
-      medication_take_source_attributes(row).merge(medication_take_event_attributes(row))
-                                            .merge(medication_take_inventory_attributes(row))
-    end
-
-    def medication_take_source_attributes(row)
-      source_type = row.fetch(:source_type)
-      source = source_record(source_type, row.fetch(:source_portable_id))
-
-      {
-        schedule: source_type == 'schedule' ? source : nil,
-        person_medication: source_type == 'person_medication' ? source : nil
-      }
-    end
-
-    def medication_take_event_attributes(row)
-      {
-        client_uuid: row[:client_uuid],
-        taken_at: row[:taken_at],
-        dose_amount: row[:dose_amount],
-        dose_unit: row[:dose_unit]
-      }
-    end
-
-    def medication_take_inventory_attributes(row)
-      {
-        taken_from_medication: medication_by_portable_id(row[:taken_from_medication_portable_id]),
-        taken_from_location: location_by_portable_id(row[:taken_from_location_portable_id])
-      }
-    end
+    include ImportWriterMedicationTakes
 
     def import_notification_preferences
       records(:notification_preferences).each do |row|

--- a/db/migrate/20260713090000_add_retirement_to_medication_administration_sources.rb
+++ b/db/migrate/20260713090000_add_retirement_to_medication_administration_sources.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddRetirementToMedicationAdministrationSources < ActiveRecord::Migration[8.1]
+  PERSON_MEDICATION_UNIQUE_INDEX = 'index_person_medications_on_person_id_and_medication_id'
+
+  def up
+    add_column :schedules, :retired_at, :datetime
+    add_column :person_medications, :retired_at, :datetime
+
+    add_index :schedules, :retired_at
+    add_index :person_medications, :retired_at
+    remove_index :person_medications, name: PERSON_MEDICATION_UNIQUE_INDEX
+    add_index :person_medications, %i[person_id medication_id], unique: true, where: 'retired_at IS NULL',
+                                                                 name: PERSON_MEDICATION_UNIQUE_INDEX
+  end
+
+  def down
+    remove_index :person_medications, name: PERSON_MEDICATION_UNIQUE_INDEX
+    add_index :person_medications, %i[person_id medication_id], unique: true,
+                                                                 name: PERSON_MEDICATION_UNIQUE_INDEX
+    remove_index :person_medications, :retired_at
+    remove_index :schedules, :retired_at
+    remove_column :person_medications, :retired_at
+    remove_column :schedules, :retired_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -780,6 +780,53 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
     t.index ["person_id"], name: "index_notification_preferences_on_person_id", unique: true
   end
 
+  create_table "oauth_applications", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "client_id", null: false
+    t.string "client_secret"
+    t.string "client_secret_hash"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.string "redirect_uri", null: false
+    t.string "scopes", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_oauth_applications_on_account_id"
+    t.index ["client_id"], name: "index_oauth_applications_on_client_id", unique: true
+  end
+
+  create_table "oauth_grants", force: :cascade do |t|
+    t.string "access_type", default: "offline", null: false
+    t.bigint "account_id", null: false
+    t.string "code"
+    t.string "code_challenge"
+    t.string "code_challenge_method"
+    t.datetime "created_at", null: false
+    t.datetime "expires_in", null: false
+    t.bigint "household_membership_id", null: false
+    t.datetime "last_used_at"
+    t.bigint "oauth_application_id", null: false
+    t.integer "permissions_version", null: false
+    t.bigint "person_id", null: false
+    t.string "redirect_uri"
+    t.string "refresh_token"
+    t.string "refresh_token_hash"
+    t.datetime "revoked_at"
+    t.string "scopes", null: false
+    t.string "token"
+    t.string "token_hash"
+    t.string "type"
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_oauth_grants_on_account_id"
+    t.index ["household_membership_id"], name: "index_oauth_grants_on_household_membership_id"
+    t.index ["oauth_application_id", "code"], name: "index_oauth_grants_on_oauth_application_id_and_code", unique: true
+    t.index ["oauth_application_id"], name: "index_oauth_grants_on_oauth_application_id"
+    t.index ["person_id"], name: "index_oauth_grants_on_person_id"
+    t.index ["refresh_token"], name: "index_oauth_grants_on_refresh_token", unique: true
+    t.index ["refresh_token_hash"], name: "index_oauth_grants_on_refresh_token_hash", unique: true
+    t.index ["token"], name: "index_oauth_grants_on_token", unique: true
+    t.index ["token_hash"], name: "index_oauth_grants_on_token_hash", unique: true
+  end
+
   create_table "notification_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "event_key", null: false
@@ -853,6 +900,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
     t.bigint "person_id", null: false
     t.string "portable_id", default: -> { "(gen_random_uuid())::text" }, null: false
     t.integer "position", null: false
+    t.datetime "retired_at"
     t.bigint "source_dosage_option_id"
     t.datetime "updated_at", null: false
     t.index ["active"], name: "index_person_medications_on_active"
@@ -861,9 +909,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
     t.index ["household_id"], name: "index_person_medications_on_household_id"
     t.index ["id", "household_id"], name: "index_person_medications_on_id_and_household_id", unique: true
     t.index ["medication_id"], name: "index_person_medications_on_medication_id"
-    t.index ["person_id", "medication_id"], name: "index_person_medications_on_person_id_and_medication_id", unique: true
+    t.index ["person_id", "medication_id"], name: "index_person_medications_on_person_id_and_medication_id", unique: true, where: "(retired_at IS NULL)"
     t.index ["person_id", "position"], name: "index_person_medications_on_person_id_and_position"
     t.index ["person_id"], name: "index_person_medications_on_person_id"
+    t.index ["retired_at"], name: "index_person_medications_on_retired_at"
     t.index ["source_dosage_option_id"], name: "index_person_medications_on_source_dosage_option_id"
   end
 
@@ -902,6 +951,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
     t.text "notes"
     t.bigint "person_id", null: false
     t.string "portable_id", default: -> { "(gen_random_uuid())::text" }, null: false
+    t.datetime "retired_at"
     t.jsonb "schedule_config", default: {}, null: false
     t.integer "schedule_type", default: 0, null: false
     t.bigint "source_dosage_option_id"
@@ -913,6 +963,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
     t.index ["id", "household_id"], name: "index_schedules_on_id_and_household_id", unique: true
     t.index ["medication_id"], name: "index_schedules_on_medication_id"
     t.index ["person_id"], name: "index_schedules_on_person_id"
+    t.index ["retired_at"], name: "index_schedules_on_retired_at"
     t.index ["schedule_config"], name: "index_schedules_on_schedule_config", using: :gin
     t.index ["schedule_type"], name: "index_schedules_on_schedule_type"
     t.index ["source_dosage_option_id"], name: "index_schedules_on_source_dosage_option_id"
@@ -1085,6 +1136,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_130200) do
   add_foreign_key "notification_preferences", "households"
   add_foreign_key "notification_preferences", "people", column: ["person_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_notification_preferences_person_id_household"
   add_foreign_key "notification_preferences", "people", deferrable: :deferred
+  add_foreign_key "oauth_applications", "accounts"
+  add_foreign_key "oauth_grants", "accounts"
+  add_foreign_key "oauth_grants", "household_memberships"
+  add_foreign_key "oauth_grants", "oauth_applications"
+  add_foreign_key "oauth_grants", "people"
   add_foreign_key "people", "accounts", deferrable: :deferred
   add_foreign_key "people", "households"
   add_foreign_key "person_access_grants", "household_memberships"

--- a/docs/adrs/0006-medication-take-aggregate-source-boundary.md
+++ b/docs/adrs/0006-medication-take-aggregate-source-boundary.md
@@ -18,8 +18,10 @@ Keep `MedicationTake` as the single dose administration record and make the sour
 
 The aggregate ownership remains:
 
-- `Schedule` owns scheduled dose records.
-- `PersonMedication` owns ad hoc dose records.
+- `Schedule` is the retained source for scheduled dose records.
+- `PersonMedication` is the retained source for ad hoc dose records.
+
+Persisted `MedicationTake` rows are immutable. Deleting an administration source from normal product flows retires the source instead of deleting it, so historical administrations keep their concrete source, household foreign keys, and portable-data references.
 
 ## Rationale
 
@@ -43,11 +45,14 @@ The check constraint enforces the invariant for every writer. The value object g
 - Domain code can depend on one explicit source object.
 - Existing reporting and API queries keep their concrete joins.
 - Household composite foreign keys remain intact.
+- Normal source deletion flows preserve administration history and source references.
 
 ### Negative
 
 - Callers still need two concrete joins when querying across both source tables.
 - The application still carries two nullable foreign keys, but the nullability is now constrained as a pair.
+- Retired sources remain stored and must be excluded explicitly from current-plan query surfaces.
+- Relation-level bulk deletion and direct SQL remain infrastructure risks until the application database role is hardened.
 
 ## Follow-up
 

--- a/spec/features/medication_stock_tracking_spec.rb
+++ b/spec/features/medication_stock_tracking_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Medication Stock Tracking', type: :system do
     medication.update!(current_supply: 10, reorder_threshold: 5)
 
     # Clear any fixture medication_takes to avoid cooldown interference
-    schedule.medication_takes.delete_all
+    MedicationTake.where(schedule: schedule).delete_all
 
     # Login as admin using helper that clears 2FA
     login_as(admin)

--- a/spec/fixtures/medication_takes.yml
+++ b/spec/fixtures/medication_takes.yml
@@ -16,6 +16,7 @@ john_afternoon_paracetamol:
 jane_morning_ibuprofen:
   household: fixture_household
   schedule: jane_ibuprofen
+  client_uuid: 123e4567-e89b-12d3-a456-426614174000
   taken_at: <%= Time.current.beginning_of_day + 8.hours %>
   dose_amount: 400.0
   dose_unit: mg

--- a/spec/jobs/low_stock_notification_job_spec.rb
+++ b/spec/jobs/low_stock_notification_job_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe LowStockNotificationJob do
   let(:take_id) { 123 }
 
   before do
+    MedicationTake.where(schedule_id: person.schedules.select(:id)).delete_all
+    MedicationTake.where(person_medication_id: person.person_medications.select(:id)).delete_all
     person.schedules.destroy_all
     person.person_medications.destroy_all
     medication.update!(household: household, location: locations(:home))

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe MedicationReminderJob do
   let(:household) { person.household }
 
   before do
+    MedicationTake.where(schedule_id: person.schedules.select(:id)).delete_all
+    MedicationTake.where(person_medication_id: person.person_medications.select(:id)).delete_all
     person.schedules.destroy_all
     person.person_medications.destroy_all
     person.create_notification_preference!(enabled: true, dose_due_enabled: true, private_text_enabled: false)

--- a/spec/jobs/missed_dose_notification_job_spec.rb
+++ b/spec/jobs/missed_dose_notification_job_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe MissedDoseNotificationJob do
   let(:scheduled_time) { '07:15' }
 
   before do
+    MedicationTake.where(schedule_id: person.schedules.select(:id)).delete_all
+    MedicationTake.where(person_medication_id: person.person_medications.select(:id)).delete_all
     person.schedules.destroy_all
     person.person_medications.destroy_all
     PushSubscription.create!(

--- a/spec/models/concerns/otel_instrumented_spec.rb
+++ b/spec/models/concerns/otel_instrumented_spec.rb
@@ -5,6 +5,18 @@ require 'rails_helper'
 # Tested through MedicationTake, which includes OtelInstrumented.
 RSpec.describe OtelInstrumented do
   let(:schedule) { create(:schedule) }
+  let(:mutable_record_class) do
+    stub_const('OtelMutableTestRecord', Class.new(ApplicationRecord) do
+      self.table_name = 'locations'
+      include OtelInstrumented
+    end)
+  end
+  let(:mutable_record) do
+    mutable_record_class.create!(
+      name: 'Mutable telemetry record',
+      household_id: create(:household).id
+    )
+  end
 
   describe '.otel_tracer' do
     it 'returns a tracer named after the model' do
@@ -26,16 +38,36 @@ RSpec.describe OtelInstrumented do
   end
 
   describe 'after-update callback (trace_update)' do
-    it 'does not raise when a record is updated' do
-      take = create(:medication_take, :for_schedule, schedule: schedule)
-      expect { take.update!(dose_amount: take.dose_amount + 1) }.not_to raise_error
+    it 'traces an update on a mutable instrumented record' do
+      tracer = instance_double(OpenTelemetry::Trace::Tracer)
+      span = instance_double(OpenTelemetry::Trace::Span, add_event: nil)
+      allow(mutable_record_class).to receive(:otel_tracer).and_return(tracer)
+      allow(tracer).to receive(:in_span).and_yield(span)
+
+      mutable_record.update!(name: 'Updated telemetry record')
+
+      expect(tracer).to have_received(:in_span).with(
+        'otel_mutable_test_record.update',
+        attributes: { 'model.name' => 'OtelMutableTestRecord', 'model.operation' => 'update' },
+        kind: :internal
+      )
     end
   end
 
   describe 'after-destroy callback (trace_destroy)' do
-    it 'does not raise when a record is destroyed' do
-      take = create(:medication_take, :for_schedule, schedule: schedule)
-      expect { take.destroy! }.not_to raise_error
+    it 'traces destruction of a mutable instrumented record' do
+      tracer = instance_double(OpenTelemetry::Trace::Tracer)
+      span = instance_double(OpenTelemetry::Trace::Span, add_event: nil)
+      allow(mutable_record_class).to receive(:otel_tracer).and_return(tracer)
+      allow(tracer).to receive(:in_span).and_yield(span)
+
+      mutable_record.destroy!
+
+      expect(tracer).to have_received(:in_span).with(
+        'otel_mutable_test_record.destroy',
+        attributes: { 'model.name' => 'OtelMutableTestRecord', 'model.operation' => 'destroy' },
+        kind: :internal
+      )
     end
   end
 

--- a/spec/models/medication_take_spec.rb
+++ b/spec/models/medication_take_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe MedicationTake do
     it { is_expected.to belong_to(:taken_from_location).class_name('Location').optional }
   end
 
+  describe 'immutability' do
+    it 'rejects updates after the administration is recorded' do
+      take = create(:medication_take, :for_schedule, schedule: schedule)
+
+      expect { take.update!(dose_amount: take.dose_amount + 1) }
+        .to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it 'rejects deletion after the administration is recorded' do
+      take = create(:medication_take, :for_schedule, schedule: schedule)
+
+      expect { take.destroy! }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it 'rejects deletion that bypasses callbacks after the administration is recorded' do
+      take = create(:medication_take, :for_schedule, schedule: schedule)
+
+      expect { take.delete }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect(described_class.exists?(take.id)).to be(true)
+    end
+  end
+
   describe '#source_type' do
     it 'returns schedule for scheduled doses' do
       expect(described_class.new(schedule: schedule).source_type).to eq('schedule')
@@ -540,7 +562,7 @@ RSpec.describe MedicationTake do
       expect(version.item_type).to eq('MedicationTake')
     end
 
-    it 'creates version on medication take update' do
+    it 'does not create a version when an update is rejected' do
       take = described_class.create!(
         schedule: schedule,
         taken_at: Time.current,
@@ -548,15 +570,11 @@ RSpec.describe MedicationTake do
       )
 
       expect do
-        take.update!(dose_amount: 10.0)
-      end.to change(PaperTrail::Version, :count).by(1)
-
-      version = take.versions.last
-      expect(version.event).to eq('update')
-      expect(version.object).to be_present
+        expect { take.update!(dose_amount: 10.0) }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end.not_to change(PaperTrail::Version, :count)
     end
 
-    it 'tracks time changes for medication takes' do
+    it 'preserves the original administration time when an update is rejected' do
       original_time = 2.hours.ago
       take = described_class.create!(
         schedule: schedule,
@@ -565,11 +583,9 @@ RSpec.describe MedicationTake do
       )
 
       new_time = 1.hour.ago
-      take.update!(taken_at: new_time)
+      expect { take.update!(taken_at: new_time) }.to raise_error(ActiveRecord::ReadOnlyRecord)
 
-      version = take.versions.last
-      reified = version.reify
-      expect(reified.taken_at.to_i).to eq(original_time.to_i)
+      expect(take.reload.taken_at.to_i).to eq(original_time.to_i)
     end
 
     it 'associates version with current user' do

--- a/spec/models/person_medication_spec.rb
+++ b/spec/models/person_medication_spec.rb
@@ -3,15 +3,44 @@
 require 'rails_helper'
 
 RSpec.describe PersonMedication do
-  describe 'associations' do
-    it { is_expected.to have_many(:medication_takes).dependent(:destroy) }
+  describe 'current assignment uniqueness' do
+    it 'allows a medication to be assigned again after the previous assignment is retired' do
+      retired_assignment = create(:person_medication)
+      retired_assignment.retire!
 
-    it 'destroys medication takes when destroyed' do
+      replacement = build(
+        :person_medication,
+        household: retired_assignment.household,
+        person: retired_assignment.person,
+        medication: retired_assignment.medication
+      )
+
+      expect { replacement.save! }.to change(described_class, :count).by(1)
+    end
+
+    it 'rejects two current assignments for the same person and medication' do
+      assignment = create(:person_medication)
+      duplicate = build(
+        :person_medication,
+        household: assignment.household,
+        person: assignment.person,
+        medication: assignment.medication
+      )
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:person_id]).to include('has already been taken')
+    end
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_many(:medication_takes).dependent(:restrict_with_error) }
+
+    it 'retains medication takes when retired' do
       person_medication = create(:person_medication)
       take = create(:medication_take, :for_person_medication, person_medication: person_medication)
 
-      expect { person_medication.destroy! }
-        .to change { MedicationTake.exists?(take.id) }.from(true).to(false)
+      expect { person_medication.retire! }.to change { person_medication.reload.retired_at }.from(nil)
+      expect(MedicationTake.exists?(take.id)).to be(true)
     end
   end
 

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -351,14 +351,14 @@ RSpec.describe Schedule do
 
   describe 'associations' do
     it { is_expected.to belong_to(:person) }
-    it { is_expected.to have_many(:medication_takes).dependent(:destroy) }
+    it { is_expected.to have_many(:medication_takes).dependent(:restrict_with_error) }
 
-    it 'destroys medication takes when destroyed' do
+    it 'retains medication takes when retired' do
       schedule = create(:schedule)
       take = create(:medication_take, :for_schedule, schedule: schedule)
 
-      expect { schedule.destroy! }
-        .to change { MedicationTake.exists?(take.id) }.from(true).to(false)
+      expect { schedule.retire! }.to change { schedule.reload.retired_at }.from(nil)
+      expect(MedicationTake.exists?(take.id)).to be(true)
     end
   end
 

--- a/spec/requests/api/v1/medication_takes_spec.rb
+++ b/spec/requests/api/v1/medication_takes_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe 'API v1 medication takes' do
       login_data = api_login(user)
       household_id = login_data.dig('household', 'id')
       existing_take = medication_takes(:jane_morning_ibuprofen)
-      existing_take.update!(client_uuid: SecureRandom.uuid)
 
       post api_v1_household_medication_takes_path(household_id),
            params: {

--- a/spec/requests/api/v1/sync_spec.rb
+++ b/spec/requests/api/v1/sync_spec.rb
@@ -112,6 +112,27 @@ RSpec.describe 'API v1 sync' do
     expect(HealthEvent.exists?(event.id)).to be(false)
   end
 
+  it 'deletes medications without administration history in batch mutations' do
+    household = Household.find(household_id)
+    medication = create(:medication, household: household, location: locations(:home))
+
+    expect do
+      post api_v1_household_sync_batches_path(household_id),
+           params: {
+             batch: {
+               operations: [
+                 { action: 'delete', resource_type: 'medication', id: medication.portable_id, attributes: {} }
+               ]
+             }
+           },
+           headers: headers,
+           as: :json
+    end.to change(ApiTombstone, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    expect(Medication.exists?(medication.id)).to be(false)
+  end
+
   it 'rejects medication batch deletion when administration history must be retained' do
     household = Household.find(household_id)
     medication = create(:medication, household: household, location: locations(:home))

--- a/spec/requests/api/v1/sync_spec.rb
+++ b/spec/requests/api/v1/sync_spec.rb
@@ -112,6 +112,35 @@ RSpec.describe 'API v1 sync' do
     expect(HealthEvent.exists?(event.id)).to be(false)
   end
 
+  it 'rejects medication batch deletion when administration history must be retained' do
+    household = Household.find(household_id)
+    medication = create(:medication, household: household, location: locations(:home))
+    schedule = create(:schedule, household: household, person: people(:john), medication: medication)
+    take = create(:medication_take, :for_schedule, household: household, schedule: schedule)
+
+    expect do
+      post api_v1_household_sync_batches_path(household_id),
+           params: {
+             batch: {
+               operations: [
+                 { action: 'delete', resource_type: 'medication', id: medication.portable_id, attributes: {} }
+               ]
+             }
+           },
+           headers: headers,
+           as: :json
+    end.not_to change(ApiTombstone, :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.fetch('error')).to include(
+      'code' => 'unprocessable_content',
+      'message' => 'operation 0 delete conflicts with retained administration history'
+    )
+    expect(Medication.exists?(medication.id)).to be(true)
+    expect(Schedule.exists?(schedule.id)).to be(true)
+    expect(MedicationTake.exists?(take.id)).to be(true)
+  end
+
   it 'updates health events in batch mutations' do
     event = HealthEvent.create!(
       household_id: household_id,

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -218,6 +218,22 @@ RSpec.describe 'Locations' do
         expect(response.body).to include("target=\"#{household_dom_target("location_show_#{location.id}")}\"")
         expect(response.body).to include('target="flash"')
       end
+
+      it 'preserves medication history and renders a Turbo validation error when deletion is restricted' do
+        medication = create(:medication, household: location.household, location: location)
+        schedule = create(:schedule, household: location.household, medication: medication)
+        create(:medication_take, :for_schedule, household: location.household, schedule: schedule)
+
+        delete location_path(location), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(Location.exists?(location.id)).to be(true)
+        expect(Medication.exists?(medication.id)).to be(true)
+        expect(Schedule.exists?(schedule.id)).to be(true)
+        expect(response.body).to include('target="flash"')
+        expect(response.body).not_to include("target=\"#{household_dom_target("location_#{location.id}")}\"")
+      end
     end
 
     context 'when authenticated as doctor (unauthorized to delete)' do

--- a/spec/requests/medications_destroy_turbo_spec.rb
+++ b/spec/requests/medications_destroy_turbo_spec.rb
@@ -6,21 +6,36 @@ RSpec.describe 'Medications destroy with turbo_stream' do
   fixtures :accounts, :people, :users, :locations, :medications
 
   let(:admin) { users(:admin) }
-  let(:medication) { medications(:vitamin_c) }
+  let(:medication) { create(:medication, household: locations(:home).household, location: locations(:home)) }
 
   before { sign_in(admin) }
 
   describe 'DELETE /medications/:id' do
     it 'returns turbo_stream and removes medication targets and updates flash' do
-      expect do
-        delete medication_path(medication), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
-      end.to change(Medication, :count).by(-1)
+      delete medication_path(medication), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
       expect(response).to have_http_status(:ok)
+      expect(Medication.exists?(medication.id)).to be(false)
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"#{household_dom_target("medication_#{medication.id}")}\"")
       expect(response.body).to include("target=\"#{household_dom_target("medication_show_#{medication.id}")}\"")
       expect(response.body).to include('target="flash"')
+    end
+
+    it 'preserves medication history and renders a Turbo validation error when deletion is restricted' do
+      historical_medication = create(:medication, household: medication.household, location: medication.location)
+      historical_schedule = create(:schedule, household: medication.household, medication: historical_medication)
+      create(:medication_take, :for_schedule, household: medication.household, schedule: historical_schedule)
+
+      delete medication_path(historical_medication), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(Medication.exists?(historical_medication.id)).to be(true)
+      expect(Schedule.exists?(historical_schedule.id)).to be(true)
+      expect(response.body).to include('target="flash"')
+      removed_target = household_dom_target("medication_#{historical_medication.id}")
+      expect(response.body).not_to include("target=\"#{removed_target}\"")
     end
   end
 end

--- a/spec/requests/people_show_actions_turbo_spec.rb
+++ b/spec/requests/people_show_actions_turbo_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'People show card actions with turbo_stream' do
     it 'returns turbo_stream and updates person show container and flash' do
       person = people(:john)
       schedule = schedules(:john_paracetamol)
+      take = create(:medication_take, :for_schedule, schedule: schedule)
 
       delete person_schedule_path(person, schedule), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
@@ -18,7 +19,9 @@ RSpec.describe 'People show card actions with turbo_stream' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"#{household_dom_target("person_show_#{person.id}")}\"")
       expect(response.body).to include('target="flash"')
-      expect(Schedule.exists?(schedule.id)).to be(false)
+      expect(schedule.reload.retired_at).to be_present
+      expect(MedicationTake.exists?(take.id)).to be(true)
+      expect(PersonShowQuery.new(person: person).call.schedules).not_to include(schedule)
     end
   end
 
@@ -26,6 +29,7 @@ RSpec.describe 'People show card actions with turbo_stream' do
     it 'returns turbo_stream and updates person show container and flash' do
       person = people(:child_user_person)
       person_medication = PersonMedication.create!(person: person, medication: medications(:vitamin_d))
+      take = create(:medication_take, :for_person_medication, person_medication: person_medication)
 
       delete person_person_medication_path(person, person_medication),
              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
@@ -34,7 +38,9 @@ RSpec.describe 'People show card actions with turbo_stream' do
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
       expect(response.body).to include("target=\"#{household_dom_target("person_show_#{person.id}")}\"")
       expect(response.body).to include('target="flash"')
-      expect(PersonMedication.exists?(person_medication.id)).to be(false)
+      expect(person_medication.reload.retired_at).to be_present
+      expect(MedicationTake.exists?(take.id)).to be(true)
+      expect(PersonShowQuery.new(person: person).call.person_medications).not_to include(person_medication)
     end
   end
 end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -381,6 +381,21 @@ RSpec.describe 'People' do
 
       expect(response).to have_http_status(:no_content)
     end
+
+    it 'preserves medication history and renders a Turbo validation error when deletion is restricted' do
+      person = create_managed_person_for(users(:admin), 'Retained History')
+      medication = create(:medication, household: person.household)
+      schedule = create(:schedule, household: person.household, person: person, medication: medication)
+      create(:medication_take, :for_schedule, household: person.household, schedule: schedule)
+
+      delete person_path(person), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(Person.exists?(person.id)).to be(true)
+      expect(Schedule.exists?(schedule.id)).to be(true)
+      expect(response.body).to include('target="flash"')
+    end
   end
 
   describe 'GET /people/:id/add_medication' do

--- a/spec/services/person_show_query_spec.rb
+++ b/spec/services/person_show_query_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe PersonShowQuery do
       expect(result.person_medications).to contain_exactly(show_data[:person_medication])
       expect(result.members).to contain_exactly(:person, :schedules, :person_medications)
     end
+
+    it 'omits retired administration sources' do
+      person = create(:person)
+      schedule = create(:schedule, person: person)
+      person_medication = create(:person_medication, person: person)
+      schedule.retire!
+      person_medication.retire!
+
+      result = described_class.new(person: person).call
+
+      expect(result.schedules).to be_empty
+      expect(result.person_medications).to be_empty
+    end
   end
 
   def create_show_data_for(person:, other_person:)

--- a/spec/services/portable_data/importer_spec.rb
+++ b/spec/services/portable_data/importer_spec.rb
@@ -346,6 +346,20 @@ RSpec.describe PortableData::Importer do
     expect(take.schedule.portable_id).to eq('schedule-portable-1')
   end
 
+  it 'round-trips medication take timestamps with microseconds idempotently' do
+    household = create(:household)
+    membership = owner_membership(household)
+    _person, schedule, = retired_source_graph(household)
+    taken_at = Time.zone.parse('2026-02-01T08:30:00Z').change(usec: 123_456)
+    take = create(:medication_take, :for_schedule, household: household, schedule: schedule, taken_at: taken_at)
+    payload = PortableData::Exporter.new(household: household, membership: membership, passphrase: nil).payload
+
+    result = import_result(household: household, membership: membership, payload: payload, dry_run: false)
+
+    expect(result).to be_applied
+    expect(take.reload.taken_at).to eq(taken_at)
+  end
+
   it 'rejects conflicting changes to an imported medication take' do
     household = create(:household)
     membership = owner_membership(household)

--- a/spec/services/portable_data/importer_spec.rb
+++ b/spec/services/portable_data/importer_spec.rb
@@ -270,6 +270,54 @@ RSpec.describe PortableData::Importer do
     expect(portable_record_counts).to eq(before_counts.transform_values { |count| count + 1 })
   end
 
+  def retired_source_graph(household)
+    location = create(:location, household: household)
+    person = create(:person, household: household, email: nil)
+    person.location_memberships.create!(household: household, location: location)
+    medication = create(:medication, household: household, location: location)
+    dosage = create(:dosage, household: household, medication: medication)
+    schedule = create(:schedule, household: household, person: person, medication: medication, dosage: dosage)
+    person_medication = create(
+      :person_medication,
+      household: household,
+      person: person,
+      medication: medication,
+      dosage: dosage
+    )
+    [person, schedule, person_medication]
+  end
+
+  def retired_source_export
+    household = create(:household)
+    membership = owner_membership(household)
+    person, schedule, person_medication = retired_source_graph(household)
+    create(:medication_take, :for_schedule, household: household, schedule: schedule)
+    create(:medication_take, :for_person_medication, household: household, person_medication: person_medication)
+    schedule.retire!
+    person_medication.retire!
+    payload = PortableData::Exporter.new(household: household, membership: membership, passphrase: nil).payload
+
+    { payload: payload, schedule: schedule, person_medication: person_medication, person: person }
+  end
+
+  def imported_retired_sources(source, household)
+    schedule = Schedule.find_by!(household: household, portable_id: source.fetch(:schedule).portable_id)
+    person_medication = PersonMedication.find_by!(
+      household: household,
+      portable_id: source.fetch(:person_medication).portable_id
+    )
+    [schedule, person_medication]
+  end
+
+  def apply_retired_source_export(source, household)
+    membership = household.household_memberships.create!(
+      account: account('portable-import-target-owner@example.test'),
+      role: :owner,
+      status: :active
+    )
+    import_result(household: household, membership: membership, payload: source.fetch(:payload), dry_run: false)
+  end
+
   it 'dry-runs without writing records and returns record counts' do
     household = create(:household)
     membership = owner_membership(household)
@@ -296,6 +344,40 @@ RSpec.describe PortableData::Importer do
     take = MedicationTake.find_by!(portable_id: 'take-portable-1')
     expect(medication.current_supply).to eq(12)
     expect(take.schedule.portable_id).to eq('schedule-portable-1')
+  end
+
+  it 'rejects conflicting changes to an imported medication take' do
+    household = create(:household)
+    membership = owner_membership(household)
+    import_result(household: household, membership: membership, dry_run: false)
+    take = MedicationTake.find_by!(household: household, portable_id: 'take-portable-1')
+    conflicting_payload = portable_payload.deep_dup
+    conflicting_payload[:records][:medication_takes].first[:dose_amount] = 7
+
+    expect do
+      import_result(
+        household: household,
+        membership: membership,
+        payload: conflicting_payload,
+        dry_run: false
+      )
+    end.to raise_error(PortableData::Importer::Error, /immutable medication take/)
+
+    expect(take.reload.dose_amount).to eq(5)
+  end
+
+  it 'round-trips retired administration sources without making them current again' do
+    source = retired_source_export
+    target_household = create(:household)
+    result = apply_retired_source_export(source, target_household)
+    imported_schedule, imported_person_medication = imported_retired_sources(source, target_household)
+    imported_person = Person.find_by!(household: target_household, portable_id: source.fetch(:person).portable_id)
+    show_data = PersonShowQuery.new(person: imported_person).call
+    expect(result).to be_applied
+    expect(imported_schedule.retired_at.iso8601).to eq(source.fetch(:schedule).retired_at.iso8601)
+    expect(imported_person_medication.retired_at.iso8601).to eq(source.fetch(:person_medication).retired_at.iso8601)
+    expect(show_data.schedules).not_to include(imported_schedule)
+    expect(show_data.person_medications).not_to include(imported_person_medication)
   end
 
   it 'grants the importing membership manage access to imported people' do


### PR DESCRIPTION
## Summary

Medication administrations used to be mutable records that could be deleted indirectly when a schedule or ad hoc assignment was removed. They are now immutable: normal removal retires the source, current-plan screens hide retired sources, and the administration keeps its concrete source and portable identity.

Retired person-medication assignments can be added again without allowing duplicate current assignments. Portable exports preserve retirement timestamps, identical historical takes remain idempotent on import, and conflicting changes are rejected.

Deleting a medication, person, or location that owns retained administration history now preserves the record and returns a useful Turbo validation error instead of reporting false success or raising an unhandled exception.

## Risks / follow-ups

- Relation-level `delete_all`, direct SQL, and database-role hardening remain infrastructure follow-ups.
- This change does not define retirement semantics for parent medications, people, or locations; it only prevents deletion while retained administration history exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->