### PR TITLE
docs(adr): record current integration architecture

### DIFF
--- a/docs/adrs/0007-external-app-integration-contract.md
+++ b/docs/adrs/0007-external-app-integration-contract.md
@@ -1,7 +1,11 @@
 # ADR 0007: External App Integration Contract
 
-- Status: Accepted
+- Status: Superseded by [ADR 0010](0010-external-integration-architecture.md)
 - Date: 2026-07-09
+
+ADR 0010 replaces this decision because SMART on FHIR support shipped after
+this document was written, leaving its deferred and implemented descriptions in
+conflict. This document remains as historical context.
 
 ## Context
 

--- a/docs/adrs/0009-bounded-context-map.md
+++ b/docs/adrs/0009-bounded-context-map.md
@@ -190,7 +190,7 @@ database, Rails engine, or namespace split.
 - [Design and Architecture](../design.md)
 - [Glossary](../glossary.md)
 - [MedicationTake Aggregate Source Boundary](0006-medication-take-aggregate-source-boundary.md)
-- [External App Integration Contract](0007-external-app-integration-contract.md)
+- [External Integration Architecture](0010-external-integration-architecture.md)
 - [Domain Events with ActiveSupport::Notifications](0004-domain-events-with-active-support-notifications.md)
 - [Authentication and Authorization Strategy](0002-authentication-and-authorization-strategy.md),
   whose six-role hierarchy, role-based policy examples, and obsolete migration

--- a/docs/adrs/0010-external-integration-architecture.md
+++ b/docs/adrs/0010-external-integration-architecture.md
@@ -1,0 +1,138 @@
+# ADR 0010: External Integration Architecture
+
+- Status: Accepted
+- Date: 2026-07-14
+- Supersedes: [ADR 0007](0007-external-app-integration-contract.md)
+
+## Context
+
+MedTracker serves first-party applications, local automation, hosted MCP
+clients, and external healthcare applications. These clients require different
+payloads, compatibility guarantees, credentials, and consent boundaries.
+
+ADR 0007 established separate product and FHIR surfaces, but it was written
+across the delivery of SMART on FHIR. It consequently describes SMART support
+as both deferred and implemented. The shipped architecture now includes a
+registered-client SMART App Launch flow, so one current decision must replace
+that contradictory record.
+
+## Decision
+
+MedTracker keeps separate integration contracts by audience. No single API is
+the canonical interface for every client.
+
+| Audience | Contract | Surface |
+| --- | --- | --- |
+| First-party mobile applications | MedTracker product API with portable IDs, household routes, session exchange, sync, and export/import | `/api/v1` |
+| First-party CLI and local automation | MedTracker product API using API sessions or API app tokens | `/api/v1` |
+| Hosted MCP clients | Read-only Streamable HTTP MCP using MedTracker bearer credentials | `/mcp` |
+| Registered third-party healthcare applications | SMART App Launch 2.x standalone authorization and FHIR R4 read/search resources | `/authorize`, `/token`, `/revoke`, and `/api/fhir/R4` |
+| Browser and operator workflows | Rails web UI and explicitly supported administration endpoints | Web routes and `/api/v1` admin routes |
+
+First-party clients use `/api/v1` for MedTracker-specific workflows. FHIR is
+not the product synchronization API and does not replace sync batches,
+tombstones, encrypted portable data, household administration, or capability
+negotiation.
+
+External healthcare applications use FHIR R4. They must not depend on
+MedTracker product payloads unless MedTracker explicitly supports them as a
+first-party or trusted product client.
+
+## First-party authorization
+
+MedTracker owns the authorization context for `/api/v1` and `/mcp`.
+
+- API sessions are minted after a valid MedTracker password login or external
+  OIDC identity exchange.
+- API app tokens are created from an authenticated MedTracker profile session.
+- Each credential is bound to an account, household, membership, and membership
+  permissions version.
+- Person access is evaluated from active grants and Pundit policy scopes.
+- Locked accounts, inactive users, revoked memberships, stale permissions, and
+  cross-household requests fail closed.
+- The hosted MCP surface uses the same bearer boundary and remains read-only.
+
+The external identity provider owns primary authentication, MFA, recovery, and
+passkeys as recorded in ADR 0005. MedTracker still owns its API session,
+household, grant, revocation, and audit behavior.
+
+## SMART on FHIR authorization
+
+MedTracker supports SMART App Launch 2.x standalone launch for registered
+third-party healthcare applications.
+
+The discovery document is published at
+`/api/fhir/R4/.well-known/smart-configuration`. The FHIR R4 capability statement
+advertises the authorization, token, and revocation endpoints.
+
+Authorization uses the code flow. Public clients use PKCE with `S256`.
+Confidential clients also authenticate with their registered client secret.
+Redirect URIs are registered in advance, must use HTTPS, and are compared
+exactly. Authorization codes are short-lived, single-use, and bound to the
+client, redirect URI, and verifier.
+
+The consent decision binds the OAuth grant to:
+
+- the registered application;
+- the signed-in account;
+- one active household membership and its permissions version;
+- one person context; and
+- the approved SMART scopes.
+
+FHIR reads must pass both the SMART resource scope and the MedTracker policy
+scope. A scope cannot expand household or person access. Changed or revoked
+memberships, locked accounts, inactive users, expired grants, and revoked grants
+fail closed before FHIR data is returned.
+
+Supported scopes are read-only SMART v2 patient and user scopes, including
+`patient/*.rs`, `user/*.rs`, and supported resource-specific forms. Access
+tokens expire after 15 minutes. Refresh tokens expire after 30 days and rotate
+on use. Revocation invalidates the complete grant.
+
+Authorization codes, access tokens, and refresh tokens are never stored in
+plaintext. Token digests and PHI-free consent and revocation evidence are stored
+without FHIR payloads or raw credentials.
+
+## Deliberate boundaries
+
+Only the shipped contract is advertised:
+
+- standalone launch is supported; EHR launch is not supported;
+- read scopes are supported; FHIR write scopes are not supported;
+- Dynamic client registration is not supported;
+- bulk-data export is not part of the SMART contract;
+- OpenID Connect identity scopes are not part of the SMART contract; and
+- `/api/v1` credentials do not become SMART grants, and SMART grants do not
+  authorize `/api/v1` product operations.
+
+Registered-client onboarding is therefore an explicit trust and operational
+process. Expanding any boundary above requires a new decision or an amendment
+that covers consent, tenant isolation, revocation, audit, and compatibility.
+
+## Consequences
+
+### Positive
+
+- Client teams have an unambiguous endpoint and credential choice.
+- Product sync can evolve without forcing MedTracker concepts into FHIR.
+- Third-party healthcare access uses standard discovery, consent, scopes, and
+  FHIR payloads.
+- SMART scope checks cannot bypass MedTracker household and person policy.
+- Discovery metadata can remain truthful about the supported launch mode.
+
+### Negative
+
+- MedTracker maintains separate product, MCP, and FHIR documentation surfaces.
+- Clients that need both product workflows and FHIR reads require separate
+  credentials and an explicit onboarding decision.
+- Registered SMART applications require operational client management until a
+  deliberately designed registration workflow exists.
+
+## Related documents
+
+- [External Identity Provider](0005-external-identity-provider.md)
+- [Bounded Context Map](0009-bounded-context-map.md)
+- [SMART on FHIR](../api/smart-on-fhir.md)
+- [SMART on FHIR security review](../security/smart-on-fhir-security-review.md)
+- [MCP integration](../mcp.md)
+- [MedTracker OpenAPI contract](../api/openapi.v1.yaml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ ensuring medications are given on time and safely.
 - [Client Tools](api/client-tools.md): install and operate the first-party
   `medtracker` CLI and `medtracker-mcp` stdio server over `/api/v1`.
 - [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
-- [External App Integration Contract](adrs/0007-external-app-integration-contract.md): choose `/api/v1`, `/mcp`, or FHIR R4 by client audience.
+- [External Integration Architecture](adrs/0010-external-integration-architecture.md): choose `/api/v1`, `/mcp`, or SMART on FHIR by client audience.
 - [Production Upload Storage](adrs/0008-production-upload-storage.md): understand the single-node persistent-volume decision and scaling boundary.
 - [Upload Storage Backup and Restore](operations/upload-storage-backup-and-restore.md): back up and verify database records with stored blobs.
 - [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.

--- a/spec/lib/external_integration_adr_document_spec.rb
+++ b/spec/lib/external_integration_adr_document_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class ExternalIntegrationAdrDocument
+  def previous = Rails.root.join('docs/adrs/0007-external-app-integration-contract.md').read
+
+  def current = Rails.root.join('docs/adrs/0010-external-integration-architecture.md').read
+
+  def index = Rails.root.join('docs/index.md').read
+end
+
+RSpec.describe ExternalIntegrationAdrDocument do
+  subject(:document) { described_class.new }
+
+  it 'supersedes the contradictory external integration decision' do
+    expect(document.previous).to include(
+      '- Status: Superseded by [ADR 0010](0010-external-integration-architecture.md)'
+    )
+  end
+
+  it 'records the shipped integration and SMART authorization architecture' do
+    expect(document.current.squish).to include(
+      '- Status: Accepted',
+      '/api/v1',
+      '/mcp',
+      '/api/fhir/R4',
+      'standalone launch',
+      'PKCE with `S256`',
+      '15 minutes',
+      '30 days',
+      'SMART resource scope',
+      'MedTracker policy scope',
+      'Dynamic client registration is not supported'
+    )
+  end
+
+  it 'makes the current decision discoverable' do
+    expect(document.index).to include(
+      '[External Integration Architecture](adrs/0010-external-integration-architecture.md)'
+    )
+  end
+end


### PR DESCRIPTION
## What changed

- adds ADR 0010 as the authoritative external integration architecture
- records the separate `/api/v1`, read-only `/mcp`, and standalone SMART on FHIR contracts
- records the shipped SMART registration, consent, PKCE, scope, policy, expiry, rotation, and audit boundaries
- marks ADR 0007 as superseded and updates current documentation links

## Why

ADR 0007 described SMART on FHIR as both deferred and implemented. That contradiction made the integration contract unreliable after SMART support shipped. ADR 0010 now records one current architecture while preserving ADR 0007 as historical context.

Closes #1631
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->