### PR TITLE
fix(ci): pass container image reference

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Git tag name to publish (e.g. v1.0.0)"
+        required: true
+        type: string
   workflow_call:
     inputs:
       tag_name:
@@ -75,6 +81,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            APP_IMAGE_REF=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag_name != '' && steps.meta.outputs.version || format('sha-{0}', github.sha) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/spec/lib/runtime_stack_contract_spec.rb
+++ b/spec/lib/runtime_stack_contract_spec.rb
@@ -19,6 +19,17 @@ end
 
 RSpec.describe RuntimeStackContract do
   let(:expected_versions) { described_class.expected_versions }
+  let(:docker_publish_workflow) do
+    YAML.safe_load(read_file('.github/workflows/docker-publish.yml'), aliases: true)
+  end
+  let(:docker_publish_triggers) do
+    docker_publish_workflow.fetch('on') { docker_publish_workflow.fetch(true) }
+  end
+  let(:docker_publish_build_step) do
+    docker_publish_workflow
+      .dig('jobs', 'build-and-push', 'steps')
+      .find { |step| step['uses'] == 'docker/build-push-action@v7' }
+  end
 
   it 'keeps Ruby runtime metadata aligned across local, Docker, CI, and agent docs' do
     expected_ruby_version = expected_versions.fetch(:ruby)
@@ -64,6 +75,21 @@ RSpec.describe RuntimeStackContract do
       expect(document).to include("- Bundler #{expected_versions.fetch(:bundler)}")
       expect(document).to include("- Playwright #{expected_versions.fetch(:playwright)}")
     end
+  end
+
+  it 'supports manually republishing an existing release tag' do
+    expect(docker_publish_triggers.dig('workflow_dispatch', 'inputs', 'tag_name')).to include(
+      'required' => true,
+      'type' => 'string'
+    )
+  end
+
+  it 'bakes an immutable image reference into published containers' do
+    build_args = docker_publish_build_step.dig('with', 'build-args')
+
+    expect(build_args).to include('APP_IMAGE_REF=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:')
+    expect(build_args).to include("inputs.tag_name != '' && steps.meta.outputs.version")
+    expect(build_args).to include("format('sha-{0}', github.sha)")
   end
 
   def read_file(path)


### PR DESCRIPTION
## Summary

Container publishing stopped when the production Dockerfile began requiring an immutable `APP_IMAGE_REF`, because the GitHub Actions build never supplied it.

This passes the release version for release builds and the published commit SHA tag for ordinary main builds. It also adds a manual release-tag trigger so an existing release such as `v0.5.11` can be republished without moving or recreating the tag.

The runtime stack contract now protects both the build argument and the recovery trigger from regressing.