### PR TITLE
docs(api): type and validate shared OpenAPI contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -172,9 +172,22 @@ paths:
       summary: List visible people in the household.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/updated_since'
       responses:
         '200':
           description: People collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     post:
       operationId: createPerson
       tags:
@@ -183,9 +196,30 @@ paths:
       summary: Create a person in the household.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonCreateRequest'
       responses:
         '201':
           description: Person created.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/people/{id}:
     get:
       operationId: getPerson
@@ -199,6 +233,21 @@ paths:
       responses:
         '200':
           description: Person resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     patch:
       operationId: updatePerson
       tags:
@@ -208,9 +257,35 @@ paths:
       parameters:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonUpdateRequest'
       responses:
         '200':
           description: Person updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     put:
       operationId: replacePerson
       tags:
@@ -220,9 +295,35 @@ paths:
       parameters:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonUpdateRequest'
       responses:
         '200':
           description: Person updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/locations:
     get:
       operationId: listLocations
@@ -1120,20 +1221,330 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+      bearerFormat: opaque
   parameters:
     household_id:
       name: household_id
       in: path
       required: true
       schema:
-        type: integer
+        $ref: '#/components/schemas/NumericId'
     id:
       name: id
       in: path
       required: true
       schema:
+        $ref: '#/components/schemas/ResourceIdentifier'
+    page:
+      name: page
+      in: query
+      required: false
+      schema:
         type: integer
+        minimum: 1
+        default: 1
+    per_page:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    updated_since:
+      name: updated_since
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/Timestamp'
+    if_match:
+      name: If-Match
+      in: header
+      required: false
+      schema:
+        type: string
+  headers:
+    etag:
+      description: Version identifier for optimistic concurrency.
+      schema:
+        type: string
+    retry_after:
+      description: Seconds until the request may be retried.
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    Unauthorized:
+      description: The bearer credential is absent, invalid, expired, revoked, or no longer active.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    Forbidden:
+      description: The credential cannot perform the operation in the routed household or person scope.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    NotFound:
+      description: The resource does not exist inside the authorized scope.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    ValidationFailed:
+      description: The submitted attributes or filters are invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    Conflict:
+      description: The resource or idempotency state conflicts with the requested mutation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    PreconditionRequired:
+      description: The mutation requires a version precondition.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    RateLimited:
+      description: The request exceeded an API rate limit.
+      headers:
+        Retry-After:
+          $ref: '#/components/headers/retry_after'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RateLimitErrorEnvelope'
   schemas:
+    NumericId:
+      type: integer
+      minimum: 1
+    PortableId:
+      type: string
+      format: uuid
+    ResourceIdentifier:
+      oneOf:
+        - $ref: '#/components/schemas/NumericId'
+        - $ref: '#/components/schemas/PortableId'
+    NullableNumericId:
+      oneOf:
+        - $ref: '#/components/schemas/NumericId'
+        - type: 'null'
+    NullablePortableId:
+      oneOf:
+        - $ref: '#/components/schemas/PortableId'
+        - type: 'null'
+    Timestamp:
+      type: string
+      format: date-time
+    Date:
+      type: string
+      format: date
+    PaginationMeta:
+      type: object
+      additionalProperties: false
+      required:
+        - page
+        - per_page
+        - total_count
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        per_page:
+          type: integer
+          minimum: 1
+          maximum: 100
+        total_count:
+          type: integer
+          minimum: 0
+    PersonAttributes:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type:
+            - string
+            - 'null'
+          format: email
+        date_of_birth:
+          oneOf:
+            - $ref: '#/components/schemas/Date'
+            - type: 'null'
+        person_type:
+          type: string
+          enum:
+            - adult
+            - minor
+            - dependent_adult
+        has_capacity:
+          type: boolean
+    Person:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - portable_id
+        - updated_at
+        - name
+        - email
+        - date_of_birth
+        - person_type
+        - has_capacity
+        - age
+        - location_ids
+        - location_portable_ids
+        - notification_preference_id
+        - notification_preference_portable_id
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        updated_at:
+          $ref: '#/components/schemas/Timestamp'
+        name:
+          type: string
+          minLength: 1
+        email:
+          type:
+            - string
+            - 'null'
+          format: email
+        date_of_birth:
+          oneOf:
+            - $ref: '#/components/schemas/Date'
+            - type: 'null'
+        person_type:
+          type: string
+          enum:
+            - adult
+            - minor
+            - dependent_adult
+        has_capacity:
+          type: boolean
+        age:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+        location_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/NumericId'
+        location_portable_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortableId'
+        notification_preference_id:
+          $ref: '#/components/schemas/NullableNumericId'
+        notification_preference_portable_id:
+          $ref: '#/components/schemas/NullablePortableId'
+    PersonCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - person
+      properties:
+        person:
+          allOf:
+            - $ref: '#/components/schemas/PersonAttributes'
+            - required:
+                - name
+                - date_of_birth
+                - person_type
+    PersonUpdateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - person
+      properties:
+        person:
+          $ref: '#/components/schemas/PersonAttributes'
+    PersonResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/Person'
+    PersonCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Person'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    ValidationErrors:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+    Error:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+        - request_id
+      properties:
+        code:
+          type: string
+          minLength: 1
+        message:
+          type: string
+          minLength: 1
+        request_id:
+          type: string
+          minLength: 1
+        errors:
+          $ref: '#/components/schemas/ValidationErrors'
+    ErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+    RateLimitError:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          const: rate_limited
+        message:
+          type: string
+          minLength: 1
+    RateLimitErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/RateLimitError'
     SyncBatchRequest:
       type: object
       required:
@@ -1168,34 +1579,10 @@ components:
             - medication
             - health_event
         id:
-          type: string
+          $ref: '#/components/schemas/ResourceIdentifier'
         if_match:
           type: string
           description: Exact ETag from the snapshot or latest resource response.
         attributes:
           type: object
           additionalProperties: true
-    ErrorEnvelope:
-      type: object
-      required:
-        - error
-      properties:
-        error:
-          type: object
-          required:
-            - code
-            - message
-            - request_id
-          properties:
-            code:
-              type: string
-            message:
-              type: string
-            request_id:
-              type: string
-            errors:
-              type: object
-              additionalProperties:
-                type: array
-                items:
-                  type: string

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -257,7 +257,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/id'
-        - $ref: '#/components/parameters/if_match'
       requestBody:
         required: true
         content:
@@ -280,22 +279,19 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationFailed'
         '429':
           $ref: '#/components/responses/RateLimited'
     put:
-      operationId: replacePerson
+      operationId: updatePersonWithPut
       tags:
         - Household
         - People
-      summary: Replace a person.
+      summary: Update a person using the PUT route.
       parameters:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/id'
-        - $ref: '#/components/parameters/if_match'
       requestBody:
         required: true
         content:
@@ -318,8 +314,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationFailed'
         '429':
@@ -345,7 +339,7 @@ paths:
       summary: Read a location.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Location resource.
@@ -381,10 +375,13 @@ paths:
       summary: Read a medication.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Medication resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
     patch:
       operationId: updateMedication
       tags:
@@ -393,10 +390,16 @@ paths:
       summary: Update a medication.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Medication updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
     put:
       operationId: replaceMedication
       tags:
@@ -405,10 +408,16 @@ paths:
       summary: Replace a medication.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Medication updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /households/{household_id}/medications/{id}/adjust_inventory:
     patch:
       operationId: adjustMedicationInventory
@@ -418,7 +427,7 @@ paths:
       summary: Adjust medication inventory.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Medication inventory adjusted.
@@ -431,7 +440,7 @@ paths:
       summary: Mark a medication reorder as ordered.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Reorder status updated.
@@ -444,7 +453,7 @@ paths:
       summary: Mark a medication reorder as received.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Reorder status updated.
@@ -480,10 +489,13 @@ paths:
       summary: Read a medication dosage option.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Dosage option resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
     patch:
       operationId: updateDosageOption
       tags:
@@ -492,10 +504,16 @@ paths:
       summary: Update a medication dosage option.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Dosage option updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
     put:
       operationId: replaceDosageOption
       tags:
@@ -504,10 +522,16 @@ paths:
       summary: Replace a medication dosage option.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Dosage option updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /households/{household_id}/health_events:
     get:
       operationId: listHealthEvents
@@ -540,10 +564,13 @@ paths:
       summary: Read a health event.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Health event resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
     patch:
       operationId: updateHealthEvent
       tags:
@@ -552,10 +579,16 @@ paths:
       summary: Update a health event.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Health event updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
     put:
       operationId: replaceHealthEvent
       tags:
@@ -564,10 +597,16 @@ paths:
       summary: Replace a health event.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Health event updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /households/{household_id}/schedules:
     get:
       operationId: listSchedules
@@ -600,10 +639,13 @@ paths:
       summary: Read a schedule.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Schedule resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
     patch:
       operationId: updateSchedule
       tags:
@@ -612,10 +654,16 @@ paths:
       summary: Update a schedule.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Schedule updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
     put:
       operationId: replaceSchedule
       tags:
@@ -624,10 +672,16 @@ paths:
       summary: Replace a schedule.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Schedule updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /households/{household_id}/schedules/{id}/pause:
     patch:
       operationId: pauseSchedule
@@ -637,7 +691,7 @@ paths:
       summary: Pause a schedule.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Schedule paused.
@@ -650,7 +704,7 @@ paths:
       summary: Resume a schedule.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Schedule resumed.
@@ -686,10 +740,13 @@ paths:
       summary: Read a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Person medication resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
     patch:
       operationId: updatePersonMedication
       tags:
@@ -698,10 +755,16 @@ paths:
       summary: Update a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Person medication updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
     put:
       operationId: replacePersonMedication
       tags:
@@ -710,10 +773,16 @@ paths:
       summary: Replace a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/if_match'
       responses:
         '200':
           description: Person medication updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /households/{household_id}/person_medications/{id}/pause:
     patch:
       operationId: pausePersonMedication
@@ -723,7 +792,7 @@ paths:
       summary: Pause a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Person medication paused.
@@ -736,7 +805,7 @@ paths:
       summary: Resume a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Person medication resumed.
@@ -749,7 +818,7 @@ paths:
       summary: Reorder a person medication assignment.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_id'
       responses:
         '200':
           description: Person medication reordered.
@@ -831,7 +900,7 @@ paths:
       summary: Revoke a native device token.
       parameters:
         - $ref: '#/components/parameters/household_id'
-        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/native_device_token'
       responses:
         '204':
           description: Device token revoked.
@@ -1002,17 +1071,9 @@ paths:
         '201':
           description: Batch applied.
         '409':
-          description: An operation used a stale resource ETag.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
+          $ref: '#/components/responses/Conflict'
         '428':
-          description: An update or delete operation omitted its required resource ETag.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
+          $ref: '#/components/responses/PreconditionRequired'
   /households/{household_id}/admin/settings:
     get:
       operationId: getHouseholdAdminSettings
@@ -1234,7 +1295,19 @@ components:
       in: path
       required: true
       schema:
+        $ref: '#/components/schemas/NumericId'
+    resource_id:
+      name: id
+      in: path
+      required: true
+      schema:
         $ref: '#/components/schemas/ResourceIdentifier'
+    native_device_token:
+      name: id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/DeviceTokenIdentifier'
     page:
       name: page
       in: query
@@ -1267,6 +1340,7 @@ components:
   headers:
     etag:
       description: Version identifier for optimistic concurrency.
+      required: true
       schema:
         type: string
     retry_after:
@@ -1332,6 +1406,9 @@ components:
       oneOf:
         - $ref: '#/components/schemas/NumericId'
         - $ref: '#/components/schemas/PortableId'
+    DeviceTokenIdentifier:
+      type: string
+      minLength: 1
     NullableNumericId:
       oneOf:
         - $ref: '#/components/schemas/NumericId'
@@ -1377,9 +1454,7 @@ components:
             - 'null'
           format: email
         date_of_birth:
-          oneOf:
-            - $ref: '#/components/schemas/Date'
-            - type: 'null'
+          $ref: '#/components/schemas/Date'
         person_type:
           type: string
           enum:
@@ -1436,7 +1511,6 @@ components:
           type:
             - integer
             - 'null'
-          minimum: 0
         location_ids:
           type: array
           items:
@@ -1461,7 +1535,6 @@ components:
             - required:
                 - name
                 - date_of_birth
-                - person_type
     PersonUpdateRequest:
       type: object
       additionalProperties: false
@@ -1547,11 +1620,13 @@ components:
           $ref: '#/components/schemas/RateLimitError'
     SyncBatchRequest:
       type: object
+      additionalProperties: false
       required:
         - batch
       properties:
         batch:
           type: object
+          additionalProperties: false
           required:
             - operations
           properties:
@@ -1562,6 +1637,7 @@ components:
                 $ref: '#/components/schemas/SyncBatchOperation'
     SyncBatchOperation:
       type: object
+      additionalProperties: false
       required:
         - action
         - resource_type

--- a/spec/fixtures/files/openapi-3.1-schema-2022-10-07.json
+++ b/spec/fixtures/files/openapi-3.1-schema-2022-10-07.json
@@ -1,0 +1,1440 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/base"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item-or-reference"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#path-item-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-form"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "name": {
+                    "pattern": "[^/#?]+$"
+                  },
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                }
+              }
+            },
+            "styles-for-form": {
+              "if": {
+                "properties": {
+                  "style": {
+                    "const": "form"
+                  }
+                },
+                "required": [
+                  "style"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "explode": {
+                    "default": true
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "explode": {
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "default": "form",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/encoding/$defs/explode-default"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "explode-default": {
+          "if": {
+            "properties": {
+              "style": {
+                "const": "form"
+              }
+            },
+            "required": [
+              "style"
+            ]
+          },
+          "then": {
+            "properties": {
+              "explode": {
+                "default": true
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "explode": {
+                "default": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'json_schemer'
 
 module OpenapiRouteCoverage
   module_function
@@ -34,14 +35,130 @@ module OpenapiRouteCoverage
   end
 end
 
+module OpenapiYamlValidation
+  def duplicate_mapping_keys(node = Psych.parse(source).root, path = '#')
+    return mapping_duplicate_keys(node, path) if node.is_a?(Psych::Nodes::Mapping)
+    return sequence_duplicate_keys(node, path) if node.is_a?(Psych::Nodes::Sequence)
+
+    []
+  end
+
+  def mapping_duplicate_keys(node, path)
+    entries = node.children.each_slice(2).to_a
+    duplicate_key_paths(entries, path) + entries.flat_map do |key, value|
+      duplicate_mapping_keys(value, "#{path}/#{key.value}")
+    end
+  end
+
+  def sequence_duplicate_keys(node, path)
+    node.children.each_with_index.flat_map do |child, index|
+      duplicate_mapping_keys(child, "#{path}/#{index}")
+    end
+  end
+
+  def duplicate_key_paths(entries, path)
+    entries.map { |key, _value| key.value }.tally.filter_map do |key, count|
+      "#{path}/#{key}" if count > 1
+    end
+  end
+
+  def unsupported_free_form_errors(value = document, path = '#')
+    errors = unsupported_free_form?(value, path) ? [path] : []
+    errors + nested_free_form_errors(value, path)
+  end
+
+  def nested_free_form_errors(value, path)
+    case value
+    when Hash
+      value.flat_map { |key, child| unsupported_free_form_errors(child, "#{path}/#{key}") }
+    when Array
+      value.each_with_index.flat_map { |child, index| unsupported_free_form_errors(child, "#{path}/#{index}") }
+    else
+      []
+    end
+  end
+
+  def unsupported_free_form?(value, path)
+    value.is_a?(Hash) && value['type'] == 'object' && value['additionalProperties'] == true &&
+      OpenapiStructure::ALLOWED_FREE_FORM_PATHS.exclude?(path)
+  end
+end
+
+module OpenapiReferenceValidation
+  def local_reference_errors(value = document, path = '#', root = document)
+    errors = broken_local_reference?(value, root) ? ["#{path}/$ref"] : []
+    errors + nested_reference_errors(value, path, root)
+  end
+
+  def nested_reference_errors(value, path, root)
+    case value
+    when Hash
+      value.flat_map { |key, child| local_reference_errors(child, "#{path}/#{key}", root) }
+    when Array
+      value.each_with_index.flat_map { |child, index| local_reference_errors(child, "#{path}/#{index}", root) }
+    else
+      []
+    end
+  end
+
+  def broken_local_reference?(value, root)
+    value.is_a?(Hash) && value.key?('$ref') && resolve_local_reference(value.fetch('$ref'), root:).nil?
+  end
+
+  def resolve_local_reference(reference, root: document)
+    return unless reference.start_with?('#/')
+
+    resolve_reference_tokens(root, reference.delete_prefix('#/').split('/'))
+  end
+
+  def resolve_reference_tokens(node, tokens)
+    return node if tokens.empty?
+    return unless node.is_a?(Hash)
+
+    token, *remaining = tokens
+    resolve_reference_tokens(node[token.gsub('~1', '/').gsub('~0', '~')], remaining)
+  end
+
+  def dereferenced_schema(name)
+    dereference(schema(name))
+  end
+
+  def dereference(value, root: document)
+    case value
+    when Hash
+      return dereference(resolve_local_reference(value.fetch('$ref'), root:), root:) if value.key?('$ref')
+
+      value.transform_values { |child| dereference(child, root:) }
+    when Array
+      value.map { |child| dereference(child, root:) }
+    else
+      value
+    end
+  end
+
+  def schema_errors(name, payload)
+    JSONSchemer.schema(dereferenced_schema(name)).validate(payload.deep_stringify_keys).map do |error|
+      error.fetch('data_pointer')
+    end
+  end
+end
+
 module OpenapiStructure
   HTTP_METHODS = %w[delete get head options patch post put trace].freeze
   AUDIENCE_TAGS = ['Public', 'Account', 'Household', 'Household administration'].freeze
+  ALLOWED_FREE_FORM_PATHS = ['#/components/schemas/SyncBatchOperation/properties/attributes'].freeze
+
+  extend OpenapiYamlValidation
+  extend OpenapiReferenceValidation
 
   module_function
 
   def document
     YAML.safe_load(Rails.root.join('docs/api/openapi.v1.yaml').read)
+  end
+
+  def source
+    Rails.root.join('docs/api/openapi.v1.yaml').read
   end
 
   def paths
@@ -59,9 +176,23 @@ module OpenapiStructure
   def defined_tags
     document.fetch('tags')
   end
+
+  def components
+    document.fetch('components')
+  end
+
+  def schema(name)
+    components.fetch('schemas').fetch(name)
+  end
+
+  def operation(path, method)
+    paths.fetch(path).fetch(method)
+  end
 end
 
-RSpec.describe OpenapiRouteCoverage do
+RSpec.describe OpenapiRouteCoverage, type: :request do
+  fixtures :accounts, :people, :users, :locations, :location_memberships, :carer_relationships
+
   it 'documents every mounted API v1 route' do
     described_class.api_route_operations.each do |path, verb|
       expect(described_class.mounted_paths).to include(path)
@@ -110,6 +241,140 @@ RSpec.describe OpenapiRouteCoverage do
       expect(defined_tags).to all(include('description'))
       expect(defined_tags.map { |tag| tag.fetch('description') }).to all(be_present)
       expect(defined_tag_names).to match_array(used_tag_names)
+    end
+
+    it 'defines distinct identifiers, timestamps, and pagination' do
+      schemas = described_class.components.fetch('schemas')
+
+      expect(schemas.fetch('NumericId')).to include('type' => 'integer', 'minimum' => 1)
+      expect(schemas.fetch('PortableId')).to include('type' => 'string', 'format' => 'uuid')
+      expect(schemas.fetch('ResourceIdentifier').fetch('oneOf')).to contain_exactly(
+        { '$ref' => '#/components/schemas/NumericId' },
+        { '$ref' => '#/components/schemas/PortableId' }
+      )
+      expect(schemas.fetch('Timestamp')).to include('type' => 'string', 'format' => 'date-time')
+      expect(schemas.fetch('PaginationMeta').fetch('required')).to contain_exactly(
+        'page', 'per_page', 'total_count'
+      )
+    end
+
+    it 'uses shared path, precondition, and response header components' do
+      parameters = described_class.components.fetch('parameters')
+      headers = described_class.components.fetch('headers')
+
+      expect(parameters.fetch('id').dig('schema', '$ref')).to eq('#/components/schemas/ResourceIdentifier')
+      expect(parameters.fetch('household_id').dig('schema', '$ref')).to eq('#/components/schemas/NumericId')
+      expect(parameters.fetch('if_match').fetch('in')).to eq('header')
+      expect(headers.fetch('etag').dig('schema', 'type')).to eq('string')
+    end
+
+    it 'defines shared errors and bearer security' do
+      responses = described_class.components.fetch('responses')
+
+      expect(responses).to include(
+        'Unauthorized', 'Forbidden', 'NotFound', 'ValidationFailed', 'Conflict',
+        'PreconditionRequired', 'RateLimited'
+      )
+      expect(described_class.components.dig('securitySchemes', 'bearerAuth')).to include(
+        'type' => 'http', 'scheme' => 'bearer'
+      )
+    end
+
+    it 'models intentional unauthenticated exceptions without weakening protected operations' do
+      unauthenticated = described_class.operations.filter_map do |path, method, operation|
+        "#{method.upcase} #{path}" if operation['security'] == []
+      end
+
+      expect(described_class.document.fetch('security')).to eq([{ 'bearerAuth' => [] }])
+      expect(unauthenticated).to contain_exactly(
+        'GET /capabilities',
+        'POST /auth/login',
+        'POST /auth/oidc_exchange',
+        'POST /auth/refresh'
+      )
+      expect(described_class.operation('/auth/logout', 'delete')).not_to include('security')
+    end
+
+    it 'validates OpenAPI structure, local references, and object boundaries' do
+      expect(described_class.document).to include('openapi' => '3.1.0')
+      expect(described_class.document).to include('info', 'servers', 'paths', 'components')
+      expect(described_class.duplicate_mapping_keys).to be_empty
+      expect(described_class.local_reference_errors).to be_empty
+      expect(described_class.unsupported_free_form_errors).to be_empty
+    end
+
+    it 'loads every reusable schema through the JSON Schema validator' do
+      expect do
+        described_class.components.fetch('schemas').each_key do |name|
+          JSONSchemer.schema(described_class.dereferenced_schema(name))
+        end
+      end.not_to raise_error
+    end
+
+    it 'matches a representative Rails request, response, and nullable fields' do
+      user = users(:jane)
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+      request_body = {
+        'person' => {
+          'name' => 'API Contract Dependent',
+          'date_of_birth' => 8.years.ago.to_date.iso8601,
+          'person_type' => 'minor'
+        }
+      }
+
+      expect(described_class.schema_errors('PersonCreateRequest', request_body)).to be_empty
+
+      post api_v1_household_people_path(household_id), params: request_body, headers:, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(described_class.schema_errors('PersonResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'matches a representative Rails validation error' do
+      login_data = api_login(users(:jane))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      patch api_v1_household_person_path(household_id, people(:child_patient)),
+            params: { person: { name: '' } }, headers:, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(described_class.schema_errors('ErrorEnvelope', response.parsed_body)).to be_empty
+    end
+
+    it 'references typed representative operation schemas and shared errors' do
+      create_person = described_class.operation('/households/{household_id}/people', 'post')
+      show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')
+      update_person = described_class.operation('/households/{household_id}/people/{id}', 'patch')
+
+      expect(create_person.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/PersonCreateRequest'
+      )
+      expect(create_person.dig('responses', '201', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/PersonResponse'
+      )
+      expect(show_person.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/PersonResponse'
+      )
+      expect(update_person.dig('responses', '409', '$ref')).to eq('#/components/responses/Conflict')
+      expect(update_person.dig('responses', '422', '$ref')).to eq('#/components/responses/ValidationFailed')
+    end
+
+    it 'reports schema failures by pointer without echoing response data' do
+      invalid_payload = {
+        'data' => {
+          'id' => 'not-an-id',
+          'name' => 'Private Patient Name',
+          'email' => 'private@example.test'
+        }
+      }
+
+      diagnostics = described_class.schema_errors('PersonResponse', invalid_payload).join(' ')
+
+      expect(diagnostics).to include('/data')
+      expect(diagnostics).not_to include('Private Patient Name', 'private@example.test', 'not-an-id')
     end
   end
 end

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -79,7 +79,8 @@ module OpenapiYamlValidation
   end
 
   def unsupported_free_form?(value, path)
-    value.is_a?(Hash) && value['type'] == 'object' && value['additionalProperties'] == true &&
+    value.is_a?(Hash) && value['type'] == 'object' &&
+      (value['additionalProperties'] == true || !value.key?('additionalProperties')) &&
       OpenapiStructure::ALLOWED_FREE_FORM_PATHS.exclude?(path)
   end
 end
@@ -147,6 +148,32 @@ module OpenapiStructure
   HTTP_METHODS = %w[delete get head options patch post put trace].freeze
   AUDIENCE_TAGS = ['Public', 'Account', 'Household', 'Household administration'].freeze
   ALLOWED_FREE_FORM_PATHS = ['#/components/schemas/SyncBatchOperation/properties/attributes'].freeze
+  LOCATOR_PATHS = %w[
+    /households/{household_id}/locations/{id}
+    /households/{household_id}/medications/{id}
+    /households/{household_id}/medications/{id}/adjust_inventory
+    /households/{household_id}/medications/{id}/mark_as_ordered
+    /households/{household_id}/medications/{id}/mark_as_received
+    /households/{household_id}/dosage_options/{id}
+    /households/{household_id}/health_events/{id}
+    /households/{household_id}/schedules/{id}
+    /households/{household_id}/schedules/{id}/pause
+    /households/{household_id}/schedules/{id}/resume
+    /households/{household_id}/person_medications/{id}
+    /households/{household_id}/person_medications/{id}/pause
+    /households/{household_id}/person_medications/{id}/resume
+    /households/{household_id}/person_medications/{id}/reorder
+  ].freeze
+  PRECONDITION_PATHS = %w[
+    /households/{household_id}/medications/{id}
+    /households/{household_id}/dosage_options/{id}
+    /households/{household_id}/health_events/{id}
+    /households/{household_id}/schedules/{id}
+    /households/{household_id}/person_medications/{id}
+  ].freeze
+  OPENAPI_SCHEMA_PATH = Rails.root.join(
+    'spec/fixtures/files/openapi-3.1-schema-2022-10-07.json'
+  )
 
   extend OpenapiYamlValidation
   extend OpenapiReferenceValidation
@@ -188,6 +215,51 @@ module OpenapiStructure
   def operation(path, method)
     paths.fetch(path).fetch(method)
   end
+
+  def document_schema_errors(openapi_document = document)
+    schema = JSON.parse(OPENAPI_SCHEMA_PATH.read)
+    JSONSchemer.schema(schema).validate(openapi_document).map { |error| error.fetch('data_pointer') }
+  end
+
+  def security_requirement_errors(openapi_document = document)
+    defined_schemes = openapi_document.dig('components', 'securitySchemes').keys
+    security_requirements(openapi_document).flat_map do |path, requirements|
+      security_errors_for(path, requirements, defined_schemes)
+    end
+  end
+
+  def security_errors_for(path, requirements, defined_schemes)
+    return [path] unless requirements.is_a?(Array)
+
+    requirements.flat_map do |requirement|
+      errors = requirement.empty? && requirements.any? ? [path] : []
+      errors + requirement.keys.filter_map do |scheme|
+        "#{path}/#{scheme}" unless defined_schemes.include?(scheme)
+      end
+    end
+  end
+
+  def security_requirements(openapi_document)
+    root = [['#/security', openapi_document.fetch('security')]]
+    openapi_document.fetch('paths').each_with_object(root) do |(path, path_item), requirements|
+      path_item.each do |method, operation|
+        next unless HTTP_METHODS.include?(method) && operation.key?('security')
+
+        pointer = "#/paths/#{path.gsub('/', '~1')}/#{method}/security"
+        requirements << [pointer, operation.fetch('security')]
+      end
+    end
+  end
+
+  def unauthenticated_operations
+    operations.filter_map do |path, method, operation|
+      "#{method.upcase} #{path}" if operation['security'] == []
+    end
+  end
+
+  def person_request_errors(attributes)
+    schema_errors('PersonCreateRequest', 'person' => attributes)
+  end
 end
 
 RSpec.describe OpenapiRouteCoverage, type: :request do
@@ -201,6 +273,15 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
   end
 
   describe OpenapiStructure do
+    let(:person_attributes) do
+      {
+        'name' => 'API Contract Dependent',
+        'date_of_birth' => 8.years.ago.to_date.iso8601,
+        'person_type' => 'minor',
+        'has_capacity' => true
+      }
+    end
+
     it 'uses the canonical API v1 server address' do
       expect(described_class.document.fetch('servers').first.fetch('url')).to eq('/api/v1')
     end
@@ -258,14 +339,60 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       )
     end
 
-    it 'uses shared path, precondition, and response header components' do
+    it 'uses shared path identifier components' do
+      parameters = described_class.components.fetch('parameters')
+
+      expect(parameters.fetch('id').dig('schema', '$ref')).to eq('#/components/schemas/NumericId')
+      expect(parameters.fetch('resource_id').dig('schema', '$ref')).to eq(
+        '#/components/schemas/ResourceIdentifier'
+      )
+      expect(parameters.fetch('native_device_token').dig('schema', '$ref')).to eq(
+        '#/components/schemas/DeviceTokenIdentifier'
+      )
+      expect(parameters.fetch('household_id').dig('schema', '$ref')).to eq('#/components/schemas/NumericId')
+    end
+
+    it 'uses shared precondition and response header components' do
       parameters = described_class.components.fetch('parameters')
       headers = described_class.components.fetch('headers')
 
-      expect(parameters.fetch('id').dig('schema', '$ref')).to eq('#/components/schemas/ResourceIdentifier')
-      expect(parameters.fetch('household_id').dig('schema', '$ref')).to eq('#/components/schemas/NumericId')
       expect(parameters.fetch('if_match').fetch('in')).to eq('header')
       expect(headers.fetch('etag').dig('schema', 'type')).to eq('string')
+      expect(headers.fetch('etag')).to include('required' => true)
+    end
+
+    it 'uses portable-or-numeric identifiers on locator-backed resource paths' do
+      described_class::LOCATOR_PATHS.each do |path|
+        described_class.paths.fetch(path).each do |method, operation|
+          next unless described_class::HTTP_METHODS.include?(method)
+
+          expect(operation.fetch('parameters')).to include(
+            { '$ref' => '#/components/parameters/resource_id' }
+          )
+        end
+      end
+    end
+
+    it 'models ETag preconditions on every controller that enforces stale-write conflicts' do
+      described_class::PRECONDITION_PATHS.each do |path|
+        %w[patch put].each do |method|
+          operation = described_class.operation(path, method)
+
+          expect(operation.fetch('parameters')).to include({ '$ref' => '#/components/parameters/if_match' })
+          expect(operation.dig('responses', '409', '$ref')).to eq('#/components/responses/Conflict')
+          expect(operation.dig('responses', '200', 'headers', 'ETag', '$ref')).to eq(
+            '#/components/headers/etag'
+          )
+        end
+      end
+    end
+
+    it 'models ETag headers on reads that supply update preconditions' do
+      described_class::PRECONDITION_PATHS.each do |path|
+        expect(described_class.operation(path, 'get').dig('responses', '200', 'headers', 'ETag', '$ref')).to eq(
+          '#/components/headers/etag'
+        )
+      end
     end
 
     it 'defines shared errors and bearer security' do
@@ -281,12 +408,9 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
     end
 
     it 'models intentional unauthenticated exceptions without weakening protected operations' do
-      unauthenticated = described_class.operations.filter_map do |path, method, operation|
-        "#{method.upcase} #{path}" if operation['security'] == []
-      end
-
       expect(described_class.document.fetch('security')).to eq([{ 'bearerAuth' => [] }])
-      expect(unauthenticated).to contain_exactly(
+      expect(described_class.security_requirement_errors).to be_empty
+      expect(described_class.unauthenticated_operations).to contain_exactly(
         'GET /capabilities',
         'POST /auth/login',
         'POST /auth/oidc_exchange',
@@ -295,12 +419,44 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.operation('/auth/logout', 'delete')).not_to include('security')
     end
 
-    it 'validates OpenAPI structure, local references, and object boundaries' do
+    it 'rejects optional and unknown security requirements' do
+      optional_security = described_class.document.deep_dup
+      optional_security['paths']['/auth/logout']['delete']['security'] = [{}]
+      unknown_security = described_class.document.deep_dup
+      unknown_security['security'] = [{ 'unknownAuth' => [] }]
+
+      expect(described_class.security_requirement_errors(optional_security)).to include(
+        '#/paths/~1auth~1logout/delete/security'
+      )
+      expect(described_class.security_requirement_errors(unknown_security)).to include(
+        '#/security/unknownAuth'
+      )
+    end
+
+    it 'declares an OpenAPI 3.1 document with required sections' do
       expect(described_class.document).to include('openapi' => '3.1.0')
       expect(described_class.document).to include('info', 'servers', 'paths', 'components')
+    end
+
+    it 'rejects duplicate YAML mapping keys including keys inside sequences' do
+      nested_duplicate = Psych.parse("items:\n  - name: first\n    name: second\n").root
+
       expect(described_class.duplicate_mapping_keys).to be_empty
+      expect(described_class.duplicate_mapping_keys(nested_duplicate)).to eq(['#/items/0/name'])
+    end
+
+    it 'rejects broken references and unsupported free-form objects' do
       expect(described_class.local_reference_errors).to be_empty
       expect(described_class.unsupported_free_form_errors).to be_empty
+      expect(described_class.unsupported_free_form_errors('type' => 'object')).to eq(['#'])
+    end
+
+    it 'validates the complete document against the pinned OpenAPI schema' do
+      expect(described_class.document_schema_errors).to be_empty
+
+      malformed_document = described_class.document.deep_dup
+      malformed_document.fetch('info').delete('title')
+      expect(described_class.document_schema_errors(malformed_document)).to include('/info')
     end
 
     it 'loads every reusable schema through the JSON Schema validator' do
@@ -311,25 +467,37 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       end.not_to raise_error
     end
 
-    it 'matches a representative Rails request, response, and nullable fields' do
-      user = users(:jane)
-      login_data = api_login(user)
+    it 'models person request fields according to Rails validation and defaults' do
+      expect(described_class.person_request_errors(person_attributes)).to be_empty
+      expect(described_class.person_request_errors(person_attributes.except('person_type'))).to be_empty
+      expect(described_class.person_request_errors(person_attributes.merge('date_of_birth' => nil))).to include(
+        '/person/date_of_birth'
+      )
+    end
+
+    it 'matches a representative Rails create request and response' do
+      login_data = api_login(users(:jane))
       household_id = login_data.dig('household', 'id')
       headers = api_auth_headers(login_data.fetch('access_token'))
-      request_body = {
-        'person' => {
-          'name' => 'API Contract Dependent',
-          'date_of_birth' => 8.years.ago.to_date.iso8601,
-          'person_type' => 'minor'
-        }
-      }
 
-      expect(described_class.schema_errors('PersonCreateRequest', request_body)).to be_empty
-
-      post api_v1_household_people_path(household_id), params: request_body, headers:, as: :json
+      post api_v1_household_people_path(household_id), params: { person: person_attributes }, headers:, as: :json
 
       expect(response).to have_http_status(:created)
+      expect(response.headers['ETag']).to be_present
+      expect(response.parsed_body.dig('data', 'has_capacity')).to be(false)
       expect(described_class.schema_errors('PersonResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'allows negative serialized ages that Rails can currently emit' do
+      person = Api::V1::PersonSerializer.new(people(:child_patient)).as_json.merge(age: -1)
+
+      expect(described_class.schema_errors('PersonResponse', { data: person })).to be_empty
+    end
+
+    it 'allows nullable response fields emitted for legacy people' do
+      person = Api::V1::PersonSerializer.new(people(:child_patient)).as_json.merge(date_of_birth: nil, age: nil)
+
+      expect(described_class.schema_errors('PersonResponse', { data: person })).to be_empty
     end
 
     it 'matches a representative Rails validation error' do
@@ -344,10 +512,9 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('ErrorEnvelope', response.parsed_body)).to be_empty
     end
 
-    it 'references typed representative operation schemas and shared errors' do
+    it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')
-      update_person = described_class.operation('/households/{household_id}/people/{id}', 'patch')
 
       expect(create_person.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
         '#/components/schemas/PersonCreateRequest'
@@ -358,8 +525,25 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(show_person.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
         '#/components/schemas/PersonResponse'
       )
-      expect(update_person.dig('responses', '409', '$ref')).to eq('#/components/responses/Conflict')
+    end
+
+    it 'does not advertise unsupported person update preconditions' do
+      update_person = described_class.operation('/households/{household_id}/people/{id}', 'patch')
+
+      expect(update_person.fetch('parameters')).not_to include(
+        { '$ref' => '#/components/parameters/if_match' }
+      )
+      expect(update_person.fetch('responses')).not_to include('409')
       expect(update_person.dig('responses', '422', '$ref')).to eq('#/components/responses/ValidationFailed')
+    end
+
+    it 'types the arbitrary native device token path separately' do
+      native_device_token = described_class.operation(
+        '/households/{household_id}/native_device_tokens/{id}', 'delete'
+      )
+      expect(native_device_token.fetch('parameters')).to include(
+        { '$ref' => '#/components/parameters/native_device_token' }
+      )
     end
 
     it 'reports schema failures by pointer without echoing response data' do


### PR DESCRIPTION
## Summary

- defines shared typed identifiers, timestamps, pagination, precondition headers, errors, bearer security, and representative person request/response schemas
- aligns identifier and concurrency contracts with the Rails controllers, including portable locators and intentionally unsupported person preconditions
- validates the complete document against a pinned official OpenAPI 3.1 schema and adds drift checks for routes, references, duplicate keys, security declarations, free-form objects, and representative payloads
- keeps validation diagnostics privacy-safe by reporting schema pointers without echoing response data

## Why

The published contract could describe identifiers, security, nullable fields, and stale-write behavior differently from the application. That drift makes generated clients unreliable and lets malformed OpenAPI changes pass review. The shared types and executable validation now make the Rails behavior the enforced contract.

Closes #1654
Closes #1658
