### PR TITLE
fix(migrations): validate FKs before RLS restore

### DIFF
--- a/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
+++ b/db/migrate/20260713130000_add_household_ownership_to_carer_relationships.rb
@@ -8,10 +8,10 @@ class AddHouseholdOwnershipToCarerRelationships < ActiveRecord::Migration[8.1]
     with_people_rls_relaxed do
       verify_legacy_relationships!
       backfill_households
+      change_column_null :carer_relationships, :household_id, false
+      add_indexes
+      add_foreign_keys
     end
-    change_column_null :carer_relationships, :household_id, false
-    add_indexes
-    add_foreign_keys
     enable_household_rls
   end
 

--- a/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
+++ b/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe EnforceStrictHouseholdTenantBoundary do
 
   describe AddHouseholdOwnershipToCarerRelationships do
     describe 'legacy data verification' do
+      it 'keeps people RLS relaxed through endpoint foreign key validation' do
+        migration = described_class.new
+        rls_relaxed = false
+
+        allow(migration).to receive(:add_reference)
+        allow(migration).to receive(:verify_legacy_relationships!)
+        allow(migration).to receive(:backfill_households)
+        allow(migration).to receive(:change_column_null)
+        allow(migration).to receive(:add_indexes)
+        allow(migration).to receive(:enable_household_rls)
+        allow(migration).to receive(:with_people_rls_relaxed) do |&operation|
+          rls_relaxed = true
+          operation.call
+        ensure
+          rls_relaxed = false
+        end
+
+        expect(migration).to receive(:add_foreign_keys) { expect(rls_relaxed).to be(true) }
+
+        migration.up
+      end
+
       it 'reads valid endpoints while migrating as the forced-RLS table owner' do
         migration = described_class.new
 

--- a/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
+++ b/spec/migrations/enforce_strict_household_tenant_boundary_spec.rb
@@ -45,12 +45,10 @@ RSpec.describe EnforceStrictHouseholdTenantBoundary do
         migration = described_class.new
         rls_relaxed = false
 
-        allow(migration).to receive(:add_reference)
-        allow(migration).to receive(:verify_legacy_relationships!)
-        allow(migration).to receive(:backfill_households)
-        allow(migration).to receive(:change_column_null)
-        allow(migration).to receive(:add_indexes)
-        allow(migration).to receive(:enable_household_rls)
+        stubbed_steps = %i[add_reference verify_legacy_relationships! backfill_households
+                           change_column_null add_indexes enable_household_rls]
+        stubbed_steps.each { |step| allow(migration).to receive(step) }
+        allow(migration).to receive(:add_foreign_keys) { expect(rls_relaxed).to be(true) }
         allow(migration).to receive(:with_people_rls_relaxed) do |&operation|
           rls_relaxed = true
           operation.call
@@ -58,9 +56,8 @@ RSpec.describe EnforceStrictHouseholdTenantBoundary do
           rls_relaxed = false
         end
 
-        expect(migration).to receive(:add_foreign_keys) { expect(rls_relaxed).to be(true) }
-
         migration.up
+        expect(migration).to have_received(:add_foreign_keys)
       end
 
       it 'reads valid endpoints while migrating as the forced-RLS table owner' do


### PR DESCRIPTION
## Summary

Release 0.5.12 allowed the carer relationship migration to verify and backfill valid legacy rows, but PostgreSQL still validated the new composite foreign keys after forced row-level security had been restored on `people`. That made valid parent rows invisible to the migration owner and caused a false foreign-key violation during production rollout.

Keep `people` RLS temporarily relaxed through index creation and foreign-key validation, then restore forced RLS through the existing `ensure` path. This preserves the strict runtime policy while allowing the schema migration to validate the real data.