### PR TITLE
feat(admin): list ambiguous legacy access grants

### DIFF
--- a/app/components/admin/ambiguous_person_access_grants/index_view.rb
+++ b/app/components/admin/ambiguous_person_access_grants/index_view.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module Components
+  module Admin
+    module AmbiguousPersonAccessGrants
+      class IndexView < Components::Base
+        attr_reader :grants, :pagy_obj
+
+        def initialize(grants:, pagy: nil)
+          @grants = grants
+          @pagy_obj = pagy
+          super()
+        end
+
+        def view_template
+          div(data: { testid: 'admin-ambiguous-person-access-grants' },
+              class: 'container mx-auto px-4 py-8 pb-24 md:pb-8 max-w-6xl space-y-8') do
+            render_header
+            render_grants_table
+            render_pagination if pagy_obj && pagy_obj.pages > 1
+          end
+        end
+
+        private
+
+        def render_header
+          div(class: 'mb-8') do
+            m3_heading(level: 1, size: '8', class: 'font-extrabold tracking-tight') do
+              t('admin.ambiguous_person_access_grants.index.title')
+            end
+            m3_text(weight: 'muted', class: 'mt-2 block') do
+              t('admin.ambiguous_person_access_grants.index.subtitle')
+            end
+          end
+        end
+
+        def render_grants_table
+          div(class: 'rounded-xl border border-border bg-card shadow-sm overflow-hidden') do
+            render RubyUI::Table.new do
+              render_table_header
+              render_table_body
+            end
+          end
+        end
+
+        def render_table_header
+          render RubyUI::TableHeader.new do
+            render RubyUI::TableRow.new do
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.id') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.carer') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.patient') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.access_level') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.relationship') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.status') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.created_at') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.expires_at') })
+              render(RubyUI::TableHead.new { t('admin.ambiguous_person_access_grants.index.table.revoked_at') })
+            end
+          end
+        end
+
+        def render_table_body
+          render RubyUI::TableBody.new do
+            if grants.empty?
+              render RubyUI::TableRow.new do
+                render RubyUI::TableCell.new(colspan: 9, class: 'py-8 text-center text-on-surface-variant') do
+                  t('admin.ambiguous_person_access_grants.index.empty')
+                end
+              end
+            else
+              grants.each { |grant| render_grant_row(grant) }
+            end
+          end
+        end
+
+        def render_grant_row(grant)
+          render RubyUI::TableRow.new(data: { grant_id: grant.id }) do
+            render RubyUI::TableCell.new(class: 'font-medium') { grant.id.to_s }
+            render(RubyUI::TableCell.new { grant.household_membership.person.name })
+            render(RubyUI::TableCell.new { grant.person.name })
+            render(RubyUI::TableCell.new { grant.access_level.to_s.humanize })
+            render(RubyUI::TableCell.new { grant.relationship_type.to_s.humanize })
+            render(RubyUI::TableCell.new { relationship_status(grant) })
+            render(RubyUI::TableCell.new { format_timestamp(grant.created_at) })
+            render(RubyUI::TableCell.new { format_timestamp(grant.expires_at) })
+            render(RubyUI::TableCell.new { format_timestamp(grant.revoked_at) })
+          end
+        end
+
+        def relationship_status(grant)
+          type = grant[:compatible_relationship_type].to_s.humanize
+          status = if grant[:compatible_relationship_active]
+                     t('admin.ambiguous_person_access_grants.index.active')
+                   else
+                     t('admin.ambiguous_person_access_grants.index.inactive')
+                   end
+          "#{type} (#{status})"
+        end
+
+        def format_timestamp(timestamp)
+          timestamp ? I18n.l(timestamp, format: :short) : t('admin.ambiguous_person_access_grants.index.not_available')
+        end
+
+        def render_pagination
+          nav(
+            class: 'flex items-center justify-between border-t border-border bg-card px-4 py-3 sm:px-6',
+            'aria-label': t('admin.ambiguous_person_access_grants.index.pagination.label')
+          ) do
+            render_pagination_info
+            div(class: 'flex items-center gap-2') do
+              render_previous_button
+              render_next_button
+            end
+          end
+        end
+
+        def render_pagination_info
+          m3_text(size: '2', class: 'text-foreground') do
+            plain "#{t('admin.ambiguous_person_access_grants.index.pagination.showing')} "
+            span(class: 'font-medium') { pagy_obj.from.to_s }
+            plain " #{t('admin.ambiguous_person_access_grants.index.pagination.to')} "
+            span(class: 'font-medium') { pagy_obj.to.to_s }
+            plain " #{t('admin.ambiguous_person_access_grants.index.pagination.of')} "
+            span(class: 'font-medium') { pagy_obj.count.to_s }
+            plain " #{t('admin.ambiguous_person_access_grants.index.pagination.results')}"
+          end
+        end
+
+        def render_previous_button
+          if pagy_obj.previous
+            render RubyUI::Link.new(
+              href: admin_ambiguous_person_access_grants_path(page: pagy_obj.previous),
+              variant: :link,
+              class: pagination_button_classes
+            ) { t('admin.ambiguous_person_access_grants.index.pagination.previous') }
+          else
+            span(class: "#{pagination_button_classes} opacity-50 cursor-not-allowed") do
+              t('admin.ambiguous_person_access_grants.index.pagination.previous')
+            end
+          end
+        end
+
+        def render_next_button
+          if pagy_obj.next
+            render RubyUI::Link.new(
+              href: admin_ambiguous_person_access_grants_path(page: pagy_obj.next),
+              variant: :link,
+              class: pagination_button_classes
+            ) { t('admin.ambiguous_person_access_grants.index.pagination.next') }
+          else
+            span(class: "#{pagination_button_classes} opacity-50 cursor-not-allowed") do
+              t('admin.ambiguous_person_access_grants.index.pagination.next')
+            end
+          end
+        end
+
+        def pagination_button_classes
+          'relative inline-flex items-center rounded-md bg-card px-3 py-2 text-sm font-semibold ' \
+            'text-foreground ring-1 ring-inset ring-border hover:bg-tertiary-container'
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/ambiguous_person_access_grants_controller.rb
+++ b/app/controllers/admin/ambiguous_person_access_grants_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  class AmbiguousPersonAccessGrantsController < BaseController
+    skip_before_action :require_hosted_privileged_action_mfa
+    before_action :require_privileged_action_mfa, if: :ambiguous_grants_mfa_required?
+
+    def index
+      authorize PersonAccessGrant, :index?
+      grants = Admin::AmbiguousPersonAccessGrantsIndexQuery.new(scope: policy_scope(PersonAccessGrant)).call
+      @pagy, grants = pagy(:offset, grants)
+
+      render Components::Admin::AmbiguousPersonAccessGrants::IndexView.new(
+        grants: grants,
+        pagy: @pagy
+      )
+    end
+
+    private
+
+    def ambiguous_grants_mfa_required?
+      current_membership&.active? && (current_membership.owner? || current_membership.administrator?)
+    end
+  end
+end

--- a/app/policies/person_access_grant_policy.rb
+++ b/app/policies/person_access_grant_policy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class PersonAccessGrantPolicy < ApplicationPolicy
+  def index?
+    return household_owner? || household_administrator? if class_record?
+
+    same_household?(record) && (household_owner? || household_administrator?)
+  end
+
+  private
+
+  def class_record?
+    record.is_a?(Class)
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none unless active_membership? && (household_owner? || household_administrator?)
+
+      scope.where(household: household)
+    end
+
+    private
+
+    def household_owner?
+      membership.owner?
+    end
+
+    def household_administrator?
+      membership.administrator?
+    end
+  end
+end

--- a/app/services/admin/ambiguous_person_access_grants_index_query.rb
+++ b/app/services/admin/ambiguous_person_access_grants_index_query.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Admin
+  class AmbiguousPersonAccessGrantsIndexQuery
+    HOUSEHOLD_MEMBERSHIP_JOIN = <<~SQL.squish.freeze
+      INNER JOIN household_memberships
+        ON household_memberships.id = person_access_grants.household_membership_id
+       AND household_memberships.household_id = person_access_grants.household_id
+    SQL
+    COMPATIBLE_RELATIONSHIP_JOIN = <<~SQL.squish.freeze
+      INNER JOIN (
+        SELECT DISTINCT ON (household_id, carer_id, patient_id)
+          id,
+          household_id,
+          carer_id,
+          patient_id,
+          relationship_type,
+          active
+        FROM carer_relationships
+        WHERE active = TRUE
+        ORDER BY household_id, carer_id, patient_id, id DESC
+      ) AS compatible_carer_relationships
+        ON compatible_carer_relationships.household_id = person_access_grants.household_id
+       AND compatible_carer_relationships.carer_id = household_memberships.person_id
+       AND compatible_carer_relationships.patient_id = person_access_grants.person_id
+    SQL
+    SELECT_COLUMNS = <<~SQL.squish.freeze
+      person_access_grants.id,
+      person_access_grants.household_id,
+      person_access_grants.household_membership_id,
+      person_access_grants.person_id,
+      person_access_grants.carer_relationship_id,
+      person_access_grants.access_level,
+      person_access_grants.relationship_type,
+      person_access_grants.expires_at,
+      person_access_grants.revoked_at,
+      person_access_grants.created_at,
+      person_access_grants.updated_at,
+      compatible_carer_relationships.id AS compatible_relationship_id,
+      compatible_carer_relationships.relationship_type AS compatible_relationship_type,
+      compatible_carer_relationships.active AS compatible_relationship_active
+    SQL
+
+    attr_reader :scope
+
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def call
+      scope
+        .merge(PersonAccessGrant.active)
+        .where(carer_relationship_id: nil)
+        .joins(household_membership_join)
+        .joins(compatible_relationship_join)
+        .includes(:person, household_membership: :person)
+        .select(select_columns)
+        .distinct
+        .order(created_at: :desc, id: :desc)
+    end
+
+    private
+
+    def household_membership_join
+      HOUSEHOLD_MEMBERSHIP_JOIN
+    end
+
+    def compatible_relationship_join
+      COMPATIBLE_RELATIONSHIP_JOIN
+    end
+
+    def select_columns
+      SELECT_COLUMNS
+    end
+  end
+end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -425,6 +425,35 @@ cy:
           to: i
           of: o
           results: canlyniad
+          previous: Blaenorol
+          next: Nesaf
+          label: Tudaleniad
+    ambiguous_person_access_grants:
+      index:
+        title: Grantiau mynediad amwys
+        subtitle: Adolygu grantiau gweithredol sydd angen tarddiad perthynas cyn newidiadau dirprwyo.
+        table:
+          id: ID grant
+          carer: Gofalwr
+          patient: Claf
+          access_level: Lefel mynediad
+          relationship: Perthynas grant
+          status: Perthynas gydnaws
+          created_at: Crëwyd
+          expires_at: Daw i ben
+          revoked_at: Diddymwyd
+        empty: Ni chanfuwyd grantiau mynediad amwys.
+        active: Gweithredol
+        inactive: Anweithredol
+        not_available: Ddim ar gael
+        pagination:
+          showing: Yn dangos
+          to: i
+          of: o
+          results: canlyniadau
+          previous: Blaenorol
+          next: Nesaf
+          label: Tudaleniad
     users:
       unauthorized: Nid oes gennych awdurdod i gyflawni'r weithred hon.
       missing_account: Nid oes gan y defnyddiwr gyfrif i'w ddilysu.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,32 @@ en:
           to: to
           of: of
           results: results
+    ambiguous_person_access_grants:
+      index:
+        title: Ambiguous access grants
+        subtitle: Review active grants that need relationship provenance before delegation changes.
+        table:
+          id: Grant ID
+          carer: Carer
+          patient: Patient
+          access_level: Access level
+          relationship: Grant relationship
+          status: Compatible relationship
+          created_at: Created
+          expires_at: Expires
+          revoked_at: Revoked
+        empty: No ambiguous access grants found.
+        active: Active
+        inactive: Inactive
+        not_available: Not available
+        pagination:
+          showing: Showing
+          to: to
+          of: of
+          results: results
+          previous: Previous
+          next: Next
+          label: Pagination
     users:
       unauthorized: You are not authorized to perform this action.
       missing_account: User does not have an account to verify.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -430,6 +430,35 @@ es:
           to: a
           of: de
           results: resultados
+          previous: Anterior
+          next: Siguiente
+          label: Paginación
+    ambiguous_person_access_grants:
+      index:
+        title: Concesiones de acceso ambiguas
+        subtitle: Revisa las concesiones activas que necesitan el origen de la relación antes de cambiar delegaciones.
+        table:
+          id: ID de concesión
+          carer: Cuidador
+          patient: Paciente
+          access_level: Nivel de acceso
+          relationship: Relación de concesión
+          status: Relación compatible
+          created_at: Creada
+          expires_at: Caduca
+          revoked_at: Revocada
+        empty: No se encontraron concesiones de acceso ambiguas.
+        active: Activa
+        inactive: Inactiva
+        not_available: No disponible
+        pagination:
+          showing: Mostrando
+          to: a
+          of: de
+          results: resultados
+          previous: Anterior
+          next: Siguiente
+          label: Paginación
     users:
       unauthorized: No está autorizado para realizar esta acción.
       missing_account: El usuario no tiene una cuenta para verificar.

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -208,6 +208,35 @@ ga:
           to: go
           of: as
           results: torthaí
+          previous: Roimhe Seo
+          next: Ar Aghaidh
+          label: Leathanachú
+    ambiguous_person_access_grants:
+      index:
+        title: Deontais rochtana débhríocha
+        subtitle: Déan athbhreithniú ar dheontais ghníomhacha a dteastaíonn bunús caidrimh uathu roimh athruithe tarmligin.
+        table:
+          id: ID deontais
+          carer: Cúramóir
+          patient: Othar
+          access_level: Leibhéal rochtana
+          relationship: Caidreamh deontais
+          status: Caidreamh comhoiriúnach
+          created_at: Cruthaithe
+          expires_at: Rachaidh in éag
+          revoked_at: Cúlghairthe
+        empty: Níor aimsíodh deontais rochtana débhríocha.
+        active: Gníomhach
+        inactive: Neamhghníomhach
+        not_available: Níl ar fáil
+        pagination:
+          showing: Ag taispeáint
+          to: go
+          of: as
+          results: torthaí
+          previous: Roimhe Seo
+          next: Ar Aghaidh
+          label: Leathanachú
     users:
       unauthorized: Níl údarás agat an gníomh seo a dhéanamh.
       missing_account: Níl cuntas ag an úsáideoir le fíorú.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -432,6 +432,35 @@ pt:
           to: a
           of: de
           results: resultados
+          previous: Anterior
+          next: Seguinte
+          label: Paginação
+    ambiguous_person_access_grants:
+      index:
+        title: Concessões de acesso ambíguas
+        subtitle: Reveja concessões ativas que precisam da origem da relação antes de alterar delegações.
+        table:
+          id: ID da concessão
+          carer: Cuidador
+          patient: Paciente
+          access_level: Nível de acesso
+          relationship: Relação da concessão
+          status: Relação compatível
+          created_at: Criada
+          expires_at: Expira
+          revoked_at: Revogada
+        empty: Não foram encontradas concessões de acesso ambíguas.
+        active: Ativa
+        inactive: Inativa
+        not_available: Não disponível
+        pagination:
+          showing: A mostrar
+          to: a
+          of: de
+          results: resultados
+          previous: Anterior
+          next: Seguinte
+          label: Paginação
     users:
       unauthorized: Não está autorizado a realizar esta ação.
       missing_account: O utilizador não tem uma conta para verificar.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,6 +293,7 @@ Rails.application.routes.draw do
           post :activate
         end
       end
+      resources :ambiguous_person_access_grants, only: %i[index]
       resources :people, only: %i[index]
       resources :audit_logs, only: %i[index show]
       resource :settings, only: %i[show update]

--- a/spec/components/admin/ambiguous_person_access_grants/index_view_spec.rb
+++ b/spec/components/admin/ambiguous_person_access_grants/index_view_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Components::Admin::AmbiguousPersonAccessGrants::IndexView, type: :component do
+  let(:pagy) do
+    Class.new do
+      attr_reader :count, :from, :to, :pages, :page, :previous, :next
+
+      def initialize
+        @count = 25
+        @from = 1
+        @to = 10
+        @pages = 3
+        @page = 1
+        @previous = nil
+        @next = 2
+      end
+    end.new
+  end
+
+  it 'renders accessible navigation links when more than one page exists' do
+    rendered = render_inline(described_class.new(grants: [], pagy: pagy))
+
+    expect(rendered.css('nav[aria-label="Pagination"]')).to be_present
+    expect(rendered.css('a').pluck('href')).to include(a_string_including('page=2'))
+    expect(rendered.text).to include('Previous', 'Next')
+  end
+end

--- a/spec/config/i18n_ambiguous_person_access_grant_locale_coverage_spec.rb
+++ b/spec/config/i18n_ambiguous_person_access_grant_locale_coverage_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe I18n do
+  let(:key_paths) do
+    %w[
+      title subtitle table.id table.carer table.patient table.access_level table.relationship table.status
+      table.created_at table.expires_at table.revoked_at empty active inactive not_available
+      pagination.showing pagination.to pagination.of pagination.results pagination.previous pagination.next
+      pagination.label
+    ].map { |path| path.split('.') }
+  end
+
+  it 'keeps the queue translations structurally present in every locale' do
+    locale_files.each do |locale_file|
+      tree = YAML.safe_load(locale_file.read).fetch(locale_file.basename('.yml').to_s)
+      key_paths.each do |key_path|
+        message = "#{locale_file} is missing " \
+                  "admin.ambiguous_person_access_grants.index.#{key_path.join('.')}"
+        expect(tree.dig('admin', 'ambiguous_person_access_grants', 'index', *key_path)).to be_present, message
+      end
+    end
+  end
+
+  def locale_files
+    Rails.root.glob('config/locales/*.yml')
+  end
+end

--- a/spec/policies/person_access_grant_policy_spec.rb
+++ b/spec/policies/person_access_grant_policy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonAccessGrantPolicy, type: :policy do
+  let(:owner) { household_policy_member(role: :owner) }
+  let(:household) { owner.fetch(:household) }
+  let(:administrator) { household_policy_member(role: :administrator, household: household) }
+  let(:member) { household_policy_member(role: :member, household: household) }
+  let(:grant) { PersonAccessGrant.new(household: household) }
+
+  it 'allows only active owners and administrators to list ambiguous grants' do
+    expect(described_class.new(owner.fetch(:context), PersonAccessGrant).index?).to be(true)
+    expect(described_class.new(administrator.fetch(:context), PersonAccessGrant).index?).to be(true)
+    expect(described_class.new(member.fetch(:context), PersonAccessGrant).index?).to be(false)
+  end
+
+  it 'scopes owners and administrators to the active household' do
+    foreign_household = create(:household)
+
+    owner_scope = described_class::Scope.new(owner.fetch(:context), PersonAccessGrant.all).resolve
+    administrator_scope = described_class::Scope.new(administrator.fetch(:context), PersonAccessGrant.all).resolve
+
+    expect(owner_scope.to_sql).to include('household_id')
+    expect(owner_scope.where(household: foreign_household)).to be_empty
+    expect(administrator_scope.where(household: foreign_household)).to be_empty
+  end
+
+  it 'returns no records for non-admin scopes' do
+    expect(described_class::Scope.new(member.fetch(:context), PersonAccessGrant.all).resolve).to be_none
+  end
+end

--- a/spec/requests/admin/ambiguous_person_access_grants_spec.rb
+++ b/spec/requests/admin/ambiguous_person_access_grants_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin ambiguous person access grants' do
+  fixtures :accounts, :people, :users, :carer_relationships
+
+  let(:admin) { users(:admin) }
+  let(:queue_data) do
+    household = Household.find_by!(slug: default_request_household_slug)
+    carer = household.people.create!(name: 'Queue Carer', date_of_birth: 35.years.ago.to_date)
+    patient = household.people.create!(name: 'Queue Patient', date_of_birth: 38.years.ago.to_date,
+                                       person_type: :adult, has_capacity: true)
+    account = Account.create!(email: 'queue-carer@example.test', status: :verified)
+    membership = household.household_memberships.create!(account: account, person: carer,
+                                                         role: :member, status: :active)
+    CarerRelationship.create!(household: household, carer: carer, patient: patient,
+                              relationship_type: :parent, active: true)
+    grant = PersonAccessGrant.create!(household: household, household_membership: membership, person: patient,
+                                      access_level: :manage, relationship_type: :professional)
+    { grant: grant, carer: carer, patient: patient }
+  end
+
+  context 'when authenticated' do
+    before { sign_in(admin) }
+
+    it 'lists eligible grants using household-safe fields after fresh MFA' do
+      allow(ApiAuthState).to receive(:web_session_oidc_mfa_verified?).and_return(true)
+      queue_data
+
+      get admin_ambiguous_person_access_grants_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(queue_data.fetch(:grant).id.to_s, queue_data.fetch(:carer).name,
+                                       queue_data.fetch(:patient).name, 'Manage', 'Parent')
+      expect(response.body).not_to include('queue-carer@example.test', 'date_of_birth', 'audit')
+    end
+
+    it 'requires fresh MFA even when hosted admin MFA is disabled' do
+      get admin_ambiguous_person_access_grants_path
+
+      expect(response).to redirect_to(profile_path)
+      expect(response.body).not_to include(queue_data.fetch(:grant).id.to_s)
+    end
+
+    it 'does not send an unauthorized member to MFA setup' do
+      sign_in(users(:jane))
+
+      get admin_ambiguous_person_access_grants_path
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).not_to include('Set up MFA or a passkey')
+    end
+  end
+
+  context 'without authentication' do
+    it 'redirects an unauthenticated visitor to login' do
+      get admin_ambiguous_person_access_grants_path
+
+      expect(response).to redirect_to(login_path)
+    end
+  end
+end

--- a/spec/services/admin/ambiguous_person_access_grants_index_query_spec.rb
+++ b/spec/services/admin/ambiguous_person_access_grants_index_query_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AmbiguousPersonAccessGrantsIndexQuery, type: :service do
+  include HouseholdPolicyHelpers
+
+  subject(:results) { described_class.new(scope: PersonAccessGrant.where(household: household)).call }
+
+  let(:household) { household_policy_member(role: :owner).fetch(:household) }
+  let(:carer_member) { household_policy_member(role: :member, household: household, name: 'Queue Carer') }
+  let(:patient) { household_policy_person(household, name: 'Queue Patient', person_type: :minor, has_capacity: false) }
+  let(:grant) do
+    CarerRelationship.create!(
+      household: household, carer: carer_member.fetch(:person), patient: patient,
+      relationship_type: :parent, active: true
+    )
+    PersonAccessGrant.create!(
+      household: household,
+      household_membership: carer_member.fetch(:membership),
+      person: patient,
+      access_level: :manage,
+      relationship_type: :professional,
+      created_at: 2.minutes.ago
+    )
+  end
+
+  it 'returns active source-null grants with compatible active relationships' do
+    expect(results).to contain_exactly(grant)
+    expect(results.first.association(:person)).to be_loaded
+    expect(results.first.association(:household_membership)).to be_loaded
+    expect(results.first.household_membership.association(:person)).to be_loaded
+    expect(results.first[:compatible_relationship_type]).to eq('parent')
+  end
+
+  it 'excludes revoked, expired, classified, and incompatible grants' do
+    revoked = grant.dup
+    revoked.revoked_at = Time.current
+    revoked.save!(validate: false)
+    create_expired_grant
+    create_classified_grant
+    create_incompatible_grant
+
+    expect(results).to contain_exactly(grant)
+  end
+
+  it 'keeps descriptive grant relationship types independent from compatibility' do
+    expect(grant.relationship_type).to eq('professional')
+    expect(results.first[:compatible_relationship_type]).to eq('parent')
+  end
+
+  it 'orders by newest creation and id without duplicate rows' do
+    grant.update!(created_at: Time.current)
+    newer_member = household_policy_member(role: :member, household: household, name: 'Newer Carer')
+    newer_patient = household_policy_person(household, name: 'Newer Patient', person_type: :minor, has_capacity: false)
+    _newer_relationship = CarerRelationship.create!(
+      household: household,
+      carer: newer_member.fetch(:person),
+      patient: newer_patient,
+      relationship_type: :parent,
+      active: true
+    )
+    newer = create_grant(newer_member, newer_patient, created_at: 1.minute.from_now)
+
+    expect(results.to_a).to eq([newer, grant])
+  end
+
+  it 'excludes a grant at its expiry boundary' do
+    freeze_time do
+      grant.update!(expires_at: Time.current)
+
+      expect(results).to be_empty
+    end
+  end
+
+  def create_grant(member, person, **attributes)
+    PersonAccessGrant.create!(
+      {
+        household: household,
+        household_membership: member.fetch(:membership),
+        person: person,
+        access_level: :manage,
+        relationship_type: :professional
+      }.merge(attributes)
+    )
+  end
+
+  def create_expired_grant
+    member = household_policy_member(role: :member, household: household, name: 'Expired Carer')
+    person = household_policy_person(household, name: 'Expired Patient', person_type: :minor, has_capacity: false)
+    create_grant(member, person, expires_at: 1.minute.ago)
+  end
+
+  def create_classified_grant
+    member = household_policy_member(role: :member, household: household, name: 'Classified Carer')
+    person = household_policy_person(household, name: 'Classified Patient', person_type: :minor, has_capacity: false)
+    relationship = CarerRelationship.create!(household: household, carer: member.fetch(:person), patient: person,
+                                             relationship_type: :parent, active: true)
+    create_grant(member, person, carer_relationship: relationship)
+  end
+
+  def create_incompatible_grant
+    member = household_policy_member(role: :member, household: household, name: 'Incompatible Carer')
+    person = household_policy_person(household, name: 'Other Patient', person_type: :minor, has_capacity: false)
+    create_grant(member, person)
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -10,6 +10,7 @@ module RequestHelpers
     admin_invitations_path admin_invitation_path resend_admin_invitation_path
     admin_carer_relationships_path admin_carer_relationship_path new_admin_carer_relationship_path
     activate_admin_carer_relationship_path
+    admin_ambiguous_person_access_grants_path
     admin_people_path admin_audit_logs_path admin_audit_log_path admin_settings_path
     admin_household_path edit_admin_household_path
     locations_path location_path new_location_path edit_location_path


### PR DESCRIPTION
## Summary

- adds a read-only admin queue for active, unexpired legacy grants that have no provenance link but exactly match an active same-household carer relationship
- restricts the queue to active household owners and administrators with fresh privileged MFA, independently of the hosted MFA environment switch
- displays only household-safe grant, carer, patient, access, relationship, and timestamp fields with accessible pagination
- keeps the query at the controller/service boundary, eager-loads rendered associations, prevents duplicate rows, and preserves all existing grants without classifying or mutating them
- provides the new screen in every supported locale

## Why

Ambiguous legacy grants currently block safe care-delegation revocation, but authorized operators had no privacy-safe way to see which records need classification. This gives them a tightly scoped review queue while leaving the actual classification workflow, audit transition, and concurrency controls to the subsequent implementation slices.

## Verification note

The focused authorization/privacy checks and full Docker browser-capable suite pass. Screenshot capture was attempted against a fixture-only development environment, but the permitted in-app browser exposed no available browser after its documented recovery path, so no screenshots are included.

Closes #1666
