### PR TITLE
feat(care): centralize delegation workflows

### DIFF
--- a/app/controllers/admin/carer_relationships_controller.rb
+++ b/app/controllers/admin/carer_relationships_controller.rb
@@ -5,13 +5,17 @@ module Admin
   class CarerRelationshipsController < BaseController
     def index
       authorize CarerRelationship
+      render_index
+    end
+
+    def render_index(status: :ok)
       relationships = Admin::CarerRelationshipsIndexQuery.new(scope: policy_scope(CarerRelationship)).call
       @pagy, relationships = pagy(:offset, relationships)
       render Components::Admin::CarerRelationships::IndexView.new(
         relationships: relationships,
         current_user: current_user,
         pagy: @pagy
-      )
+      ), status: status
     end
 
     def new
@@ -44,8 +48,7 @@ module Admin
       options = carer_relationship_options
 
       respond_to do |format|
-        if @relationship.save
-          grant_relationship_access(@relationship)
+        if assign_relationship
           format.html { redirect_to admin_carer_relationships_path, notice: t('admin.carer_relationships.created') }
           format.turbo_stream do
             flash.now[:notice] = t('admin.carer_relationships.created')
@@ -86,8 +89,7 @@ module Admin
       @relationship = policy_scope(CarerRelationship).find(params.expect(:id))
       authorize @relationship
 
-      @relationship.deactivate!
-      revoke_relationship_access(@relationship)
+      CareDelegation::Revoke.new(relationship: @relationship).call
       respond_to do |format|
         format.html { redirect_to admin_carer_relationships_path, notice: t('admin.carer_relationships.deactivated') }
         format.turbo_stream do
@@ -95,14 +97,20 @@ module Admin
           render turbo_stream: relationship_row_streams(@relationship)
         end
       end
+    rescue CareDelegation::Revoke::Error => e
+      render_delegation_error(e.message)
     end
 
     def activate
       @relationship = policy_scope(CarerRelationship).find(params.expect(:id))
       authorize @relationship
 
-      @relationship.activate!
-      grant_relationship_access(@relationship)
+      @relationship = CareDelegation::Assign.new(
+        carer: @relationship.carer,
+        patient: @relationship.patient,
+        relationship_type: @relationship.relationship_type,
+        granted_by_membership: relationship_actor_membership(@relationship)
+      ).call
       respond_to do |format|
         format.html { redirect_to admin_carer_relationships_path, notice: t('admin.carer_relationships.activated') }
         format.turbo_stream do
@@ -110,6 +118,8 @@ module Admin
           render turbo_stream: relationship_row_streams(@relationship)
         end
       end
+    rescue CareDelegation::Assign::Error => e
+      render_delegation_error(e.message)
     end
 
     private
@@ -132,71 +142,35 @@ module Admin
       ]
     end
 
-    def grant_relationship_access(relationship)
-      household = admin_household
-      return unless household && relationship.carer.account
-
-      relationship.carer.update!(household: household) if relationship.carer.household_id.blank?
-      return unless relationship.carer.household_id == household.id
-
-      membership = household.household_memberships.find_or_initialize_by(account: relationship.carer.account)
-      membership.person = relationship.carer
-      membership.role ||= :member
-      membership.status = :active
-      membership.save!
-
-      grant_access(household, membership, relationship.carer, :manage, :self)
-      grant_access(
-        household,
-        membership,
-        relationship.patient,
-        access_level_for(relationship.relationship_type),
-        grant_relationship_type_for(relationship.relationship_type)
-      )
+    def assign_relationship
+      @relationship = CareDelegation::Assign.new(
+        carer: @relationship.carer,
+        patient: @relationship.patient,
+        relationship_type: @relationship.relationship_type,
+        granted_by_membership: relationship_actor_membership(@relationship)
+      ).call
+      true
+    rescue ActiveRecord::RecordInvalid => e
+      @relationship = e.record if e.record.is_a?(CarerRelationship)
+      @relationship.errors.add(:base, e.message) if @relationship.errors.empty?
+      false
+    rescue CareDelegation::Assign::Error => e
+      @relationship.errors.add(:base, e.message)
+      false
     end
 
-    def revoke_relationship_access(relationship)
-      household = admin_household
-      return unless household && relationship.carer.account
-
-      membership = household.household_memberships.find_by(account: relationship.carer.account)
-      return unless membership
-
-      household.person_access_grants.active.find_by(
-        household_membership: membership,
-        person: relationship.patient
-      )&.update!(revoked_at: Time.current)
+    def render_delegation_error(message)
+      flash.now[:alert] = message
+      respond_to do |format|
+        format.html { render_index(status: :unprocessable_content) }
+        format.turbo_stream do
+          render turbo_stream: relationship_row_streams(@relationship), status: :unprocessable_content
+        end
+      end
     end
 
-    def grant_access(household, membership, person, access_level, relationship_type)
-      grant = household.person_access_grants.find_or_initialize_by(
-        household_membership: membership,
-        person: person
-      )
-      grant.access_level = access_level
-      grant.relationship_type = relationship_type
-      grant.granted_by_membership = current_membership || admin_membership_for(household) || membership
-      grant.revoked_at = nil
-      grant.save!
-    end
-
-    def admin_household
-      current_household || current_account&.first_active_household
-    end
-
-    def admin_membership_for(household)
-      current_membership || current_account&.active_household_membership_for(household)
-    end
-
-    def access_level_for(relationship_type)
-      relationship_type == 'professional_carer' ? :record : :manage
-    end
-
-    def grant_relationship_type_for(relationship_type)
-      return :professional if relationship_type == 'professional_carer'
-      return :parent if relationship_type == 'parent'
-
-      :family_member
+    def relationship_actor_membership(relationship)
+      current_membership || current_account&.active_household_membership_for(relationship.household)
     end
   end
 end

--- a/app/controllers/api/v1/admin/person_access_grants_controller.rb
+++ b/app/controllers/api/v1/admin/person_access_grants_controller.rb
@@ -25,6 +25,11 @@ module Api
 
         def destroy
           grant = PersonAccessGrant.where(household: current_household).find(params.expect(:id))
+          if grant.carer_relationship
+            grant.errors.add(:base, 'Relationship-owned grants must be revoked through their carer relationship')
+            return render_validation_errors(grant)
+          end
+
           grant.update!(revoked_at: Time.current)
           audit_admin_action!(event_type: 'api/admin/person_access_grant/revoked', target: grant, outcome: 'success')
           head :no_content

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -19,11 +19,9 @@ module Api
         person = Person.new(person_params)
         person.household = current_household
         authorize person
-        assign_created_person_carer_relationship(person)
 
-        return render_validation_errors(person) unless person.save
+        return render_validation_errors(person) unless persist_created_person(person)
 
-        grant_created_person_access(person)
         render_resource(person.reload, serializer: PersonSerializer, status: :created)
       end
 
@@ -53,14 +51,31 @@ module Api
         end
       end
 
-      def assign_created_person_carer_relationship(person)
-        return unless current_membership&.person.present? && (person.minor? || person.dependent_adult?)
+      def persist_created_person(person)
+        ActiveRecord::Base.transaction do
+          if auto_assign_created_person_carer_relationship?(person)
+            CareDelegation::Assign.new(
+              carer: current_membership.person,
+              patient: person,
+              relationship_type: :family_member,
+              granted_by_membership: current_membership
+            ).call
+          else
+            person.save!
+            grant_created_person_access(person)
+          end
+        end
+        true
+      rescue ActiveRecord::RecordInvalid => e
+        person.errors.merge!(e.record.errors) unless e.record == person
+        false
+      rescue CareDelegation::Assign::Error => e
+        person.errors.add(:base, e.message)
+        false
+      end
 
-        person.carer_relationships.build(
-          carer: current_membership.person,
-          relationship_type: :family_member,
-          active: true
-        )
+      def auto_assign_created_person_carer_relationship?(person)
+        current_membership&.person.present? && (person.minor? || person.dependent_adult?)
       end
     end
   end

--- a/app/controllers/people/carer_relationships_controller.rb
+++ b/app/controllers/people/carer_relationships_controller.rb
@@ -20,6 +20,8 @@ module People
       else
         create_parent_assignment
       end
+    rescue CareDelegation::Assign::Error => e
+      render_invalid_assignment(e.message)
     end
 
     private
@@ -35,13 +37,13 @@ module People
         return
       end
 
-      relationships = DependentRelationshipAssigner.new(
+      DependentRelationshipAssigner.new(
         carer: carer,
         dependent_ids: [@patient.id],
         relationship_type: admin_assignment_params[:relationship_type],
-        scope: @patient.household.people
+        scope: @patient.household.people,
+        granted_by_membership: current_membership
       ).call
-      grant_assignment_access(carer.user, relationships, admin_assignment_params[:relationship_type])
       redirect_to @patient, notice: t('people.carer_relationships.created')
     end
 
@@ -58,13 +60,13 @@ module People
     end
 
     def assign_existing_user(user)
-      relationships = DependentRelationshipAssigner.new(
+      DependentRelationshipAssigner.new(
         carer: user.person,
         dependent_ids: [@patient.id],
         relationship_type: 'parent',
-        scope: @patient.household.people
+        scope: @patient.household.people,
+        granted_by_membership: current_membership
       ).call
-      grant_assignment_access(user, relationships, 'parent')
       redirect_to @patient, notice: t('people.carer_relationships.created')
     end
 
@@ -151,62 +153,6 @@ module People
     rescue ActiveRecord::RecordInvalid => e
       invitation.errors.merge!(e.record.errors) unless e.record == invitation
       false
-    end
-
-    def grant_assignment_access(user, relationships, legacy_relationship_type)
-      person = assignment_person_for(user)
-      return unless person
-
-      membership = assignment_membership_for(user, person)
-      grant_access(membership, person, :manage, :self)
-      relationships.each do |relationship|
-        grant_access(
-          membership,
-          relationship.patient,
-          access_level_for(legacy_relationship_type),
-          grant_relationship_type_for(legacy_relationship_type)
-        )
-      end
-    end
-
-    def assignment_person_for(user)
-      return unless current_household && user&.person&.account
-
-      person = user.person
-      person.update!(household: current_household) if person.household_id.blank?
-      person if person.household_id == current_household.id
-    end
-
-    def assignment_membership_for(_user, person)
-      membership = current_household.household_memberships.find_or_initialize_by(account: person.account)
-      membership.person = person
-      membership.role = :member if membership.new_record?
-      membership.status = :active
-      membership.save!
-      membership
-    end
-
-    def grant_access(membership, person, access_level, relationship_type)
-      grant = current_household.person_access_grants.find_or_initialize_by(
-        household_membership: membership,
-        person: person
-      )
-      grant.access_level = access_level
-      grant.relationship_type = relationship_type
-      grant.granted_by_membership = current_membership || membership
-      grant.revoked_at = nil
-      grant.save!
-    end
-
-    def access_level_for(legacy_relationship_type)
-      legacy_relationship_type == 'professional_carer' ? :record : :manage
-    end
-
-    def grant_relationship_type_for(legacy_relationship_type)
-      return :professional if legacy_relationship_type == 'professional_carer'
-      return :parent if legacy_relationship_type == 'parent'
-
-      :family_member
     end
 
     def parent_user_by_email

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -51,17 +51,8 @@ class PeopleController < ApplicationController
     authorize @person
     @person.primary_location = primary_location
 
-    if auto_assign_created_person_carer_relationship?
-      @person.carer_relationships.build(
-        carer: current_membership.person,
-        relationship_type: :family_member,
-        active: true
-      )
-    end
-
     respond_to do |format|
-      if @person.save
-        grant_created_person_access
+      if persist_created_person
         format.html { redirect_to @person, notice: t('people.created') }
         format.turbo_stream do
           flash.now[:notice] = t('people.created')
@@ -135,6 +126,29 @@ class PeopleController < ApplicationController
   end
 
   private
+
+  def persist_created_person
+    ActiveRecord::Base.transaction do
+      if auto_assign_created_person_carer_relationship?
+        CareDelegation::Assign.new(
+          carer: current_membership.person,
+          patient: @person,
+          relationship_type: :family_member,
+          granted_by_membership: current_membership
+        ).call
+      else
+        @person.save!
+        grant_created_person_access
+      end
+    end
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    @person.errors.merge!(e.record.errors) unless e.record == @person
+    false
+  rescue CareDelegation::Assign::Error => e
+    @person.errors.add(:base, e.message)
+    false
+  end
 
   def destroy_person
     if MedicationAdministrationHistory.exists_for?(@person)

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -280,28 +280,33 @@ class RodauthMain < Rodauth::Rails::Auth
 
       def apply_household_invitation_grants!(membership, person, invitation)
         invitation.household_invitation_grants.find_each do |grant|
-          invitation.household.person_access_grants.create!(
-            household_membership: membership,
-            person: grant.person,
-            access_level: grant.access_level,
-            relationship_type: grant.relationship_type,
-            expires_at: grant.expires_at,
-            granted_by_membership: invitation.invited_by_membership
-          )
-          assign_invited_dependent_relationship!(person, grant)
+          apply_household_invitation_grant!(membership, person, invitation, grant)
         end
       end
 
-      def assign_invited_dependent_relationship!(person, grant)
+      def apply_household_invitation_grant!(membership, person, invitation, grant)
         relationship_type = carer_relationship_type_for_invitation_grant(grant.relationship_type)
-        return unless relationship_type
+        return create_invitation_manual_grant!(membership, invitation, grant) unless relationship_type
 
-        DependentRelationshipAssigner.new(
+        CareDelegation::Assign.new(
           carer: person,
-          dependent_ids: [grant.person_id],
+          patient: grant.person,
           relationship_type: relationship_type,
-          scope: grant.household.people
+          access_level: grant.access_level,
+          expires_at: grant.expires_at,
+          granted_by_membership: invitation.invited_by_membership
         ).call
+      end
+
+      def create_invitation_manual_grant!(membership, invitation, grant)
+        invitation.household.person_access_grants.create!(
+          household_membership: membership,
+          person: grant.person,
+          access_level: grant.access_level,
+          relationship_type: grant.relationship_type,
+          expires_at: grant.expires_at,
+          granted_by_membership: invitation.invited_by_membership
+        )
       end
 
       def carer_relationship_type_for_invitation_grant(relationship_type)

--- a/app/models/carer_relationship.rb
+++ b/app/models/carer_relationship.rb
@@ -8,6 +8,7 @@ class CarerRelationship < ApplicationRecord
   belongs_to :household
   belongs_to :carer, class_name: 'Person', inverse_of: :patient_relationships
   belongs_to :patient, class_name: 'Person', inverse_of: :carer_relationships
+  has_many :person_access_grants, dependent: :destroy
 
   # Audit trail for carer assignments and removals
   # Important for safeguarding: tracks who has access to patient records
@@ -22,14 +23,6 @@ class CarerRelationship < ApplicationRecord
   validate :endpoints_belong_to_household
 
   scope :active, -> { where(active: true) }
-
-  def deactivate!
-    update!(active: false)
-  end
-
-  def activate!
-    update!(active: true)
-  end
 
   private
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -104,22 +104,18 @@ class Person < ApplicationRecord
   end
 
   def assign_carer!(carer, relationship_type: nil)
-    transaction do
-      relationship = carer_relationships.find_or_initialize_by(carer: carer)
-      relationship.relationship_type = relationship_type.presence ||
-                                       relationship.relationship_type.presence ||
-                                       'family_member'
-      relationship.active = true
-      relationship.save!
-
-      relationship
-    end
+    existing_relationship = carer_relationships.find_by(carer: carer)
+    CareDelegation::Assign.new(
+      carer: carer,
+      patient: self,
+      relationship_type: relationship_type.presence || existing_relationship&.relationship_type || 'family_member'
+    ).call
   end
 
   def remove_carer!(carer)
     transaction do
       relationship = carer_relationships.find_by!(carer: carer, active: true)
-      relationship.deactivate!
+      CareDelegation::Revoke.new(relationship: relationship).call
       carer_relationships.reset
       active_carer_relationships.reset
       validate!

--- a/app/models/person_access_grant.rb
+++ b/app/models/person_access_grant.rb
@@ -11,6 +11,7 @@ class PersonAccessGrant < ApplicationRecord
   belongs_to :household_membership
   belongs_to :person
   belongs_to :granted_by_membership, class_name: 'HouseholdMembership', optional: true
+  belongs_to :carer_relationship, optional: true
 
   enum :access_level, { view: 'view', record: 'record', manage: 'manage' }, validate: true
   enum :relationship_type,
@@ -18,7 +19,11 @@ class PersonAccessGrant < ApplicationRecord
        validate: true
 
   validates :household_membership_id, uniqueness: { scope: :person_id, conditions: -> { where(revoked_at: nil) } }
-  validate :linked_records_must_belong_to_household
+  validate :membership_must_belong_to_household
+  validate :person_must_belong_to_household
+  validate :relationship_must_belong_to_household
+  validate :grantor_must_belong_to_household
+  validate :delegation_must_match_relationship
 
   scope :active, -> { where(revoked_at: nil).where('expires_at IS NULL OR expires_at > ?', Time.current) }
 
@@ -26,16 +31,42 @@ class PersonAccessGrant < ApplicationRecord
     ACCESS_LEVEL_ORDER.fetch(access_level) >= ACCESS_LEVEL_ORDER.fetch(requested_access_level.to_s)
   end
 
+  def cover_expiry?(requested_expires_at)
+    return expires_at.nil? if requested_expires_at.nil?
+
+    expires_at.nil? || expires_at >= requested_expires_at
+  end
+
   private
 
-  def linked_records_must_belong_to_household
-    if household_membership&.household_id != household_id
-      errors.add(:household_membership,
-                 'must belong to the same household')
-    end
+  def membership_must_belong_to_household
+    return if household_membership&.household_id == household_id
+
+    errors.add(:household_membership, 'must belong to the same household')
+  end
+
+  def person_must_belong_to_household
     errors.add(:person, 'must belong to the same household') if person&.household_id != household_id
+  end
+
+  def relationship_must_belong_to_household
+    return if carer_relationship.blank? || carer_relationship.household_id == household_id
+
+    errors.add(:carer_relationship, 'must belong to the same household')
+  end
+
+  def grantor_must_belong_to_household
     return if granted_by_membership.blank? || granted_by_membership.household_id == household_id
 
     errors.add(:granted_by_membership, 'must belong to the same household')
+  end
+
+  def delegation_must_match_relationship
+    return unless carer_relationship
+
+    errors.add(:person, 'must match the delegated patient') if person_id != carer_relationship.patient_id
+    return if household_membership&.person_id == carer_relationship.carer_id
+
+    errors.add(:household_membership, 'must belong to the delegated carer')
   end
 end

--- a/app/services/admin/user_provisioner.rb
+++ b/app/services/admin/user_provisioner.rb
@@ -20,6 +20,9 @@ module Admin
     rescue ActiveRecord::RecordInvalid => e
       copy_account_email_errors(e.record)
       Result.new(false, user, :invalid_record)
+    rescue CareDelegation::Assign::InvalidAccessLevel
+      user.errors.add(:dependent_access_level, :inclusion)
+      Result.new(false, user, :invalid_access_level)
     end
 
     private
@@ -61,7 +64,7 @@ module Admin
         save_user!(account)
         membership = create_membership!(account)
         grant_person_access!(membership, user.person, :manage, :self)
-        assign_dependents!(membership)
+        assign_dependents!
       end
     end
 
@@ -90,18 +93,17 @@ module Admin
       )
     end
 
-    def assign_dependents!(membership)
+    def assign_dependents!
       return if carer_relationship_type.blank?
 
-      relationships = DependentRelationshipAssigner.new(
+      DependentRelationshipAssigner.new(
         carer: user.person,
         dependent_ids: user.dependent_ids,
         relationship_type: carer_relationship_type,
-        scope: dependent_assignment_scope
+        access_level: user.dependent_access_level,
+        scope: dependent_assignment_scope,
+        granted_by_membership: actor_membership
       ).call
-      relationships.each do |relationship|
-        grant_person_access!(membership, relationship.patient, dependent_access_level, dependent_relationship_type)
-      end
     end
 
     def dependent_assignment_scope
@@ -129,13 +131,6 @@ module Admin
       return requested_role if MembershipRoleUpdater::ALLOWED_ROLES.include?(requested_role)
 
       requested_role || 'member'
-    end
-
-    def dependent_access_level
-      requested_level = user.dependent_access_level.presence
-      return requested_level if PersonAccessGrant.access_levels.key?(requested_level)
-
-      dependent_relationship_type == 'parent' ? :manage : :record
     end
 
     def dependent_relationship_type

--- a/app/services/care_delegation/assign.rb
+++ b/app/services/care_delegation/assign.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module CareDelegation
+  class Assign
+    class Error < StandardError; end
+    class GrantConflict < Error; end
+    class InvalidAccessLevel < Error; end
+    class InvalidRelationshipType < Error; end
+
+    GRANT_ATTRIBUTES = {
+      'family_member' => %i[manage family_member],
+      'parent' => %i[manage parent],
+      'professional_carer' => %i[record professional],
+      'self' => %i[manage self]
+    }.freeze
+
+    def initialize(carer:, patient:, relationship_type:, **options)
+      @carer = carer
+      @patient = patient
+      @relationship_type = relationship_type.to_s
+      @access_level = options[:access_level]&.to_s
+      @granted_by_membership = options[:granted_by_membership]
+      @expires_at = options[:expires_at]
+    end
+
+    def call
+      ActiveRecord::Base.transaction(requires_new: true) do
+        access_level, grant_relationship_type = grant_attributes
+        patient.household.lock!
+        relationship = persist_relationship!
+        membership = persist_membership!(relationship.household)
+        if membership
+          persist_self_grant!(membership)
+          persist_patient_grant!(relationship, membership, access_level, grant_relationship_type) unless
+            self_relationship?(relationship)
+        end
+        relationship
+      end
+    end
+
+    private
+
+    attr_reader :carer, :patient, :relationship_type, :access_level, :granted_by_membership, :expires_at
+
+    def persist_relationship!
+      relationship = CarerRelationship.find_or_initialize_by(
+        household: patient&.household,
+        carer: carer,
+        patient: patient
+      )
+      relationship.relationship_type = relationship_type
+      relationship.active = true
+      relationship.save! if relationship.new_record? || relationship.changed?
+      relationship
+    end
+
+    def persist_membership!(household)
+      account = carer&.account
+      return unless account
+
+      membership = household.household_memberships.find_or_initialize_by(account: account)
+      persist_membership_record!(membership)
+      membership
+    end
+
+    def persist_membership_record!(membership)
+      membership.person = carer
+      membership.role = :member if membership.role.blank?
+      membership.status = :active
+      membership.save! if membership.new_record? || membership.changed?
+    end
+
+    def persist_self_grant!(membership)
+      grant = self_grant(membership)
+      grant.assign_attributes(access_level: :manage, relationship_type: :self, expires_at: nil, revoked_at: nil,
+                              carer_relationship: nil)
+      grant.granted_by_membership ||= granted_by_membership || membership
+      persist_changed!(grant)
+    end
+
+    def persist_patient_grant!(relationship, membership, required_access_level, grant_relationship_type)
+      grant = available_patient_grant(membership)
+      return preserve_manual_grant!(grant, required_access_level) if manual_grant?(grant, relationship)
+
+      grant ||= owned_patient_grant(relationship, membership)
+      assign_patient_grant(grant, membership, required_access_level, grant_relationship_type)
+      persist_changed!(grant)
+    end
+
+    def available_patient_grant(membership)
+      grant = unrevoked_grant(membership, patient)
+      return grant unless grant_expired?(grant)
+
+      retire_expired_grant!(grant)
+      nil
+    end
+
+    def manual_grant?(grant, relationship)
+      grant && grant.carer_relationship_id != relationship.id
+    end
+
+    def self_relationship?(relationship)
+      relationship.carer_id == relationship.patient_id && relationship.relationship_type == 'self'
+    end
+
+    def owned_patient_grant(relationship, membership)
+      relationship.person_access_grants
+                  .where(household_membership: membership, person: patient)
+                  .order(id: :desc).first ||
+        relationship.person_access_grants.build(
+          household: relationship.household,
+          household_membership: membership,
+          person: patient
+        )
+    end
+
+    def assign_patient_grant(grant, membership, required_access_level, grant_relationship_type)
+      grant.assign_attributes(
+        access_level: required_access_level,
+        relationship_type: grant_relationship_type,
+        granted_by_membership: granted_by_membership || membership,
+        expires_at: expires_at,
+        revoked_at: nil
+      )
+    end
+
+    def self_grant(membership)
+      active_grant(membership, carer) || latest_grant(membership, carer) ||
+        membership.person_access_grants.build(household: membership.household, person: carer)
+    end
+
+    def persist_changed!(grant)
+      grant.save! if grant.new_record? || grant.changed?
+    end
+
+    def preserve_manual_grant!(grant, required_access_level)
+      return if grant.cover_access?(required_access_level) && grant.cover_expiry?(expires_at)
+
+      raise GrantConflict, 'existing manual grant does not cover the delegated access level'
+    end
+
+    def active_grant(membership, grant_person)
+      membership.person_access_grants.active.lock.find_by(person: grant_person)
+    end
+
+    def unrevoked_grant(membership, grant_person)
+      membership.person_access_grants.where(person: grant_person, revoked_at: nil).lock.first
+    end
+
+    def retire_expired_grant!(grant)
+      grant.update!(revoked_at: Time.current)
+    end
+
+    def grant_expired?(grant)
+      grant&.expires_at.present? && grant.expires_at <= Time.current
+    end
+
+    def latest_grant(membership, grant_person)
+      membership.person_access_grants.where(person: grant_person).order(id: :desc).first
+    end
+
+    def grant_attributes
+      default_access_level, grant_relationship_type = GRANT_ATTRIBUTES.fetch(relationship_type) do
+        raise InvalidRelationshipType, "unsupported carer relationship type: #{relationship_type}"
+      end
+      [resolved_access_level(default_access_level), grant_relationship_type]
+    end
+
+    def resolved_access_level(default_access_level)
+      return default_access_level if access_level.blank?
+      return access_level if PersonAccessGrant.access_levels.key?(access_level)
+
+      raise InvalidAccessLevel, "unsupported access level: #{access_level}"
+    end
+  end
+end

--- a/app/services/care_delegation/revoke.rb
+++ b/app/services/care_delegation/revoke.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CareDelegation
+  class Revoke
+    class Error < StandardError; end
+    class AmbiguousGrant < Error; end
+
+    def initialize(relationship:)
+      @relationship = relationship
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        relationship.lock!
+        revoke_delegated_access! unless self_relationship?
+        relationship.update!(active: false) if relationship.active?
+        relationship
+      end
+    end
+
+    private
+
+    attr_reader :relationship
+
+    def self_relationship?
+      relationship.carer_id == relationship.patient_id && relationship.relationship_type == 'self'
+    end
+
+    def revoke_delegated_access!
+      raise_if_unowned_grant_authorizes!
+      relationship.person_access_grants.where(revoked_at: nil).lock.find_each do |grant|
+        grant.update!(revoked_at: Time.current)
+      end
+    end
+
+    def raise_if_unowned_grant_authorizes!
+      membership = relationship.household.household_memberships.find_by(person: relationship.carer)
+      return unless membership
+
+      unowned_grants = membership.person_access_grants.active
+      return unless unowned_grants.exists?(person: relationship.patient, carer_relationship: nil)
+
+      raise AmbiguousGrant, 'an active unowned grant still authorizes this patient'
+    end
+  end
+end

--- a/app/services/dependent_relationship_assigner.rb
+++ b/app/services/dependent_relationship_assigner.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class DependentRelationshipAssigner
-  attr_reader :carer, :dependent_ids, :relationship_type, :scope
+  attr_reader :carer, :dependent_ids, :relationship_type, :access_level, :scope, :granted_by_membership
 
-  def initialize(carer:, dependent_ids:, relationship_type:, scope:)
+  def initialize(carer:, dependent_ids:, relationship_type:, scope:, **options)
     @carer = carer
     @dependent_ids = dependent_ids
     @relationship_type = relationship_type
+    @access_level = options[:access_level]
     @scope = scope
+    @granted_by_membership = options[:granted_by_membership]
   end
 
   def call
@@ -29,11 +31,13 @@ class DependentRelationshipAssigner
   end
 
   def assign(dependent)
-    relationship = CarerRelationship.find_or_initialize_by(carer: carer, patient: dependent)
-    relationship.relationship_type = resolved_relationship_type
-    relationship.active = true
-    relationship.save! if relationship.new_record? || relationship.changed?
-    relationship
+    CareDelegation::Assign.new(
+      carer: carer,
+      patient: dependent,
+      relationship_type: resolved_relationship_type,
+      access_level: access_level,
+      granted_by_membership: granted_by_membership
+    ).call
   end
 
   def resolved_relationship_type

--- a/app/services/fixture_household_setup.rb
+++ b/app/services/fixture_household_setup.rb
@@ -78,7 +78,8 @@ module FixtureHouseholdSetup
     person.active_patient_relationships.find_each do |relationship|
       grant_access(household: household, membership: membership, person: relationship.patient,
                    access_level: access_level_for_relationship(relationship),
-                   relationship_type: grant_relationship_type_for(relationship), grantor: owner_membership)
+                   relationship_type: grant_relationship_type_for(relationship), grantor: owner_membership,
+                   carer_relationship: relationship)
     end
   end
 
@@ -101,9 +102,13 @@ module FixtureHouseholdSetup
     person = attributes.fetch(:person)
 
     grant = household.person_access_grants.find_or_initialize_by(household_membership: membership, person: person)
-    grant.access_level = attributes.fetch(:access_level)
-    grant.relationship_type = attributes.fetch(:relationship_type)
-    grant.granted_by_membership = attributes.fetch(:grantor)
+    carer_relationship = attributes[:carer_relationship] if grant.new_record?
+    grant.assign_attributes(
+      access_level: attributes.fetch(:access_level),
+      relationship_type: attributes.fetch(:relationship_type),
+      granted_by_membership: attributes.fetch(:grantor),
+      carer_relationship: carer_relationship || grant.carer_relationship
+    )
     grant.save!
   end
 

--- a/app/services/households/local_migrator.rb
+++ b/app/services/households/local_migrator.rb
@@ -55,9 +55,7 @@ module Households
 
     attr_reader :owner_email, :household_name, :apply
 
-    def dry_run_result(before_counts)
-      Result.new(applied: false, household: nil, before_counts: before_counts, after_counts: before_counts)
-    end
+    def dry_run_result(before_counts) = Result.new(false, nil, before_counts, before_counts)
 
     def validate_inputs!
       raise Error, 'OWNER_EMAIL is required' if owner_email.blank?
@@ -226,7 +224,8 @@ module Households
           person: relationship.patient,
           access_level: access_level_for_relationship(relationship),
           relationship_type: relationship_type_for_grant(relationship),
-          granted_by_membership: household.household_memberships.owner.active.first
+          granted_by_membership: household.household_memberships.owner.active.first,
+          carer_relationship: relationship
         )
       end
     end
@@ -240,17 +239,73 @@ module Households
       :family_member
     end
 
-    def upsert_grant(membership:, person:, access_level:, relationship_type:, granted_by_membership:)
-      grant = PersonAccessGrant.find_or_initialize_by(
-        household: membership.household,
-        household_membership: membership,
-        person: person,
-        revoked_at: nil
-      )
-      grant.access_level = access_level
-      grant.relationship_type = relationship_type
-      grant.granted_by_membership = granted_by_membership
-      grant.save!
+    def upsert_grant(membership:, person:, **attributes)
+      GrantReconciler.new(membership: membership, person: person, attributes: attributes).call
+    end
+
+    class GrantReconciler
+      def initialize(membership:, person:, attributes:)
+        @membership = membership
+        @person = person
+        @attributes = attributes
+      end
+
+      def call
+        grant = current_grant
+        return persist_new_grant!(grant, attributes) if grant.new_record?
+        return preserve_manual_grant!(grant, attributes) if grant.carer_relationship_id.nil?
+        return reconcile_relationship_grant!(grant, attributes) if same_relationship_source?(grant, attributes)
+
+        raise LocalMigrator::Error, 'existing grant belongs to another relationship'
+      end
+
+      private
+
+      attr_reader :membership, :person, :attributes
+
+      def current_grant
+        PersonAccessGrant.find_or_initialize_by(
+          household: membership.household,
+          household_membership: membership,
+          person: person,
+          revoked_at: nil
+        )
+      end
+
+      def persist_new_grant!(grant, attributes)
+        grant.assign_attributes(
+          authority_attributes(attributes).merge(
+            granted_by_membership: attributes[:granted_by_membership],
+            carer_relationship: attributes[:carer_relationship]
+          )
+        )
+        grant.save!
+        grant
+      end
+
+      def preserve_manual_grant!(grant, attributes)
+        return grant if grant.cover_access?(attributes[:access_level]) && grant.cover_expiry?(attributes[:expires_at])
+
+        raise LocalMigrator::Error, 'existing manual grant does not cover the migrated relationship access'
+      end
+
+      def reconcile_relationship_grant!(grant, attributes)
+        grant.assign_attributes(authority_attributes(attributes))
+        grant.save! if grant.changed?
+        grant
+      end
+
+      def same_relationship_source?(grant, attributes)
+        attributes[:carer_relationship] && grant.carer_relationship_id == attributes[:carer_relationship].id
+      end
+
+      def authority_attributes(attributes)
+        {
+          access_level: attributes[:access_level],
+          relationship_type: attributes[:relationship_type],
+          expires_at: attributes[:expires_at]
+        }
+      end
     end
   end
 end

--- a/app/services/portable_data/import_writer.rb
+++ b/app/services/portable_data/import_writer.rb
@@ -72,10 +72,18 @@ module PortableData
       grant = household.person_access_grants
                        .where(revoked_at: nil)
                        .find_or_initialize_by(household_membership: membership, person: person)
+      return if grant.carer_relationship && preserve_relationship_grant!(grant)
+
       grant.access_level = :manage
       grant.relationship_type ||= :family_member
       grant.granted_by_membership ||= membership
       grant.save!
+    end
+
+    def preserve_relationship_grant!(grant)
+      return true if grant.manage? && grant.expires_at.nil?
+
+      raise Importer::Error, 'relationship-owned access grant conflicts with imported manage access'
     end
 
     def import_location_memberships

--- a/db/migrate/20260713150000_add_carer_relationship_source_to_person_access_grants.rb
+++ b/db/migrate/20260713150000_add_carer_relationship_source_to_person_access_grants.rb
@@ -1,0 +1,23 @@
+class AddCarerRelationshipSourceToPersonAccessGrants < ActiveRecord::Migration[8.1]
+  FOREIGN_KEY_NAME = 'fk_person_access_grants_carer_relationship_household'
+
+  def up
+    add_reference :person_access_grants, :carer_relationship, index: false
+    add_index :person_access_grants,
+              %i[carer_relationship_id household_id],
+              name: 'idx_person_access_grants_on_delegation_household'
+    add_foreign_key :person_access_grants,
+                    :carer_relationships,
+                    column: %i[carer_relationship_id household_id],
+                    primary_key: %i[id household_id],
+                    validate: false,
+                    name: FOREIGN_KEY_NAME
+    validate_foreign_key :person_access_grants, name: FOREIGN_KEY_NAME
+  end
+
+  def down
+    remove_foreign_key :person_access_grants, name: FOREIGN_KEY_NAME
+    remove_index :person_access_grants, name: 'idx_person_access_grants_on_delegation_household'
+    remove_column :person_access_grants, :carer_relationship_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -880,6 +880,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
     t.string "relationship_type", null: false
     t.datetime "revoked_at"
     t.datetime "updated_at", null: false
+    t.bigint "carer_relationship_id"
+    t.index ["carer_relationship_id", "household_id"], name: "idx_person_access_grants_on_delegation_household"
     t.index ["granted_by_membership_id"], name: "index_person_access_grants_on_granted_by_membership_id"
     t.index ["household_id"], name: "index_person_access_grants_on_household_id"
     t.index ["household_membership_id", "person_id"], name: "idx_on_household_membership_id_person_id_6ddc5a2882", unique: true, where: "(revoked_at IS NULL)"
@@ -1149,6 +1151,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_130000) do
   add_foreign_key "oauth_grants", "people"
   add_foreign_key "people", "accounts", deferrable: :deferred
   add_foreign_key "people", "households"
+  add_foreign_key "person_access_grants", "carer_relationships", column: ["carer_relationship_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_person_access_grants_carer_relationship_household"
   add_foreign_key "person_access_grants", "household_memberships"
   add_foreign_key "person_access_grants", "household_memberships", column: "granted_by_membership_id"
   add_foreign_key "person_access_grants", "household_memberships", column: ["granted_by_membership_id", "household_id"], primary_key: ["id", "household_id"], name: "fk_person_access_grants_granted_by_membership_id_household"

--- a/spec/migrations/add_carer_relationship_source_to_person_access_grants_spec.rb
+++ b/spec/migrations/add_carer_relationship_source_to_person_access_grants_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260713150000_add_carer_relationship_source_to_person_access_grants')
+
+RSpec.describe AddCarerRelationshipSourceToPersonAccessGrants do
+  self.use_transactional_tests = false
+
+  let(:household) { Household.create!(name: "Provenance Migration Test #{SecureRandom.hex(4)}") }
+  let(:carer) { create_account_person('backfill-carer') }
+  let(:patient) { create(:person, household: household) }
+  let(:membership) do
+    household.household_memberships.create!(
+      account: carer.account,
+      person: carer,
+      role: :member,
+      status: :active
+    )
+  end
+  let(:relationship) do
+    CarerRelationship.create!(
+      household: household,
+      carer: carer,
+      patient: patient,
+      relationship_type: :parent,
+      active: true
+    )
+  end
+
+  before { ensure_migration_applied }
+
+  after do
+    ensure_migration_applied
+    cleanup_households
+  end
+
+  it 'leaves an exact legacy grant unowned because provenance cannot be inferred safely' do
+    migrate_down
+    grant = create_grant(access_level: :manage, relationship_type: :parent)
+
+    migrate_up
+
+    expect(grant.reload.carer_relationship_id).to be_nil
+  end
+
+  it 'does not classify inactive, revoked, or expired legacy grants' do
+    migrate_down
+    inactive_grant = create_legacy_grant(relationship_active: false)
+    revoked_grant = create_legacy_grant(revoked_at: 1.day.ago)
+    expired_grant = create_legacy_grant(expires_at: 1.day.ago)
+
+    migrate_up
+
+    expect([inactive_grant, revoked_grant, expired_grant].map { it.reload.carer_relationship_id }).to all(be_nil)
+  end
+
+  it 'supports structural rollback and reapplication' do
+    migrate_down
+    expect(PersonAccessGrant.column_names).not_to include('carer_relationship_id')
+
+    migrate_up
+    expect(PersonAccessGrant.column_names).to include('carer_relationship_id')
+  end
+
+  def create_account_person(prefix)
+    account = Account.create!(
+      email: "#{prefix}-#{SecureRandom.hex(4)}@example.com",
+      password_hash: BCrypt::Password.create('password'),
+      status: :verified
+    )
+    create(:person, household: household, account: account)
+  end
+
+  def create_grant(access_level:, relationship_type:)
+    household.person_access_grants.create!(
+      household_membership: membership,
+      person: patient,
+      access_level: access_level,
+      relationship_type: relationship_type,
+      granted_by_membership: membership
+    ).tap { relationship }
+  end
+
+  def create_legacy_grant(relationship_active: true, revoked_at: nil, expires_at: nil)
+    suffix = SecureRandom.hex(4)
+    legacy_carer = create_account_person("legacy-#{suffix}")
+    legacy_patient = create(:person, household: household)
+    legacy_membership = create_legacy_membership(legacy_carer)
+    create_legacy_relationship(legacy_carer, legacy_patient, relationship_active)
+    household.person_access_grants.create!(
+      household_membership: legacy_membership,
+      person: legacy_patient,
+      access_level: :manage,
+      relationship_type: :parent,
+      granted_by_membership: legacy_membership,
+      revoked_at: revoked_at,
+      expires_at: expires_at
+    )
+  end
+
+  def create_legacy_membership(legacy_carer)
+    household.household_memberships.create!(
+      account: legacy_carer.account,
+      person: legacy_carer,
+      role: :member,
+      status: :active
+    )
+  end
+
+  def create_legacy_relationship(legacy_carer, legacy_patient, relationship_active)
+    CarerRelationship.create!(
+      household: household,
+      carer: legacy_carer,
+      patient: legacy_patient,
+      relationship_type: :parent,
+      active: relationship_active
+    )
+  end
+
+  def migrate_down
+    described_class.new.migrate(:down)
+    PersonAccessGrant.reset_column_information
+  end
+
+  def migrate_up
+    described_class.new.migrate(:up)
+    PersonAccessGrant.reset_column_information
+  end
+
+  def ensure_migration_applied
+    return if PersonAccessGrant.connection.column_exists?(:person_access_grants, :carer_relationship_id)
+
+    migrate_up
+  end
+
+  def cleanup_households
+    Household.where("name LIKE 'Provenance Migration Test %'").find_each do |target_household|
+      cleanup_household(target_household)
+    end
+  end
+
+  def cleanup_household(target_household)
+    account_ids = target_household.household_memberships.pluck(:account_id) +
+                  target_household.people.pluck(:account_id).compact
+    [PersonAccessGrant, CarerRelationship, HouseholdMembership, LocationMembership, Location, Person].each do |model|
+      model.where(household: target_household).delete_all
+    end
+    target_household.delete
+    Account.where(id: account_ids).delete_all
+  end
+end

--- a/spec/models/carer_relationship_spec.rb
+++ b/spec/models/carer_relationship_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CarerRelationship do
     it { is_expected.to belong_to(:household) }
     it { is_expected.to belong_to(:carer).class_name('Person') }
     it { is_expected.to belong_to(:patient).class_name('Person') }
+    it { is_expected.to have_many(:person_access_grants).dependent(:destroy) }
   end
 
   describe 'factory' do
@@ -166,33 +167,12 @@ RSpec.describe CarerRelationship do
     end
   end
 
-  describe '#deactivate!' do
-    it 'sets active to false' do
-      relationship = described_class.create!(
-        carer: household.people.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
-        patient: household.people.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
-        relationship_type: 'parent',
-        active: true
-      )
+  describe 'lifecycle mutation boundary' do
+    it 'does not expose direct activation helpers' do
+      relationship = described_class.new
 
-      relationship.deactivate!
-
-      expect(relationship.reload.active).to be false
-    end
-  end
-
-  describe '#activate!' do
-    it 'sets active to true' do
-      relationship = described_class.create!(
-        carer: household.people.create!(name: 'Carer', date_of_birth: 30.years.ago, person_type: :adult),
-        patient: household.people.create!(name: 'Patient', date_of_birth: 5.years.ago, person_type: :adult),
-        relationship_type: 'parent',
-        active: false
-      )
-
-      relationship.activate!
-
-      expect(relationship.reload.active).to be true
+      expect(relationship).not_to respond_to(:activate!)
+      expect(relationship).not_to respond_to(:deactivate!)
     end
   end
 
@@ -250,7 +230,7 @@ RSpec.describe CarerRelationship do
       )
 
       expect do
-        relationship.deactivate!
+        relationship.update!(active: false)
       end.to change(PaperTrail::Version, :count).by(1)
 
       version = relationship.versions.last

--- a/spec/models/person_access_grant_spec.rb
+++ b/spec/models/person_access_grant_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe PersonAccessGrant do
     expect(grant.cover_access?(:manage)).to be(false)
   end
 
+  it 'treats an indefinite expiry as the only coverage for indefinite authority' do
+    household, membership = household_bundle
+    grant = create_grant_for(household, membership, 'Expiry Target')
+
+    expect(grant.cover_expiry?(nil)).to be(true)
+    grant.expires_at = 2.days.from_now
+    expect(grant.cover_expiry?(nil)).to be(false)
+    expect(grant.cover_expiry?(1.day.from_now)).to be(true)
+    expect(grant.cover_expiry?(3.days.from_now)).to be(false)
+  end
+
   it 'excludes revoked and expired grants from active authorization' do
     household, membership = household_bundle
     active = create_grant_for(household, membership, 'Active Target')
@@ -102,5 +113,38 @@ RSpec.describe PersonAccessGrant do
 
     valid_grant = build_grant(household: household, membership: membership, person: person, grantor: nil)
     expect(valid_grant).to be_valid
+  end
+
+  it 'binds delegation-owned grants to the relationship carer and patient' do
+    household, membership, relationship = delegation_fixture
+    patient = grant_target_person(household, name: 'Delegated Patient')
+    other_patient = grant_target_person(household, name: 'Other Patient')
+    relationship.update!(patient: patient)
+    other_membership = other_carer_membership(household)
+
+    wrong_patient = build_grant(household: household, membership: membership, person: other_patient)
+    wrong_patient.carer_relationship = relationship
+    wrong_carer = build_grant(household: household, membership: other_membership, person: patient)
+    wrong_carer.carer_relationship = relationship
+
+    expect(wrong_patient).not_to be_valid
+    expect(wrong_patient.errors[:person]).to include('must match the delegated patient')
+    expect(wrong_carer).not_to be_valid
+    expect(wrong_carer.errors[:household_membership]).to include('must belong to the delegated carer')
+  end
+
+  def delegation_fixture
+    household, membership, carer = household_bundle
+    patient = grant_target_person(household, name: 'Initial Delegated Patient')
+    relationship = CarerRelationship.create!(household: household, carer: carer, patient: patient,
+                                             relationship_type: :parent)
+    [household, membership, relationship]
+  end
+
+  def other_carer_membership(household)
+    other_carer = grant_target_person(household, name: 'Other Carer')
+    account = Account.create!(email: "other-carer-#{SecureRandom.hex(4)}@example.test", status: :verified)
+    other_carer.update!(account: account)
+    household.household_memberships.create!(account: account, person: other_carer, role: :member, status: :active)
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe Person do
 
       it 'reactivates an existing inactive relationship' do
         relationship = patient.carer_relationships.find_by!(carer: carer)
-        relationship.deactivate!
+        relationship.update!(active: false)
 
         patient.assign_carer!(carer)
 

--- a/spec/requests/admin_create_update_turbo_spec.rb
+++ b/spec/requests/admin_create_update_turbo_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe 'Admin create and update turbo flows' do
 
     it 'keeps membership role separate from relationship access grants' do
       doctor = users(:doctor)
-      patient = people(:child_patient)
+      patient = create(:person, household: household, name: 'Professional Grant Patient')
 
       post admin_carer_relationships_path,
            params: {

--- a/spec/requests/admin_turbo_actions_spec.rb
+++ b/spec/requests/admin_turbo_actions_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe 'Admin turbo actions' do
 
   let(:admin) { users(:admin) }
 
-  before { sign_in(admin) }
+  before do
+    FixtureHouseholdSetup.apply!
+    sign_in(admin)
+  end
 
   describe 'POST /admin/users/:id/activate' do
     it 'returns turbo_stream and updates the user row and flash' do
@@ -104,11 +107,52 @@ RSpec.describe 'Admin turbo actions' do
       expect(response.body).to include('target="flash"')
       expect(relationship.reload).to be_active
     end
+
+    it 'returns unprocessable content when a manual grant conflicts with activation' do
+      relationship = carer_relationships(:inactive_relationship)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      relationship.household.person_access_grants.where(
+        household_membership: membership,
+        person: relationship.patient
+      ).delete_all
+      grant = relationship.household.person_access_grants.create!(
+        household_membership: membership,
+        person: relationship.patient,
+        access_level: :view,
+        relationship_type: :family_member,
+        granted_by_membership: membership
+      )
+
+      post activate_admin_carer_relationship_path(relationship), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include('existing manual grant')
+      expect(relationship.reload).not_to be_active
+      expect(grant.reload).to have_attributes(access_level: 'view', revoked_at: nil)
+    end
+
+    it 'returns unprocessable content for an unsupported legacy relationship type' do
+      relationship = carer_relationships(:inactive_relationship)
+      relationship.update!(relationship_type: 'guardian')
+
+      post activate_admin_carer_relationship_path(relationship), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include('unsupported carer relationship type')
+      expect(relationship.reload).not_to be_active
+    end
   end
 
   describe 'DELETE /admin/carer_relationships/:id' do
     it 'returns turbo_stream and updates the relationship row and flash' do
       relationship = carer_relationships(:jane_cares_for_child)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      relationship.household.person_access_grants.find_by!(
+        household_membership: membership,
+        person: relationship.patient
+      ).update!(carer_relationship: relationship)
 
       delete admin_carer_relationship_path(relationship), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
@@ -117,6 +161,24 @@ RSpec.describe 'Admin turbo actions' do
       expect(response.body).to include("target=\"carer_relationship_#{relationship.id}\"")
       expect(response.body).to include('target="flash"')
       expect(relationship.reload).not_to be_active
+    end
+
+    it 'returns unprocessable content without revoking an unowned grant' do
+      relationship = carer_relationships(:jane_cares_for_child)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      manual_grant = relationship.household.person_access_grants.find_by!(
+        household_membership: membership,
+        person: relationship.patient
+      )
+      manual_grant.update!(carer_relationship: nil)
+
+      delete admin_carer_relationship_path(relationship), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include('unowned grant')
+      expect(relationship.reload).to be_active
+      expect(manual_grant.reload.revoked_at).to be_nil
     end
   end
 end

--- a/spec/requests/api/v1/admin_api_spec.rb
+++ b/spec/requests/api/v1/admin_api_spec.rb
@@ -166,6 +166,28 @@ RSpec.describe 'API v1 household administration' do
     expect(PersonAccessGrant.find(grant_id)).to be_revoked_at
   end
 
+  it 'refuses to revoke relationship-owned person access grants' do
+    api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
+    household = Household.find(household_id)
+    carer_account = Account.create!(email: 'api.delegated.carer@example.test', status: :verified)
+    carer = create(:person, household: household, account: carer_account)
+    relationship = CareDelegation::Assign.new(
+      carer: carer,
+      patient: people(:john),
+      relationship_type: :parent,
+      granted_by_membership: api_session.household_membership
+    ).call
+    grant = relationship.person_access_grants.sole
+
+    delete api_v1_household_admin_person_access_grant_path(household_id, grant.id), headers: headers, as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig('error', 'errors', 'base'))
+      .to include('Relationship-owned grants must be revoked through their carer relationship')
+    expect(relationship.reload).to be_active
+    expect(grant.reload.revoked_at).to be_nil
+  end
+
   it 'returns validation errors for invalid person access grants and lists revoked timestamps' do
     api_session.update!(oidc_mfa_verified: true, mfa_verified_at: Time.current)
 

--- a/spec/requests/api/v1/people_controller_spec.rb
+++ b/spec/requests/api/v1/people_controller_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe Api::V1::PeopleController do
     end
   end
 
+  describe 'POST /api/v1/households/:household_id/people' do
+    it 'creates a dependent through the transactional care delegation workflow' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+
+      expect do
+        post api_v1_household_people_path(household_id),
+             params: {
+               person: {
+                 name: 'API Dependent',
+                 date_of_birth: 8.years.ago.to_date,
+                 person_type: 'minor'
+               }
+             },
+             headers: api_auth_headers(login_data.fetch('access_token')),
+             as: :json
+      end.to change(Person, :count).by(1).and change(CarerRelationship, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      person = Person.find_by!(name: 'API Dependent')
+      relationship = person.carer_relationships.sole
+      grant = person.person_access_grants.find_by!(household_membership: relationship.carer.household_membership)
+      expect(grant.carer_relationship).to eq(relationship)
+    end
+  end
+
   describe 'GET /api/v1/households/:household_id/people household grants' do
     it 'returns only people granted to the session membership inside the routed household' do
       account = user.person.account

--- a/spec/requests/api/v1/people_controller_spec.rb
+++ b/spec/requests/api/v1/people_controller_spec.rb
@@ -74,6 +74,32 @@ RSpec.describe Api::V1::PeopleController do
       grant = person.person_access_grants.find_by!(household_membership: relationship.carer.household_membership)
       expect(grant.carer_relationship).to eq(relationship)
     end
+
+    it 'returns nested delegation validation errors without creating the dependent' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      invalid_grant = PersonAccessGrant.new
+      invalid_grant.errors.add(:base, 'Delegated access is invalid')
+      assignment = instance_double(CareDelegation::Assign)
+      allow(CareDelegation::Assign).to receive(:new).and_return(assignment)
+      allow(assignment).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(invalid_grant))
+
+      expect do
+        post api_v1_household_people_path(household_id),
+             params: {
+               person: {
+                 name: 'Invalid API Dependent',
+                 date_of_birth: 8.years.ago.to_date,
+                 person_type: 'minor'
+               }
+             },
+             headers: api_auth_headers(login_data.fetch('access_token')),
+             as: :json
+      end.not_to change(Person, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body.dig('error', 'errors', 'base')).to include('Delegated access is invalid')
+    end
   end
 
   describe 'GET /api/v1/households/:household_id/people household grants' do

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -136,8 +136,40 @@ RSpec.describe 'Invitations' do
       expect(relationship.relationship_type).to eq('parent')
       expect(relationship.active).to be true
       expect(accepted_membership.role).to eq('member')
-      expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'parent')
+      expect(grant).to have_attributes(
+        access_level: 'manage',
+        relationship_type: 'parent',
+        carer_relationship: relationship
+      )
       expect(invitation.reload.accepted_at).to be_present
+    end
+
+    it 'preserves the access level selected for an accepted invitation' do
+      household, membership = household_bundle(email: 'view-owner@example.test', name: 'View Invitation')
+      dependent = create_dependent(household: household, name: 'View Invitation Child', carer: membership.person)
+      invitation = create_household_invitation_with_grant(
+        household: household,
+        membership: membership,
+        email: 'view.invitee@example.com',
+        dependent: dependent,
+        grant: { access_level: :view, relationship_type: :family_member }
+      )
+
+      post create_account_path,
+           params: {
+             invitation_token: invitation.token,
+             name: 'View Invitee',
+             date_of_birth: '1985-05-15',
+             email: 'view.invitee@example.com',
+             password: 'SecureP@ssword123!',
+             'password-confirm': 'SecureP@ssword123!'
+           }
+
+      invitee = Person.find_by!(email: 'view.invitee@example.com')
+      relationship = CarerRelationship.find_by!(carer: invitee, patient: dependent)
+      accepted_membership = household.household_memberships.find_by!(account: invitee.account)
+      expect(relationship.person_access_grants.find_by!(household_membership: accepted_membership))
+        .to have_attributes(access_level: 'view', relationship_type: 'family_member')
     end
 
     it 'links accepted carer invitations to selected existing dependents' do
@@ -170,7 +202,11 @@ RSpec.describe 'Invitations' do
       expect(relationship.relationship_type).to eq('professional_carer')
       expect(relationship.active).to be true
       expect(accepted_membership.role).to eq('member')
-      expect(grant).to have_attributes(access_level: 'record', relationship_type: 'professional')
+      expect(grant).to have_attributes(
+        access_level: 'record',
+        relationship_type: 'professional',
+        carer_relationship: relationship
+      )
       expect(invitation.reload.accepted_at).to be_present
     end
   end

--- a/spec/requests/people_carer_relationships_spec.rb
+++ b/spec/requests/people_carer_relationships_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe 'People carer relationships' do
       relationship = CarerRelationship.find_by!(carer: users(:jane).person, patient: people(:child_user_person))
       expect(relationship.relationship_type).to eq('family_member')
       expect(relationship.active).to be true
+      membership = relationship.household.household_memberships.find_by!(account: relationship.carer.account)
+      expect(membership.person_access_grants.find_by!(person: relationship.patient).carer_relationship)
+        .to eq(relationship)
       expect(response).to redirect_to(person_path(people(:child_user_person)))
     end
 
@@ -35,6 +38,39 @@ RSpec.describe 'People carer relationships' do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('Select an adult user to assign')
+    end
+
+    it 'preserves a weaker manual grant when an admin assignment conflicts with it' do
+      sign_in(users(:admin))
+      household = Household.find_by!(slug: default_request_household_slug)
+      admin_membership = household.household_memberships.find_by!(account: users(:admin).person.account)
+      jane = users(:jane).person
+      jane_membership = household.household_memberships.find_or_create_by!(account: jane.account, person: jane)
+      manual_grant = household.person_access_grants.create!(
+        household_membership: jane_membership,
+        person: people(:child_user_person),
+        access_level: :view,
+        relationship_type: :professional,
+        granted_by_membership: admin_membership
+      )
+
+      expect do
+        post person_carer_relationships_path(people(:child_user_person)),
+             params: {
+               carer_relationship: {
+                 carer_id: jane.id,
+                 relationship_type: 'family_member'
+               }
+             }
+      end.not_to change(CarerRelationship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(manual_grant.reload).to have_attributes(
+        access_level: 'view',
+        relationship_type: 'professional',
+        carer_relationship_id: nil,
+        revoked_at: nil
+      )
     end
 
     it 'allows an existing parent to link another parent by email for their child' do
@@ -85,11 +121,10 @@ RSpec.describe 'People carer relationships' do
       post person_carer_relationships_path(people(:child_user_person)),
            params: { carer_relationship: { email: users(:jane).email_address } }
 
-      expect(grant.reload).to have_attributes(
-        revoked_at: nil,
-        access_level: 'manage',
-        relationship_type: 'parent'
-      )
+      relationship = CarerRelationship.find_by!(carer: jane, patient: people(:child_user_person))
+      expect(grant.reload.revoked_at).to be_present
+      expect(relationship.person_access_grants.sole)
+        .to have_attributes(access_level: 'manage', relationship_type: 'parent', revoked_at: nil)
     end
 
     it 'creates a parent invitation when the second parent does not have an account' do

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe 'People' do
         grant = created_person.person_access_grants.find_by(household_membership: current_membership)
 
         expect(grant.access_level).to eq('manage')
+        expect(grant.carer_relationship).to eq(relationship)
       end
 
       it 'creates a dependent adult and auto-links carer relationship' do

--- a/spec/services/admin/user_provisioner_spec.rb
+++ b/spec/services/admin/user_provisioner_spec.rb
@@ -58,8 +58,29 @@ RSpec.describe Admin::UserProvisioner do
     expect(membership).to have_attributes(person: user.person, role: 'administrator', status: 'active')
     expect(grant_for(membership, user.person))
       .to have_attributes(access_level: 'manage', relationship_type: 'self')
+    relationship = CarerRelationship.find_by!(carer: user.person, patient: dependent)
     expect(grant_for(membership, dependent))
-      .to have_attributes(access_level: 'manage', relationship_type: 'parent')
+      .to have_attributes(access_level: 'manage', relationship_type: 'parent', carer_relationship: relationship)
+  end
+
+  it 'preserves the selected dependent access level' do
+    user.dependent_access_level = 'view'
+
+    expect(result).to be_success
+
+    membership = household.household_memberships.find_by!(account: user.person.account)
+    relationship = CarerRelationship.find_by!(carer: user.person, patient: dependent)
+    expect(grant_for(membership, dependent))
+      .to have_attributes(access_level: 'view', relationship_type: 'parent', carer_relationship: relationship)
+  end
+
+  it 'rejects an unsupported dependent access level without writing partial records' do
+    user.dependent_access_level = 'unsupported'
+
+    expect { result }.not_to(change { provisioned_record_counts })
+
+    expect(result).to have_attributes(success?: false, error: :invalid_access_level, user: user)
+    expect(user.errors[:dependent_access_level]).to include('is not included in the list')
   end
 
   it 'rejects duplicate accounts without writing partial records' do
@@ -88,5 +109,9 @@ RSpec.describe Admin::UserProvisioner do
 
   def grant_for(membership, person)
     household.person_access_grants.find_by!(household_membership: membership, person: person)
+  end
+
+  def provisioned_record_counts
+    [Account, User, HouseholdMembership, PersonAccessGrant, CarerRelationship].map(&:count)
   end
 end

--- a/spec/services/care_delegation/assign_concurrency_spec.rb
+++ b/spec/services/care_delegation/assign_concurrency_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'timeout'
+
+RSpec.describe CareDelegation::Assign do
+  self.use_transactional_tests = false
+
+  it 'serializes concurrent assignment at the household boundary' do
+    Household.where("name LIKE 'Concurrent Assignment %'").find_each { cleanup_household(it) }
+    records = concurrency_records
+    outcomes = concurrent_outcomes(records)
+
+    expect(outcomes).to all(be_a(Integer))
+    expect(outcomes.uniq.one?).to be(true)
+    expect_assignment_counts(records)
+  ensure
+    cleanup_household(records[:household]) if records
+  end
+
+  it 'fails promptly when a worker cannot acquire a database connection' do
+    records = concurrency_records
+    connection_pool = instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool)
+    allow(connection_pool).to receive(:with_connection).and_raise('connection unavailable')
+
+    expect { concurrent_outcomes(records, connection_pool: connection_pool) }
+      .to raise_error(RuntimeError, 'connection unavailable')
+  ensure
+    cleanup_household(records[:household]) if records
+  end
+
+  def concurrency_records
+    household = Household.create!(name: "Concurrent Assignment #{SecureRandom.hex(4)}")
+    carer_account = create_account('concurrent-carer')
+    actor_account = create_account('concurrent-actor')
+    carer = create(:person, household: household, account: carer_account)
+    patient = create(:person, household: household)
+    actor = create(:person, household: household, account: actor_account)
+    actor_membership = household.household_memberships.create!(
+      account: actor_account,
+      person: actor,
+      role: :owner,
+      status: :active
+    )
+    { household: household, carer: carer, patient: patient, actor_membership: actor_membership }
+  end
+
+  def concurrent_outcomes(records, connection_pool: ActiveRecord::Base.connection_pool)
+    queues = [Queue.new, Queue.new, Queue.new]
+    threads = build_assignment_threads(records, queues, connection_pool)
+    run_assignment_threads(threads, queues)
+  ensure
+    terminate_threads(threads)
+  end
+
+  def build_assignment_threads(records, queues, connection_pool)
+    ready, start, results = queues
+    2.times.map { assignment_thread(records, ready, start, results, connection_pool) }
+  end
+
+  def run_assignment_threads(threads, queues)
+    ready, start, results = queues
+    readiness = 2.times.map { wait_for_queue(ready, 'assignment workers') }
+    raise_worker_setup_error(readiness)
+    2.times { start << true }
+    threads.each { join_thread(it) }
+    2.times.map { wait_for_queue(results, 'assignment results') }
+  end
+
+  def raise_worker_setup_error(readiness)
+    error = readiness.find { it.is_a?(StandardError) }
+    raise error if error
+  end
+
+  def terminate_threads(threads)
+    Array(threads).each do |thread|
+      thread.kill if thread.alive?
+      thread.join(thread_timeout)
+    end
+  end
+
+  def assignment_thread(records, ready, start, results, connection_pool)
+    Thread.new do
+      ready_signaled = false
+      begin
+        connection_pool.with_connection do
+          ready << true
+          ready_signaled = true
+          wait_for_queue(start, 'assignment start')
+          results << assignment_result(records)
+        end
+      rescue StandardError => e
+        ready << e unless ready_signaled
+        results << e
+      end
+    end
+  end
+
+  def wait_for_queue(queue, description)
+    Timeout.timeout(thread_timeout) { queue.pop }
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for #{description}"
+  end
+
+  def join_thread(thread)
+    return if thread.join(thread_timeout)
+
+    raise Timeout::Error, 'timed out waiting for assignment worker completion'
+  end
+
+  def thread_timeout = 10
+
+  def assignment_result(records)
+    described_class.new(
+      carer: Person.find(records[:carer].id),
+      patient: Person.find(records[:patient].id),
+      relationship_type: :parent,
+      granted_by_membership: HouseholdMembership.find(records[:actor_membership].id)
+    ).call.id
+  end
+
+  def expect_assignment_counts(records)
+    scope = { household: records[:household], carer: records[:carer], patient: records[:patient] }
+    expect(CarerRelationship.where(scope).count).to eq(1)
+    expect(PersonAccessGrant.where(household: records[:household], person: records[:patient], revoked_at: nil).count)
+      .to eq(1)
+  end
+
+  def create_account(prefix)
+    Account.create!(
+      email: "#{prefix}-#{SecureRandom.hex(4)}@example.com",
+      password_hash: BCrypt::Password.create('password'),
+      status: :verified
+    )
+  end
+
+  def cleanup_household(household)
+    account_ids = household.household_memberships.pluck(:account_id) + household.people.pluck(:account_id).compact
+    [PersonAccessGrant, CarerRelationship, HouseholdMembership, LocationMembership, Location, Person].each do |model|
+      model.where(household: household).delete_all
+    end
+    Household.where(id: household.id).delete_all
+    Account.where(id: account_ids).delete_all
+  end
+end

--- a/spec/services/care_delegation/assign_spec.rb
+++ b/spec/services/care_delegation/assign_spec.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CareDelegation::Assign do
+  subject(:assign_delegation) { assigner.call }
+
+  def assigner
+    described_class.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'parent',
+      granted_by_membership: actor_membership
+    )
+  end
+
+  let(:household) { create(:household) }
+  let(:carer) { create_account_person(household, 'carer') }
+  let(:patient) { create(:person, household: household) }
+  let(:actor) { create_account_person(household, 'actor') }
+  let!(:actor_membership) { create_membership(actor, role: :owner) }
+
+  it 'atomically creates the relationship, membership, self grant, and patient grant' do
+    expect { assign_delegation }
+      .to change(CarerRelationship, :count).by(1)
+      .and change(HouseholdMembership, :count).by(1)
+      .and change(PersonAccessGrant, :count).by(2)
+
+    relationship = CarerRelationship.find_by!(carer: carer, patient: patient)
+    membership = household.household_memberships.find_by!(account: carer.account)
+    self_grant = membership.person_access_grants.find_by!(person: carer)
+    patient_grant = membership.person_access_grants.find_by!(person: patient)
+
+    expect_created_assignment(relationship, membership, self_grant, patient_grant)
+  end
+
+  it 'maps professional carers to record access with professional metadata' do
+    relationship = described_class.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'professional_carer',
+      granted_by_membership: actor_membership
+    ).call
+
+    grant = relationship.person_access_grants.sole
+    expect(grant).to have_attributes(access_level: 'record', relationship_type: 'professional')
+  end
+
+  it 'maps family relationships to manage access with family metadata' do
+    relationship = described_class.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'family_member',
+      granted_by_membership: actor_membership
+    ).call
+
+    grant = relationship.person_access_grants.sole
+    expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'family_member')
+  end
+
+  it 'uses an explicit access level without changing relationship metadata' do
+    relationship = described_class.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'family_member',
+      access_level: :view,
+      granted_by_membership: actor_membership
+    ).call
+
+    expect(relationship.person_access_grants.sole)
+      .to have_attributes(access_level: 'view', relationship_type: 'family_member')
+  end
+
+  it 'rejects an unsupported explicit access level without partial writes' do
+    original_counts = [CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]
+
+    expect do
+      described_class.new(
+        carer: carer,
+        patient: patient,
+        relationship_type: 'parent',
+        access_level: :administer,
+        granted_by_membership: actor_membership
+      ).call
+    end.to raise_error(CareDelegation::Assign::InvalidAccessLevel)
+
+    expect([CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]).to eq(original_counts)
+  end
+
+  it 'applies the delegated access expiry' do
+    expires_at = 2.days.from_now
+
+    relationship = described_class.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'parent',
+      granted_by_membership: actor_membership,
+      expires_at: expires_at
+    ).call
+
+    expect(relationship.person_access_grants.sole.expires_at).to be_within(1.second).of(expires_at)
+  end
+
+  it 'persists a new dependent through the same transactional assignment' do
+    new_patient = build(:person, :minor, household: household)
+
+    relationship = described_class.new(
+      carer: carer,
+      patient: new_patient,
+      relationship_type: 'family_member',
+      granted_by_membership: actor_membership
+    ).call
+
+    expect(new_patient).to be_persisted
+    expect(relationship).to be_persisted
+    expect(relationship.person_access_grants.sole.person).to eq(new_patient)
+  end
+
+  it 'keeps a self relationship descriptive and the identity grant membership-owned' do
+    membership = create_membership(carer)
+    identity_grant = create_self_grant(membership)
+    original_attributes = identity_grant.attributes
+
+    relationship = described_class.new(
+      carer: carer,
+      patient: carer,
+      relationship_type: :self,
+      granted_by_membership: actor_membership
+    ).call
+
+    expect(relationship).to be_active
+    expect(relationship.person_access_grants).to be_empty
+    expect(identity_grant.reload.attributes).to eq(original_attributes)
+  end
+
+  it 'releases a legacy sourced self grant back to membership ownership' do
+    membership = create_membership(carer)
+    relationship = CarerRelationship.create!(household: household, carer: carer, patient: carer,
+                                             relationship_type: :self, active: true)
+    identity_grant = create_self_grant(membership)
+    identity_grant.update!(carer_relationship: relationship)
+
+    result = described_class.new(carer: carer, patient: carer, relationship_type: :self).call
+
+    expect(result).to eq(relationship)
+    expect(identity_grant.reload).to have_attributes(carer_relationship_id: nil, revoked_at: nil)
+  end
+
+  it 'creates only the descriptive relationship for an accountless carer' do
+    accountless_carer = create(:person, household: household)
+    original_counts = [HouseholdMembership.count, PersonAccessGrant.count]
+
+    relationship = described_class.new(
+      carer: accountless_carer,
+      patient: patient,
+      relationship_type: :family_member,
+      granted_by_membership: actor_membership
+    ).call
+
+    expect(relationship).to have_attributes(carer: accountless_carer, patient: patient, active: true)
+    expect([HouseholdMembership.count, PersonAccessGrant.count]).to eq(original_counts)
+  end
+
+  it 'reactivates the same relationship and owned grant' do
+    relationship = assign_delegation
+    grant = relationship.person_access_grants.sole
+    CareDelegation::Revoke.new(relationship: relationship).call
+
+    expect { assigner.call }
+      .not_to(change { [CarerRelationship.count, PersonAccessGrant.count] })
+
+    expect(relationship.reload).to be_active
+    expect(grant.reload.revoked_at).to be_nil
+  end
+
+  it 'is idempotent for an active assignment' do
+    relationship = assigner.call
+    grant = relationship.person_access_grants.sole
+
+    expect { assigner.call }
+      .not_to(change { [CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count] })
+
+    expect(assigner.call).to eq(relationship)
+    expect(relationship.reload.person_access_grants.sole).to eq(grant)
+  end
+
+  it 'rejects cross-household assignments without partial writes' do
+    foreign_carer = create_account_person(create(:household), 'foreign-carer')
+
+    original_counts = [CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]
+
+    expect do
+      described_class.new(
+        carer: foreign_carer,
+        patient: patient,
+        relationship_type: 'parent',
+        granted_by_membership: actor_membership
+      ).call
+    end.to raise_error(ActiveRecord::RecordInvalid)
+
+    expect([CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]).to eq(original_counts)
+  end
+
+  it 'rolls back every write when grant persistence fails' do
+    foreign_actor = create_account_person(create(:household), 'foreign-actor')
+    foreign_membership = create_membership(foreign_actor, role: :owner)
+
+    original_counts = [CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]
+
+    expect do
+      described_class.new(
+        carer: carer,
+        patient: patient,
+        relationship_type: 'parent',
+        granted_by_membership: foreign_membership
+      ).call
+    end.to raise_error(ActiveRecord::RecordInvalid)
+
+    expect([CarerRelationship.count, HouseholdMembership.count, PersonAccessGrant.count]).to eq(original_counts)
+  end
+
+  it 'preserves a sufficient manually granted access record' do
+    membership = create_membership(carer)
+    create_self_grant(membership)
+    manual_grant = create_manual_grant(membership, access_level: :manage)
+    original_attributes = manual_grant.attributes
+
+    relationship = assign_delegation
+
+    expect(manual_grant.reload.attributes).to eq(original_attributes)
+    expect(relationship.person_access_grants).to be_empty
+
+    expect { CareDelegation::Revoke.new(relationship: relationship).call }
+      .to raise_error(CareDelegation::Revoke::AmbiguousGrant)
+    expect(relationship.reload).to be_active
+    expect(manual_grant.reload.revoked_at).to be_nil
+  end
+
+  it 'rejects an insufficient manual grant without changing either record' do
+    membership = create_membership(carer)
+    create_self_grant(membership)
+    manual_grant = create_manual_grant(membership, access_level: :view)
+
+    original_count = CarerRelationship.count
+
+    expect { assign_delegation }.to raise_error(CareDelegation::Assign::GrantConflict)
+
+    expect(CarerRelationship.count).to eq(original_count)
+
+    expect(manual_grant.reload).to have_attributes(access_level: 'view', revoked_at: nil)
+  end
+
+  it 'retires an expired manual grant before creating an owned grant' do
+    membership = create_membership(carer)
+    create_self_grant(membership)
+    manual_grant = create_manual_grant(membership, access_level: :manage, expires_at: 1.minute.ago)
+
+    relationship = assign_delegation
+
+    expect(manual_grant.reload.revoked_at).to be_present
+    expect(relationship.person_access_grants.sole)
+      .to have_attributes(access_level: 'manage', relationship_type: 'parent', revoked_at: nil)
+  end
+
+  def create_account_person(target_household, prefix)
+    account = Account.create!(
+      email: "#{prefix}-#{SecureRandom.hex(4)}@example.com",
+      password_hash: BCrypt::Password.create('password'),
+      status: :verified
+    )
+    create(:person, household: target_household, account: account)
+  end
+
+  def expect_created_assignment(relationship, membership, self_grant, patient_grant)
+    expect(relationship).to have_attributes(household: household, relationship_type: 'parent', active: true)
+    expect(membership).to have_attributes(person: carer, role: 'member', status: 'active')
+    expect(self_grant).to have_attributes(access_level: 'manage', relationship_type: 'self', revoked_at: nil)
+    expect(patient_grant).to have_attributes(access_level: 'manage', relationship_type: 'parent',
+                                             carer_relationship: relationship, revoked_at: nil)
+  end
+
+  def create_membership(person, role: :member)
+    person.household.household_memberships.create!(
+      account: person.account,
+      person: person,
+      role: role,
+      status: :active
+    )
+  end
+
+  def create_self_grant(membership)
+    membership.household.person_access_grants.create!(
+      household_membership: membership,
+      person: membership.person,
+      access_level: :manage,
+      relationship_type: :self,
+      granted_by_membership: membership
+    )
+  end
+
+  def create_manual_grant(membership, access_level:, expires_at: nil)
+    household.person_access_grants.create!(
+      household_membership: membership,
+      person: patient,
+      access_level: access_level,
+      relationship_type: :family_member,
+      granted_by_membership: actor_membership,
+      expires_at: expires_at
+    )
+  end
+end

--- a/spec/services/care_delegation/revoke_spec.rb
+++ b/spec/services/care_delegation/revoke_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CareDelegation::Revoke do
+  subject(:revoke_delegation) { described_class.new(relationship: relationship).call }
+
+  let(:household) { create(:household) }
+  let(:carer) { create_account_person(household, 'carer') }
+  let(:patient) { create(:person, household: household) }
+  let(:actor_membership) { create_membership(create_account_person(household, 'actor'), role: :owner) }
+  let(:relationship) do
+    CareDelegation::Assign.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'parent',
+      granted_by_membership: actor_membership
+    ).call
+  end
+
+  it 'deactivates the relationship and revokes its owned grant together' do
+    patient_grant = relationship.person_access_grants.sole
+    membership = relationship.household.household_memberships.find_by!(person: carer)
+    self_grant = membership.person_access_grants.find_by!(person: carer)
+
+    expect(revoke_delegation).to eq(relationship)
+    expect(relationship.reload).not_to be_active
+    expect(patient_grant.reload.revoked_at).to be_present
+    expect(self_grant.reload.revoked_at).to be_nil
+  end
+
+  it 'deactivates a self relationship without revoking or sourcing its identity grant' do
+    membership = create_membership(carer)
+    identity_grant = create_self_grant(membership)
+    self_relationship = CareDelegation::Assign.new(
+      carer: carer,
+      patient: carer,
+      relationship_type: :self,
+      granted_by_membership: actor_membership
+    ).call
+
+    expect(described_class.new(relationship: self_relationship).call).to eq(self_relationship)
+    expect(self_relationship.reload).not_to be_active
+    expect(identity_grant.reload).to have_attributes(carer_relationship_id: nil, revoked_at: nil)
+  end
+
+  it 'deactivates an accountless descriptive relationship without access records' do
+    accountless_carer = create(:person, household: household)
+    descriptive_relationship = CarerRelationship.create!(
+      household: household,
+      carer: accountless_carer,
+      patient: patient,
+      relationship_type: :family_member,
+      active: true
+    )
+
+    expect(described_class.new(relationship: descriptive_relationship).call).to eq(descriptive_relationship)
+    expect(descriptive_relationship.reload).not_to be_active
+    expect(descriptive_relationship.person_access_grants).to be_empty
+  end
+
+  it 'refuses to deactivate while an unowned grant still authorizes the patient' do
+    manual_relationship, manual_grant = create_manual_delegation
+
+    expect { described_class.new(relationship: manual_relationship).call }
+      .to raise_error(CareDelegation::Revoke::AmbiguousGrant, /unowned grant/)
+
+    expect(manual_relationship.reload).to be_active
+    expect(manual_grant.reload.revoked_at).to be_nil
+  end
+
+  it 'revokes expired owned grants and releases the unrevoked uniqueness slot' do
+    expiring_relationship = create_expiring_delegation
+    patient_grant = expiring_relationship.person_access_grants.sole
+    patient_grant.update!(expires_at: 1.hour.ago)
+
+    described_class.new(relationship: expiring_relationship).call
+
+    expect(patient_grant.reload.revoked_at).to be_present
+    expect { create_replacement_grant(patient_grant.household_membership) }
+      .to change(PersonAccessGrant, :count).by(1)
+  end
+
+  it 'is idempotent when the assignment is already revoked' do
+    patient_grant = relationship.person_access_grants.sole
+    revoke_delegation
+    relationship_updated_at = relationship.reload.updated_at
+    grant_updated_at = patient_grant.reload.updated_at
+
+    expect { described_class.new(relationship: relationship).call }
+      .not_to(change { [relationship.reload.updated_at, patient_grant.reload.updated_at] })
+
+    expect(relationship.updated_at).to eq(relationship_updated_at)
+    expect(patient_grant.updated_at).to eq(grant_updated_at)
+  end
+
+  it 'rolls back relationship deactivation when grant revocation fails' do
+    patient_grant = relationship.person_access_grants.sole
+    PersonAccessGrant.connection.execute(
+      "UPDATE person_access_grants SET access_level = 'invalid' WHERE id = #{patient_grant.id}"
+    )
+
+    expect { revoke_delegation }.to raise_error(ActiveRecord::RecordInvalid)
+
+    expect(relationship.reload).to be_active
+    expect(patient_grant.reload.revoked_at).to be_nil
+  end
+
+  def create_account_person(target_household, prefix)
+    account = Account.create!(
+      email: "#{prefix}-#{SecureRandom.hex(4)}@example.com",
+      password_hash: BCrypt::Password.create('password'),
+      status: :verified
+    )
+    create(:person, household: target_household, account: account)
+  end
+
+  def create_membership(person, role: :member)
+    person.household.household_memberships.create!(
+      account: person.account,
+      person: person,
+      role: role,
+      status: :active
+    )
+  end
+
+  def create_self_grant(membership)
+    membership.household.person_access_grants.create!(
+      household_membership: membership,
+      person: membership.person,
+      access_level: :manage,
+      relationship_type: :self,
+      granted_by_membership: membership
+    )
+  end
+
+  def create_manual_delegation
+    membership = create_membership(carer)
+    grant = household.person_access_grants.create!(
+      household_membership: membership,
+      person: patient,
+      access_level: :manage,
+      relationship_type: :parent,
+      granted_by_membership: actor_membership
+    )
+    relationship = CarerRelationship.create!(household: household, carer: carer, patient: patient,
+                                             relationship_type: :parent, active: true)
+    [relationship, grant]
+  end
+
+  def create_expiring_delegation
+    CareDelegation::Assign.new(
+      carer: carer,
+      patient: patient,
+      relationship_type: 'parent',
+      granted_by_membership: actor_membership,
+      expires_at: 1.hour.from_now
+    ).call
+  end
+
+  def create_replacement_grant(membership)
+    household.person_access_grants.create!(
+      household_membership: membership,
+      person: patient,
+      access_level: :view,
+      relationship_type: :family_member,
+      granted_by_membership: actor_membership
+    )
+  end
+end

--- a/spec/services/dependent_relationship_assigner_spec.rb
+++ b/spec/services/dependent_relationship_assigner_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe DependentRelationshipAssigner do
         ).call
       end.not_to change(CarerRelationship, :count)
 
-      expect(relationship.reload).to have_attributes(
-        relationship_type: 'parent',
-        active: true
-      )
+      expect_reactivated_assignment(relationship, carer, dependent)
     end
 
     it 'ignores adults and unrelated ids' do
@@ -77,6 +74,13 @@ RSpec.describe DependentRelationshipAssigner do
         )
       end.to raise_error(ArgumentError, /scope/)
     end
+  end
+
+  def expect_reactivated_assignment(relationship, carer, dependent)
+    expect(relationship.reload).to have_attributes(relationship_type: 'parent', active: true)
+    membership = carer.household.household_memberships.find_by!(account: carer.account)
+    grant = membership.person_access_grants.find_by!(person: dependent, carer_relationship: relationship)
+    expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'parent', revoked_at: nil)
   end
 
   def inactive_relationship(carer, dependent)

--- a/spec/services/fixture_household_setup_spec.rb
+++ b/spec/services/fixture_household_setup_spec.rb
@@ -9,13 +9,10 @@ RSpec.describe FixtureHouseholdSetup do
     before do
       PersonAccessGrant.delete_all
       HouseholdMembership.delete_all
-      SpecFixtureLoader.load(:accounts, :people, :users)
+      SpecFixtureLoader.load(:accounts, :people, :users, :carer_relationships)
     end
 
-    after do
-      PersonAccessGrant.delete_all
-      HouseholdMembership.delete_all
-    end
+    after { described_class.apply! }
 
     it 'creates tenant memberships and self grants for account-linked fixture people', :aggregate_failures do
       described_class.apply!
@@ -27,6 +24,46 @@ RSpec.describe FixtureHouseholdSetup do
 
       expect(membership).to have_attributes(household: household, person: user.person, role: 'member', status: 'active')
       expect(grant).to have_attributes(access_level: 'manage', relationship_type: 'self')
+    end
+
+    it 'links relationship-derived grants to their delegation source' do
+      described_class.apply!
+
+      relationship = CarerRelationship.find_by!(relationship_type: :parent, active: true)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      grant = relationship.household.person_access_grants.find_by!(
+        household_membership: membership,
+        person: relationship.patient
+      )
+
+      expect(grant.carer_relationship).to eq(relationship)
+    end
+
+    it 'does not relabel an existing manual grant as relationship-owned' do
+      described_class.apply!
+      relationship = CarerRelationship.find_by!(relationship_type: :parent, active: true)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      grant = relationship.household.person_access_grants.find_by!(
+        household_membership: membership,
+        person: relationship.patient
+      )
+      grant.update!(carer_relationship: nil)
+
+      described_class.apply!
+
+      expect(grant.reload.carer_relationship).to be_nil
+    end
+
+    it 'keeps self grants independent from legacy self relationships' do
+      described_class.apply!
+      relationship = CarerRelationship.find_by!(relationship_type: '0', active: true)
+      membership = relationship.household.household_memberships.find_by!(person: relationship.carer)
+      grant = relationship.household.person_access_grants.find_by!(
+        household_membership: membership,
+        person: relationship.patient
+      )
+
+      expect(grant.carer_relationship).to be_nil
     end
   end
 end

--- a/spec/services/households/local_migrator_spec.rb
+++ b/spec/services/households/local_migrator_spec.rb
@@ -171,6 +171,116 @@ RSpec.describe Households::LocalMigrator do
     expect(migrator.send(:legacy_user_role, legacy_user)).to eq(:doctor)
   end
 
+  it 'links relationship grants through the public migration transaction' do
+    household, owner, patient, relationship = local_delegation_fixture
+    stub_account_enumeration(owner)
+
+    result = run_migration(owner, household.name)
+
+    membership = household.household_memberships.find_by!(account: owner)
+    expect(result).to be_applied
+    expect(household.person_access_grants.find_by!(household_membership: membership, person: patient))
+      .to have_attributes(carer_relationship: relationship, access_level: 'manage', relationship_type: 'parent')
+  end
+
+  it 'preserves an existing manual grant through the public migration transaction' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = household.person_access_grants.create!(
+      household_membership: membership,
+      person: patient,
+      access_level: :manage,
+      relationship_type: :parent,
+      granted_by_membership: membership
+    )
+    original_attributes = grant.attributes
+    stub_account_enumeration(owner)
+
+    run_migration(owner, household.name)
+
+    expect(grant.reload.attributes).to eq(original_attributes)
+  end
+
+  it 'preserves an existing self grant through the public migration transaction' do
+    household, owner, _patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    CarerRelationship.create!(household: household, carer: relationship.carer, patient: relationship.carer,
+                              relationship_type: :self, active: true)
+    grant = household.person_access_grants.create!(
+      household_membership: membership,
+      person: relationship.carer,
+      access_level: :manage,
+      relationship_type: :self,
+      granted_by_membership: membership
+    )
+    original_attributes = grant.attributes
+    stub_account_enumeration(owner)
+
+    run_migration(owner, household.name)
+
+    expect(grant.reload.attributes).to eq(original_attributes)
+  end
+
+  it 'rejects insufficient manual access through the public migration transaction' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = create_local_grant(household, membership, patient, access_level: :view)
+
+    expect_public_migration_conflict(household, owner, grant, /manual grant does not cover/)
+  end
+
+  it 'rejects expired manual access through the public migration transaction' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = create_local_grant(household, membership, patient, access_level: :manage, expires_at: 1.minute.ago)
+
+    expect_public_migration_conflict(household, owner, grant, /manual grant does not cover/)
+  end
+
+  it 'rejects time-limited manual access for an indefinite relationship' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = create_local_grant(household, membership, patient, access_level: :manage, expires_at: 1.day.from_now)
+
+    expect_public_migration_conflict(household, owner, grant, /manual grant does not cover/)
+  end
+
+  it 'reconciles authority already owned by the same relationship without changing provenance' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = create_owned_local_grant(household, membership, patient, relationship)
+    stub_account_enumeration(owner)
+
+    run_migration(owner, household.name)
+
+    expect(grant.reload).to have_attributes(
+      access_level: 'manage',
+      relationship_type: 'parent',
+      expires_at: nil,
+      carer_relationship: relationship
+    )
+  end
+
+  it 'rejects a grant sourced to another relationship without stealing provenance' do
+    household, owner, patient, relationship = local_delegation_fixture
+    membership = create_local_membership(household, owner, relationship.carer)
+    grant = create_foreign_sourced_grant(household, membership, patient, relationship)
+
+    expect_public_migration_conflict(household, owner, grant, /another relationship/)
+  end
+
+  it 'rolls back memberships and grants when relationship migration fails' do
+    household, owner, = local_delegation_fixture
+    stub_account_enumeration(owner)
+    migrator = described_class.new(owner_email: owner.email, household_name: household.name, apply: true)
+    allow(migrator).to receive(:migrate_carer_relationship_grants).and_raise(described_class::Error, 'failed')
+
+    expect { migrator.call }.to raise_error(described_class::Error, 'failed')
+
+    expect(household.household_memberships.where(account: owner)).to be_empty
+    expect(household.person_access_grants).to be_empty
+  end
+
   it 'dry-runs without mutating data and reports counts' do
     owner, = create_legacy_account(
       email: 'dry-run-owner@example.test',
@@ -210,5 +320,86 @@ RSpec.describe Households::LocalMigrator do
     expect do
       described_class.new(owner_email: 'owner@example.test', household_name: ' ', apply: false).call
     end.to raise_error(described_class::Error, /HOUSEHOLD_NAME/)
+  end
+
+  def local_delegation_fixture
+    account = Account.create!(email: 'source-owner@example.test', status: :verified)
+    household = Household.create!(name: 'Source', created_by_account: account)
+    owner = create(:person, household: household, account: account)
+    patient = create(:person, household: household)
+    relationship = CarerRelationship.create!(household: household, carer: owner, patient: patient,
+                                             relationship_type: :parent, active: true)
+    [household, account, patient, relationship]
+  end
+
+  def create_local_membership(household, account, person)
+    household.household_memberships.create!(
+      account: account,
+      person: person,
+      role: :owner,
+      status: :active
+    )
+  end
+
+  def create_local_grant(household, membership, person, **attributes)
+    household.person_access_grants.create!(
+      {
+        household_membership: membership,
+        person: person,
+        access_level: :manage,
+        relationship_type: :parent,
+        granted_by_membership: membership
+      }.merge(attributes)
+    )
+  end
+
+  def create_owned_local_grant(household, membership, person, relationship)
+    create_local_grant(
+      household,
+      membership,
+      person,
+      access_level: :view,
+      expires_at: 1.day.from_now,
+      carer_relationship: relationship
+    )
+  end
+
+  def create_foreign_sourced_grant(household, membership, patient, relationship)
+    other_patient = create(:person, household: household)
+    other_relationship = CarerRelationship.create!(
+      household: household,
+      carer: relationship.carer,
+      patient: other_patient,
+      relationship_type: :parent
+    )
+    grant = create_local_grant(household, membership, patient, carer_relationship: relationship)
+    write_raw_column(grant, :carer_relationship_id, other_relationship.id)
+    grant
+  end
+
+  def expect_public_migration_conflict(household, owner, grant, message)
+    additional_account = rollback_account
+    original_attributes = grant.reload.attributes
+    stub_account_enumeration(owner, additional_account)
+
+    expect_migration_error(household, owner, message)
+    expect_grant_unchanged(grant, original_attributes)
+    expect_membership_rolled_back(household, additional_account)
+  end
+
+  def expect_migration_error(household, owner, message)
+    expect { run_migration(owner, household.name) }.to raise_error(described_class::Error, message)
+  end
+
+  def expect_grant_unchanged(grant, original_attributes)
+    expect(grant.reload.attributes).to eq(original_attributes)
+  end
+
+  def expect_membership_rolled_back(household, account)
+    expect(household.household_memberships.where(account: account)).to be_empty
+  end
+
+  def rollback_account
+    Account.create!(email: "rollback-member-#{SecureRandom.hex(4)}@example.test", status: :verified)
   end
 end

--- a/spec/services/portable_data/importer_spec.rb
+++ b/spec/services/portable_data/importer_spec.rb
@@ -167,6 +167,37 @@ RSpec.describe PortableData::Importer do
     )
   end
 
+  def imported_person_delegation(household, access_level:)
+    membership = owner_membership(household)
+    carer = create(:person, household: household, account: membership.account)
+    membership.update!(person: carer)
+    person = create(:person, household: household, portable_id: 'person-portable-1')
+    relationship = create_import_relationship(household, carer, person)
+    grant = create_import_grant(household, membership, person, relationship, access_level)
+    [membership, person, relationship, grant]
+  end
+
+  def create_import_relationship(household, carer, person)
+    CarerRelationship.create!(
+      household: household,
+      carer: carer,
+      patient: person,
+      relationship_type: :professional_carer,
+      active: true
+    )
+  end
+
+  def create_import_grant(household, membership, person, relationship, access_level)
+    household.person_access_grants.create!(
+      household_membership: membership,
+      person: person,
+      access_level: access_level,
+      relationship_type: :professional,
+      granted_by_membership: membership,
+      carer_relationship: relationship
+    )
+  end
+
   def payload_with_unmanaged_schedule_reference(household:, manageable_person:, unmanaged_person:)
     medication = create(:medication, household: household, portable_id: 'existing-medication-portable')
     payload = solo_person_payload_for(manageable_person)
@@ -410,6 +441,42 @@ RSpec.describe PortableData::Importer do
         access_level: :manage
       )
     ).to be(true)
+  end
+
+  it 'preserves a relationship-owned grant that already provides imported authority' do
+    household = create(:household)
+    membership, person, relationship, grant = imported_person_delegation(household, access_level: :manage)
+    original_attributes = grant.attributes
+
+    result = import_result(
+      household: household,
+      membership: membership,
+      payload: solo_person_payload_for(person),
+      dry_run: false
+    )
+
+    expect(result).to be_applied
+    expect(grant.reload.attributes).to eq(original_attributes)
+    expect(grant.carer_relationship).to eq(relationship)
+  end
+
+  it 'rejects imported authority that would overwrite a relationship-owned grant' do
+    household = create(:household)
+    membership, person, _relationship, grant = imported_person_delegation(household, access_level: :record)
+    original_grant_attributes = grant.attributes
+    original_person_attributes = person.attributes
+
+    expect do
+      import_result(
+        household: household,
+        membership: membership,
+        payload: solo_person_payload_for(person),
+        dry_run: false
+      )
+    end.to raise_error(PortableData::Importer::Error, /relationship-owned access grant/)
+
+    expect(grant.reload.attributes).to eq(original_grant_attributes)
+    expect(person.reload.attributes).to eq(original_person_attributes)
   end
 
   it 'rejects member imports that reference unmanaged household people outside the top-level people array' do

--- a/spec/system/admin_manages_carer_relationships_spec.rb
+++ b/spec/system/admin_manages_carer_relationships_spec.rb
@@ -39,11 +39,24 @@ RSpec.describe 'AdminManagesCarerRelationships' do
       click_button 'Create Relationship'
 
       expect(page).to have_text('Carer relationship was successfully created')
+      relationship = CarerRelationship.find_by!(carer: jane, patient: people(:john))
+      expect(relationship.person_access_grants.sole).to have_attributes(
+        access_level: 'manage',
+        relationship_type: 'family_member'
+      )
     end
 
     it 'allows admin to deactivate a carer relationship', :js do
-      relationship = carer_relationships(:jane_cares_for_child)
       login_as(admin)
+      household = admin.person.household
+      actor_membership = household.household_memberships.find_by!(account: admin.person.account)
+      relationship = CareDelegation::Assign.new(
+        carer: carer.person,
+        patient: people(:john),
+        relationship_type: :family_member,
+        granted_by_membership: actor_membership
+      ).call
+      grant = relationship.person_access_grants.sole
 
       visit admin_carer_relationships_path
 
@@ -57,6 +70,8 @@ RSpec.describe 'AdminManagesCarerRelationships' do
       end
 
       expect(page).to have_text('Carer relationship has been deactivated')
+      expect(relationship.reload).not_to be_active
+      expect(grant.reload.revoked_at).to be_present
     end
 
     it 'allows admin to reactivate a deactivated carer relationship' do
@@ -71,6 +86,7 @@ RSpec.describe 'AdminManagesCarerRelationships' do
       end
 
       expect(page).to have_text('Carer relationship has been activated')
+      expect(relationship.reload.person_access_grants.sole.carer_relationship).to eq(relationship)
 
       within "[data-relationship-id='#{relationship.id}']" do
         expect(page).to have_text('Active')


### PR DESCRIPTION
## Summary

Care relationships and access grants were previously coordinated across multiple controllers, services, import paths, and household bootstrap code. That made the descriptive relationship and the authority it creates vulnerable to drifting apart or being only partly updated.

This change routes assignment, reactivation, and revocation through `CareDelegation::Assign` and `CareDelegation::Revoke`, giving those operations one transactional household boundary. Relationship-owned grants now carry explicit provenance, while manual grants and self authority remain separate and preserved. Caller-selected access levels remain intact, and concurrent assignment attempts serialize and converge on the same relationship and grant.

## Operational behavior

Legacy grants are not automatically claimed as relationship-owned. When deactivation encounters ambiguous active authority with no owner, it fails safely and requires that authority to be explicitly resolved before deactivation can proceed.