### PR TITLE
fix(api): make mobile sync authoritative

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -169,15 +169,6 @@ module Api
         false
       end
 
-      def record_api_change(record, action:)
-        Api::ChangeRecorder.new(
-          household: current_household,
-          credential: current_api_session,
-          membership: current_membership,
-          request: request
-        ).record(record, action: action)
-      end
-
       def apply_collection_filters(scope)
         filtered = scope.order(:id)
         return filtered unless params[:updated_since].present? && scope.klass.column_names.include?('updated_at')
@@ -245,7 +236,7 @@ module Api
       end
 
       def api_etag(record)
-        %("#{Digest::SHA256.hexdigest([record.class.name, record.id, record.updated_at.to_f].join(':'))}")
+        Api::RecordEtag.for(record)
       end
 
       def with_api_idempotency

--- a/app/controllers/api/v1/dosage_options_controller.rb
+++ b/app/controllers/api/v1/dosage_options_controller.rb
@@ -22,7 +22,6 @@ module Api
 
         return render_validation_errors(dosage_option) unless dosage_option.save
 
-        record_api_change(dosage_option, action: 'create')
         render_resource(dosage_option.reload, serializer: DosageOptionSerializer, status: :created)
       end
 
@@ -33,7 +32,6 @@ module Api
 
         return render_validation_errors(dosage_option) unless dosage_option.update(dosage_option_update_params)
 
-        record_api_change(dosage_option, action: 'update')
         render_resource(dosage_option.reload, serializer: DosageOptionSerializer)
       end
 

--- a/app/controllers/api/v1/health_events_controller.rb
+++ b/app/controllers/api/v1/health_events_controller.rb
@@ -22,7 +22,6 @@ module Api
 
         return render_validation_errors(health_event) unless health_event.save
 
-        record_api_change(health_event, action: 'create')
         render_resource(health_event.reload, serializer: HealthEventSerializer, status: :created)
       end
 
@@ -33,7 +32,6 @@ module Api
 
         return render_validation_errors(health_event) unless health_event.update(health_event_update_params)
 
-        record_api_change(health_event, action: 'update')
         render_resource(health_event.reload, serializer: HealthEventSerializer)
       end
 

--- a/app/controllers/api/v1/medications_controller.rb
+++ b/app/controllers/api/v1/medications_controller.rb
@@ -24,7 +24,6 @@ module Api
 
         return render_validation_errors(medication) unless medication.save
 
-        record_api_change(medication, action: 'create')
         render_resource(medication.reload, serializer: MedicationSerializer, status: :created)
       end
 
@@ -37,7 +36,6 @@ module Api
 
         return render_validation_errors(medication) unless medication.update(medication_params)
 
-        record_api_change(medication, action: 'update')
         render_resource(medication.reload, serializer: MedicationSerializer)
       end
 
@@ -51,7 +49,6 @@ module Api
         )
         return render_unprocessable(result.error.to_s) unless result.success?
 
-        record_api_change(medication.reload, action: 'update')
         render_resource(medication, serializer: MedicationSerializer)
       end
 
@@ -73,7 +70,6 @@ module Api
           status: status,
           order_details: order_details_params
         )
-        record_api_change(medication.reload, action: 'update')
         render_resource(medication, serializer: MedicationSerializer)
       end
 

--- a/app/controllers/api/v1/person_medications_controller.rb
+++ b/app/controllers/api/v1/person_medications_controller.rb
@@ -26,7 +26,6 @@ module Api
 
         return render_validation_errors(person_medication) unless person_medication.save
 
-        record_api_change(person_medication, action: 'create')
         render_resource(person_medication.reload, serializer: PersonMedicationSerializer, status: :created)
       end
 
@@ -41,7 +40,6 @@ module Api
 
         return render_validation_errors(person_medication) unless person_medication.update(attributes)
 
-        record_api_change(person_medication, action: 'update')
         render_resource(person_medication.reload, serializer: PersonMedicationSerializer)
       end
 
@@ -61,7 +59,6 @@ module Api
           person_medication: person_medication,
           direction: params.expect(:direction)
         )
-        record_api_change(person_medication.reload, action: 'update')
         render_resource(person_medication, serializer: PersonMedicationSerializer)
       end
 
@@ -72,7 +69,6 @@ module Api
                                             params.expect(:id))
         authorize person_medication, :update?
         person_medication.public_send(method_name)
-        record_api_change(person_medication.reload, action: 'update')
         render_resource(person_medication, serializer: PersonMedicationSerializer)
       end
 

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -25,7 +25,6 @@ module Api
 
         return render_validation_errors(schedule) unless schedule.save
 
-        record_api_change(schedule, action: 'create')
         render_resource(schedule.reload, serializer: ScheduleSerializer, status: :created)
       end
 
@@ -39,7 +38,6 @@ module Api
 
         return render_validation_errors(schedule) unless schedule.update(attributes)
 
-        record_api_change(schedule, action: 'update')
         render_resource(schedule.reload, serializer: ScheduleSerializer)
       end
 
@@ -57,7 +55,6 @@ module Api
         schedule = find_api_record(policy_scope(Schedule).includes(:person, :medication), params.expect(:id))
         authorize schedule, :update?
         schedule.public_send(method_name)
-        record_api_change(schedule.reload, action: 'update')
         render_resource(schedule, serializer: ScheduleSerializer)
       end
 

--- a/app/controllers/api/v1/sync/batches_controller.rb
+++ b/app/controllers/api/v1/sync/batches_controller.rb
@@ -5,6 +5,8 @@ module Api
     module Sync
       class BatchesController < Api::V1::BaseController
         class BatchError < StandardError; end
+        class PreconditionRequired < BatchError; end
+        class SyncConflict < BatchError; end
 
         def create
           results = []
@@ -15,6 +17,10 @@ module Api
           end
 
           render json: { data: { applied: true, results: results } }, status: :created
+        rescue PreconditionRequired => e
+          render_api_error(code: 'precondition_required', message: e.message, status: :precondition_required)
+        rescue SyncConflict => e
+          render_conflict(e.message, code: 'sync_conflict')
         rescue BatchError => e
           render_unprocessable(e.message)
         end
@@ -22,7 +28,7 @@ module Api
         private
 
         def operations
-          params.expect(batch: [{ operations: [[:action, :resource_type, :id, { attributes: {} }]] }])
+          params.expect(batch: [{ operations: [[:action, :resource_type, :id, :if_match, { attributes: {} }]] }])
                 .fetch(:operations)
         end
 
@@ -40,31 +46,42 @@ module Api
         def update_record(operation, index)
           record = find_batch_record(operation)
           authorize record, :update?
-          attributes = permitted_attributes_for(record, operation.fetch(:attributes, {}))
-          raise BatchError, "operation #{index} attributes are invalid" unless record.update(attributes)
+          record.with_lock do
+            validate_precondition!(record, operation, index)
+            attributes = permitted_attributes_for(record, operation.fetch(:attributes, {}))
+            raise BatchError, "operation #{index} attributes are invalid" unless record.update(attributes)
 
-          record_api_change(record, action: 'update')
-          { index: index, action: 'update', record_type: record.class.name, record_portable_id: record.portable_id }
+            batch_result(record, index, 'update').merge(etag: api_etag(record))
+          end
         end
 
         def delete_record(operation, index)
           record = find_batch_record(operation)
           authorize record, :destroy?
-          ensure_deletable!(record, index)
-          portable_id = record.portable_id
-          record_type = record.class.name
-          record.destroy!
-          ApiTombstone.create!(
-            household: current_household,
-            account: current_account,
-            household_membership: current_membership,
-            record_type: record_type,
-            record_portable_id: portable_id,
-            action: 'delete',
-            deleted_at: Time.current,
-            metadata: { record_type: record_type }
-          )
-          { index: index, action: 'delete', record_type: record_type, record_portable_id: portable_id }
+          record.with_lock do
+            validate_precondition!(record, operation, index)
+            ensure_deletable!(record, index)
+            result = batch_result(record, index, 'delete')
+            record.destroy!
+            result
+          end
+        end
+
+        def validate_precondition!(record, operation, index)
+          expected = operation[:if_match].to_s
+          raise PreconditionRequired, "operation #{index} if_match is required" if expected.blank?
+          return if ActiveSupport::SecurityUtils.secure_compare(expected, api_etag(record))
+
+          raise SyncConflict, "operation #{index} record has changed since it was last read"
+        end
+
+        def batch_result(record, index, action)
+          {
+            index: index,
+            action: action,
+            record_type: record.class.name,
+            record_portable_id: record.portable_id
+          }
         end
 
         def ensure_deletable!(record, index)

--- a/app/controllers/api/v1/sync/feeds_controller.rb
+++ b/app/controllers/api/v1/sync/feeds_controller.rb
@@ -5,8 +5,7 @@ module Api
     module Sync
       class FeedsController < Api::V1::BaseController
         def snapshot
-          payload = exporter.payload.merge(format: 'medtracker.portable.v2', cursor: Time.current.iso8601)
-          render json: { data: payload }
+          render json: { data: Api::SyncSnapshot.new(household: current_household, exporter: exporter).payload }
         end
 
         def changes
@@ -28,11 +27,13 @@ module Api
         end
 
         def changes_payload(since)
-          {
-            cursor: Time.current.iso8601,
-            changes: change_events_since(since).map { |event| change_payload(event) },
-            tombstones: tombstones_since(since).map { |tombstone| tombstone_payload(tombstone) }
-          }
+          Api::ConsistentSyncRead.new(household: current_household).call do |cursor|
+            {
+              cursor: cursor,
+              changes: change_events_since(since).map { |event| change_payload(event) },
+              tombstones: tombstones_since(since).map { |tombstone| tombstone_payload(tombstone) }
+            }
+          end
         end
 
         def change_events_since(since)

--- a/app/controllers/health_events_controller.rb
+++ b/app/controllers/health_events_controller.rb
@@ -106,6 +106,7 @@ class HealthEventsController < ApplicationController
       }
     end
     HealthEventMedication.insert_all!(records) # rubocop:disable Rails/SkipsModelValidations
+    @health_event.refresh_sync_version!
   end
 
   def health_event_params

--- a/app/models/api_change_event.rb
+++ b/app/models/api_change_event.rb
@@ -2,8 +2,8 @@
 
 class ApiChangeEvent < ApplicationRecord
   belongs_to :household
-  belongs_to :account
-  belongs_to :household_membership
+  belongs_to :account, optional: true
+  belongs_to :household_membership, optional: true
 
   validates :record_type, :record_id, :action, :occurred_at, presence: true
 end

--- a/app/models/api_tombstone.rb
+++ b/app/models/api_tombstone.rb
@@ -2,8 +2,8 @@
 
 class ApiTombstone < ApplicationRecord
   belongs_to :household
-  belongs_to :account
-  belongs_to :household_membership
+  belongs_to :account, optional: true
+  belongs_to :household_membership, optional: true
 
   validates :record_type, :record_portable_id, :action, :deleted_at, presence: true
 end

--- a/app/models/concerns/portable_identifiable.rb
+++ b/app/models/concerns/portable_identifiable.rb
@@ -4,6 +4,8 @@ module PortableIdentifiable
   extend ActiveSupport::Concern
 
   included do
+    include SyncTrackable
+
     before_validation :assign_portable_id, on: :create
 
     validates :portable_id, presence: true, uniqueness: { scope: :household_id }

--- a/app/models/concerns/sync_trackable.rb
+++ b/app/models/concerns/sync_trackable.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SyncTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create -> { record_sync_change('create') }
+    after_update -> { record_sync_change('update') }
+    after_touch -> { record_sync_change('update') }
+    after_destroy -> { record_sync_change('delete') }
+  end
+
+  def refresh_sync_version!
+    PaperTrail.request(enabled: false) do
+      self.updated_at = Time.current
+      save!(validate: false)
+    end
+  end
+
+  def record_sync_deletion!
+    record_sync_change('delete')
+  end
+
+  private
+
+  def record_sync_change(action)
+    return unless Current.household&.id == household_id
+
+    Api::ChangeRecorder.new(
+      household: household,
+      account: Current.account,
+      membership: Current.membership,
+      request_id: Current.request_id
+    ).record(self, action: action)
+  end
+end

--- a/app/models/health_event_medication.rb
+++ b/app/models/health_event_medication.rb
@@ -7,6 +7,9 @@ class HealthEventMedication < ApplicationRecord
 
   before_validation :assign_household
   before_validation :snapshot_medication_name
+  after_create :touch_sync_health_event
+  after_update :touch_sync_health_event
+  after_destroy :touch_sync_health_event
 
   validates :medication_name, presence: true
   validates :medication_id, uniqueness: {
@@ -15,6 +18,10 @@ class HealthEventMedication < ApplicationRecord
   }, allow_nil: true
 
   private
+
+  def touch_sync_health_event
+    health_event.refresh_sync_version! unless destroyed_by_association
+  end
 
   def assign_household
     self.household ||= health_event&.household

--- a/app/models/location_membership.rb
+++ b/app/models/location_membership.rb
@@ -8,11 +8,18 @@ class LocationMembership < ApplicationRecord
   belongs_to :person
 
   before_validation :assign_household
+  after_create :touch_sync_person
+  after_update :touch_sync_person
+  after_destroy :touch_sync_person
 
   validates :person_id, uniqueness: { scope: :location_id }
   validate :linked_records_must_belong_to_household, if: :household_id?
 
   private
+
+  def touch_sync_person
+    person.refresh_sync_version! unless destroyed_by_association || person.previously_new_record?
+  end
 
   def assign_household
     self.household ||= location&.household || person&.household

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -61,7 +61,7 @@ class Medication < ApplicationRecord # :nodoc:
   validate :single_dose_switch_requires_no_schedules
   validate :nested_dosage_records_are_valid
   before_validation :assign_household
-  after_commit :sync_dosages, on: :update
+  after_update :sync_dosages
 
   enum :reorder_status, { ordered: 1, received: 2 }, prefix: :reorder
 
@@ -100,13 +100,7 @@ class Medication < ApplicationRecord # :nodoc:
     # When switching to single-dose mode (dose_amount is set),
     # remove all orphaned multi-dose records to prevent data pollution.
     # Uses SQL to comply with RuboCop and project standards.
-    binds = [ActiveRecord::Relation::QueryAttribute.new('medication_id', id, ActiveRecord::Type::BigInteger.new)]
-    ActiveRecord::Base.connection.exec_update(
-      'UPDATE person_medications SET source_dosage_option_id = NULL WHERE medication_id = $1',
-      'Sync Person Medication Dosage Sources',
-      binds
-    )
-    ActiveRecord::Base.connection.exec_delete('DELETE FROM dosages WHERE medication_id = $1', 'Sync Dosages', binds)
+    MedicationDoseModeSynchronizer.new(self).call
   end
 
   def restock!(quantity:) # rubocop:disable Naming/PredicateMethod

--- a/app/models/medication_dosage_option.rb
+++ b/app/models/medication_dosage_option.rb
@@ -92,6 +92,7 @@ class MedicationDosageOption < ApplicationRecord
       ActiveRecord::Relation::QueryAttribute.new('id', medication_id, ActiveRecord::Type::BigInteger.new)
     ]
     ActiveRecord::Base.connection.exec_update(stmt, 'Sync Medication Dosage', binds)
+    medication.refresh_sync_version!
   end
 
   def sync_medication_inventory

--- a/app/services/api/change_recorder.rb
+++ b/app/services/api/change_recorder.rb
@@ -2,38 +2,57 @@
 
 module Api
   class ChangeRecorder
-    def initialize(household:, credential:, membership:, request:)
+    def initialize(household:, membership:, account: nil, request_id: nil)
       @household = household
-      @credential = credential
+      @account = account
       @membership = membership
-      @request = request
+      @request_id = request_id
     end
 
     def record(record, action:)
       return unless recordable?(record)
+
+      household.lock!
+      return ApiTombstone.create!(tombstone_attributes(record)) if action == 'delete'
 
       ApiChangeEvent.create!(change_attributes(record, action))
     end
 
     private
 
-    attr_reader :household, :credential, :membership, :request
+    attr_reader :household, :account, :membership, :request_id
 
     def recordable?(record)
-      household && credential&.account && membership && record&.persisted?
+      return false unless household && record
+      return false unless record.respond_to?(:household_id) && record.respond_to?(:portable_id)
+
+      record.household_id == household.id && record.portable_id.present?
     end
 
     def change_attributes(record, action)
       {
         household: household,
-        account: credential.account,
+        account: account,
         household_membership: membership,
-        request_id: request.request_id,
+        request_id: request_id,
         record_type: record.class.name,
         record_id: record.id,
         record_portable_id: portable_id(record),
         action: action,
         occurred_at: Time.current,
+        metadata: metadata_for(record)
+      }
+    end
+
+    def tombstone_attributes(record)
+      {
+        household: household,
+        account: account,
+        household_membership: membership,
+        record_type: record.class.name,
+        record_portable_id: record.portable_id,
+        action: 'delete',
+        deleted_at: Time.current,
         metadata: metadata_for(record)
       }
     end

--- a/app/services/api/consistent_sync_read.rb
+++ b/app/services/api/consistent_sync_read.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  class ConsistentSyncRead
+    def initialize(household:)
+      @household = household
+    end
+
+    def call
+      ActiveRecord::Base.transaction(requires_new: true) do
+        household.lock!
+        yield Time.current.iso8601
+      end
+    end
+
+    private
+
+    attr_reader :household
+  end
+end

--- a/app/services/api/record_etag.rb
+++ b/app/services/api/record_etag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  class RecordEtag
+    def self.for(record)
+      %("#{Digest::SHA256.hexdigest([record.class.name, record.id, record.updated_at.to_f].join(':'))}")
+    end
+  end
+end

--- a/app/services/api/sync_snapshot.rb
+++ b/app/services/api/sync_snapshot.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  class SyncSnapshot
+    def initialize(household:, exporter:)
+      @household = household
+      @exporter = exporter
+    end
+
+    def payload
+      Api::ConsistentSyncRead.new(household: household).call do |cursor|
+        exporter.mobile_payload.merge(format: 'medtracker.portable.v2', cursor: cursor)
+      end
+    end
+
+    private
+
+    attr_reader :household, :exporter
+  end
+end

--- a/app/services/medication_dose_mode_synchronizer.rb
+++ b/app/services/medication_dose_mode_synchronizer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class MedicationDoseModeSynchronizer
+  def initialize(medication)
+    @medication = medication
+  end
+
+  def call
+    affected_person_medications = medication.person_medications.where.not(source_dosage_option_id: nil).to_a
+    deleted_dosages = MedicationDosageOption.where(medication: medication).to_a
+    binds = medication_id_binds
+    clear_person_medication_sources(binds)
+    delete_dosages(binds)
+    deleted_dosages.each(&:record_sync_deletion!)
+    affected_person_medications.each(&:refresh_sync_version!)
+  end
+
+  private
+
+  attr_reader :medication
+
+  def medication_id_binds
+    [
+      ActiveRecord::Relation::QueryAttribute.new(
+        'medication_id',
+        medication.id,
+        ActiveRecord::Type::BigInteger.new
+      )
+    ]
+  end
+
+  def clear_person_medication_sources(binds)
+    ActiveRecord::Base.connection.exec_update(
+      'UPDATE person_medications SET source_dosage_option_id = NULL WHERE medication_id = $1',
+      'Sync Person Medication Dosage Sources',
+      binds
+    )
+  end
+
+  def delete_dosages(binds)
+    ActiveRecord::Base.connection.exec_delete('DELETE FROM dosages WHERE medication_id = $1', 'Sync Dosages', binds)
+  end
+end

--- a/app/services/portable_data/export_event_record_serializer.rb
+++ b/app/services/portable_data/export_event_record_serializer.rb
@@ -13,14 +13,23 @@ module PortableData
                                                   .merge(notification_preference_times(preference))
     end
 
+    def health_event_payload(event)
+      sync_identity(event).merge(
+        person_portable_id: event.person.portable_id,
+        event_kind: event.event_kind,
+        severity: event.severity,
+        title: event.title,
+        notes: event.notes,
+        started_on: event.started_on&.iso8601,
+        ended_on: event.ended_on&.iso8601,
+        medication_portable_ids: event.medications.map(&:portable_id)
+      )
+    end
+
     private
 
     def medication_take_identity(take)
-      {
-        portable_id: take.portable_id,
-        client_uuid: take.client_uuid,
-        updated_at: take.updated_at.iso8601
-      }
+      sync_identity(take).merge(client_uuid: take.client_uuid)
     end
 
     def medication_take_source(take)
@@ -48,11 +57,7 @@ module PortableData
     end
 
     def notification_preference_identity(preference)
-      {
-        portable_id: preference.portable_id,
-        person_portable_id: preference.person.portable_id,
-        updated_at: preference.updated_at.iso8601
-      }
+      sync_identity(preference).merge(person_portable_id: preference.person.portable_id)
     end
 
     def notification_preference_flags(preference)
@@ -76,6 +81,14 @@ module PortableData
 
     def formatted_time(value)
       value&.strftime('%H:%M:%S')
+    end
+
+    def sync_identity(record)
+      {
+        portable_id: record.portable_id,
+        updated_at: record.updated_at.iso8601,
+        etag: Api::RecordEtag.for(record)
+      }
     end
   end
 end

--- a/app/services/portable_data/export_record_serializer.rb
+++ b/app/services/portable_data/export_record_serializer.rb
@@ -10,7 +10,8 @@ module PortableData
       schedules: :schedule_payload,
       person_medications: :person_medication_payload,
       medication_takes: :event_medication_take_payload,
-      notification_preferences: :event_notification_preference_payload
+      notification_preferences: :event_notification_preference_payload,
+      health_events: :event_health_event_payload
     }.freeze
 
     def initialize(records)
@@ -18,8 +19,9 @@ module PortableData
     end
 
     def as_json
-      COLLECTIONS.to_h do |record_type, serializer_method|
-        [record_type, records.fetch(record_type).map { |record| send(serializer_method, record) }]
+      records.to_h do |record_type, collection|
+        serializer_method = COLLECTIONS.fetch(record_type)
+        [record_type, collection.map { |record| send(serializer_method, record) }]
       end
     end
 
@@ -32,10 +34,7 @@ module PortableData
     end
 
     def person_identity(person)
-      {
-        portable_id: person.portable_id,
-        updated_at: person.updated_at.iso8601
-      }
+      sync_identity(person)
     end
 
     def person_profile(person)
@@ -56,12 +55,10 @@ module PortableData
     end
 
     def location_payload(location)
-      {
-        portable_id: location.portable_id,
+      sync_identity(location).merge(
         name: location.name,
-        description: location.description,
-        updated_at: location.updated_at.iso8601
-      }
+        description: location.description
+      )
     end
 
     def medication_payload(medication)
@@ -71,15 +68,13 @@ module PortableData
     end
 
     def medication_identity(medication)
-      {
-        portable_id: medication.portable_id,
+      sync_identity(medication).merge(
         location_portable_id: medication.location&.portable_id,
         name: medication.name,
         friendly_name: medication.friendly_name,
         category: medication.category,
-        description: medication.description,
-        updated_at: medication.updated_at.iso8601
-      }
+        description: medication.description
+      )
     end
 
     def medication_dose(medication)
@@ -111,15 +106,13 @@ module PortableData
     end
 
     def dosage_identity(dosage)
-      {
-        portable_id: dosage.portable_id,
+      sync_identity(dosage).merge(
         medication_portable_id: dosage.medication.portable_id,
         amount: dosage.amount,
         unit: dosage.unit,
         frequency: dosage.frequency,
-        description: dosage.description,
-        updated_at: dosage.updated_at.iso8601
-      }
+        description: dosage.description
+      )
     end
 
     def dosage_defaults(dosage)
@@ -146,12 +139,10 @@ module PortableData
     end
 
     def schedule_identity(schedule)
-      {
-        portable_id: schedule.portable_id,
+      sync_identity(schedule).merge(
         source_dosage_option_portable_id: schedule.source_dosage_option&.portable_id,
-        retired_at: schedule.retired_at&.iso8601,
-        updated_at: schedule.updated_at.iso8601
-      }
+        retired_at: schedule.retired_at&.iso8601
+      )
     end
 
     def schedule_subjects(schedule)
@@ -190,12 +181,10 @@ module PortableData
     end
 
     def person_medication_identity(person_medication)
-      {
-        portable_id: person_medication.portable_id,
+      sync_identity(person_medication).merge(
         source_dosage_option_portable_id: person_medication.source_dosage_option&.portable_id,
-        retired_at: person_medication.retired_at&.iso8601,
-        updated_at: person_medication.updated_at.iso8601
-      }
+        retired_at: person_medication.retired_at&.iso8601
+      )
     end
 
     def person_medication_subjects(person_medication)
@@ -228,6 +217,18 @@ module PortableData
 
     def event_notification_preference_payload(preference)
       event_record_serializer.notification_preference_payload(preference)
+    end
+
+    def event_health_event_payload(event)
+      event_record_serializer.health_event_payload(event)
+    end
+
+    def sync_identity(record)
+      {
+        portable_id: record.portable_id,
+        updated_at: record.updated_at.iso8601,
+        etag: Api::RecordEtag.for(record)
+      }
     end
 
     def event_record_serializer

--- a/app/services/portable_data/exporter.rb
+++ b/app/services/portable_data/exporter.rb
@@ -19,8 +19,7 @@ module PortableData
       envelope
     end
 
-    def export_unencrypted(export_mode:, event_type: 'portable_data.exported')
-      export_payload = payload
+    def export_unencrypted(export_mode:, event_type: 'portable_data.exported', export_payload: payload)
       result = yield(export_payload)
       record_audit_event(export_payload, event_type: event_type, encrypted: false, export_mode: export_mode)
       result
@@ -29,7 +28,8 @@ module PortableData
     def mobile_snapshot
       export_unencrypted(
         export_mode: 'mobile_snapshot',
-        event_type: 'portable_data.mobile_snapshot_read'
+        event_type: 'portable_data.mobile_snapshot_read',
+        export_payload: mobile_payload
       ) do |export_payload|
         export_payload
       end
@@ -39,22 +39,26 @@ module PortableData
       export_payload
     end
 
+    def mobile_payload
+      export_payload(include_health_events: true)
+    end
+
     private
 
     attr_reader :household, :membership, :passphrase, :person_ids, :request
 
-    def export_payload
+    def export_payload(include_health_events: false)
       {
         format: FORMAT,
         scope: 'single_person',
         exported_at: Time.current.iso8601,
         source_instance_id: source_instance_id,
-        records: records_payload
+        records: records_payload(include_health_events: include_health_events)
       }
     end
 
-    def records_payload
-      ExportRecordSerializer.new(
+    def records_payload(include_health_events:)
+      records = {
         people: people,
         locations: locations,
         medications: medications,
@@ -63,7 +67,9 @@ module PortableData
         person_medications: person_medications,
         medication_takes: medication_takes,
         notification_preferences: notification_preferences
-      ).as_json
+      }
+      records[:health_events] = health_events if include_health_events
+      ExportRecordSerializer.new(records).as_json
     end
 
     def source_instance_id
@@ -106,6 +112,7 @@ module PortableData
       @medication_id_values ||= begin
         ids = schedules.pluck(:medication_id)
         ids.concat(person_medications.pluck(:medication_id))
+        ids.concat(health_events.joins(:health_event_medications).pluck('health_event_medications.medication_id'))
         ids.compact.uniq
       end
     end
@@ -150,6 +157,12 @@ module PortableData
       @notification_preferences ||= NotificationPreference.where(household: household, person_id: person_id_values)
                                                           .includes(:person)
                                                           .order(:id)
+    end
+
+    def health_events
+      @health_events ||= HealthEvent.where(household: household, person_id: person_id_values)
+                                    .includes(:person, :medications)
+                                    .order(:id)
     end
 
     def record_audit_event(payload, export_mode:, event_type: 'portable_data.exported', encrypted: true)

--- a/app/services/portable_data/exporter.rb
+++ b/app/services/portable_data/exporter.rb
@@ -60,9 +60,9 @@ module PortableData
     def records_payload(include_health_events:)
       records = {
         people: people,
-        locations: locations,
-        medications: medications,
-        dosage_options: dosage_options,
+        locations: locations(include_health_events:),
+        medications: medications(include_health_events:),
+        dosage_options: dosage_options(include_health_events:),
         schedules: schedules,
         person_medications: person_medications,
         medication_takes: medication_takes,
@@ -99,36 +99,48 @@ module PortableData
       @person_id_values ||= people.pluck(:id)
     end
 
-    def location_id_values
-      @location_id_values ||= begin
+    def location_id_values(include_health_events:)
+      @location_id_values ||= {}
+      @location_id_values[include_health_events] ||= begin
         ids = LocationMembership.where(household: household, person_id: person_id_values).pluck(:location_id)
-        ids.concat(medications.pluck(:location_id))
+        ids.concat(medications(include_health_events:).pluck(:location_id))
         ids.concat(medication_takes.pluck(:taken_from_location_id))
         ids.compact.uniq
       end
     end
 
-    def medication_id_values
-      @medication_id_values ||= begin
+    def medication_id_values(include_health_events:)
+      @medication_id_values ||= {}
+      @medication_id_values[include_health_events] ||= begin
         ids = schedules.pluck(:medication_id)
         ids.concat(person_medications.pluck(:medication_id))
-        ids.concat(health_events.joins(:health_event_medications).pluck('health_event_medications.medication_id'))
+        if include_health_events
+          ids.concat(health_events.joins(:health_event_medications).pluck('health_event_medications.medication_id'))
+        end
         ids.compact.uniq
       end
     end
 
-    def locations
-      @locations ||= household.locations.where(id: location_id_values).order(:id)
+    def locations(include_health_events:)
+      @locations ||= {}
+      @locations[include_health_events] ||=
+        household.locations.where(id: location_id_values(include_health_events:)).order(:id)
     end
 
-    def medications
-      @medications ||= household.medications.where(id: medication_id_values).includes(:location).order(:id)
+    def medications(include_health_events:)
+      @medications ||= {}
+      @medications[include_health_events] ||=
+        household.medications.where(id: medication_id_values(include_health_events:))
+                 .includes(:location)
+                 .order(:id)
     end
 
-    def dosage_options
-      @dosage_options ||= MedicationDosageOption.where(household: household, medication_id: medication_id_values)
-                                                .includes(:medication)
-                                                .order(:id)
+    def dosage_options(include_health_events:)
+      @dosage_options ||= {}
+      @dosage_options[include_health_events] ||= MedicationDosageOption.where(
+        household: household,
+        medication_id: medication_id_values(include_health_events:)
+      ).includes(:medication).order(:id)
     end
 
     def schedules

--- a/db/migrate/20260713123000_allow_system_api_sync_events.rb
+++ b/db/migrate/20260713123000_allow_system_api_sync_events.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AllowSystemApiSyncEvents < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :api_change_events, :account_id, true
+    change_column_null :api_change_events, :household_membership_id, true
+    change_column_null :api_tombstones, :account_id, true
+    change_column_null :api_tombstones, :household_membership_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,10 +184,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
 
   create_table "api_change_events", force: :cascade do |t|
     t.string "action", null: false
-    t.bigint "account_id", null: false
+    t.bigint "account_id"
     t.datetime "created_at", null: false
     t.bigint "household_id", null: false
-    t.bigint "household_membership_id", null: false
+    t.bigint "household_membership_id"
     t.jsonb "metadata", default: {}, null: false
     t.datetime "occurred_at", null: false
     t.string "record_portable_id"
@@ -263,11 +263,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
 
   create_table "api_tombstones", force: :cascade do |t|
     t.string "action", default: "delete", null: false
-    t.bigint "account_id", null: false
+    t.bigint "account_id"
     t.datetime "created_at", null: false
     t.datetime "deleted_at", null: false
     t.bigint "household_id", null: false
-    t.bigint "household_membership_id", null: false
+    t.bigint "household_membership_id"
     t.jsonb "metadata", default: {}, null: false
     t.string "record_portable_id", null: false
     t.string "record_type", null: false

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -562,9 +562,27 @@ paths:
       summary: Apply transactional sync batch operations.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncBatchRequest'
       responses:
         '201':
           description: Batch applied.
+        '409':
+          description: An operation used a stale resource ETag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '428':
+          description: An update or delete operation omitted its required resource ETag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
   /api/v1/households/{household_id}/admin/settings:
     get:
       summary: Read household administration settings.
@@ -719,6 +737,47 @@ components:
       schema:
         type: integer
   schemas:
+    SyncBatchRequest:
+      type: object
+      required:
+        - batch
+      properties:
+        batch:
+          type: object
+          required:
+            - operations
+          properties:
+            operations:
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/SyncBatchOperation'
+    SyncBatchOperation:
+      type: object
+      required:
+        - action
+        - resource_type
+        - id
+        - if_match
+      properties:
+        action:
+          type: string
+          enum:
+            - update
+            - delete
+        resource_type:
+          type: string
+          enum:
+            - medication
+            - health_event
+        id:
+          type: string
+        if_match:
+          type: string
+          description: Exact ETag from the snapshot or latest resource response.
+        attributes:
+          type: object
+          additionalProperties: true
     ErrorEnvelope:
       type: object
       required:

--- a/spec/models/dosage_spec.rb
+++ b/spec/models/dosage_spec.rb
@@ -44,5 +44,11 @@ RSpec.describe Dosage do
       end.to change { medication.reload.dose_amount }.from(500).to(nil)
       expect(medication.reload.dose_unit).to eq('mg')
     end
+
+    it 'records the medication representation change for sync clients' do
+      expect do
+        create(:dosage, medication: medication, amount: 10, unit: 'mg')
+      end.to change { ApiChangeEvent.where(record_type: 'Medication', action: 'update').count }.by(1)
+    end
   end
 end

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -627,6 +627,23 @@ RSpec.describe Medication do
           medication.update!(dose_amount: 500, dose_unit: 'mg')
         end.to change { medication.dosages.count }.from(2).to(0)
       end
+
+      it 'records relationship changes for sync clients' do
+        create(
+          :person_medication,
+          medication: medication,
+          source_dosage_option: medication.dosage_records.first
+        )
+
+        TenantContext.with(account: nil, household: medication.household) do
+          expect do
+            medication.update!(dose_amount: 500, dose_unit: 'mg')
+          end.to(
+            change { ApiTombstone.where(record_type: 'MedicationDosageOption').count }.by(2)
+              .and(change { ApiChangeEvent.where(record_type: 'PersonMedication', action: 'update').count }.by(1))
+          )
+        end
+      end
     end
 
     context 'when schedules still use the dosage options' do

--- a/spec/requests/api/v1/sync_spec.rb
+++ b/spec/requests/api/v1/sync_spec.rb
@@ -11,16 +11,86 @@ RSpec.describe 'API v1 sync' do
   let(:headers) { api_auth_headers(login_data.fetch('access_token')) }
 
   it 'returns a portable v2 snapshot without sensitive platform records' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Snapshot cold',
+      started_on: '2026-02-25'
+    )
+
     get api_v1_household_sync_snapshot_path(household_id), headers: headers, as: :json
 
     expect(response).to have_http_status(:ok)
     data = response.parsed_body.fetch('data')
     expect(data.fetch('format')).to eq('medtracker.portable.v2')
-    expect(data.fetch('records')).to include('people', 'medications', 'schedules')
+    expect(data.fetch('records')).to include('people', 'medications', 'schedules', 'health_events')
+    expect(data.dig('records', 'health_events')).to contain_exactly(
+      include(
+        'portable_id' => event.portable_id,
+        'person_portable_id' => event.person.portable_id,
+        'title' => 'Snapshot cold',
+        'etag' => be_present
+      )
+    )
     expect(data.fetch('records')).not_to include('api_sessions', 'api_app_tokens', 'native_device_tokens',
                                                  'push_subscriptions', 'household_invitations',
                                                  'security_audit_events')
     expect(data.fetch('cursor')).to be_present
+  end
+
+  it 'records model changes and tombstones outside API controllers' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Web-originated cold',
+      started_on: '2026-02-25'
+    )
+    session = ApiSession.lookup_by_access_token(login_data.fetch('access_token'))
+
+    TenantContext.with(
+      account: session.account,
+      household: session.household_membership.household,
+      membership: session.household_membership,
+      request_id: 'web-request'
+    ) do
+      expect { event.update!(title: 'Web-originated recovery') }
+        .to change { ApiChangeEvent.where(record_type: 'HealthEvent', action: 'update').count }.by(1)
+      expect { event.destroy! }
+        .to change { ApiTombstone.where(record_type: 'HealthEvent', action: 'delete').count }.by(1)
+    end
+  end
+
+  it 'records changes to mobile-visible relationship collections' do
+    event = HealthEvent.create!(
+      household_id: household_id,
+      person: people(:john),
+      event_kind: :illness,
+      title: 'Relationship sync cold',
+      started_on: '2026-02-25'
+    )
+    session = ApiSession.lookup_by_access_token(login_data.fetch('access_token'))
+    household = session.household_membership.household
+
+    TenantContext.with(
+      account: session.account,
+      household: household,
+      membership: session.household_membership,
+      request_id: 'relationship-request'
+    ) do
+      location = Location.create!(household: household, name: 'Relationship sync location')
+
+      expect { LocationMembership.create!(household: household, location: location, person: people(:john)) }
+        .to change { ApiChangeEvent.where(record_type: 'Person', action: 'update').count }.by(1)
+      expect do
+        HealthEventMedication.create!(
+          household: household,
+          health_event: event,
+          medication: medications(:paracetamol)
+        )
+      end.to change { ApiChangeEvent.where(record_type: 'HealthEvent', action: 'update').count }.by(1)
+    end
   end
 
   it 'returns cursor changes and tombstones' do
@@ -68,6 +138,7 @@ RSpec.describe 'API v1 sync' do
                  action: 'update',
                  resource_type: 'medication',
                  id: medication.portable_id,
+                 if_match: Api::RecordEtag.for(medication),
                  attributes: { name: 'Batch Updated Paracetamol' }
                },
                {
@@ -86,6 +157,87 @@ RSpec.describe 'API v1 sync' do
     expect(medication.reload.name).to eq(original_name)
   end
 
+  it 'requires a version precondition for batch updates' do
+    medication = medications(:paracetamol)
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'medication',
+                 id: medication.portable_id,
+                 attributes: { name: 'Unsafe update' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:precondition_required)
+    expect(response.parsed_body.dig('error', 'code')).to eq('precondition_required')
+    expect(medication.reload.name).not_to eq('Unsafe update')
+  end
+
+  it 'rejects stale batch versions with a machine-readable conflict' do
+    medication = medications(:paracetamol)
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'medication',
+                 id: medication.portable_id,
+                 if_match: '"stale-etag"',
+                 attributes: { name: 'Stale update' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(response.parsed_body.dig('error', 'code')).to eq('sync_conflict')
+    expect(medication.reload.name).not_to eq('Stale update')
+  end
+
+  it 'rechecks the version after acquiring the mutation lock' do
+    medication = medications(:paracetamol)
+    original_etag = Api::RecordEtag.for(medication)
+    locked_record = Medication.find(medication.id)
+    locator = instance_double(Api::PortableRecordLocator, find: locked_record)
+    allow(Api::PortableRecordLocator).to receive(:new).and_return(locator)
+    allow(locked_record).to receive(:with_lock).and_wrap_original do |method, *args, &block|
+      medication.update!(name: 'Concurrent web update')
+      method.call(*args, &block)
+    end
+
+    post api_v1_household_sync_batches_path(household_id),
+         params: {
+           batch: {
+             operations: [
+               {
+                 action: 'update',
+                 resource_type: 'medication',
+                 id: medication.portable_id,
+                 if_match: original_etag,
+                 attributes: { name: 'Unsafe native overwrite' }
+               }
+             ]
+           }
+         },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(medication.reload.name).not_to eq('Unsafe native overwrite')
+  end
+
   it 'records tombstones for batch deletes' do
     event = HealthEvent.create!(
       household_id: household_id,
@@ -100,7 +252,13 @@ RSpec.describe 'API v1 sync' do
            params: {
              batch: {
                operations: [
-                 { action: 'delete', resource_type: 'health_event', id: event.portable_id, attributes: {} }
+                 {
+                   action: 'delete',
+                   resource_type: 'health_event',
+                   id: event.portable_id,
+                   if_match: Api::RecordEtag.for(event),
+                   attributes: {}
+                 }
                ]
              }
            },
@@ -121,7 +279,13 @@ RSpec.describe 'API v1 sync' do
            params: {
              batch: {
                operations: [
-                 { action: 'delete', resource_type: 'medication', id: medication.portable_id, attributes: {} }
+                 {
+                   action: 'delete',
+                   resource_type: 'medication',
+                   id: medication.portable_id,
+                   if_match: Api::RecordEtag.for(medication),
+                   attributes: {}
+                 }
                ]
              }
            },
@@ -144,7 +308,13 @@ RSpec.describe 'API v1 sync' do
            params: {
              batch: {
                operations: [
-                 { action: 'delete', resource_type: 'medication', id: medication.portable_id, attributes: {} }
+                 {
+                   action: 'delete',
+                   resource_type: 'medication',
+                   id: medication.portable_id,
+                   if_match: Api::RecordEtag.for(medication),
+                   attributes: {}
+                 }
                ]
              }
            },
@@ -179,6 +349,7 @@ RSpec.describe 'API v1 sync' do
                  action: 'update',
                  resource_type: 'health_event',
                  id: event.portable_id,
+                 if_match: Api::RecordEtag.for(event),
                  attributes: { title: 'Recovered cold', severity: 'mild', ended_on: '2026-02-26' }
                }
              ]
@@ -231,6 +402,7 @@ RSpec.describe 'API v1 sync' do
                  action: 'update',
                  resource_type: 'health_event',
                  id: event.portable_id,
+                 if_match: Api::RecordEtag.for(event),
                  attributes: { title: '', ended_on: '2026-02-24' }
                }
              ]

--- a/spec/requests/health_events_spec.rb
+++ b/spec/requests/health_events_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe 'Health events' do
              health_event: side_effect_params(title: 'Nausea', started_on: '2026-02-10'),
              medication_ids: [medication.id]
            }
-    end.to change(HealthEvent.suspected_side_effect, :count).by(1)
+    end.to(
+      change(HealthEvent.suspected_side_effect, :count).by(1)
+        .and(change { ApiChangeEvent.where(record_type: 'HealthEvent', action: 'update').count }.by(1))
+    )
 
     event = HealthEvent.suspected_side_effect.order(:id).last
     expect(event.health_event_medications.sole.medication_name).to eq('Paracetamol')

--- a/spec/services/api/change_recorder_spec.rb
+++ b/spec/services/api/change_recorder_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Api::ChangeRecorder do
   let(:membership) do
     household.household_memberships.create!(account: account, person: person, role: :owner, status: :active)
   end
-  let(:credential) { instance_double(ApiSession, account: account) }
 
   it 'records persisted record changes with portable metadata' do
     change_recorder.record(person, action: 'updated')
@@ -32,19 +31,28 @@ RSpec.describe Api::ChangeRecorder do
     expect(event.metadata).to include('portable_id' => person.portable_id)
   end
 
-  it 'skips changes without the required tenant and record context' do
+  it 'skips changes without household or portable record context' do
     expect do
-      invalid_contexts.each { |context| record_context(context) }
+      missing_household_contexts.each { |context| record_context(context) }
     end.not_to change(ApiChangeEvent, :count)
   end
 
-  it 'records persisted records that do not expose portable IDs' do
-    change_recorder.record(account, action: 'updated')
+  it 'records system changes without an actor account or membership' do
+    described_class.new(
+      household: household,
+      account: nil,
+      membership: nil,
+      request_id: 'system-job'
+    ).record(person, action: 'updated')
 
     event = ApiChangeEvent.order(:id).last
-    expect(event.record_type).to eq('Account')
-    expect(event.record_portable_id).to be_nil
-    expect(event.metadata).not_to have_key('portable_id')
+    expect(event).to have_attributes(
+      record_type: 'Person',
+      record_portable_id: person.portable_id,
+      account: nil,
+      household_membership: nil,
+      request_id: 'system-job'
+    )
   end
 
   def create_person_for(account, household)
@@ -59,56 +67,44 @@ RSpec.describe Api::ChangeRecorder do
   end
 
   def change_recorder
-    described_class.new(household: household, credential: credential, membership: membership, request: request)
+    described_class.new(
+      household: household,
+      account: account,
+      membership: membership,
+      request_id: request.request_id
+    )
   end
 
   def request
     instance_double(ActionDispatch::Request, request_id: 'request-123')
   end
 
-  def invalid_contexts
+  def missing_household_contexts
     [
       missing_household_context,
-      missing_credential_context,
-      blank_credential_context,
-      missing_membership_context,
       missing_record_context,
-      unpersisted_record_context
+      missing_portable_record_context
     ]
   end
 
   def missing_household_context
-    { household: nil, credential: credential, membership: membership, record: person }
-  end
-
-  def missing_credential_context
-    { household: household, credential: nil, membership: membership, record: person }
-  end
-
-  def blank_credential_context
-    blank_credential = instance_double(ApiSession, account: nil)
-
-    { household: household, credential: blank_credential, membership: membership, record: person }
-  end
-
-  def missing_membership_context
-    { household: household, credential: credential, membership: nil, record: person }
+    { household: nil, account: account, membership: membership, record: person }
   end
 
   def missing_record_context
-    { household: household, credential: credential, membership: membership, record: nil }
+    { household: household, account: account, membership: membership, record: nil }
   end
 
-  def unpersisted_record_context
-    { household: household, credential: credential, membership: membership, record: Person.new }
+  def missing_portable_record_context
+    { household: household, account: account, membership: membership, record: account }
   end
 
   def record_context(context)
     described_class.new(
       household: context.fetch(:household),
-      credential: context.fetch(:credential),
+      account: context.fetch(:account),
       membership: context.fetch(:membership),
-      request: request
+      request_id: request.request_id
     ).record(context.fetch(:record), action: 'updated')
   end
 end

--- a/spec/services/api/consistent_sync_read_spec.rb
+++ b/spec/services/api/consistent_sync_read_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::ConsistentSyncRead do
+  it 'locks the household and captures the cursor before reading sync data' do
+    household = instance_double(Household)
+    cursor = Time.zone.parse('2026-07-13 12:00:00')
+    reader = proc { { records: [] } }
+
+    allow(household).to receive(:lock!)
+    allow(Time).to receive(:current).and_return(cursor)
+    allow(reader).to receive(:call).and_call_original
+
+    payload = described_class.new(household: household).call do |captured_cursor|
+      reader.call.merge(cursor: captured_cursor)
+    end
+
+    expect(household).to have_received(:lock!).ordered
+    expect(Time).to have_received(:current).ordered
+    expect(reader).to have_received(:call).ordered
+    expect(payload).to eq(records: [], cursor: cursor.iso8601)
+  end
+end

--- a/spec/services/api/sync_snapshot_spec.rb
+++ b/spec/services/api/sync_snapshot_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::SyncSnapshot do
+  it 'locks the household and captures the cursor before exporting records' do
+    household = instance_double(Household)
+    exporter = instance_double(PortableData::Exporter)
+    cursor = Time.zone.parse('2026-07-13 12:00:00')
+
+    allow(household).to receive(:lock!)
+    allow(Time).to receive(:current).and_return(cursor)
+    allow(exporter).to receive(:mobile_payload).and_return(records: {})
+
+    payload = described_class.new(household: household, exporter: exporter).payload
+
+    expect(household).to have_received(:lock!).ordered
+    expect(Time).to have_received(:current).ordered
+    expect(exporter).to have_received(:mobile_payload).ordered
+    expect(payload).to include(format: 'medtracker.portable.v2', cursor: cursor.iso8601, records: {})
+  end
+end

--- a/spec/services/portable_data/exporter_spec.rb
+++ b/spec/services/portable_data/exporter_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe PortableData::Exporter do
                                     passphrase: passphrase)
   end
 
+  def create_health_event_medication(household:)
+    person = create(:person, household: household)
+    medication = create(:medication, household: household, name: 'Health Event Medicine')
+    event = HealthEvent.create!(
+      person: person,
+      event_kind: :suspected_side_effect,
+      title: 'Nausea',
+      started_on: Date.new(2026, 7, 13)
+    )
+    HealthEventMedication.create!(health_event: event, medication: medication)
+    [event, medication]
+  end
+
   it 'exports an encrypted bundle for every person an owner can manage' do
     household = create(:household)
     owner = membership(household: household, role: :owner, email: 'owner@example.test')
@@ -62,6 +75,21 @@ RSpec.describe PortableData::Exporter do
     expect(payload.dig('records', 'people').pluck('portable_id')).to contain_exactly(person.portable_id)
     expect(payload.dig('records', 'medications').pluck('name')).to contain_exactly('Quiet Medicine')
     expect(payload.dig('records', 'medications').pluck('location_portable_id')).to all(be_present)
+  end
+
+  it 'excludes medications referenced only by health events from encrypted bundles' do
+    household = create(:household)
+    owner = membership(household: household, role: :owner, email: 'health-event-owner@example.test')
+    event, medication = create_health_event_medication(household: household)
+
+    exporter = described_class.new(household: household, membership: owner, passphrase: passphrase)
+    payload = exporter.payload
+    mobile_payload = exporter.mobile_payload
+
+    expect(payload.dig(:records, :health_events)).to be_nil
+    expect(payload.dig(:records, :medications)).to be_empty
+    expect(mobile_payload.dig(:records, :health_events).pluck(:portable_id)).to contain_exactly(event.portable_id)
+    expect(mobile_payload.dig(:records, :medications).pluck(:portable_id)).to contain_exactly(medication.portable_id)
   end
 
   it 'limits member exports to people with manage grants' do


### PR DESCRIPTION
## Summary

Mobile clients could miss web or background changes, receive incomplete snapshots, or overwrite newer server state with stale offline writes.

- records portable model creates, updates, touches, and deletions through one model-level feed path, including bulk relationship changes
- makes snapshot and change-feed cursors transactionally consistent and includes health events plus record ETags in mobile payloads
- requires locked ETag preconditions for batch updates and deletes, with distinct missing-precondition and stale-conflict errors
- keeps portable backup exports round-trippable while enriching only mobile payloads
- preserves the retained administration-history deletion rules introduced by #1615

Closes #1608
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->