### PR TITLE
fix(client-tools): align sync requests with Rails

### DIFF
--- a/client-tools/crates/medtracker-api-client/src/client.rs
+++ b/client-tools/crates/medtracker-api-client/src/client.rs
@@ -77,6 +77,21 @@ impl ApiClient {
         Ok(envelope.data)
     }
 
+    pub(crate) async fn get_data_with_query<T>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let mut url = self.url(path)?;
+        url.query_pairs_mut().extend_pairs(query);
+        let request = self.authorize(self.http.get(url));
+        let envelope: DataEnvelope<T> = self.send_json(request).await?;
+        Ok(envelope.data)
+    }
+
     fn authorize(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.bearer_token {
             Some(token) => request.bearer_auth(token),

--- a/client-tools/crates/medtracker-api-client/src/models.rs
+++ b/client-tools/crates/medtracker-api-client/src/models.rs
@@ -35,6 +35,11 @@ pub enum PortableImportMode {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BatchMutationRequest {
+    pub batch: BatchMutationPayload,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BatchMutationPayload {
     pub operations: Vec<Value>,
 }
 

--- a/client-tools/crates/medtracker-api-client/src/sync.rs
+++ b/client-tools/crates/medtracker-api-client/src/sync.rs
@@ -19,11 +19,11 @@ impl ApiClient {
     ) -> Result<Value, ApiError> {
         self.require_capability("sync change feed", &["sync", "change_feed"])
             .await?;
-        let suffix = since.map_or_else(String::new, |value| format!("?cursor={value}"));
-        self.get_data(&format!(
-            "/api/v1/households/{household_id}/sync/changes{suffix}"
-        ))
-        .await
+        let path = format!("/api/v1/households/{household_id}/sync/changes");
+        match since {
+            Some(cursor) => self.get_data_with_query(&path, &[("cursor", cursor)]).await,
+            None => self.get_data(&path).await,
+        }
     }
 
     pub async fn sync_batch(
@@ -58,7 +58,7 @@ mod tests {
         mount_sync_capabilities(&server).await;
         Mock::given(method("GET"))
             .and(path("/api/v1/households/household-1/sync/changes"))
-            .and(query_param("cursor", "2026-07-14T12:00:00Z"))
+            .and(query_param("cursor", "2026-07-14T12:00:00+05:00"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "data": { "cursor": "next", "changes": [], "tombstones": [] }
             })))
@@ -67,7 +67,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri(), Some("test-token".to_string())).unwrap();
         let result = client
-            .sync_changes("household-1", Some("2026-07-14T12:00:00Z"))
+            .sync_changes("household-1", Some("2026-07-14T12:00:00+05:00"))
             .await;
 
         assert!(result.is_ok());

--- a/client-tools/crates/medtracker-api-client/src/sync.rs
+++ b/client-tools/crates/medtracker-api-client/src/sync.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::client::ApiClient;
 use crate::error::ApiError;
-use crate::models::BatchMutationRequest;
+use crate::models::{BatchMutationPayload, BatchMutationRequest};
 
 impl ApiClient {
     pub async fn sync_snapshot(&self, household_id: &str) -> Result<Value, ApiError> {
@@ -19,7 +19,7 @@ impl ApiClient {
     ) -> Result<Value, ApiError> {
         self.require_capability("sync change feed", &["sync", "change_feed"])
             .await?;
-        let suffix = since.map_or_else(String::new, |value| format!("?since={value}"));
+        let suffix = since.map_or_else(String::new, |value| format!("?cursor={value}"));
         self.get_data(&format!(
             "/api/v1/households/{household_id}/sync/changes{suffix}"
         ))
@@ -33,11 +33,88 @@ impl ApiClient {
     ) -> Result<Value, ApiError> {
         self.require_capability("sync batch mutations", &["sync", "batch_mutations"])
             .await?;
-        let request = BatchMutationRequest { operations };
+        let request = BatchMutationRequest {
+            batch: BatchMutationPayload { operations },
+        };
         self.post_json_data(
             &format!("/api/v1/households/{household_id}/sync/batches"),
             &request,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use wiremock::matchers::{body_json, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sync_changes_sends_the_rails_cursor_parameter() {
+        let server = MockServer::start().await;
+        mount_sync_capabilities(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/households/household-1/sync/changes"))
+            .and(query_param("cursor", "2026-07-14T12:00:00Z"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "cursor": "next", "changes": [], "tombstones": [] }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri(), Some("test-token".to_string())).unwrap();
+        let result = client
+            .sync_changes("household-1", Some("2026-07-14T12:00:00Z"))
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sync_batch_sends_the_rails_batch_envelope() {
+        let server = MockServer::start().await;
+        mount_sync_capabilities(&server).await;
+        let operations = vec![json!({
+            "action": "delete",
+            "resource_type": "medications",
+            "id": "medication-1"
+        })];
+        Mock::given(method("POST"))
+            .and(path("/api/v1/households/household-1/sync/batches"))
+            .and(body_json(json!({ "batch": { "operations": operations } })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "results": [] }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri(), Some("test-token".to_string())).unwrap();
+        let result = client.sync_batch("household-1", operations).await;
+
+        assert!(result.is_ok());
+    }
+
+    async fn mount_sync_capabilities(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "format": "medtracker.api.capabilities.v1",
+                    "api_version": "v1",
+                    "client_tools": {
+                        "cli": { "supported": true },
+                        "mcp_server": { "supported": true }
+                    },
+                    "sync": {
+                        "change_feed": true,
+                        "batch_mutations": true
+                    }
+                }
+            })))
+            .mount(server)
+            .await;
     }
 }


### PR DESCRIPTION
## What changed

- send the Rails `cursor` query parameter for incremental sync
- wrap batch mutations in the required `batch` envelope
- verify both request contracts at the HTTP boundary

## Why

The shipped Rust client generated requests that the Rails API did not accept, so incremental sync and batch mutation calls could not interoperate with the server.

Closes #1652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->