### PR TITLE
docs: repair family setup and OIDC links

### DIFF
--- a/docs/families/quick-setup.md
+++ b/docs/families/quick-setup.md
@@ -1,0 +1,38 @@
+# Quick Setup for Families
+
+Use this path to prepare a household and record its first dose safely.
+
+## Before you begin
+
+Ask the person who runs MedTracker for your sign-in or invitation. Deployment
+owners can follow the [self-hosting guide](../self-hosting.md) before inviting
+family members and carers.
+
+## 1. Set up the people you support
+
+Sign in, select the correct household, and check that each person you support
+has a profile. Follow [Manage your family members](../user-management.md) to
+add or update those profiles.
+
+## 2. Add a medicine
+
+Open the person's profile and follow [Add your first
+medicine](adding-first-medicine.md). Check the medicine, dose, schedule, and
+instructions before saving.
+
+## 3. Record the first dose
+
+Follow [Record a dose](taking-first-dose.md). Confirm the person, medicine,
+dose, and time before submitting the record.
+
+## 4. Verify the history
+
+Return to the person's medication history and confirm that the new record has
+the expected medicine, dose, and time. Medication history is an audit record,
+so ask a household administrator to investigate any mistake instead of trying
+to erase it.
+
+## Technical setup
+
+Contributors running MedTracker locally can use the [technical quick
+start](../quick-start.md).

--- a/docs/passkey-setup.md
+++ b/docs/passkey-setup.md
@@ -404,7 +404,7 @@ When migrating users from passwords to passkeys:
 
 ## Related Documentation
 
-- [OAuth Setup](oauth-setup.md)
+- [OpenID Connect (OIDC) Setup](oidc-setup.md)
 - [Audit Trail](audit-trail.md)
 - [Design](design.md)
 - [Rodauth Documentation](https://rodauth.jeremyevans.net/rdoc/files/doc/webauthn_rdoc.html)

--- a/spec/lib/documentation_links_spec.rb
+++ b/spec/lib/documentation_links_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Documentation links' do
+  def local_links(source)
+    source.read.scan(/\[[^\]]+\]\(([^)]+)\)/).flatten.filter_map do |target|
+      next if target.start_with?('http://', 'https://', '#')
+
+      source.dirname.join(target.split('#', 2).first)
+    end
+  end
+
+  it 'resolves links from the documentation entry points' do
+    sources = [Rails.root.join('docs/index.md'), Rails.root.join('docs/passkey-setup.md')]
+    missing = sources.flat_map { |source| local_links(source) }.reject(&:exist?)
+
+    expect(missing).to be_empty, "Missing documentation targets: #{missing.join(', ')}"
+  end
+
+  it 'connects the family quick setup journey' do
+    guide = Rails.root.join('docs/families/quick-setup.md').read
+
+    expect(guide).to include(
+      '../self-hosting.md',
+      'adding-first-medicine.md',
+      'taking-first-dose.md',
+      '../user-management.md'
+    )
+  end
+end

--- a/spec/lib/documentation_links_spec.rb
+++ b/spec/lib/documentation_links_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Documentation links' do
+RSpec.describe 'DocumentationLinks' do
   def local_links(source)
     source.read.scan(/\[[^\]]+\]\(([^)]+)\)/).flatten.filter_map do |target|
       next if target.start_with?('http://', 'https://', '#')

--- a/spec/lib/documentation_links_spec.rb
+++ b/spec/lib/documentation_links_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe 'DocumentationLinks' do
   end
 
   it 'resolves links from the documentation entry points' do
-    sources = [Rails.root.join('docs/index.md'), Rails.root.join('docs/passkey-setup.md')]
+    sources = [
+      Rails.root.join('docs/index.md'),
+      Rails.root.join('docs/passkey-setup.md'),
+      Rails.root.join('docs/families/quick-setup.md')
+    ]
     missing = sources.flat_map { |source| local_links(source) }.reject(&:exist?)
 
     expect(missing).to be_empty, "Missing documentation targets: #{missing.join(', ')}"

--- a/zensical.toml
+++ b/zensical.toml
@@ -10,6 +10,7 @@ site_dir = "site"
 nav = [
   { Home = "index.md" },
   { "🏠 For Families" = [
+    { "Quick Setup" = "families/quick-setup.md" },
     { "Add your first medicine" = "families/adding-first-medicine.md" },
     { "Record a dose" = "families/taking-first-dose.md" },
     { "Managing Your Family" = "user-management.md" }


### PR DESCRIPTION
## What changed

- adds the missing family quick-setup journey and includes it in the documentation navigation
- repairs the passkey guide link to the existing OIDC setup guide
- adds a focused documentation-link contract so these entry-point links cannot silently break again

## Why

The documentation home page linked to a guide that did not exist, while the passkey guide linked to a removed OAuth filename. Readers hit dead ends in both paths.

Closes #1630
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->