### PR TITLE
docs(architecture): define bounded contexts

### DIFF
--- a/docs/adrs/0002-authentication-and-authorization-strategy.md
+++ b/docs/adrs/0002-authentication-and-authorization-strategy.md
@@ -1,7 +1,13 @@
 # ADR 0002: Authentication and Authorization Strategy
 
-- Status: Accepted
+- Status: Accepted; six-role hierarchy, role-based policy examples, and obsolete
+  migration status superseded by [ADR 0009](0009-bounded-context-map.md)
 - Date: 2025-11-27
+
+ADR 0009 supersedes this ADR's six-role authorization hierarchy, role-based
+policy examples, and obsolete migration-status section. The Rodauth
+authentication, deny-by-default Pundit framework, and base PaperTrail audit
+decisions remain accepted.
 
 ## Context
 

--- a/docs/adrs/0009-bounded-context-map.md
+++ b/docs/adrs/0009-bounded-context-map.md
@@ -1,0 +1,191 @@
+# ADR 0009: Bounded Context Map
+
+- Status: Accepted
+- Date: 2026-07-13
+
+## Context
+
+MedTracker has domain rules for medication identity, stock, administration,
+care responsibility, authorization, authentication, data exchange, and audit.
+Those rules currently live in one Rails application and sometimes share the
+same Active Record models and tables. Without an explicit context map, a model
+name can be mistaken for ownership of every concern stored on that record, and
+descriptive care relationships can be mistaken for authorization.
+
+The application is a modular monolith. Its bounded contexts are semantic and
+transactional boundaries today. They are not separate Rails engines, services,
+deployment units, or databases.
+
+## Decision
+
+Use the following bounded contexts and supporting capabilities to describe
+present ownership and dependency direction. This map covers the current
+medication, care, safety, access, integration, reporting, notification, and
+compliance capabilities named below; it is not an exhaustive classification of
+every Rails or operational component. Existing Rails models and tables may act
+as shared persistence adapters. A shared adapter may expose fields used by more
+than one context without making those contexts the same domain.
+
+| Context | Present responsibility and ownership | Current code landmarks |
+| --- | --- | --- |
+| Medication Administration | Defines scheduled and direct administration sources, applies dose and timing rules, owns regimen defaults, and records immutable dose history. It owns `Schedule`, `PersonMedication`, and `MedicationTake` semantics. | `TakeMedicationService`, `MedicationDoseSource`, `DoseTimingPolicy`, `DoseCycle`, administration defaults on `Medication` and `MedicationDosageOption`, medication-take controllers |
+| Medication Catalogue | Defines medicine/product identity, catalogue codes, display data, and selectable dose identity. It does not own household stock, regimen defaults, or administration history. | Catalogue attributes on `Medication`, dose identity on `MedicationDosageOption`, `BarcodeCatalogEntry`, `NhsDmdBarcode`, `NhsDmd::*`, `BarcodeCatalog::*` |
+| Inventory | Tracks location-bound quantities, restocks, reorder state, thresholds, and the tracked stock source consumed by an administration. | Inventory attributes on `Medication` and `MedicationDosageOption`, `SupplyLevel`, `RestockMedicationService`, `AdjustMedicationInventoryService`, `MedicationStockSourceResolver`, `MedicationTakeStockMutation` |
+| Health and Medication Safety | Owns recorded illnesses and suspected side effects, medication-interaction evidence, and the practitioner-review state and immutable evidence snapshots created from that evidence. It does not own administration history or medicine identity. | `HealthEvent`, `HealthEventMedication`, `HealthEvents::*`, `MedicationReviewEvidenceRecord`, `MedicationReviewPrompt`, `MedicationReviewPromptSync` |
+| People and Care Delegation | Defines the tracked person, care capacity, and descriptive responsibility between people. It coordinates creation and revocation of the authority needed to act on that responsibility. | `Person`, `CarerRelationship`, `CareDelegation::Assign`, `CareDelegation::Revoke`, people and carer-relationship controllers |
+| Household Access | Owns tenant participation and authorization: household membership, household roles, person-scoped grants, access levels, expiry, and revocation. | `Household`, `HouseholdMembership`, `PersonAccessGrant`, `AuthorizationContext`, `TenantContext`, Pundit policies and scopes |
+| Identity | Owns authentication identities, credentials, account state, sessions, and tokens. It establishes who is acting but does not decide which person records they may access. | `Account`, `AccountIdentity`, Rodauth credential models, `User`, `ApiSession`, `ApiAppToken`, `OauthGrant`, authentication controllers and services |
+| Interoperability | Translates authenticated, authorized domain data for external clients and applies imports through domain persistence boundaries. It does not own medication history, stock, people, or grants. | `Api::V1::*`, `Api::Fhir::R4::*`, `Fhir::R4::Serializer`, `PortableData::*`, `Api::SyncSnapshot`, MCP tools and resources |
+| Reporting and Insights (supporting) | Builds read-only report projections and derived insights from records owned by other contexts. It owns presentation-specific calculations and detector results, not the underlying administration, inventory, health, or safety facts. | `Reports::*`, `SmartInsights::*`, report controllers and report views |
+| Notifications (supporting) | Owns person notification preferences, delivery deduplication, subscriptions, and push transport. It consumes administration and inventory outcomes without owning the rule or fact that triggered a message. | `NotificationPreference`, `NotificationEvent`, `PushNotificationService`, `NativePush::*`, reminder and stock notification jobs |
+| Audit and Compliance | Observes security and domain outcomes, preserves attributable change history and append-only evidence, and exports or verifies that evidence. It does not make medication or authorization decisions. | PaperTrail versions, `SecurityAuditEvent`, `Audit::Event`, `AuditLedgerEntry`, `AuditCheckpoint`, `Audit::EvidenceExporter`, audit verification and Object Lock services |
+
+## Ownership Rules
+
+### Medication Administration
+
+`Schedule` and `PersonMedication` are the two retained administration sources.
+`MedicationTake` records the dose snapshot and exactly one source through
+`MedicationDoseSource`. Persisted takes are immutable. Administration depends
+on Catalogue for medicine and selectable dose identity, Inventory for
+availability and stock mutation, People for the care recipient, and Household
+Access for the caller scope.
+
+`Schedule` is a date-bounded source that supports scheduled types and the
+retained `prn` type. `PersonMedication` is the direct routine or as-needed
+source; it is not the only current representation of as-needed administration.
+
+### Medication Catalogue and Inventory
+
+`Medication` is currently a shared persistence adapter. Catalogue owns the
+meaning of fields such as product names, dm+d identifiers, barcodes, category,
+and selectable dose identity. Medication Administration owns regimen defaults,
+including default schedule type and configuration, frequency, maximum daily
+doses, minimum hours between doses, dose cycle, and age-based default selection
+through `default_for_adults` and `default_for_children`. Inventory owns the
+meaning of location, current supply, last-restock supply, reorder thresholds,
+reorder state, and stock mutation. `MedicationDosageOption` is also shared: its
+dose amount, unit, and description belong to Catalogue; its regimen and
+age-based selection defaults belong to Medication Administration; and its
+optional supply and threshold fields belong to Inventory.
+
+Inventory may depend on Catalogue identifiers to determine which product or
+dose is stocked. Catalogue lookup and import code must not infer household
+stock, a person's regimen, or dose history.
+
+### Health and Medication Safety
+
+`HealthEvent` records illnesses and suspected side effects for a person.
+`MedicationReviewEvidenceRecord` provides interaction evidence, while
+`MedicationReviewPrompt` owns the resulting practitioner-review state and its
+immutable evidence snapshot. This context may consume Catalogue identity and
+Administration history without taking ownership of those source records.
+
+### People, Care Delegation, and Household Access
+
+`CarerRelationship` describes responsibility between a carer and a person
+receiving care. It is not the authorization source. `PersonAccessGrant` is the
+authority record for one `HouseholdMembership` and one `Person`, with `view`,
+`record`, or `manage` access.
+
+`CareDelegation::Assign` and `CareDelegation::Revoke` coordinate the two
+contexts transactionally. Every assignment creates or reactivates the
+descriptive relationship. When the carer has an account, assignment ensures the
+carer's membership and standalone self grant. Account-backed non-self
+delegation also creates or validates the relationship-owned person grant.
+Non-self revocation disables the relationship and revokes only grants it owns;
+it refuses to silently remove independent authority when an unowned grant
+remains. An account-backed self relationship uses a standalone self grant whose
+`carer_relationship` is absent, and deactivating the descriptive self
+relationship does not revoke that grant. An accountless assignment, including
+self assignment, creates no membership or access grant; revocation only
+deactivates its descriptive relationship.
+
+Person-scoped policy decisions derive authority from active
+`PersonAccessGrant` records, not from relationship labels. Medication and
+inventory policy decisions also recognize the current `owner` and
+`administrator` household governance roles and the narrow creator-owned,
+unlinked medication exception. Those household roles are distinct from the
+obsolete application-wide role hierarchy.
+
+### Identity and Household Access
+
+Identity authenticates an `Account` and manages credential/session lifecycle.
+Household Access binds the authenticated account to an active
+`HouseholdMembership` and establishes `AuthorizationContext` and
+`TenantContext`. Session and app-token records retain the membership and its
+permissions version, but grant evaluation remains owned by Household Access.
+
+### Interoperability and Audit
+
+Interoperability is an adapter around the domain contexts. API, FHIR, portable
+data, sync, and MCP paths authenticate through Identity and authorize through
+Household Access. Each adapter reads or writes according to its published
+contract; the hosted MCP surface is currently read-only. Importers may
+coordinate a transaction, but imported clinical history remains owned by
+Medication Administration and imported stock remains owned by Inventory.
+
+Audit and Compliance consumes attributable outcomes and change records from
+all contexts. Domain decisions must not depend on audit queries or evidence
+exports succeeding, except where a workflow explicitly requires an audit write
+to be atomic for compliance.
+
+### Reporting, Insights, and Notifications
+
+`Reports::*` and `SmartInsights::*` create read-only projections and derived
+insights from records owned by other contexts. They own report calculations and
+detector results, not administration, inventory, health, or safety source
+facts.
+
+Notifications own person preferences, subscription and delivery mechanics,
+delivery deduplication, and push transport. Reminder and stock notification
+jobs consume domain outcomes; they do not own the administration or inventory
+rules that trigger delivery.
+
+## Dependency Direction
+
+- Web and API controllers are delivery adapters and call application services
+  or domain records; controllers do not own domain rules.
+- Medication Administration depends on Catalogue, Inventory, People, and
+  Household Access, not the reverse.
+- Health and Medication Safety depends on People and Catalogue identity and may
+  consume Administration history; it owns its health-event and review records.
+- Inventory depends on Catalogue identity, not on administration history for
+  product meaning. An administration may trigger an inventory mutation.
+- People and Care Delegation may coordinate Household Access writes, while
+  Household Access remains the authority source.
+- Identity establishes the actor; Household Access establishes the actor's
+  tenant and person scope.
+- Interoperability depends on the owning contexts and must not become a second
+  source of truth for their records.
+- Reporting and Insights reads owning-context records and produces derived
+  projections; it does not write back new source facts.
+- Notifications owns preferences and delivery mechanics while consuming
+  outcomes from the contexts that define administration and inventory rules.
+- Audit and Compliance observes outcomes and preserves evidence; it does not
+  decide whether a dose or access request is allowed.
+
+## Consequences
+
+The context map gives maintainers concrete ownership language without a
+physical reorganization. New rules should be placed with the owning context,
+even when they currently use a shared Active Record adapter. Changes to shared
+models must identify which context owns the changed behavior and which other
+contexts consume it.
+
+The current layout does not enforce these boundaries at compile time. Shared
+models, callbacks, and transactions still couple contexts, so tests and review
+must protect dependency direction. This ADR does not authorize a microservice,
+database, Rails engine, or namespace split.
+
+## Related Documents
+
+- [Design and Architecture](../design.md)
+- [Glossary](../glossary.md)
+- [MedicationTake Aggregate Source Boundary](0006-medication-take-aggregate-source-boundary.md)
+- [External App Integration Contract](0007-external-app-integration-contract.md)
+- [Domain Events with ActiveSupport::Notifications](0004-domain-events-with-active-support-notifications.md)
+- [Authentication and Authorization Strategy](0002-authentication-and-authorization-strategy.md),
+  whose six-role hierarchy, role-based policy examples, and obsolete migration
+  status are superseded by this ADR; its Rodauth, deny-by-default Pundit, and
+  base PaperTrail audit decisions remain in force

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,66 +2,124 @@
 
 ## Purpose
 
-MedTracker records medication schedules and administrations with guardrails
-for timing and daily-dose safety, while preserving an auditable history.
+MedTracker records medication schedules, direct assignments, and
+administrations with guardrails for timing, dose limits, and stock, while
+preserving attributable history inside a household authorization boundary.
 
 ## Architecture
 
 - Backend: Ruby on Rails
-- Frontend: Hotwire (Turbo + Stimulus) with Phlex components
-- Authentication: account-based auth with password + generic OIDC (any provider) + passkey support
+- Frontend: Hotwire (Turbo and Stimulus) with Phlex components
+- Authentication: Rodauth accounts with password, generic OIDC, passkeys, and
+  household-bound API credentials
+- Authorization: household memberships plus person-scoped access grants
 - Database: PostgreSQL in development, test, and production
-- Audit trail: PaperTrail on critical clinical and identity models
+- Audit trail: PaperTrail change history plus security and compliance evidence
 
-Domain logic is enforced on the server. UI forms and pages render server-sent
-HTML and use Turbo Streams for updates.
+MedTracker is a modular monolith. Domain logic is enforced on the server. UI
+forms and pages render server-sent HTML and use Turbo Streams for updates.
 
-Phlex components are composition roots and rendering units, not the home of core medication business rules. New UI code should consume server-side domain objects and query objects rather than re-implementing supply, filtering, or administration logic inline.
+The [bounded-context map](adrs/0009-bounded-context-map.md) defines present
+ownership and dependency direction for Medication Administration, Medication
+Catalogue, Inventory, Health and Medication Safety, People and Care Delegation,
+Household Access, Identity, Interoperability, Audit and Compliance, and the
+supporting Reporting and Insights and Notifications capabilities. These are
+not separate services or databases. Shared Rails models and tables may act as
+persistence adapters for more than one context.
 
-## Core domain entities
+Phlex components are composition roots and rendering units, not the home of
+core medication business rules. UI code consumes domain records, value objects,
+presenters, and query objects rather than reimplementing supply, filtering,
+authorization, or administration rules.
 
-- `Person`: demographic and care-capacity record for an individual
-- `User`: login-enabled identity linked one-to-one to `Person`
-- `Medicine`: medicine catalog and supply attributes
-- `Prescription`: prescribed regimen for a person
-- `PersonMedicine`: non-prescription/ad-hoc medicine assignment
-- `MedicationTake`: immutable dose record for safety and compliance
-- `CarerRelationship`: mapping of carers to dependent people
+## Core Domain Records
 
-Use the [Glossary](glossary.md) as the source of truth for domain terms (for example, **Remaining Supply** vs **Stock**).
+| Record | Present responsibility |
+| --- | --- |
+| `Person` | Demographic details, care capacity, and the individual whose care data is tracked |
+| `Account` and `User` | Authentication identity and the active application user linked to a person |
+| `HouseholdMembership` | An account's participation and role in one household |
+| `PersonAccessGrant` | Authority for a membership to view, record for, or manage one person |
+| `CarerRelationship` | Descriptive care responsibility between two people; not authority by itself |
+| `Medication` | Shared catalogue, administration-default, and inventory persistence record for one medicine/product |
+| `MedicationDosageOption` | Shared selectable dose identity, age-based and regimen administration defaults, and optional dose-specific inventory record |
+| `Schedule` | Date-bounded administration source supporting scheduled types and retained PRN semantics |
+| `PersonMedication` | Direct routine or as-needed administration source without a schedule |
+| `MedicationTake` | Immutable record of one completed administration from exactly one source |
+| `HealthEvent` | Recorded illness or suspected side effect for a person |
+| `MedicationReviewPrompt` | Practitioner-review state with an immutable medication-interaction evidence snapshot |
 
-## Safety rules
+Use the [Glossary](glossary.md) as the source of truth for these terms and for
+the distinction between care responsibility and authority.
 
-Timing restrictions are enforced in model logic:
+## Medication Safety Rules
+
+`Schedule` and `PersonMedication` expose the applicable dose and timing rules.
+`TakeMedicationService` checks source state, stock availability, dose amount,
+timing restrictions, and overlapping administration rules before creating a
+`MedicationTake`. The take stores a dose snapshot and its concrete source.
+Persisting a valid take mutates only the selected tracked inventory source when
+inventory tracking is enabled and retains the selected source on the historical
+record. A valid take may use untracked inventory without changing a quantity.
+
+Important timing concepts include:
 
 - `max_daily_doses`
 - `min_hours_between_doses`
+- `dose_cycle`
+- schedule-specific effective doses and dates
 
-These rules apply before a dose is persisted to prevent unsafe administration.
+## Person Types and Authority
 
-## Person types vs user roles
-
-Person type models care needs:
+Person type models care capacity:
 
 - `adult`
 - `minor`
 - `dependent_adult`
 
-User role models application permissions:
+Household membership role models tenant governance:
 
+- `owner`
 - `administrator`
-- `doctor`
-- `nurse`
-- `carer`
-- `parent`
-- `minor`
+- `member`
 
-## Auditing and compliance
+Person access level models authority over a specific person's records:
 
-Critical model changes are versioned for traceability, including medication
-administrations and identity/relationship updates. See [Audit Trail](audit-trail.md).
+- `view`
+- `record`
+- `manage`
 
-## UI and accessibility direction
+Relationship labels describe why access may exist. They are not substitutes
+for an active `PersonAccessGrant`. Every care assignment creates or reactivates
+the descriptive relationship. Only an account-backed carer receives household
+membership and a standalone self grant; account-backed non-self delegation also
+coordinates relationship-owned access. Deactivating an account-backed self
+relationship leaves its standalone grant active. Accountless delegation,
+including self delegation, has no access records, so revocation only deactivates
+the description. Person-scoped authority comes from active grants; medication
+and inventory policies additionally recognize household `owner` and
+`administrator` governance and the narrow creator-owned, unlinked medication
+exception.
+
+## Supporting Read Models and Delivery
+
+`Reports::*` and `SmartInsights::*` build read-only projections and derived
+insights from administration, inventory, health, and safety records. They own
+their report calculations and detector results, not the source facts.
+
+Notifications own person preferences, subscriptions, delivery deduplication,
+and push transport. Reminder and stock notification jobs consume outcomes from
+the contexts that own administration and inventory rules.
+
+## Auditing and Compliance
+
+Critical model changes are versioned for traceability. Security and workflow
+events are recorded with household, account, membership, and request context,
+then projected into append-only compliance evidence. Audit records observe
+domain outcomes; they do not own medication, inventory, or authorization
+decisions. See [Audit Trail](audit-trail.md).
+
+## UI and Accessibility Direction
 
 UI behavior and styling are guided by:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,100 +1,258 @@
 # Glossary
 
-This glossary defines MedTracker's core domain language so model names, UI copy, and business rules stay consistent.
+This glossary defines MedTracker's core domain language so model names, UI
+copy, documentation, and business rules stay consistent.
 
-UI components and presenters must use these domain terms and consume server-side
-domain objects rather than inventing parallel terminology.
+UI components and presenters use these terms and consume server-side domain
+objects rather than inventing parallel terminology. The
+[bounded-context map](adrs/0009-bounded-context-map.md) defines which context
+owns each concept when Rails persistence records are shared.
 
-Prefer these names in new code, UI copy, documentation, and tests. Avoid introducing new patient, individual, plan, routine, stock, or dose-record names unless the surrounding bounded context already requires them.
+Prefer these names in new code, UI copy, documentation, and tests.
+Avoid introducing new patient, individual, plan, routine, stock, or dose-record
+names unless the surrounding bounded context requires them.
 
-## People and care terms
+## People and Care Terms
 
 ### Person
 
 The individual receiving medication or being represented in MedTracker.
 
 - `Person` is the canonical model and code term for the tracked individual.
-- User-facing copy may say "person" or a more specific relationship label when context is clearer.
-- Avoid introducing parallel `Patient`, `Individual`, or `Subject` abstractions for this concept.
+- User-facing copy may say "person" or a specific relationship label when that
+  is clearer.
+- Avoid introducing parallel `Patient`, `Individual`, or `Subject`
+  abstractions for this concept.
 
 ### Carer
 
-A person with delegated responsibility for another person.
+A person with responsibility for supporting another person's care.
 
-- Carer relationships grant scoped access to the dependent person's medication records.
-- Use `CarerRelationship` for the relationship record.
-- Use "carer", "parent", or another explicit relationship label in UI copy when
-  that is clearer than a generic user role.
+- Being described as a carer does not itself grant access.
+- Use "carer", "parent", or another explicit relationship label in UI copy
+  when that is clearer than a generic actor label.
 
-## Medication inventory terms
+### CarerRelationship
+
+The descriptive record of care responsibility between a carer and a person
+receiving care.
+
+- `CarerRelationship` records the two people, relationship type, household,
+  and whether that responsibility is active.
+- It answers **who is responsible for whom**, not **what may this account do**.
+- The current model names the care-recipient association `patient`, but
+  `Person` remains the canonical domain term.
+- Code must not infer authority from this record alone.
+
+### Care Delegation
+
+The transactional workflow that coordinates responsibility and authority.
+
+- `CareDelegation::Assign` always creates or reactivates a
+  `CarerRelationship`.
+- When the carer has an account, assignment ensures household participation and
+  a standalone self grant.
+- Account-backed non-self delegation creates or validates the
+  relationship-owned `PersonAccessGrant`; revocation deactivates the
+  relationship and revokes only the grants that relationship owns.
+- An account-backed self relationship uses a standalone self grant whose
+  `carer_relationship` is absent. Deactivating the descriptive self
+  relationship does not revoke that grant.
+- Accountless delegation, including self delegation, creates no membership or
+  grant. Revocation only deactivates the descriptive relationship.
+- An independent manual grant is preserved and must be resolved explicitly
+  when it conflicts with delegation changes.
+
+## Household Access Terms
+
+### HouseholdMembership
+
+An account's participation in one household.
+
+- Membership roles are `owner`, `administrator`, and `member`.
+- Membership status is independent of a person's care relationship.
+- Identity establishes the account; an active membership establishes the
+  household in which that account is acting.
+
+### PersonAccessGrant
+
+The authority for one household membership to access one person.
+
+- Access levels are `view`, `record`, and `manage`.
+- A grant may expire or be revoked.
+- A grant may be owned by a `CarerRelationship` or exist independently.
+- Person-scoped Pundit decisions authorize from active grants, not from
+  relationship labels.
+- Medication and inventory policies also recognize household `owner` and
+  `administrator` governance and the narrow creator-owned, unlinked medication
+  exception. Household governance roles are not the obsolete application-wide
+  roles.
+
+### Care Relationship Type
+
+The descriptive responsibility recorded by `CarerRelationship`.
+
+- Exact values are `parent`, `family_member`, `professional_carer`, and `self`.
+- This value is separate from household membership role, person access level,
+  and grant relationship metadata.
+
+### Grant Relationship Metadata
+
+The descriptive reason stored on a `PersonAccessGrant`.
+
+- Exact values are `self`, `parent`, `family_member`, `carer`, and
+  `professional`.
+- The default access-level/metadata mappings are `parent` to `manage`/`parent`,
+  `family_member` to `manage`/`family_member`, and `professional_carer` to
+  `record`/`professional`.
+- A valid explicit non-self access level overrides only the default access
+  level; the mapped grant relationship metadata does not change.
+- Account-backed self delegation always ensures a standalone
+  `manage`/`self` grant rather than a relationship-owned grant. Care delegation
+  does not currently create the `carer` grant metadata value.
+
+## Medication Inventory Terms
 
 ### Supply
 
 The inventory quantity for a medication.
 
 - Use `Supply` as the umbrella domain term for inventory quantity.
-- Use the more specific terms below when describing current quantity, last restock quantity, or reorder thresholds.
-- Prefer "Remaining Supply" over "Stock" for new patient/carer-facing copy when the meaning is the amount left now.
+- Use the more specific terms below for current quantity, last-restock
+  quantity, or reorder thresholds.
+- Prefer "Remaining Supply" over "Stock" in person- and carer-facing copy when
+  the meaning is the amount left now.
 
 ### Remaining Supply (`medications.current_supply`)
 
 The number of dispensable units left **right now**.
 
-- Decrements by 1 each time a dose is recorded.
-- Drives low/out-of-stock logic.
-- Should be shown in patient/carer-facing quantity displays.
-- Prefer **Remaining Supply** or **units remaining** in new UI copy over generic
-  **Stock** where the meaning is "what is left now".
+- Decrements when a dose is recorded against that selected, tracked inventory
+  source. A valid dose against untracked inventory does not change a quantity.
+- Drives low- and out-of-stock logic.
+- Should be shown in person- and carer-facing quantity displays.
+- Prefer **Remaining Supply** or **units remaining** over generic **Stock**
+  where the meaning is "what is left now".
 
 ### Supply at Last Restock (`medications.supply_at_last_restock`)
 
 The value of `current_supply` immediately after the most recent restock.
 
-- Set automatically by `Medication#restock!`.
-- Used as the denominator for progress bars so the bar drains proportionally from 100% → 0%.
-- Falls back to `reorder_threshold` when nil (e.g. legacy data before this column existed).
+- Set by `Medication#restock!`.
+- Used as the denominator for progress bars so the bar drains proportionally
+  from 100% to 0%.
+- Falls back to `reorder_threshold` when absent on older data.
 
 ### Reorder Threshold (`medications.reorder_threshold`)
 
 The level at or below which a medication is considered low stock.
 
-- `low_stock?` is true when `remaining_supply <= reorder_threshold`.
+- `low_stock?` is true when remaining supply is at or below the threshold.
 
-## Medication administration terms
+## Medication Catalogue Terms
 
 ### Medication
 
-The aggregate root for dosage options, supply attributes, and administration sources.
+The canonical record for one medicine or product held by a household.
 
-- `Medication` remains the canonical term in code for this aggregate.
-- Do not introduce parallel model names for the same concept in this pass.
+- Catalogue semantics include product names, dm+d identity, barcode, category,
+  and selectable dose identity.
+- Administration semantics include default schedule configuration, frequency,
+  dose limits, minimum timing, and dose cycle.
+- Inventory semantics include location, supply, restock, and reorder state.
+- `Medication` is currently a shared persistence adapter for these contexts; it
+  does not collapse Catalogue, Medication Administration, and Inventory into
+  one bounded context.
+
+### MedicationDosageOption
+
+A selectable dose identity, regimen defaults, and optional inventory for a
+medication.
+
+- Dose amount, unit, and description belong to Catalogue semantics.
+- Frequency, default maximum daily doses, default minimum hours between doses,
+  and default dose cycle belong to Medication Administration semantics.
+- `default_for_adults` and `default_for_children` belong to Medication
+  Administration's age-based default-selection semantics.
+- Optional dose-specific supply and threshold values belong to Inventory
+  semantics.
+- The model persists in the `dosages` table for compatibility.
+
+## Medication Administration Terms
 
 ### Schedule
 
-A time-based medication regimen tied to a person.
+A date-bounded medication administration source tied to a person.
 
-- Schedules remain distinct from ad-hoc medications.
-- A `Schedule` is one source of medication administration.
+- A `Schedule` carries dose and timing snapshots for its active period and
+  supports scheduled types plus the retained `prn` type.
+- It is one source of medication administration.
 
 ### PersonMedication
 
-An ad-hoc medication assignment outside the scheduled regimen flow.
+A direct routine or as-needed medication assignment without a schedule.
 
 - `PersonMedication` remains distinct from `Schedule`.
 - It is the second source of medication administration.
 
 ### MedicationTake
 
-The persisted dose record for a single administration event.
+The persisted record of one completed administration event.
 
-- `MedicationTake` remains the canonical persistence term in this pass.
-- UI copy may use "dose" or "administration" where clearer for users, but code should not introduce a second model name.
-- Avoid introducing a separate `DoseRecord` model name unless a future ADR changes the persistence boundary.
+- A take has exactly one source: `Schedule` or `PersonMedication`.
+- It stores the administered dose and selected inventory source as history.
+- Persisted takes are immutable.
+- UI copy may use "dose" or "administration" where clearer, but code should
+  not introduce a second model name.
+- Avoid introducing a separate `DoseRecord` model name unless an ADR changes
+  the persistence boundary.
 
-## Usage guidance
+## Health and Medication Safety Terms
 
-- Use **Remaining Supply** in UI copy where users need "what is left now".
-- Use **Reorder Threshold** to indicate the danger zone for re-ordering.
-- Progress bars use `current_supply / supply_at_last_restock` for a proportional drain.
-- Use **Schedule** for time-based medication regimens, not **Plan** or **Routine** in new code.
-- Use **MedicationTake** for persisted administration records, not **DoseRecord** in new code.
+### HealthEvent
+
+A recorded illness or suspected side effect for a person.
+
+- Event kinds are `illness` and `suspected_side_effect`.
+- An event may identify associated medications without becoming medication
+  administration history.
+
+### MedicationReviewPrompt
+
+The practitioner-review state created for a detected medication interaction.
+
+- A prompt retains an immutable snapshot of the evidence that produced it.
+- Review status and practitioner acknowledgement belong to Health and
+  Medication Safety, not Medication Catalogue.
+
+## Supporting Capability Terms
+
+### Report and Insight
+
+A read-only projection or derived interpretation of records owned by domain
+contexts.
+
+- `Reports::*` owns report-specific calculations and presentation records.
+- `SmartInsights::*` owns detector results derived from administration,
+  inventory, health, and safety records.
+- Neither capability owns or writes back the source facts it reads.
+
+### Notification Preference
+
+A person's choices for reminder and stock-notification delivery.
+
+- Notifications own preferences, subscription and delivery mechanics,
+  delivery deduplication, and push transport.
+- The context that produces an administration or inventory outcome retains
+  ownership of the fact that triggered a notification.
+
+## Usage Guidance
+
+- Use **Remaining Supply** where users need to know what is left now.
+- Use **Reorder Threshold** for the level that triggers low-stock behavior.
+- Use **Schedule** for date-bounded administration sources, including the
+  retained `prn` type, not **Plan** or **Routine** in new code.
+- Use **MedicationTake** for persisted administration records, not
+  **DoseRecord** in new code.
+- Use **CarerRelationship** for responsibility and **PersonAccessGrant** for
+  authority; use **Care Delegation** for the workflow that coordinates them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ ensuring medications are given on time and safely.
 - [**Technical Quick Start**](quick-start.md): run the full stack with Docker.
 - [Testing Guide](testing.md): run the RSpec and Capybara/Playwright test suites.
 - [Design & Architecture](design.md): explore the domain model and safety guardrails.
+- [Bounded Context Map](adrs/0009-bounded-context-map.md): see present domain ownership and dependency direction in the Rails modular monolith.
 - [Audit & Compliance](audit-trail.md): details on versioning and data history.
 - [MCP Integration](mcp.md): set up the hosted MCP server and connect Codex,
   Claude Code, or VS Code to read medication context.


### PR DESCRIPTION
## Summary

Domain ownership was scattered across stale terms and contradictory role language, which made it difficult to tell where medication, care, access, safety, and supporting rules belong.

This change:

- adds ADR 0009 to map the current semantic and transactional boundaries in the Rails modular monolith
- separates descriptive care responsibility from person-scoped access authority
- documents shared Rails models as persistence adapters without collapsing Catalogue, Administration, and Inventory ownership
- assigns Health and Medication Safety, Reporting and Insights, Notifications, Interoperability, Identity, Household Access, and Audit responsibilities explicitly
- updates the design guide and glossary to use the current domain language and concrete delegation rules
- narrowly supersedes ADR 0002’s obsolete six-role hierarchy and role-based examples while preserving its Rodauth, deny-by-default Pundit, and base PaperTrail decisions

This documents the application as it exists today. It does not propose extracting services, databases, Rails engines, or deployment units.