### PR TITLE
feat(care): enforce household relationships

### DIFF
--- a/app/models/carer_relationship.rb
+++ b/app/models/carer_relationship.rb
@@ -5,6 +5,7 @@
 class CarerRelationship < ApplicationRecord
   RELATIONSHIP_TYPES = %w[parent family_member professional_carer self].map { |v| [v.humanize, v] }.freeze
 
+  belongs_to :household
   belongs_to :carer, class_name: 'Person', inverse_of: :patient_relationships
   belongs_to :patient, class_name: 'Person', inverse_of: :carer_relationships
 
@@ -14,8 +15,11 @@ class CarerRelationship < ApplicationRecord
   # @see docs/audit-trail.md
   has_paper_trail
 
-  validates :carer_id, uniqueness: { scope: :patient_id }
+  before_validation :assign_household_from_patient
+
+  validates :carer_id, uniqueness: { scope: %i[patient_id household_id] }
   validates :relationship_type, presence: true
+  validate :endpoints_belong_to_household
 
   scope :active, -> { where(active: true) }
 
@@ -25,5 +29,18 @@ class CarerRelationship < ApplicationRecord
 
   def activate!
     update!(active: true)
+  end
+
+  private
+
+  def assign_household_from_patient
+    self.household ||= patient&.household
+  end
+
+  def endpoints_belong_to_household
+    return if household.blank?
+
+    errors.add(:carer, 'must belong to the relationship household') if carer && carer.household_id != household_id
+    errors.add(:patient, 'must belong to the relationship household') if patient && patient.household_id != household_id
   end
 end

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -17,6 +17,7 @@ class Household < ApplicationRecord
   has_many :person_medications, dependent: :restrict_with_error
   has_many :medication_takes, dependent: :restrict_with_error
   has_many :health_events, dependent: :restrict_with_error
+  has_many :carer_relationships, dependent: :restrict_with_error
   has_many :notification_preferences, dependent: :restrict_with_error
   has_many :person_access_grants, dependent: :destroy
   has_many :household_invitations, dependent: :destroy

--- a/app/policies/carer_relationship_policy.rb
+++ b/app/policies/carer_relationship_policy.rb
@@ -6,16 +6,21 @@ class CarerRelationshipPolicy < ApplicationPolicy
   end
 
   def show?
-    household_manager? || person_grant_allows?(record.patient, :view)
+    relationship_in_household? && (household_manager? || person_grant_allows?(record.patient, :view))
   end
 
   def create?
-    return true if household_manager?
+    return household_manager? if class_record?
+
+    relationship_in_household? && (household_manager? || assign_dependent?)
+  end
+
+  def new?
+    return household_manager? if class_record?
+    return household_manager? if record.patient.nil? && record.carer.nil?
 
     assign_dependent?
   end
-
-  alias new? create?
 
   def update?
     household_manager? && relationship_in_household?
@@ -32,7 +37,8 @@ class CarerRelationshipPolicy < ApplicationPolicy
   end
 
   def assign_dependent?
-    dependent_patient? && (household_manager? || person_grant_allows?(record.patient, :manage))
+    relationship_in_household? && dependent_patient? &&
+      (household_manager? || person_grant_allows?(record.patient, :manage))
   end
 
   private
@@ -44,7 +50,22 @@ class CarerRelationshipPolicy < ApplicationPolicy
   end
 
   def relationship_in_household?
-    household.present? && record.patient&.household_id == household.id && record.carer&.household_id == household.id
+    return false if household.blank?
+    return false if class_record?
+
+    record_household_id == household.id && carer_in_household?
+  end
+
+  def record_household_id
+    record.household_id || record.patient&.household_id
+  end
+
+  def carer_in_household?
+    record.carer.nil? || record.carer.household_id == household.id
+  end
+
+  def class_record?
+    !record.respond_to?(:household_id)
   end
 
   class Scope < ApplicationPolicy::Scope
@@ -58,8 +79,7 @@ class CarerRelationshipPolicy < ApplicationPolicy
     private
 
     def household_relationship_scope
-      person_ids = Person.where(household: household).select(:id)
-      scope.where(patient_id: person_ids, carer_id: person_ids)
+      scope.where(household: household)
     end
   end
 end

--- a/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
+++ b/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
@@ -1,0 +1,118 @@
+class AddHouseholdOwnershipToCarerRelationships < ActiveRecord::Migration[8.1]
+  HOUSEHOLD_FOREIGN_KEY = 'fk_carer_relationships_household'
+  CARER_FOREIGN_KEY = 'fk_carer_relationships_carer_household'
+  PATIENT_FOREIGN_KEY = 'fk_carer_relationships_patient_household'
+
+  def up
+    add_reference :carer_relationships, :household, index: false
+    verify_legacy_relationships!
+    backfill_households
+    change_column_null :carer_relationships, :household_id, false
+    add_indexes
+    add_foreign_keys
+    enable_household_rls
+  end
+
+  def down
+    disable_household_rls
+    remove_foreign_keys
+    remove_indexes
+    remove_column :carer_relationships, :household_id
+  end
+
+  private
+
+  def verify_legacy_relationships!
+    mismatches = legacy_relationship_mismatches
+    return if mismatches.empty?
+
+    ids = mismatches.pluck('id').join(', ')
+    raise ActiveRecord::MigrationError,
+          "carer relationships have missing or cross-household endpoints: #{ids}"
+  end
+
+  def legacy_relationship_mismatches
+    select_all(<<~SQL.squish).to_a
+      SELECT carer_relationships.id,
+             patients.household_id AS patient_household_id,
+             carers.household_id AS carer_household_id
+      FROM carer_relationships
+      LEFT JOIN people patients ON patients.id = carer_relationships.patient_id
+      LEFT JOIN people carers ON carers.id = carer_relationships.carer_id
+      WHERE patients.household_id IS NULL
+         OR carers.household_id IS NULL
+         OR patients.household_id <> carers.household_id
+      ORDER BY carer_relationships.id
+    SQL
+  end
+
+  def backfill_households
+    execute <<~SQL.squish
+      UPDATE carer_relationships
+      SET household_id = patients.household_id
+      FROM people patients
+      WHERE patients.id = carer_relationships.patient_id
+    SQL
+  end
+
+  def add_indexes
+    add_index :carer_relationships, :household_id
+    add_index :carer_relationships, %i[id household_id], unique: true
+    add_index :carer_relationships,
+              %i[household_id carer_id patient_id],
+              unique: true,
+              name: 'index_carer_relationships_on_household_carer_patient'
+    remove_index :carer_relationships, column: %i[carer_id patient_id]
+  end
+
+  def remove_indexes
+    add_index :carer_relationships, %i[carer_id patient_id], unique: true
+    remove_index :carer_relationships, name: 'index_carer_relationships_on_household_carer_patient'
+    remove_index :carer_relationships, column: %i[id household_id]
+    remove_index :carer_relationships, :household_id
+  end
+
+  def add_foreign_keys
+    add_foreign_key :carer_relationships,
+                    :households,
+                    column: :household_id,
+                    validate: false,
+                    name: HOUSEHOLD_FOREIGN_KEY
+    add_endpoint_foreign_key(:carer_id, CARER_FOREIGN_KEY)
+    add_endpoint_foreign_key(:patient_id, PATIENT_FOREIGN_KEY)
+    validate_foreign_key :carer_relationships, name: HOUSEHOLD_FOREIGN_KEY
+    validate_foreign_key :carer_relationships, name: CARER_FOREIGN_KEY
+    validate_foreign_key :carer_relationships, name: PATIENT_FOREIGN_KEY
+  end
+
+  def add_endpoint_foreign_key(column, name)
+    add_foreign_key :carer_relationships,
+                    :people,
+                    column: [column, :household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: name
+  end
+
+  def remove_foreign_keys
+    remove_foreign_key :carer_relationships, name: PATIENT_FOREIGN_KEY
+    remove_foreign_key :carer_relationships, name: CARER_FOREIGN_KEY
+    remove_foreign_key :carer_relationships, name: HOUSEHOLD_FOREIGN_KEY
+  end
+
+  def enable_household_rls
+    execute 'ALTER TABLE carer_relationships ENABLE ROW LEVEL SECURITY;'
+    execute 'ALTER TABLE carer_relationships FORCE ROW LEVEL SECURITY;'
+    execute <<~SQL.squish
+      CREATE POLICY household_tenant_isolation ON carer_relationships
+      USING (household_id = med_tracker.current_household_id())
+      WITH CHECK (household_id = med_tracker.current_household_id());
+    SQL
+  end
+
+  def disable_household_rls
+    execute 'DROP POLICY IF EXISTS household_tenant_isolation ON carer_relationships;'
+    execute 'ALTER TABLE carer_relationships NO FORCE ROW LEVEL SECURITY;'
+    execute 'ALTER TABLE carer_relationships DISABLE ROW LEVEL SECURITY;'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -401,12 +401,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_090000) do
     t.boolean "active", default: true, null: false
     t.bigint "carer_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "household_id", null: false
     t.bigint "patient_id", null: false
     t.string "relationship_type"
     t.datetime "updated_at", null: false
     t.index ["active"], name: "index_carer_relationships_on_active"
-    t.index ["carer_id", "patient_id"], name: "index_carer_relationships_on_carer_id_and_patient_id", unique: true
     t.index ["carer_id"], name: "index_carer_relationships_on_carer_id"
+    t.index ["household_id", "carer_id", "patient_id"], name: "index_carer_relationships_on_household_carer_patient", unique: true
+    t.index ["household_id"], name: "index_carer_relationships_on_household_id"
+    t.index ["id", "household_id"], name: "index_carer_relationships_on_id_and_household_id", unique: true
     t.index ["patient_id"], name: "index_carer_relationships_on_patient_id"
   end
 
@@ -1074,8 +1077,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_090000) do
   add_foreign_key "audit_export_deliveries", "audit_checkpoints"
   add_foreign_key "audit_export_deliveries", "audit_ledger_entries"
   add_foreign_key "audit_ledger_entries", "households"
+  add_foreign_key "carer_relationships", "households", name: "fk_carer_relationships_household"
   add_foreign_key "carer_relationships", "people", column: "carer_id", deferrable: :deferred
   add_foreign_key "carer_relationships", "people", column: "patient_id", deferrable: :deferred
+  add_foreign_key "carer_relationships", "people", column: ["carer_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_carer_relationships_carer_household"
+  add_foreign_key "carer_relationships", "people", column: ["patient_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_carer_relationships_patient_household"
   add_foreign_key "dosages", "households"
   add_foreign_key "dosages", "medications", column: ["medication_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_dosages_medication_id_household"
   add_foreign_key "dosages", "medications", deferrable: :deferred
@@ -1216,6 +1222,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_090000) do
     health_events
     health_event_medications
     notification_events
+    carer_relationships
     household_memberships
     person_access_grants
     household_invitations

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -14,6 +14,7 @@ class SchemaInventory
     health_events
     health_event_medications
     notification_events
+    carer_relationships
     household_memberships
     person_access_grants
     household_invitations
@@ -52,7 +53,6 @@ class SchemaInventory
     audit_ledger_entries
     audit_signing_keys
     barcode_catalog_entries
-    carer_relationships
     households
     medication_review_evidence_records
     medication_review_evidence_refresh_runs

--- a/spec/factories/carer_relationships.rb
+++ b/spec/factories/carer_relationships.rb
@@ -2,8 +2,9 @@
 
 FactoryBot.define do
   factory :carer_relationship do
-    carer { association :person }
-    patient { association :person }
+    household { nil }
+    patient { association :person, household: household || association(:household) }
+    carer { association :person, household: household || patient.household }
     relationship_type { 'family_member' }
     active { true }
   end

--- a/spec/fixtures/carer_relationships.yml
+++ b/spec/fixtures/carer_relationships.yml
@@ -1,5 +1,6 @@
 ---
 jane_cares_for_child:
+  household: fixture_household
   carer: jane
   patient: child_patient
   relationship_type: parent
@@ -8,6 +9,7 @@ jane_cares_for_child:
   updated_at: <%= Time.current %>
 
 nurse_cares_for_john:
+  household: fixture_household
   carer: nurse_smith
   patient: john
   relationship_type: professional_carer
@@ -16,6 +18,7 @@ nurse_cares_for_john:
   updated_at: <%= Time.current %>
 
 adult_patient_self_care:
+  household: fixture_household
   carer: adult_patient_person
   patient: adult_patient_person
   relationship_type: 0  # self
@@ -23,6 +26,7 @@ adult_patient_self_care:
   updated_at: <%= Time.current %>
 
 parent_cares_for_child:
+  household: fixture_household
   carer: parent_person
   patient: child_user_person
   relationship_type: parent
@@ -31,6 +35,7 @@ parent_cares_for_child:
   updated_at: <%= Time.current %>
 
 carer_cares_for_patient:
+  household: fixture_household
   carer: carer_person
   patient: child_patient
   relationship_type: professional_carer
@@ -39,6 +44,7 @@ carer_cares_for_patient:
   updated_at: <%= Time.current %>
 
 carer_cares_for_child_user:
+  household: fixture_household
   carer: carer_person
   patient: child_user_person
   relationship_type: professional_carer
@@ -47,6 +53,7 @@ carer_cares_for_child_user:
   updated_at: <%= Time.current %>
 
 inactive_relationship:
+  household: fixture_household
   carer: bob
   patient: john
   relationship_type: family_member

--- a/spec/lib/schema_inventory_spec.rb
+++ b/spec/lib/schema_inventory_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SchemaInventory do
       health_events
       health_event_medications
       notification_events
+      carer_relationships
       household_memberships
       person_access_grants
       household_invitations
@@ -30,7 +31,6 @@ RSpec.describe SchemaInventory do
       api_app_tokens
       api_sessions
       barcode_catalog_entries
-      carer_relationships
       households
       medication_review_evidence_records
       native_device_tokens
@@ -78,5 +78,12 @@ RSpec.describe SchemaInventory do
     end
 
     expect(nullable).to be_empty
+  end
+
+  it 'keeps every household-owned table in the fresh-schema RLS installer' do
+    schema_source = Rails.root.join('db/schema.rb').read
+    rls_tables = schema_source.match(/%w\[(?<tables>.*?)\]\.each do \|table_name\|/m)[:tables].split
+
+    expect(rls_tables).to match_array(described_class.household_owned_tables)
   end
 end

--- a/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
+++ b/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
@@ -2,39 +2,112 @@
 
 require 'rails_helper'
 
-RSpec.describe 'EnforceStrictHouseholdTenantBoundary' do
+load Rails.root.join('db/migrate/20260624091000_enforce_strict_household_tenant_boundary.rb') unless
+  defined?(EnforceStrictHouseholdTenantBoundary)
+load Rails.root.join('db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb') unless
+  defined?(AddHouseholdOwnershipToCarerRelationships)
+
+RSpec.describe EnforceStrictHouseholdTenantBoundary do
   delegate :connection, to: :'ActiveRecord::Base'
 
-  before do
-    unless defined?(EnforceStrictHouseholdTenantBoundary)
-      load Rails.root.join('db/migrate/20260624091000_enforce_strict_household_tenant_boundary.rb')
+  describe EnforceStrictHouseholdTenantBoundary do
+    around do |example|
+      connection.transaction(requires_new: true) do
+        example.run
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    it 'relaxes forced RLS before legacy household backfill runs' do
+      migration = described_class.new
+      table_name = 'people'
+
+      connection.execute("ALTER TABLE #{connection.quote_table_name(table_name)} FORCE ROW LEVEL SECURITY")
+
+      expect { migration.send(:relax_forced_rls_for_backfill) }
+        .to change { forced_rls?(table_name) }
+        .from(true)
+        .to(false)
+    end
+
+    def forced_rls?(table_name)
+      connection.select_value(<<~SQL.squish)
+        SELECT relforcerowsecurity
+        FROM pg_class
+        WHERE oid = #{connection.quote(table_name)}::regclass
+      SQL
     end
   end
 
-  around do |example|
-    connection.transaction(requires_new: true) do
-      example.run
-      raise ActiveRecord::Rollback
+  describe AddHouseholdOwnershipToCarerRelationships do
+    describe 'legacy data verification' do
+      it 'aborts with the invalid relationship ids before backfilling' do
+        migration = described_class.new
+        allow(migration).to receive(:legacy_relationship_mismatches).and_return(
+          [
+            { 'id' => 41, 'patient_household_id' => nil, 'carer_household_id' => 7 },
+            { 'id' => 42, 'patient_household_id' => 7, 'carer_household_id' => 8 }
+          ]
+        )
+
+        expect { migration.send(:verify_legacy_relationships!) }
+          .to raise_error(ActiveRecord::MigrationError, /41, 42/)
+      end
+
+      it 'allows a backfill only when every endpoint belongs to one household' do
+        migration = described_class.new
+        allow(migration).to receive(:legacy_relationship_mismatches).and_return([])
+
+        expect { migration.send(:verify_legacy_relationships!) }.not_to raise_error
+      end
     end
-  end
 
-  it 'relaxes forced RLS before legacy household backfill runs' do
-    migration = EnforceStrictHouseholdTenantBoundary.new
-    table_name = 'people'
+    describe 'database contract' do
+      it 'requires household ownership and tenant-scoped uniqueness' do
+        household_column = connection.columns(:carer_relationships).find { it.name == 'household_id' }
+        indexes = connection.indexes(:carer_relationships).index_by(&:name)
 
-    connection.execute("ALTER TABLE #{connection.quote_table_name(table_name)} FORCE ROW LEVEL SECURITY")
+        expect(household_column).not_to be_nil
+        expect(household_column.null).to be(false)
+        expect(indexes.fetch('index_carer_relationships_on_id_and_household_id').columns)
+          .to eq(%w[id household_id])
+        expect(indexes.fetch('index_carer_relationships_on_household_carer_patient').columns)
+          .to eq(%w[household_id carer_id patient_id])
+        expect(indexes.fetch('index_carer_relationships_on_household_carer_patient').unique).to be(true)
+      end
 
-    expect { migration.send(:relax_forced_rls_for_backfill) }
-      .to change { forced_rls?(table_name) }
-      .from(true)
-      .to(false)
-  end
+      it 'binds both endpoints to the relationship household' do
+        foreign_keys = connection.foreign_keys(:carer_relationships).index_by(&:name)
 
-  def forced_rls?(table_name)
-    connection.select_value(<<~SQL.squish)
-      SELECT relforcerowsecurity
-      FROM pg_class
-      WHERE oid = #{connection.quote(table_name)}::regclass
-    SQL
+        expect(foreign_keys.fetch('fk_carer_relationships_household').to_table).to eq('households')
+        expect(foreign_keys.fetch('fk_carer_relationships_carer_household').options).to include(
+          column: %w[carer_id household_id],
+          primary_key: %w[id household_id]
+        )
+        expect(foreign_keys.fetch('fk_carer_relationships_patient_household').options).to include(
+          column: %w[patient_id household_id],
+          primary_key: %w[id household_id]
+        )
+      end
+
+      it 'forces the strict household tenant policy' do
+        relation = connection.select_one(<<~SQL.squish)
+          SELECT relrowsecurity, relforcerowsecurity
+          FROM pg_class
+          WHERE oid = 'carer_relationships'::regclass
+        SQL
+        policy = connection.select_one(<<~SQL.squish)
+          SELECT qual, with_check
+          FROM pg_policies
+          WHERE schemaname = 'public'
+            AND tablename = 'carer_relationships'
+            AND policyname = 'household_tenant_isolation'
+        SQL
+
+        expect(relation).to eq('relrowsecurity' => true, 'relforcerowsecurity' => true)
+        expect(policy.fetch('qual')).to include('med_tracker.current_household_id()')
+        expect(policy.fetch('with_check')).to include('med_tracker.current_household_id()')
+      end
+    end
   end
 end

--- a/spec/models/carer_relationship_spec.rb
+++ b/spec/models/carer_relationship_spec.rb
@@ -3,14 +3,54 @@
 require 'rails_helper'
 
 RSpec.describe CarerRelationship do
+  let(:household) { create(:household) }
+
   describe 'associations' do
+    it { is_expected.to belong_to(:household) }
     it { is_expected.to belong_to(:carer).class_name('Person') }
     it { is_expected.to belong_to(:patient).class_name('Person') }
   end
 
+  describe 'factory' do
+    it 'builds both endpoints in one derived household by default' do
+      relationship = build(:carer_relationship)
+
+      expect(relationship.patient.household).to eq(relationship.carer.household)
+      expect(relationship).to be_valid
+      expect(relationship.household).to eq(relationship.patient.household)
+    end
+
+    it 'builds both endpoints in an explicitly selected household' do
+      relationship = build(:carer_relationship, household: household)
+
+      expect(relationship.patient.household).to eq(household)
+      expect(relationship.carer.household).to eq(household)
+      expect(relationship).to be_valid
+    end
+
+    it 'preserves explicit same-household endpoint overrides' do
+      patient = create(:person, household: household)
+      carer = create(:person, household: household)
+      relationship = build(:carer_relationship, patient: patient, carer: carer)
+
+      expect(relationship).to have_attributes(patient: patient, carer: carer)
+      expect(relationship).to be_valid
+      expect(relationship.household).to eq(household)
+    end
+
+    it 'does not hide explicit cross-household endpoint overrides' do
+      patient = create(:person, household: household)
+      carer = create(:person, household: create(:household))
+      relationship = build(:carer_relationship, patient: patient, carer: carer)
+
+      expect(relationship).not_to be_valid
+      expect(relationship.errors[:carer]).to include('must belong to the relationship household')
+    end
+  end
+
   describe 'validations' do
     let(:carer) do
-      Person.create!(
+      household.people.create!(
         name: 'Carer Person',
         date_of_birth: 30.years.ago,
         person_type: :adult
@@ -18,7 +58,7 @@ RSpec.describe CarerRelationship do
     end
 
     let(:patient) do
-      Person.create!(
+      household.people.create!(
         name: 'Patient Person',
         date_of_birth: 5.years.ago,
         person_type: :adult,
@@ -52,11 +92,46 @@ RSpec.describe CarerRelationship do
       expect(relationship).not_to be_valid
       expect(relationship.errors[:relationship_type]).to include("can't be blank")
     end
+
+    it 'derives household ownership from the patient' do
+      relationship = described_class.create!(
+        carer: carer,
+        patient: patient,
+        relationship_type: 'parent'
+      )
+
+      expect(relationship.household).to eq(household)
+    end
+
+    it 'rejects carers from another household' do
+      other_carer = create(:person, household: create(:household))
+      relationship = described_class.new(
+        household: household,
+        carer: other_carer,
+        patient: patient,
+        relationship_type: 'parent'
+      )
+
+      expect(relationship).not_to be_valid
+      expect(relationship.errors[:carer]).to include('must belong to the relationship household')
+    end
+
+    it 'rejects a household that differs from the patient household' do
+      relationship = described_class.new(
+        household: create(:household),
+        carer: carer,
+        patient: patient,
+        relationship_type: 'parent'
+      )
+
+      expect(relationship).not_to be_valid
+      expect(relationship.errors[:patient]).to include('must belong to the relationship household')
+    end
   end
 
   describe 'scopes' do
     let(:carer) do
-      Person.create!(
+      household.people.create!(
         name: 'Carer Person',
         date_of_birth: 30.years.ago,
         person_type: :adult
@@ -64,7 +139,7 @@ RSpec.describe CarerRelationship do
     end
 
     let(:patient) do
-      Person.create!(
+      household.people.create!(
         name: 'Patient Person',
         date_of_birth: 5.years.ago,
         person_type: :adult
@@ -81,7 +156,7 @@ RSpec.describe CarerRelationship do
 
       inactive_relationship = described_class.create!(
         carer: carer,
-        patient: Person.create!(name: 'Another Patient', date_of_birth: 10.years.ago),
+        patient: household.people.create!(name: 'Another Patient', date_of_birth: 10.years.ago),
         relationship_type: 'guardian',
         active: false
       )
@@ -94,8 +169,8 @@ RSpec.describe CarerRelationship do
   describe '#deactivate!' do
     it 'sets active to false' do
       relationship = described_class.create!(
-        carer: Person.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
-        patient: Person.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
+        carer: household.people.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
+        patient: household.people.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
         relationship_type: 'parent',
         active: true
       )
@@ -109,8 +184,8 @@ RSpec.describe CarerRelationship do
   describe '#activate!' do
     it 'sets active to true' do
       relationship = described_class.create!(
-        carer: Person.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
-        patient: Person.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
+        carer: household.people.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
+        patient: household.people.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
         relationship_type: 'parent',
         active: false
       )

--- a/spec/models/household_row_level_security_spec.rb
+++ b/spec/models/household_row_level_security_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe Household do
     )
   end
 
+  def carer_relationship_for(household, prefix:)
+    CarerRelationship.create!(
+      carer: household.people.create!(name: "#{prefix} Carer", date_of_birth: 30.years.ago.to_date),
+      patient: household.people.create!(name: "#{prefix} Patient", date_of_birth: 10.years.ago.to_date),
+      relationship_type: 'parent'
+    )
+  end
+
+  def rls_household(label)
+    described_class.create!(name: "RLS #{label} Household", slug: "rls-#{label.parameterize}")
+  end
+
   it 'configures the runtime role without superuser or bypassrls' do
     role = connection.select_one(<<~SQL.squish)
       SELECT rolsuper, rolbypassrls
@@ -157,6 +169,56 @@ RSpec.describe Household do
     with_runtime_role(household: household) do
       expect(Location.where(id: [visible_location.id,
                                  hidden_location.id]).pluck(:id)).to contain_exactly(visible_location.id)
+    end
+  end
+
+  it 'isolates carer relationships by current household' do
+    household = described_class.create!(name: 'RLS Relationship Household', slug: 'rls-relationship-household')
+    other_household = described_class.create!(name: 'RLS Hidden Relationship Household',
+                                              slug: 'rls-hidden-relationship-household')
+    visible_relationship = carer_relationship_for(household, prefix: 'Visible')
+    hidden_relationship = carer_relationship_for(other_household, prefix: 'Hidden')
+
+    with_runtime_role(household: household) do
+      expect(CarerRelationship.where(id: [visible_relationship.id, hidden_relationship.id]).pluck(:id))
+        .to contain_exactly(visible_relationship.id)
+    end
+  end
+
+  it 'rejects inserting a relationship for another household through the runtime role' do
+    household = rls_household('Insert')
+    other_household = rls_household('Foreign Insert')
+    foreign_relationship = carer_relationship_for(other_household, prefix: 'Foreign Insert')
+
+    with_runtime_role(household: household) do
+      expect do
+        connection.execute(<<~SQL.squish)
+          INSERT INTO carer_relationships
+            (household_id, carer_id, patient_id, relationship_type, active, created_at, updated_at)
+          VALUES
+            (#{foreign_relationship.household_id}, #{foreign_relationship.carer_id},
+             #{foreign_relationship.patient_id}, 'parent', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        SQL
+      end.to raise_error(ActiveRecord::StatementInvalid, /row-level security policy/)
+    end
+  end
+
+  it 'rejects moving a visible relationship to another household through the runtime role' do
+    household = rls_household('Update')
+    other_household = rls_household('Foreign Update')
+    visible_relationship = carer_relationship_for(household, prefix: 'Visible Update')
+    foreign_relationship = carer_relationship_for(other_household, prefix: 'Foreign Update')
+
+    with_runtime_role(household: household) do
+      expect do
+        connection.execute(<<~SQL.squish)
+          UPDATE carer_relationships
+          SET household_id = #{foreign_relationship.household_id},
+              carer_id = #{foreign_relationship.carer_id},
+              patient_id = #{foreign_relationship.patient_id}
+          WHERE id = #{visible_relationship.id}
+        SQL
+      end.to raise_error(ActiveRecord::StatementInvalid, /row-level security policy/)
     end
   end
 

--- a/spec/models/household_spec.rb
+++ b/spec/models/household_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Household do
+  describe 'associations' do
+    it { is_expected.to have_many(:carer_relationships).dependent(:restrict_with_error) }
+  end
+
   describe '.create_with_owner!' do
     subject(:household) do
       described_class.create_with_owner!(

--- a/spec/policies/carer_relationship_policy_spec.rb
+++ b/spec/policies/carer_relationship_policy_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe CarerRelationshipPolicy, type: :policy do
   let(:relationship) do
     CarerRelationship.create!(patient: patient, carer: carer, relationship_type: :carer)
   end
+  let(:other_household) { create(:household) }
+  let(:foreign_relationship) do
+    CarerRelationship.new(
+      household: other_household,
+      patient: household_policy_person(other_household, person_type: :minor, has_capacity: false),
+      carer: household_policy_person(other_household),
+      relationship_type: :carer
+    )
+  end
 
   it 'allows household managers to administer relationships in their household' do
     expect(policy_results(owner.fetch(:context), relationship,
@@ -21,6 +30,17 @@ RSpec.describe CarerRelationshipPolicy, type: :policy do
                             destroy?: true,
                             activate?: true,
                             assign_dependent?: true
+                          )
+  end
+
+  it 'allows only creation checks for a class-level relationship authorization' do
+    expect(policy_results(owner.fetch(:context), CarerRelationship,
+                          %i[create? new? update? destroy? activate?])).to eq(
+                            create?: true,
+                            new?: true,
+                            update?: false,
+                            destroy?: false,
+                            activate?: false
                           )
   end
 
@@ -40,6 +60,18 @@ RSpec.describe CarerRelationshipPolicy, type: :policy do
     expect(described_class.new(member.fetch(:context), relationship).destroy?).to be(false)
   end
 
+  it 'rejects records whose household ownership differs from the active household' do
+    expect(policy_results(owner.fetch(:context), foreign_relationship,
+                          %i[show? create? update? destroy? activate? assign_dependent?])).to eq(
+                            show?: false,
+                            create?: false,
+                            update?: false,
+                            destroy?: false,
+                            activate?: false,
+                            assign_dependent?: false
+                          )
+  end
+
   it 'scopes relationships to managers or granted patients' do
     relationship
     other = CarerRelationship.create!(
@@ -54,6 +86,22 @@ RSpec.describe CarerRelationshipPolicy, type: :policy do
 
     expect(manager_scope).to include(relationship, other)
     expect(member_scope).to contain_exactly(relationship)
+  end
+
+  it 'excludes relationships owned by another household from every scope' do
+    other_household = create(:household)
+    foreign_relationship = CarerRelationship.create!(
+      household: other_household,
+      patient: household_policy_person(other_household, person_type: :minor, has_capacity: false),
+      carer: household_policy_person(other_household),
+      relationship_type: :carer
+    )
+
+    manager_scope = described_class::Scope.new(owner.fetch(:context), CarerRelationship.all).resolve
+    member_scope = described_class::Scope.new(member.fetch(:context), CarerRelationship.all).resolve
+
+    expect(manager_scope).not_to include(foreign_relationship)
+    expect(member_scope).not_to include(foreign_relationship)
   end
 
   def policy_results(context, record, actions)


### PR DESCRIPTION
## Summary

Care relationships used to infer tenancy indirectly through their carer and patient endpoints. They now carry explicit household ownership, with the same household boundary enforced consistently by Rails validations, composite PostgreSQL foreign keys, tenant-scoped uniqueness, and row-level security.

Fresh schema loads preserve the same RLS contract as migrated databases, and authorization scopes relationships directly through their owning household while keeping class-level creation checks fail-closed for mutation actions.

## Risks / follow-ups

Transactional assign/revoke orchestration is deliberately reserved for PR3 so this change stays focused on ownership and invariants.

The migration is reversible, but the repository has no task-wrapped rollback command for an automated down/up smoke.