### PR TITLE
fix(migrations): relax forced RLS for carer ownership backfill

### DIFF
--- a/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
+++ b/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
@@ -5,8 +5,10 @@ class AddHouseholdOwnershipToCarerRelationships < ActiveRecord::Migration[8.1]
 
   def up
     add_reference :carer_relationships, :household, index: false
-    verify_legacy_relationships!
-    backfill_households
+    with_people_rls_relaxed do
+      verify_legacy_relationships!
+      backfill_households
+    end
     change_column_null :carer_relationships, :household_id, false
     add_indexes
     add_foreign_keys
@@ -21,6 +23,22 @@ class AddHouseholdOwnershipToCarerRelationships < ActiveRecord::Migration[8.1]
   end
 
   private
+
+  def with_people_rls_relaxed
+    forced = people_forced_row_level_security?
+    execute 'ALTER TABLE people NO FORCE ROW LEVEL SECURITY' if forced
+    yield
+  ensure
+    execute 'ALTER TABLE people FORCE ROW LEVEL SECURITY' if forced
+  end
+
+  def people_forced_row_level_security?
+    select_value(<<~SQL.squish)
+      SELECT relforcerowsecurity
+      FROM pg_class
+      WHERE oid = 'people'::regclass
+    SQL
+  end
 
   def verify_legacy_relationships!
     mismatches = legacy_relationship_mismatches

--- a/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
+++ b/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
@@ -41,6 +41,32 @@ RSpec.describe EnforceStrictHouseholdTenantBoundary do
 
   describe AddHouseholdOwnershipToCarerRelationships do
     describe 'legacy data verification' do
+      it 'reads valid endpoints while migrating as the forced-RLS table owner' do
+        migration = described_class.new
+
+        connection.execute('SET LOCAL ROLE med_tracker_owner')
+        connection.execute("SELECT set_config('med_tracker.current_household_id', '', true)")
+
+        migration.send(:with_people_rls_relaxed) do
+          expect(migration.send(:legacy_relationship_mismatches)).to be_empty
+        end
+      end
+
+      it 'restores forced people RLS when legacy verification fails' do
+        migration = described_class.new
+
+        expect do
+          migration.send(:with_people_rls_relaxed) { raise ActiveRecord::MigrationError }
+        end.to raise_error(ActiveRecord::MigrationError)
+
+        forced = connection.select_value(<<~SQL.squish)
+          SELECT relforcerowsecurity
+          FROM pg_class
+          WHERE oid = 'people'::regclass
+        SQL
+        expect(forced).to be(true)
+      end
+
       it 'aborts with the invalid relationship ids before backfilling' do
         migration = described_class.new
         allow(migration).to receive(:legacy_relationship_mismatches).and_return(


### PR DESCRIPTION
The 0.5.11 production upgrade reaches the carer relationship ownership migration, but the migration validates endpoint households while running as `med_tracker_owner` with no tenant context. Because `people` uses forced row-level security, every valid endpoint is hidden and the migration incorrectly reports all relationships as missing.\n\nThis temporarily relaxes forced RLS on `people` only while the migration validates and backfills legacy relationships, then restores forced RLS in an ensure block. The migration still rejects genuinely missing or cross-household endpoints, while valid upgrades can complete without weakening the runtime policy.