### PR TITLE
fix(database): separate runtime database logins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
+      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       COVERAGE: true
       SIMPLECOV_COMMAND_NAME: rspec-non-system
@@ -119,13 +121,25 @@ jobs:
           ruby-version: "4.0.6"
           bundler-cache: true
 
+      - name: Bootstrap database roles
+        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+
       - name: Set up database
+        env:
+          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Precompile assets
+        env:
+          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Run non-browser tests
+        env:
+          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_ROLE:
         run: bundle exec rspec --format RSpec::Github::Formatter --tag ~browser
 
       - name: Upload SimpleCov coverage report
@@ -161,7 +175,9 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
+      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       CI: true
 
@@ -174,6 +190,9 @@ jobs:
         with:
           ruby-version: "4.0.6"
           bundler-cache: true
+
+      - name: Bootstrap database roles
+        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -194,12 +213,21 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Set up database
+        env:
+          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Precompile assets
+        env:
+          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Run browser tests (shard ${{ matrix.shard }}/2)
+        env:
+          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_ROLE:
         shell: bash
         run: |
           # Get all spec files and split tagged browser examples for this shard
@@ -254,7 +282,9 @@ jobs:
           --health-retries 5
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
+      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
     steps:
       - name: Checkout code
@@ -268,7 +298,13 @@ jobs:
           ruby-version: "4.0.6"
           bundler-cache: true
 
+      - name: Bootstrap database roles
+        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+
       - name: Set up database
+        env:
+          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Ensure base ref is available
@@ -277,6 +313,9 @@ jobs:
       # Only mutates subjects changed since main (mutant --since), so a typical
       # PR is fast. usage: opensource (config/mutant.yml) means no licence/token.
       - name: Mutation test changed subjects (advisory)
+        env:
+          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_ROLE:
         run: bundle exec mutant run --since origin/main
 
   lighthouse:
@@ -302,7 +341,9 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
+      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       CI: true
 
@@ -315,6 +356,9 @@ jobs:
         with:
           ruby-version: "4.0.6"
           bundler-cache: true
+
+      - name: Bootstrap database roles
+        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -336,15 +380,27 @@ jobs:
         run: npm ci
 
       - name: Set up database
-        run: bundle exec rails db:prepare
+        env:
+          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_owner
+        run: bundle exec rails db:migrate
 
       - name: Seed database
+        env:
+          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_ROLE:
         run: bundle exec rails db:seed
 
       - name: Precompile assets
+        env:
+          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Start Rails server
+        env:
+          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_ROLE: med_tracker_app
         run: |
           bundle exec rails server -p 3000 > tmp/lighthouse-server.log 2>&1 &
           for attempt in {1..30}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,6 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
-      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
-      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       COVERAGE: true
       SIMPLECOV_COMMAND_NAME: rspec-non-system
@@ -122,23 +119,25 @@ jobs:
           bundler-cache: true
 
       - name: Bootstrap database roles
-        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+        env:
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+        run: psql "$DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up database
         env:
-          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Precompile assets
         env:
-          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Run non-browser tests
         env:
-          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
           DATABASE_ROLE:
         run: bundle exec rspec --format RSpec::Github::Formatter --tag ~browser
 
@@ -175,9 +174,6 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
-      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
-      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       CI: true
 
@@ -192,7 +188,9 @@ jobs:
           bundler-cache: true
 
       - name: Bootstrap database roles
-        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+        env:
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+        run: psql "$DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -214,19 +212,19 @@ jobs:
 
       - name: Set up database
         env:
-          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Precompile assets
         env:
-          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Run browser tests (shard ${{ matrix.shard }}/2)
         env:
-          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
           DATABASE_ROLE:
         shell: bash
         run: |
@@ -282,9 +280,6 @@ jobs:
           --health-retries 5
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
-      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
-      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
     steps:
       - name: Checkout code
@@ -299,11 +294,13 @@ jobs:
           bundler-cache: true
 
       - name: Bootstrap database roles
-        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+        env:
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+        run: psql "$DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up database
         env:
-          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
@@ -314,7 +311,7 @@ jobs:
       # PR is fast. usage: opensource (config/mutant.yml) means no licence/token.
       - name: Mutation test changed subjects (advisory)
         env:
-          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
           DATABASE_ROLE:
         run: bundle exec mutant run --since origin/main
 
@@ -341,9 +338,6 @@ jobs:
 
     env:
       TEST_DATABASE_ADAPTER: postgresql
-      BOOTSTRAP_DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
-      MIGRATION_DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
-      RUNTIME_DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
       RAILS_ENV: test
       CI: true
 
@@ -358,7 +352,9 @@ jobs:
           bundler-cache: true
 
       - name: Bootstrap database roles
-        run: psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+        env:
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
+        run: psql "$DATABASE_URL" --file compose/init-roles.sql
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -381,25 +377,25 @@ jobs:
 
       - name: Set up database
         env:
-          DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_owner
         run: bundle exec rails db:migrate
 
       - name: Seed database
         env:
-          DATABASE_URL: ${{ env.BOOTSTRAP_DATABASE_URL }}
+          DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test
           DATABASE_ROLE:
         run: bundle exec rails db:seed
 
       - name: Precompile assets
         env:
-          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_app
         run: bundle exec rails assets:precompile
 
       - name: Start Rails server
         env:
-          DATABASE_URL: ${{ env.RUNTIME_DATABASE_URL }}
+          DATABASE_URL: postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test
           DATABASE_ROLE: med_tracker_app
         run: |
           bundle exec rails server -p 3000 > tmp/lighthouse-server.log 2>&1 &

--- a/TESTING.md
+++ b/TESTING.md
@@ -50,7 +50,8 @@ web-test:
     target: test       # Uses 'test' stage from Dockerfile
   environment:
     RAILS_ENV: test
-    DATABASE_URL: postgresql://medtracker:medtracker_password@db-test:5432/medtracker
+    DATABASE_URL: postgresql://medtracker_runtime:local_runtime_only@db-test:5432/medtracker
+    DATABASE_ROLE: med_tracker_app
 ```
 
 The `test` stage extends the `assets` stage (which has all build tools and gems) and adds Playwright browser dependencies.
@@ -144,7 +145,7 @@ tasks:
       - task: internal:run
         vars:
           ENVIRONMENT: test
-          SERVICE: web
+          SERVICE: test-runner
           COMMAND: 'bundle exec rspec {{ .TEST_FILE | default "spec" }}'
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,7 @@ tasks:
       - task: internal:run
         vars:
           ENVIRONMENT: test
+          SERVICE: test-runner
           COMMAND: 'bundle exec rspec --profile 20 --format documentation {{ .TEST_FILE | default "spec" }}'
           TEST_FILE: '{{ .TEST_FILE | default "spec" }}'
 

--- a/Taskfiles/internal.yml
+++ b/Taskfiles/internal.yml
@@ -117,9 +117,9 @@ tasks:
     requires:
       vars: [ENVIRONMENT]
     vars:
-      WEB_SERVICE: "web-{{ .ENVIRONMENT }}"
+      MIGRATION_SERVICE: "migrate-{{ .ENVIRONMENT }}"
     cmds:
-      - "{{ .COMPOSE_CMD }} --profile {{ .ENVIRONMENT }} run --rm {{ .WEB_SERVICE }} rails db:migrate"
+      - "{{ .COMPOSE_CMD }} --profile {{ .ENVIRONMENT }} run --rm {{ .MIGRATION_SERVICE }} rails db:migrate"
 
   # Follow logs from Docker containers
   # Press Ctrl+C to stop following logs
@@ -156,11 +156,14 @@ tasks:
     internal: true
     requires:
       vars: [ENVIRONMENT]
+    vars:
+      SERVICE: '{{ .SERVICE | default (printf "web-%s" .ENVIRONMENT) }}'
     cmds:
       - echo "Seeding {{ .ENVIRONMENT }} database..."
       - task: run
         vars:
           ENVIRONMENT: { ref: .ENVIRONMENT }
+          SERVICE: { ref: .SERVICE }
           COMMAND: "rails db:seed"
       - defer: echo "✓ Database seeding completed"
 

--- a/Taskfiles/local.yml
+++ b/Taskfiles/local.yml
@@ -35,6 +35,12 @@ tasks:
       - sleep 3
       - docker exec {{.DB_CONTAINER}} pg_isready -U {{.DB_USER}}
 
+  db:bootstrap:
+    desc: Apply local database role bootstrap
+    deps: [db:up]
+    cmds:
+      - docker exec -i {{.DB_CONTAINER}} psql --username {{.DB_USER}} --dbname {{.DB_NAME}} --file /dev/stdin < {{.ROOT_DIR}}/compose/init-roles.sql
+
   # Stop and remove PostgreSQL container
   # Usage: task local:db:down
   db:down:
@@ -47,7 +53,7 @@ tasks:
   # Usage: task local:db:prepare
   db:prepare:
     desc: Run database migrations
-    deps: [db:up]
+    deps: [db:bootstrap]
     env:
       DATABASE_URL: '{{.MIGRATION_DATABASE_URL}}'
       DATABASE_ROLE: med_tracker_owner

--- a/Taskfiles/local.yml
+++ b/Taskfiles/local.yml
@@ -11,7 +11,9 @@ vars:
   DB_USER: medtracker
   DB_PASSWORD: medtracker
   DB_NAME: medtracker_test
-  DATABASE_URL: 'postgres://{{.DB_USER}}:{{.DB_PASSWORD}}@localhost:{{.DB_PORT}}/{{.DB_NAME}}'
+  BOOTSTRAP_DATABASE_URL: 'postgres://{{.DB_USER}}:{{.DB_PASSWORD}}@localhost:{{.DB_PORT}}/{{.DB_NAME}}'
+  MIGRATION_DATABASE_URL: 'postgres://medtracker_migration:local_migration_only@localhost:{{.DB_PORT}}/{{.DB_NAME}}'
+  RUNTIME_DATABASE_URL: 'postgres://medtracker_runtime:local_runtime_only@localhost:{{.DB_PORT}}/{{.DB_NAME}}'
 
 tasks:
   # Start PostgreSQL container for local testing
@@ -27,6 +29,7 @@ tasks:
           -e POSTGRES_PASSWORD={{.DB_PASSWORD}} \
           -e POSTGRES_DB={{.DB_NAME}} \
           -p {{.DB_PORT}}:5432 \
+          -v {{.ROOT_DIR}}/compose/init-roles.sql:/docker-entrypoint-initdb.d/001-init-roles.sql:ro \
           postgres:18-alpine
       - echo "Waiting for PostgreSQL to be ready..."
       - sleep 3
@@ -46,7 +49,8 @@ tasks:
     desc: Run database migrations
     deps: [db:up]
     env:
-      DATABASE_URL: '{{.DATABASE_URL}}'
+      DATABASE_URL: '{{.MIGRATION_DATABASE_URL}}'
+      DATABASE_ROLE: med_tracker_owner
       RAILS_ENV: test
     cmds:
       - bundle exec rails db:migrate
@@ -58,7 +62,8 @@ tasks:
     desc: Run non-browser tests locally
     deps: [db:prepare]
     env:
-      DATABASE_URL: '{{.DATABASE_URL}}'
+      DATABASE_URL: '{{.BOOTSTRAP_DATABASE_URL}}'
+      DATABASE_ROLE:
       RAILS_ENV: test
     cmds:
       - bundle exec rspec --tag '~browser' {{.TEST_FILE | default ""}}
@@ -69,11 +74,16 @@ tasks:
     desc: Run browser tests locally (requires Playwright)
     deps: [db:prepare]
     env:
-      DATABASE_URL: '{{.DATABASE_URL}}'
       RAILS_ENV: test
     cmds:
-      - bundle exec rails assets:precompile
-      - bundle exec rspec --tag browser {{.TEST_FILE | default ""}}
+      - cmd: bundle exec rails assets:precompile
+        env:
+          DATABASE_URL: '{{.RUNTIME_DATABASE_URL}}'
+          DATABASE_ROLE: med_tracker_app
+      - cmd: bundle exec rspec --tag browser {{.TEST_FILE | default ""}}
+        env:
+          DATABASE_URL: '{{.BOOTSTRAP_DATABASE_URL}}'
+          DATABASE_ROLE:
 
   # Run all tests locally
   # Usage: task local:test:all
@@ -81,11 +91,16 @@ tasks:
     desc: Run all tests locally
     deps: [db:prepare]
     env:
-      DATABASE_URL: '{{.DATABASE_URL}}'
       RAILS_ENV: test
     cmds:
-      - bundle exec rails assets:precompile
-      - bundle exec rspec {{.TEST_FILE | default ""}}
+      - cmd: bundle exec rails assets:precompile
+        env:
+          DATABASE_URL: '{{.RUNTIME_DATABASE_URL}}'
+          DATABASE_ROLE: med_tracker_app
+      - cmd: bundle exec rspec {{.TEST_FILE | default ""}}
+        env:
+          DATABASE_URL: '{{.BOOTSTRAP_DATABASE_URL}}'
+          DATABASE_ROLE:
 
   # Clean up - stop database container
   # Usage: task local:clean

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -47,12 +47,12 @@ tasks:
       - task: :internal:run
         vars:
           ENVIRONMENT: test
-          SERVICE: test-runner
+          SERVICE: web-test
           COMMAND: "rails tailwindcss:build"
       - task: :internal:run
         vars:
           ENVIRONMENT: test
-          SERVICE: test-runner
+          SERVICE: web-test
           COMMAND: '{{ .CMD }}'
 
   portless:
@@ -118,12 +118,12 @@ tasks:
       - task: :internal:run
         vars:
           ENVIRONMENT: test
-          SERVICE: test-runner
+          SERVICE: web-test
           COMMAND: "find public/assets -mindepth 1 -maxdepth 1 -exec rm -rf {} +"
       - task: :internal:run
         vars:
           ENVIRONMENT: test
-          SERVICE: test-runner
+          SERVICE: web-test
           COMMAND: "rails assets:precompile"
 
   rebuild:

--- a/Taskfiles/test.yml
+++ b/Taskfiles/test.yml
@@ -47,10 +47,12 @@ tasks:
       - task: :internal:run
         vars:
           ENVIRONMENT: test
+          SERVICE: test-runner
           COMMAND: "rails tailwindcss:build"
       - task: :internal:run
         vars:
           ENVIRONMENT: test
+          SERVICE: test-runner
           COMMAND: '{{ .CMD }}'
 
   portless:
@@ -76,7 +78,7 @@ tasks:
       Usage: task test:seed
     cmds:
       - task: :internal:seed
-        vars: { ENVIRONMENT: test }
+        vars: { ENVIRONMENT: test, SERVICE: test-runner }
 
   stop:
     desc: Stop test server
@@ -116,10 +118,12 @@ tasks:
       - task: :internal:run
         vars:
           ENVIRONMENT: test
+          SERVICE: test-runner
           COMMAND: "find public/assets -mindepth 1 -maxdepth 1 -exec rm -rf {} +"
       - task: :internal:run
         vars:
           ENVIRONMENT: test
+          SERVICE: test-runner
           COMMAND: "rails assets:precompile"
 
   rebuild:
@@ -142,7 +146,7 @@ tasks:
       - task: :internal:up-db
         vars: { ENVIRONMENT: test }
       - task: :internal:seed
-        vars: { ENVIRONMENT: test }
+        vars: { ENVIRONMENT: test, SERVICE: test-runner }
 
   port:
     desc: Print the host port of the running test server

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,9 +43,9 @@ services:
     environment: &rails_env_dev
       RAILS_ENV: development
       RAILS_FORCE_SSL: "false"
-      DATABASE_URL: postgresql://medtracker:medtracker_password@db-dev:5432/medtracker
-      DATABASE_ROLE: ${DEV_MIGRATION_DATABASE_ROLE:-}
-      SOLID_QUEUE_DATABASE_URL: postgresql://medtracker:medtracker_password@db-dev:5432/medtracker_queue
+      DATABASE_URL: postgresql://medtracker_migration:local_migration_only@db-dev:5432/medtracker
+      DATABASE_ROLE: ${DEV_MIGRATION_DATABASE_ROLE:-med_tracker_owner}
+      SOLID_QUEUE_DATABASE_URL: postgresql://medtracker_auxiliary:local_auxiliary_only@db-dev:5432/medtracker_queue
       NHS_DMD_CLIENT_ID: ${NHS_DMD_CLIENT_ID:-}
       NHS_DMD_CLIENT_SECRET: ${NHS_DMD_CLIENT_SECRET:-}
       APP_URL: ${APP_URL:-http://localhost:3000}
@@ -80,7 +80,8 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *rails_env_dev
-      DATABASE_ROLE: ${DEV_DATABASE_ROLE:-}
+      DATABASE_URL: postgresql://medtracker_runtime:local_runtime_only@db-dev:5432/medtracker
+      DATABASE_ROLE: ${DEV_DATABASE_ROLE:-med_tracker_app}
       SOLID_QUEUE_IN_PUMA: "true"
     volumes:
       - .:/app
@@ -132,8 +133,8 @@ services:
         condition: service_healthy
     environment: &rails_env_test
       RAILS_ENV: test
-      DATABASE_URL: postgresql://medtracker:medtracker_password@db-test:5432/medtracker
-      DATABASE_ROLE: ${TEST_MIGRATION_DATABASE_ROLE:-}
+      DATABASE_URL: postgresql://medtracker_migration:local_migration_only@db-test:5432/medtracker
+      DATABASE_ROLE: ${TEST_MIGRATION_DATABASE_ROLE:-med_tracker_owner}
       SMTP_ADDRESS: mail-test
       APP_URL: ${TEST_APP_URL:-http://localhost:3000}
       OIDC_CLIENT_ID: ${TEST_OIDC_CLIENT_ID:-}
@@ -166,7 +167,39 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *rails_env_test
-      DATABASE_ROLE: ${TEST_DATABASE_ROLE:-}
+      DATABASE_URL: postgresql://medtracker_runtime:local_runtime_only@db-test:5432/medtracker
+      DATABASE_ROLE: ${TEST_DATABASE_ROLE:-med_tracker_app}
+    volumes:
+      - .:/app
+      - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
+      - medtracker_test_bundle:/usr/local/bundle
+      - medtracker_test_node_modules:/app/node_modules
+      - ./tmp/capybara:/app/tmp/capybara
+    tmpfs:
+      - /app/tmp/pids:uid=1000,gid=1000
+      - /app/tmp/cache:uid=1000,gid=1000
+      - /app/public/assets:uid=1000,gid=1000
+    healthcheck:
+      disable: true
+
+  test-runner:
+    extends:
+      file: compose/base.yml
+      service: rails
+    image: med-tracker-web-test
+    profiles: [test]
+    networks: [test]
+    depends_on:
+      db-test:
+        condition: service_healthy
+      mail-test:
+        condition: service_started
+      migrate-test:
+        condition: service_completed_successfully
+    environment:
+      <<: *rails_env_test
+      DATABASE_URL: postgresql://medtracker:medtracker_password@db-test:5432/medtracker
+      DATABASE_ROLE:
     volumes:
       - .:/app
       - ${MEDTRACKER_GIT_COMMON_DIR:-.git}:${MEDTRACKER_GIT_COMMON_DIR:-.git}:ro
@@ -236,12 +269,12 @@ services:
       APP_URL: ${APP_URL:-http://localhost}
       ACTIVE_STORAGE_SERVICE: ${ACTIVE_STORAGE_SERVICE:-persistent}
       ACTIVE_STORAGE_ROOT: ${ACTIVE_STORAGE_ROOT:-/app/storage}
-      DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker
+      DATABASE_URL: postgresql://medtracker_migration:local_migration_only@db-prod:5432/medtracker
       DATABASE_ROLE: ${MIGRATION_DATABASE_ROLE:-med_tracker_owner}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-local-prod-testing-only-not-for-real-use}
-      SOLID_QUEUE_DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker_production_queue
-      SOLID_CACHE_DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker_production_cache
-      SOLID_CABLE_DATABASE_URL: postgresql://medtracker:medtracker_password@db-prod:5432/medtracker_production_cable
+      SOLID_QUEUE_DATABASE_URL: postgresql://medtracker_auxiliary:local_auxiliary_only@db-prod:5432/medtracker_production_queue
+      SOLID_CACHE_DATABASE_URL: postgresql://medtracker_auxiliary:local_auxiliary_only@db-prod:5432/medtracker_production_cache
+      SOLID_CABLE_DATABASE_URL: postgresql://medtracker_auxiliary:local_auxiliary_only@db-prod:5432/medtracker_production_cable
     volumes:
       - medtracker_prod_storage:/app/storage
 
@@ -263,6 +296,7 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *rails_env_prod
+      DATABASE_URL: postgresql://medtracker_runtime:local_runtime_only@db-prod:5432/medtracker
       DATABASE_ROLE: ${DATABASE_ROLE:-med_tracker_app}
       SOLID_QUEUE_IN_PUMA: "true"
     ports:

--- a/compose/init-multiple-dbs.sh
+++ b/compose/init-multiple-dbs.sh
@@ -4,11 +4,79 @@ set -e
 if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
   for db in $(echo "$POSTGRES_MULTIPLE_DATABASES" | tr ',' ' '); do
     echo "Creating additional database: $db"
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "${POSTGRES_DB:-$POSTGRES_USER}" <<-EOSQL
       SELECT 'CREATE DATABASE $db OWNER medtracker_auxiliary'
       WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db')\gexec
-      REVOKE CONNECT ON DATABASE $db FROM PUBLIC;
+      ALTER DATABASE $db OWNER TO medtracker_auxiliary;
+      REVOKE CONNECT, TEMPORARY ON DATABASE $db FROM PUBLIC;
       GRANT CONNECT ON DATABASE $db TO medtracker_auxiliary;
+EOSQL
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$db" <<-EOSQL
+      ALTER SCHEMA public OWNER TO medtracker_auxiliary;
+      REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+      DO \$\$
+      DECLARE
+        owned_object record;
+        object_type text;
+      BEGIN
+        FOR owned_object IN
+          SELECT namespace.nspname, object.relname, object.relkind
+          FROM pg_class object
+          JOIN pg_namespace namespace ON namespace.oid = object.relnamespace
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg_%'
+            AND object.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')
+        LOOP
+          object_type := CASE owned_object.relkind
+            WHEN 'S' THEN 'SEQUENCE'
+            WHEN 'v' THEN 'VIEW'
+            WHEN 'm' THEN 'MATERIALIZED VIEW'
+            WHEN 'f' THEN 'FOREIGN TABLE'
+            ELSE 'TABLE'
+          END;
+          EXECUTE format(
+            'ALTER %s %I.%I OWNER TO medtracker_auxiliary',
+            object_type,
+            owned_object.nspname,
+            owned_object.relname
+          );
+        END LOOP;
+
+        FOR owned_object IN
+          SELECT namespace.nspname,
+                 routine.proname,
+                 pg_get_function_identity_arguments(routine.oid) AS arguments
+          FROM pg_proc routine
+          JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg_%'
+        LOOP
+          EXECUTE format(
+            'ALTER ROUTINE %I.%I(%s) OWNER TO medtracker_auxiliary',
+            owned_object.nspname,
+            owned_object.proname,
+            owned_object.arguments
+          );
+        END LOOP;
+
+        FOR owned_object IN
+          SELECT namespace.nspname, type.typname, type.typtype
+          FROM pg_type type
+          JOIN pg_namespace namespace ON namespace.oid = type.typnamespace
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg_%'
+            AND type.typtype IN ('d', 'e')
+        LOOP
+          object_type := CASE owned_object.typtype WHEN 'd' THEN 'DOMAIN' ELSE 'TYPE' END;
+          EXECUTE format(
+            'ALTER %s %I.%I OWNER TO medtracker_auxiliary',
+            object_type,
+            owned_object.nspname,
+            owned_object.typname
+          );
+        END LOOP;
+      END
+      \$\$;
 EOSQL
   done
 fi

--- a/compose/init-multiple-dbs.sh
+++ b/compose/init-multiple-dbs.sh
@@ -5,8 +5,10 @@ if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
   for db in $(echo "$POSTGRES_MULTIPLE_DATABASES" | tr ',' ' '); do
     echo "Creating additional database: $db"
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-      SELECT 'CREATE DATABASE $db OWNER $POSTGRES_USER'
+      SELECT 'CREATE DATABASE $db OWNER medtracker_auxiliary'
       WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db')\gexec
+      REVOKE CONNECT ON DATABASE $db FROM PUBLIC;
+      GRANT CONNECT ON DATABASE $db TO medtracker_auxiliary;
 EOSQL
   done
 fi

--- a/compose/init-roles.sql
+++ b/compose/init-roles.sql
@@ -1,3 +1,16 @@
+\if :{?runtime_password}
+\else
+\set runtime_password 'local_runtime_only'
+\endif
+\if :{?migration_password}
+\else
+\set migration_password 'local_migration_only'
+\endif
+\if :{?auxiliary_password}
+\else
+\set auxiliary_password 'local_auxiliary_only'
+\endif
+
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_owner') THEN
@@ -26,23 +39,43 @@ BEGIN
 END
 $$;
 
+SELECT format('CREATE ROLE medtracker_runtime LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_runtime') \gexec
+SELECT format('CREATE ROLE medtracker_migration LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_migration') \gexec
+SELECT format('CREATE ROLE medtracker_auxiliary LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'auxiliary_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_auxiliary') \gexec
+
 ALTER ROLE med_tracker_owner NOLOGIN;
 ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+SELECT format('ALTER ROLE medtracker_runtime LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password') \gexec
+SELECT format('ALTER ROLE medtracker_migration LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password') \gexec
+SELECT format('ALTER ROLE medtracker_auxiliary LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'auxiliary_password') \gexec
 ALTER ROLE med_tracker_audit_exporter NOLOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE medtracker_audit_exporter LOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE med_tracker_audit_verifier NOLOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE medtracker_audit_verifier LOGIN NOSUPERUSER NOBYPASSRLS;
 
-GRANT med_tracker_owner TO medtracker;
-GRANT med_tracker_app TO medtracker;
+SELECT format('REVOKE med_tracker_owner, med_tracker_app FROM %I', current_user) \gexec
+REVOKE med_tracker_owner FROM medtracker_runtime;
+REVOKE med_tracker_app FROM medtracker_migration;
+REVOKE med_tracker_owner, med_tracker_app FROM medtracker_auxiliary;
+GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;
+GRANT med_tracker_owner TO medtracker_migration WITH INHERIT FALSE, SET TRUE;
 GRANT med_tracker_audit_exporter TO medtracker_audit_exporter;
 GRANT med_tracker_audit_verifier TO medtracker_audit_verifier;
 
-ALTER DATABASE medtracker OWNER TO med_tracker_owner;
+SELECT format('ALTER DATABASE %I OWNER TO med_tracker_owner', current_database()) \gexec
 ALTER SCHEMA public OWNER TO med_tracker_owner;
 
-GRANT CONNECT ON DATABASE medtracker TO med_tracker_owner, med_tracker_app;
-GRANT CONNECT ON DATABASE medtracker TO med_tracker_audit_exporter;
-GRANT CONNECT ON DATABASE medtracker TO med_tracker_audit_verifier;
+SELECT format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database()) \gexec
+SELECT format('GRANT CONNECT ON DATABASE %I TO med_tracker_owner, med_tracker_app', current_database()) \gexec
+SELECT format('GRANT CONNECT ON DATABASE %I TO medtracker_runtime, medtracker_migration', current_database()) \gexec
+SELECT format('GRANT CONNECT ON DATABASE %I TO med_tracker_audit_exporter, medtracker_audit_exporter', current_database()) \gexec
+SELECT format('GRANT CONNECT ON DATABASE %I TO med_tracker_audit_verifier, medtracker_audit_verifier', current_database()) \gexec
 GRANT USAGE, CREATE ON SCHEMA public TO med_tracker_owner;
 GRANT USAGE ON SCHEMA public TO med_tracker_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO med_tracker_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public
+GRANT USAGE, SELECT ON SEQUENCES TO med_tracker_app;

--- a/compose/init-roles.sql
+++ b/compose/init-roles.sql
@@ -1,10 +1,24 @@
+\set ON_ERROR_STOP on
+
+\if :{?runtime_password}
+\else
+\getenv runtime_password RUNTIME_DATABASE_PASSWORD
+\endif
 \if :{?runtime_password}
 \else
 \set runtime_password 'local_runtime_only'
 \endif
 \if :{?migration_password}
 \else
+\getenv migration_password MIGRATION_DATABASE_PASSWORD
+\endif
+\if :{?migration_password}
+\else
 \set migration_password 'local_migration_only'
+\endif
+\if :{?auxiliary_password}
+\else
+\getenv auxiliary_password AUXILIARY_DATABASE_PASSWORD
 \endif
 \if :{?auxiliary_password}
 \else
@@ -46,8 +60,8 @@ WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_migration')
 SELECT format('CREATE ROLE medtracker_auxiliary LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'auxiliary_password')
 WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'medtracker_auxiliary') \gexec
 
-ALTER ROLE med_tracker_owner NOLOGIN;
-ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
+ALTER ROLE med_tracker_owner NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS;
+ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS;
 SELECT format('ALTER ROLE medtracker_runtime LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password') \gexec
 SELECT format('ALTER ROLE medtracker_migration LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password') \gexec
 SELECT format('ALTER ROLE medtracker_auxiliary LOGIN PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'auxiliary_password') \gexec
@@ -57,16 +71,21 @@ ALTER ROLE med_tracker_audit_verifier NOLOGIN NOSUPERUSER NOBYPASSRLS;
 ALTER ROLE medtracker_audit_verifier LOGIN NOSUPERUSER NOBYPASSRLS;
 
 SELECT format('REVOKE med_tracker_owner, med_tracker_app FROM %I', current_user) \gexec
-REVOKE med_tracker_owner FROM medtracker_runtime;
-REVOKE med_tracker_app FROM medtracker_migration;
-REVOKE med_tracker_owner, med_tracker_app FROM medtracker_auxiliary;
-GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;
-GRANT med_tracker_owner TO medtracker_migration WITH INHERIT FALSE, SET TRUE;
+SELECT format('REVOKE %I FROM %I', granted.rolname, member.rolname)
+FROM pg_auth_members memberships
+JOIN pg_roles granted ON granted.oid = memberships.roleid
+JOIN pg_roles member ON member.oid = memberships.member
+WHERE member.rolname IN ('medtracker_auxiliary', 'medtracker_migration', 'medtracker_runtime')
+ORDER BY granted.rolname, member.rolname
+\gexec
+GRANT med_tracker_app TO medtracker_runtime WITH ADMIN FALSE, INHERIT FALSE, SET TRUE;
+GRANT med_tracker_owner TO medtracker_migration WITH ADMIN FALSE, INHERIT FALSE, SET TRUE;
 GRANT med_tracker_audit_exporter TO medtracker_audit_exporter;
 GRANT med_tracker_audit_verifier TO medtracker_audit_verifier;
 
 SELECT format('ALTER DATABASE %I OWNER TO med_tracker_owner', current_database()) \gexec
 ALTER SCHEMA public OWNER TO med_tracker_owner;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
 SELECT format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database()) \gexec
 SELECT format('GRANT CONNECT ON DATABASE %I TO med_tracker_owner, med_tracker_app', current_database()) \gexec

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,18 +7,20 @@ development:
   primary:
     adapter: postgresql
     url: <%= ENV['DATABASE_URL'] %>
+    seeds: false
 <% if primary_database_role != "" %>
     variables:
       role: <%= primary_database_role %>
 <% end %>
   queue:
     adapter: postgresql
-    url: <%= ENV.fetch('SOLID_QUEUE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_queue') } %>
+    url: <%= ENV['SOLID_QUEUE_DATABASE_URL'] %>
     migrations_paths: db/queue_migrate
 
 test:
   adapter: postgresql
   url: <%= ENV['DATABASE_URL'] %>
+  seeds: false
   prepared_statements: false
 <% if primary_database_role != "" %>
   variables:
@@ -35,13 +37,13 @@ production:
 <% end %>
   cache:
     adapter: postgresql
-    url: <%= ENV.fetch('SOLID_CACHE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_production_cache') } %>
+    url: <%= ENV['SOLID_CACHE_DATABASE_URL'] %>
     migrations_paths: db/cache_migrate
   queue:
     adapter: postgresql
-    url: <%= ENV.fetch('SOLID_QUEUE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_production_queue') } %>
+    url: <%= ENV['SOLID_QUEUE_DATABASE_URL'] %>
     migrations_paths: db/queue_migrate
   cable:
     adapter: postgresql
-    url: <%= ENV.fetch('SOLID_CABLE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_production_cable') } %>
+    url: <%= ENV['SOLID_CABLE_DATABASE_URL'] %>
     migrations_paths: db/cable_migrate

--- a/db/migrate/20260622001000_configure_database_runtime_roles.rb
+++ b/db/migrate/20260622001000_configure_database_runtime_roles.rb
@@ -92,6 +92,8 @@ class ConfigureDatabaseRuntimeRoles < ActiveRecord::Migration[8.1]
   end
 
   def grant_roles_to_login
+    return unless can_create_roles?
+
     execute <<~SQL
       DO $$
       DECLARE

--- a/db/migrate/20260715090000_refresh_database_runtime_privileges.rb
+++ b/db/migrate/20260715090000_refresh_database_runtime_privileges.rb
@@ -1,0 +1,30 @@
+class RefreshDatabaseRuntimePrivileges < ActiveRecord::Migration[8.1]
+  def up
+    execute 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO med_tracker_app;'
+    execute 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO med_tracker_app;'
+    execute 'GRANT USAGE ON SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;'
+    execute 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;'
+    execute <<~SQL
+      REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+      ON TABLE schema_migrations, ar_internal_metadata
+      FROM med_tracker_app;
+    SQL
+    execute 'GRANT SELECT ON TABLE schema_migrations, ar_internal_metadata TO med_tracker_app;'
+    execute <<~SQL
+      ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public
+      GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO med_tracker_app;
+    SQL
+    execute <<~SQL
+      ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public
+      GRANT USAGE, SELECT ON SEQUENCES TO med_tracker_app;
+    SQL
+    execute <<~SQL
+      ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA med_tracker
+      GRANT EXECUTE ON FUNCTIONS TO med_tracker_app;
+    SQL
+  end
+
+  def down
+    up
+  end
+end

--- a/db/migrate/20260715090000_refresh_database_runtime_privileges.rb
+++ b/db/migrate/20260715090000_refresh_database_runtime_privileges.rb
@@ -1,4 +1,8 @@
 class RefreshDatabaseRuntimePrivileges < ActiveRecord::Migration[8.1]
+  LEDGER_TABLES = %w[
+    audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
+  ].freeze
+
   def up
     execute 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO med_tracker_app;'
     execute 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO med_tracker_app;'
@@ -22,9 +26,44 @@ class RefreshDatabaseRuntimePrivileges < ActiveRecord::Migration[8.1]
       ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA med_tracker
       GRANT EXECUTE ON FUNCTIONS TO med_tracker_app;
     SQL
+    enforce_audit_ledger_immutability
   end
 
   def down
     up
+  end
+
+  private
+
+  def enforce_audit_ledger_immutability
+    execute 'SET LOCAL ROLE med_tracker_owner;'
+    execute <<~SQL.squish
+      REVOKE UPDATE, DELETE ON TABLE versions, security_audit_events
+      FROM med_tracker_app GRANTED BY med_tracker_owner;
+    SQL
+    LEDGER_TABLES.each do |table_name|
+      execute <<~SQL.squish
+        REVOKE ALL PRIVILEGES ON TABLE #{table_name}
+        FROM med_tracker_app GRANTED BY med_tracker_owner;
+      SQL
+      execute <<~SQL.squish
+        REVOKE ALL PRIVILEGES ON SEQUENCE #{table_name}_id_seq
+        FROM med_tracker_app GRANTED BY med_tracker_owner;
+      SQL
+    end
+    execute 'REVOKE ALL PRIVILEGES ON TABLE versions, security_audit_events FROM PUBLIC;'
+    execute 'GRANT SELECT, INSERT ON TABLE versions, security_audit_events TO med_tracker_app;'
+    execute 'GRANT USAGE, SELECT ON SEQUENCE versions_id_seq, security_audit_events_id_seq TO med_tracker_app;'
+    execute <<~SQL
+      DO $$
+      BEGIN
+        IF to_regclass('public.household_audit_ledger_entries') IS NOT NULL THEN
+          EXECUTE 'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+                   ON TABLE household_audit_ledger_entries FROM med_tracker_app GRANTED BY med_tracker_owner;';
+          EXECUTE 'GRANT SELECT ON household_audit_ledger_entries TO med_tracker_app;';
+        END IF;
+      END
+      $$;
+    SQL
   end
 end

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,14 +47,11 @@ task test
 If you need to run the production compose file locally:
 
 ```bash
-docker compose -f docker-compose.yml up -d
+task prod:up
 ```
 
-Run migrations inside the web container:
-
-```bash
-docker compose -f docker-compose.yml run --rm web rails db:migrate
-```
+The dedicated `migrate-prod` service completes migrations before `web-prod`
+starts.
 
 ## Environment and database notes
 
@@ -64,8 +61,44 @@ docker compose -f docker-compose.yml run --rm web rails db:migrate
 - Existing databases created before 0.5 need the
   [pre-0.5 database upgrade](pre-0-5-database-upgrade.md) bootstrap before
   running 0.5 migrations.
-- Run migrations with `DATABASE_ROLE=med_tracker_owner`; run the web process
-  with `DATABASE_ROLE=med_tracker_app`.
+
+## Database login boundaries
+
+Use independent secrets and URLs for every database boundary. The local Compose
+passwords are development-only defaults and must not be reused in a deployment.
+
+| Setting | Login | Session role | Used by |
+|---|---|---|---|
+| `BOOTSTRAP_DATABASE_URL` | Cluster administrator | None | One-time role bootstrap only |
+| `MIGRATION_DATABASE_URL` | `medtracker_migration` | `med_tracker_owner` | Migrations and legacy upgrades |
+| `RUNTIME_DATABASE_URL` | `medtracker_runtime` | `med_tracker_app` | Web and job processes |
+| `SOLID_QUEUE_DATABASE_URL` | `medtracker_auxiliary` | None | Solid Queue |
+| `SOLID_CACHE_DATABASE_URL` | `medtracker_auxiliary` | None | Solid Cache |
+| `SOLID_CABLE_DATABASE_URL` | `medtracker_auxiliary` | None | Solid Cable |
+
+Supply `MIGRATION_DATABASE_URL` as the migration container's `DATABASE_URL` with
+`DATABASE_ROLE=med_tracker_owner`. Supply `RUNTIME_DATABASE_URL` as every web or
+job container's `DATABASE_URL` with `DATABASE_ROLE=med_tracker_app`. Never mount
+`BOOTSTRAP_DATABASE_URL` into either workload. The auxiliary URLs must use
+separate databases; their login is deliberately denied access to the primary
+database.
+
+For an existing PostgreSQL cluster, stop application traffic and run the
+idempotent role bootstrap from the release checkout with deployment-specific
+passwords:
+
+```bash
+psql "$BOOTSTRAP_DATABASE_URL" \
+  --set=runtime_password="$RUNTIME_DATABASE_PASSWORD" \
+  --set=migration_password="$MIGRATION_DATABASE_PASSWORD" \
+  --set=auxiliary_password="$AUXILIARY_DATABASE_PASSWORD" \
+  --file compose/init-roles.sql
+```
+
+Run `db:migrate` through the migration login, then restart web and job workloads
+through the runtime login. Remove the bootstrap credential from the deployment
+environment after the SQL completes. The detailed legacy cutover and verification
+queries are in the [pre-0.5 database upgrade](pre-0-5-database-upgrade.md) guide.
 
 ## External API credentials
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -87,12 +87,31 @@ For an existing PostgreSQL cluster, stop application traffic and run the
 idempotent role bootstrap from the release checkout with deployment-specific
 passwords:
 
-```bash
-psql "$BOOTSTRAP_DATABASE_URL" \
-  --set=runtime_password="$RUNTIME_DATABASE_PASSWORD" \
-  --set=migration_password="$MIGRATION_DATABASE_PASSWORD" \
-  --set=auxiliary_password="$AUXILIARY_DATABASE_PASSWORD" \
-  --file compose/init-roles.sql
+```fish
+read --silent --export --prompt-str 'Runtime database password: ' RUNTIME_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Migration database password: ' MIGRATION_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Auxiliary database password: ' AUXILIARY_DATABASE_PASSWORD
+psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+set --erase RUNTIME_DATABASE_PASSWORD MIGRATION_DATABASE_PASSWORD AUXILIARY_DATABASE_PASSWORD
+```
+
+The SQL reads the three passwords from its environment and stops on the first
+error. The passwords are not placed in `psql` arguments. Configure the bootstrap
+connection itself with an operator-controlled `PGPASSFILE`.
+
+For existing auxiliary databases, run the same idempotent ownership repair used
+by fresh Compose initialization. It preserves rows while transferring the
+database, public schema, tables, sequences, views, routines, and user-defined
+types to `medtracker_auxiliary`:
+
+```fish
+set -lx POSTGRES_MULTIPLE_DATABASES medtracker_production_queue,medtracker_production_cache,medtracker_production_cable
+set -lx POSTGRES_USER cluster_admin
+set -lx POSTGRES_DB postgres
+set -lx PGHOST database.example.test
+set -lx PGPORT 5432
+set -lx PGPASSFILE /secure/path/to/admin.pgpass
+compose/init-multiple-dbs.sh
 ```
 
 Run `db:migrate` through the migration login, then restart web and job workloads

--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -13,69 +13,54 @@ Run this bootstrap when all of these are true:
 
 - The database was created by a MedTracker release before 0.5.
 - The deployment uses PostgreSQL roles without app-superuser privileges.
-- The 0.5 release will run migrations with `DATABASE_ROLE=med_tracker_owner`.
+- The release will use distinct migration and runtime login credentials.
 
-Do not run the web process as the migration role. The app runtime should use
-`DATABASE_ROLE=med_tracker_app`.
+Do not give the runtime process the migration credential or the bootstrap
+credential.
 
 ## One-time bootstrap
 
-Run this SQL as a database administrator, superuser, or a role allowed to create
-and manage PostgreSQL roles. Replace `<database_name>` and `<app_login_role>`
-with the actual database and login role names. Quote names that contain hyphens.
+Stop web and job workloads. From the matching release checkout, run the shared
+bootstrap artifact as a database administrator or another role allowed to create
+and manage PostgreSQL roles:
 
-```sql
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_owner') THEN
-    CREATE ROLE med_tracker_owner NOLOGIN;
-  END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
-    CREATE ROLE med_tracker_app NOLOGIN;
-  END IF;
-END
-$$;
-
-ALTER ROLE med_tracker_owner NOLOGIN;
-ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;
-
-GRANT med_tracker_owner TO <app_login_role>;
-GRANT med_tracker_app TO <app_login_role>;
-
-ALTER DATABASE <database_name> OWNER TO med_tracker_owner;
-ALTER SCHEMA public OWNER TO med_tracker_owner;
-
-GRANT CONNECT ON DATABASE <database_name> TO med_tracker_owner, med_tracker_app;
-GRANT USAGE, CREATE ON SCHEMA public TO med_tracker_owner;
-GRANT USAGE ON SCHEMA public TO med_tracker_app;
-
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'med_tracker') THEN
-    GRANT USAGE ON SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;
-  END IF;
-END
-$$;
+```bash
+psql "$BOOTSTRAP_DATABASE_URL" \
+  --set=runtime_password="$RUNTIME_DATABASE_PASSWORD" \
+  --set=migration_password="$MIGRATION_DATABASE_PASSWORD" \
+  --set=auxiliary_password="$AUXILIARY_DATABASE_PASSWORD" \
+  --file compose/init-roles.sql
 ```
 
-The app login should remain a normal non-superuser role. Do not grant it
-`CREATEROLE`, `BYPASSRLS`, or admin option on the runtime roles for normal
-upgrades.
+The SQL is idempotent and applies to the database named by
+`BOOTSTRAP_DATABASE_URL`. It creates `medtracker_migration`,
+`medtracker_runtime`, and `medtracker_auxiliary` as non-superuser logins. The
+memberships are deliberately narrow:
+
+```sql
+GRANT med_tracker_owner TO medtracker_migration WITH INHERIT FALSE, SET TRUE;
+GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;
+```
+
+Provision separate databases owned by `medtracker_auxiliary` for Solid Queue,
+Solid Cache, and Solid Cable. Revoke public connection access to those databases
+and grant it only to the auxiliary login. Do not grant the auxiliary login any
+role on the primary database.
 
 ## Preflight check
 
 After the bootstrap SQL and before running migrations, run the read-only Rails
-preflight from a Rails container using the same database login the deployment
-uses:
+preflight through `MIGRATION_DATABASE_URL` with
+`DATABASE_ROLE=med_tracker_owner`:
 
 ```bash
 rails med_tracker:pre_0_5_database_upgrade_preflight
 ```
 
-The preflight checks that both runtime roles exist, are `NOLOGIN`, are not
-superusers, do not have `BYPASSRLS`, and that the app login is a member of both
-roles. If it fails, fix the bootstrap state before running `db:prepare`.
+The preflight checks that the group and login roles have safe attributes, that
+the migration login can set only `med_tracker_owner`, and that the runtime login
+can set only `med_tracker_app`. If it fails, fix the bootstrap state before
+running `db:migrate`.
 
 ## Account access bootstrap
 
@@ -110,13 +95,19 @@ configuration:
 initContainers:
   migrate:
     env:
+      DATABASE_URL: ${MIGRATION_DATABASE_URL}
       DATABASE_ROLE: med_tracker_owner
 
 containers:
   app:
     env:
+      DATABASE_URL: ${RUNTIME_DATABASE_URL}
       DATABASE_ROLE: med_tracker_app
 ```
+
+Do not add `BOOTSTRAP_DATABASE_URL` to either workload. Store the bootstrap
+credential only in the operator-controlled process that runs
+`compose/init-roles.sql`, then remove it after the bootstrap succeeds.
 
 With Flux or another GitOps controller, commit those values to the source repo
 before reconciling the release.
@@ -126,13 +117,21 @@ before reconciling the release.
 After the migration and app startup complete, verify the role state:
 
 ```sql
-SELECT rolname, rolcreaterole, rolsuper, rolbypassrls
+SELECT rolname, rolcreaterole, rolcreatedb, rolreplication, rolsuper, rolbypassrls
 FROM pg_roles
-WHERE rolname IN ('med_tracker_owner', 'med_tracker_app', '<app_login_role>')
+WHERE rolname IN (
+  'med_tracker_owner',
+  'med_tracker_app',
+  'medtracker_migration',
+  'medtracker_runtime',
+  'medtracker_auxiliary'
+)
 ORDER BY rolname;
 
 SELECT m.roleid::regrole AS granted_role,
        m.member::regrole AS member_role,
+       m.inherit_option,
+       m.set_option,
        m.admin_option
 FROM pg_auth_members m
 WHERE m.roleid IN ('med_tracker_owner'::regrole, 'med_tracker_app'::regrole)
@@ -141,10 +140,24 @@ ORDER BY 1::text, 2::text;
 
 Expected result:
 
-- `med_tracker_owner` is `NOLOGIN`, not superuser, and not `BYPASSRLS`.
-- `med_tracker_app` is `NOLOGIN`, not superuser, and not `BYPASSRLS`.
-- The app login is a member of both runtime roles.
-- `admin_option` is `false` for the app login memberships.
+- `med_tracker_owner` is `NOLOGIN`, not superuser, and cannot create roles,
+  create databases, replicate, or bypass RLS.
+- `med_tracker_app` is `NOLOGIN`, not superuser, and cannot create roles,
+  create databases, replicate, or bypass RLS.
+- `medtracker_migration`, `medtracker_runtime`, and `medtracker_auxiliary` are
+  login roles, but are not superusers and cannot create roles, create databases,
+  replicate, or bypass RLS.
+- `medtracker_migration` has only the `med_tracker_owner` membership.
+- `medtracker_runtime` has only the `med_tracker_app` membership.
+- Both memberships have `inherit_option=false`, `set_option=true`, and
+  `admin_option=false`.
+- `medtracker_auxiliary` has neither membership and cannot connect to the primary
+  database.
+
+Connect through `RUNTIME_DATABASE_URL` and verify `SET ROLE med_tracker_app`
+succeeds while `SET ROLE med_tracker_owner` is denied. Connect through
+`MIGRATION_DATABASE_URL` and verify the inverse. Do not test these credentials
+against production from an unapproved network path.
 
 Verify household backfill and migration completion:
 

--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -24,12 +24,12 @@ Stop web and job workloads. From the matching release checkout, run the shared
 bootstrap artifact as a database administrator or another role allowed to create
 and manage PostgreSQL roles:
 
-```bash
-psql "$BOOTSTRAP_DATABASE_URL" \
-  --set=runtime_password="$RUNTIME_DATABASE_PASSWORD" \
-  --set=migration_password="$MIGRATION_DATABASE_PASSWORD" \
-  --set=auxiliary_password="$AUXILIARY_DATABASE_PASSWORD" \
-  --file compose/init-roles.sql
+```fish
+read --silent --export --prompt-str 'Runtime database password: ' RUNTIME_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Migration database password: ' MIGRATION_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Auxiliary database password: ' AUXILIARY_DATABASE_PASSWORD
+psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+set --erase RUNTIME_DATABASE_PASSWORD MIGRATION_DATABASE_PASSWORD AUXILIARY_DATABASE_PASSWORD
 ```
 
 The SQL is idempotent and applies to the database named by
@@ -43,9 +43,13 @@ GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;
 ```
 
 Provision separate databases owned by `medtracker_auxiliary` for Solid Queue,
-Solid Cache, and Solid Cable. Revoke public connection access to those databases
-and grant it only to the auxiliary login. Do not grant the auxiliary login any
-role on the primary database.
+Solid Cache, and Solid Cable. For existing auxiliary databases, run
+`compose/init-multiple-dbs.sh` with `POSTGRES_MULTIPLE_DATABASES`, `POSTGRES_USER`,
+`POSTGRES_DB`, `PGHOST`, `PGPORT`, and an operator-controlled `PGPASSFILE`. The
+script preserves populated tables while repairing database, schema, and object
+ownership. Revoke public connection access to those databases and grant it only
+to the auxiliary login. Do not grant the auxiliary login any role on the primary
+database.
 
 ## Preflight check
 
@@ -81,14 +85,29 @@ are the usual failure mode.
 
 ## Kubernetes and CNPG
 
-For CloudNativePG, run the bootstrap against the primary PostgreSQL pod. Example:
+For CloudNativePG, forward the primary service to an approved operator
+workstation and run the shared artifact there. Keep the administrator password
+in a protected passfile and read the three new login passwords without terminal
+echo or process arguments:
 
-```bash
-kubectl exec -n <namespace> <primary-postgres-pod> -c postgres -- \
-  psql -d <database_name> -v ON_ERROR_STOP=1
+```fish
+set namespace your-namespace
+set rw_service your-cluster-rw
+set database_name medtracker
+set database_admin database-admin
+set -lx PGPASSFILE /secure/path/to/cnpg-admin.pgpass
+kubectl port-forward -n $namespace service/$rw_service 55432:5432 &
+set port_forward_pid $last_pid
+set -lx BOOTSTRAP_DATABASE_URL "postgresql://$database_admin@127.0.0.1:55432/$database_name"
+read --silent --export --prompt-str 'Runtime database password: ' RUNTIME_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Migration database password: ' MIGRATION_DATABASE_PASSWORD
+read --silent --export --prompt-str 'Auxiliary database password: ' AUXILIARY_DATABASE_PASSWORD
+psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql
+set --erase RUNTIME_DATABASE_PASSWORD MIGRATION_DATABASE_PASSWORD AUXILIARY_DATABASE_PASSWORD
+kill $port_forward_pid
 ```
 
-Paste the bootstrap SQL into that `psql` session, then update the workload
+The SQL stops on the first error. After it succeeds, update the workload
 configuration:
 
 ```yaml

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,21 @@ task test TEST_FILE=spec/models/user_spec.rb
 - Dockerized test environment: `task test` and `task test:*` tasks
 - Local CI-like environment: `task local:*` tasks
 
+The test stack preserves the same connection boundary as a deployment:
+
+- `migrate-test` connects as `medtracker_migration` and sets
+  `med_tracker_owner` while applying migrations.
+- `web-test` connects as `medtracker_runtime` and sets `med_tracker_app` for
+  server behavior.
+- The ephemeral `test-runner` is the only Rails service given the bootstrap credential.
+  Rails fixture maintenance needs PostgreSQL system-trigger and forced-RLS access
+  that the runtime and migration logins intentionally lack.
+
+The fixture exception exists only in the test profile. Do not copy the
+`test-runner` credential into `web-test`, development, production, web, job, or
+migration services. CI likewise scopes bootstrap access to fixture-backed RSpec
+and seed steps; migrations and server processes still use their isolated logins.
+
 Useful local commands:
 
 ```bash

--- a/lib/tasks/pre_0_5_database_upgrade.rake
+++ b/lib/tasks/pre_0_5_database_upgrade.rake
@@ -2,7 +2,24 @@
 
 module MedTracker
   class Pre05DatabaseUpgradePreflight
-    ROLE_NAMES = %w[med_tracker_owner med_tracker_app].freeze
+    ROLE_LOGIN_EXPECTATIONS = {
+      'med_tracker_owner' => false,
+      'med_tracker_app' => false,
+      'medtracker_auxiliary' => true,
+      'medtracker_migration' => true,
+      'medtracker_runtime' => true
+    }.freeze
+    EXPECTED_MEMBERSHIPS = [
+      ['med_tracker_app', 'medtracker_runtime', false, true],
+      ['med_tracker_owner', 'medtracker_migration', false, true]
+    ].freeze
+    UNSAFE_ROLE_ATTRIBUTES = {
+      'rolsuper' => 'SUPERUSER',
+      'rolcreaterole' => 'CREATEROLE',
+      'rolcreatedb' => 'CREATEDB',
+      'rolreplication' => 'REPLICATION',
+      'rolbypassrls' => 'BYPASSRLS'
+    }.freeze
     UPGRADE_RUNBOOK_URL = 'https://damacus.github.io/med-tracker/pre-0-5-database-upgrade/'
 
     def initialize(connection)
@@ -11,11 +28,12 @@ module MedTracker
 
     def call
       role_rows = runtime_role_rows.index_by { |row| row.fetch('rolname') }
-      missing_roles = ROLE_NAMES - role_rows.keys
+      missing_roles = ROLE_LOGIN_EXPECTATIONS.keys - role_rows.keys
 
       missing_role_errors(missing_roles) +
         unsafe_role_errors(role_rows) +
-        membership_errors(missing_roles)
+        membership_errors +
+        current_login_errors
     end
 
     private
@@ -24,9 +42,15 @@ module MedTracker
 
     def runtime_role_rows
       connection.select_all(<<~SQL.squish).to_a
-        SELECT rolname, rolcanlogin, rolsuper, rolbypassrls
+        SELECT rolname, rolcanlogin, rolsuper, rolcreaterole, rolcreatedb, rolreplication, rolbypassrls
         FROM pg_roles
-        WHERE rolname IN ('med_tracker_owner', 'med_tracker_app')
+        WHERE rolname IN (
+          'med_tracker_owner',
+          'med_tracker_app',
+          'medtracker_auxiliary',
+          'medtracker_migration',
+          'medtracker_runtime'
+        )
         ORDER BY rolname
       SQL
     end
@@ -36,36 +60,68 @@ module MedTracker
     end
 
     def unsafe_role_errors(role_rows)
-      ROLE_NAMES.filter_map do |role_name|
+      ROLE_LOGIN_EXPECTATIONS.filter_map do |role_name, login_expected|
         role_row = role_rows[role_name]
         next if role_row.blank?
 
-        unsafe_attributes = unsafe_attributes_for(role_row)
+        unsafe_attributes = unsafe_attributes_for(role_row, login_expected)
         next if unsafe_attributes.empty?
 
         "#{role_name} has unsafe attributes: #{unsafe_attributes.join(', ')}"
       end
     end
 
-    def unsafe_attributes_for(role_row)
-      attributes = []
-      attributes << 'LOGIN' if truthy?(role_row.fetch('rolcanlogin'))
-      attributes << 'SUPERUSER' if truthy?(role_row.fetch('rolsuper'))
-      attributes << 'BYPASSRLS' if truthy?(role_row.fetch('rolbypassrls'))
-      attributes
+    def unsafe_attributes_for(role_row, login_expected)
+      [login_attribute_error(role_row, login_expected), *unsafe_privilege_attributes(role_row)].compact
     end
 
-    def membership_errors(missing_roles)
-      (ROLE_NAMES - missing_roles).filter_map do |role_name|
-        next if truthy?(runtime_role_member?(role_name))
+    def login_attribute_error(role_row, login_expected)
+      return if truthy?(role_row.fetch('rolcanlogin')) == login_expected
 
-        "Current database login is not a member of #{role_name}"
+      login_expected ? 'NOLOGIN' : 'LOGIN'
+    end
+
+    def unsafe_privilege_attributes(role_row)
+      UNSAFE_ROLE_ATTRIBUTES.filter_map do |attribute, label|
+        label if truthy?(role_row.fetch(attribute))
       end
     end
 
-    def runtime_role_member?(role_name)
-      connection.select_value(<<~SQL.squish)
-        SELECT pg_has_role(session_user, #{connection.quote(role_name)}, 'member')
+    def membership_errors
+      return [] if role_memberships == EXPECTED_MEMBERSHIPS
+
+      ['Database logins do not have isolated role membership']
+    end
+
+    def role_memberships
+      connection.select_all(role_membership_query).map do |row|
+        [
+          row.fetch('granted_role'),
+          row.fetch('member_role'),
+          truthy?(row.fetch('inherit_option')),
+          truthy?(row.fetch('set_option'))
+        ]
+      end
+    end
+
+    def current_login_errors
+      return [] if connection.select_value('SELECT session_user') == 'medtracker_migration'
+
+      ['Preflight must connect through medtracker_migration']
+    end
+
+    def role_membership_query
+      <<~SQL.squish
+        SELECT granted.rolname AS granted_role,
+               member.rolname AS member_role,
+               memberships.inherit_option,
+               memberships.set_option
+        FROM pg_auth_members memberships
+        JOIN pg_roles granted ON granted.oid = memberships.roleid
+        JOIN pg_roles member ON member.oid = memberships.member
+        WHERE granted.rolname IN ('med_tracker_owner', 'med_tracker_app')
+          AND member.rolname IN ('medtracker_auxiliary', 'medtracker_migration', 'medtracker_runtime')
+        ORDER BY granted.rolname, member.rolname
       SQL
     end
 

--- a/lib/tasks/pre_0_5_database_upgrade.rake
+++ b/lib/tasks/pre_0_5_database_upgrade.rake
@@ -10,8 +10,16 @@ module MedTracker
       'medtracker_runtime' => true
     }.freeze
     EXPECTED_MEMBERSHIPS = [
-      ['med_tracker_app', 'medtracker_runtime', false, true],
-      ['med_tracker_owner', 'medtracker_migration', false, true]
+      ['med_tracker_app', 'medtracker_runtime', false, false, true],
+      ['med_tracker_owner', 'medtracker_migration', false, false, true]
+    ].freeze
+    EXPECTED_SET_ROLE_PATHS = [
+      ['medtracker_auxiliary', 'med_tracker_app', false],
+      ['medtracker_auxiliary', 'med_tracker_owner', false],
+      ['medtracker_migration', 'med_tracker_app', false],
+      ['medtracker_migration', 'med_tracker_owner', true],
+      ['medtracker_runtime', 'med_tracker_app', true],
+      ['medtracker_runtime', 'med_tracker_owner', false]
     ].freeze
     UNSAFE_ROLE_ATTRIBUTES = {
       'rolsuper' => 'SUPERUSER',
@@ -33,6 +41,7 @@ module MedTracker
       missing_role_errors(missing_roles) +
         unsafe_role_errors(role_rows) +
         membership_errors +
+        set_role_path_errors +
         current_login_errors
     end
 
@@ -98,9 +107,22 @@ module MedTracker
         [
           row.fetch('granted_role'),
           row.fetch('member_role'),
+          truthy?(row.fetch('admin_option')),
           truthy?(row.fetch('inherit_option')),
           truthy?(row.fetch('set_option'))
         ]
+      end
+    end
+
+    def set_role_path_errors
+      return [] if set_role_paths == EXPECTED_SET_ROLE_PATHS
+
+      ['Database logins do not have isolated SET ROLE paths']
+    end
+
+    def set_role_paths
+      connection.select_all(set_role_path_query).map do |row|
+        [row.fetch('login_role'), row.fetch('granted_role'), truthy?(row.fetch('can_set'))]
       end
     end
 
@@ -114,6 +136,7 @@ module MedTracker
       <<~SQL.squish
         SELECT granted.rolname AS granted_role,
                member.rolname AS member_role,
+               memberships.admin_option,
                memberships.inherit_option,
                memberships.set_option
         FROM pg_auth_members memberships
@@ -122,6 +145,19 @@ module MedTracker
         WHERE granted.rolname IN ('med_tracker_owner', 'med_tracker_app')
           AND member.rolname IN ('medtracker_auxiliary', 'medtracker_migration', 'medtracker_runtime')
         ORDER BY granted.rolname, member.rolname
+      SQL
+    end
+
+    def set_role_path_query
+      <<~SQL.squish
+        SELECT login.rolname AS login_role,
+               granted.rolname AS granted_role,
+               pg_has_role(login.rolname, granted.rolname, 'SET') AS can_set
+        FROM pg_roles login
+        CROSS JOIN pg_roles granted
+        WHERE login.rolname IN ('medtracker_auxiliary', 'medtracker_migration', 'medtracker_runtime')
+          AND granted.rolname IN ('med_tracker_app', 'med_tracker_owner')
+        ORDER BY login.rolname, granted.rolname
       SQL
     end
 

--- a/spec/config/database_role_config_spec.rb
+++ b/spec/config/database_role_config_spec.rb
@@ -2,36 +2,247 @@
 
 require 'rails_helper'
 require 'erb'
+require 'open3'
+require 'pg'
+require 'uri'
 
 module DatabaseRoleConfig
 end
 
 RSpec.describe DatabaseRoleConfig do
-  around do |example|
-    original_database_role = ENV.fetch('DATABASE_ROLE', nil)
-    ENV['DATABASE_ROLE'] = 'med_tracker_app'
-    example.run
-  ensure
-    ENV['DATABASE_ROLE'] = original_database_role
+  context 'with database.yml' do
+    around do |example|
+      database_environment = {
+        'DATABASE_ROLE' => 'med_tracker_app',
+        'DATABASE_URL' => 'postgresql://runtime@database/primary',
+        'SOLID_QUEUE_DATABASE_URL' => 'postgresql://auxiliary@database/queue',
+        'SOLID_CACHE_DATABASE_URL' => 'postgresql://auxiliary@database/cache',
+        'SOLID_CABLE_DATABASE_URL' => 'postgresql://auxiliary@database/cable'
+      }
+      original_environment = ENV.to_h.slice(*database_environment.keys)
+      ENV.update(database_environment)
+      example.run
+    ensure
+      database_environment.each_key do |key|
+        original_environment.key?(key) ? ENV[key] = original_environment[key] : ENV.delete(key)
+      end
+    end
+
+    it 'applies DATABASE_ROLE to primary tenant database connections' do
+      expect(config.dig('development', 'primary', 'variables', 'role')).to eq('med_tracker_app')
+      expect(config.dig('test', 'variables', 'role')).to eq('med_tracker_app')
+      expect(config.dig('production', 'primary', 'variables', 'role')).to eq('med_tracker_app')
+    end
+
+    it 'does not apply DATABASE_ROLE to development auxiliary databases' do
+      expect(config.dig('development', 'queue', 'variables')).to be_nil
+    end
+
+    it 'does not apply DATABASE_ROLE to production auxiliary databases' do
+      expect(config.dig('production', 'queue', 'variables')).to be_nil
+      expect(config.dig('production', 'cache', 'variables')).to be_nil
+      expect(config.dig('production', 'cable', 'variables')).to be_nil
+    end
+
+    it 'preserves distinct primary and auxiliary connection URLs' do
+      expect(configured_urls).to eq(
+        development_primary: 'postgresql://runtime@database/primary',
+        development_queue: 'postgresql://auxiliary@database/queue',
+        production_primary: 'postgresql://runtime@database/primary',
+        production_queue: 'postgresql://auxiliary@database/queue',
+        production_cache: 'postgresql://auxiliary@database/cache',
+        production_cable: 'postgresql://auxiliary@database/cable'
+      )
+    end
+
+    it 'does not derive auxiliary credentials from the primary URL' do
+      expect(database_config_source).not_to include("ENV['DATABASE_URL']&.gsub")
+    end
+
+    it 'keeps database preparation from seeding through the migration login' do
+      expect(config.dig('development', 'primary', 'seeds')).to be(false)
+      expect(config.dig('test', 'seeds')).to be(false)
+    end
+
+    def config
+      YAML.safe_load(ERB.new(database_config_source).result, aliases: true)
+    end
+
+    def configured_urls
+      {
+        development_primary: config.dig('development', 'primary', 'url'),
+        development_queue: config.dig('development', 'queue', 'url'),
+        production_primary: config.dig('production', 'primary', 'url'),
+        production_queue: config.dig('production', 'queue', 'url'),
+        production_cache: config.dig('production', 'cache', 'url'),
+        production_cable: config.dig('production', 'cable', 'url')
+      }
+    end
+
+    def database_config_source
+      Rails.root.join('config/database.yml').read
+    end
   end
 
-  it 'applies DATABASE_ROLE to primary tenant database connections' do
-    expect(config.dig('development', 'primary', 'variables', 'role')).to eq('med_tracker_app')
-    expect(config.dig('test', 'variables', 'role')).to eq('med_tracker_app')
-    expect(config.dig('production', 'primary', 'variables', 'role')).to eq('med_tracker_app')
+  context 'with database login documentation' do
+    let(:deployment_guide) { Rails.root.join('docs/deployment.md').read }
+    let(:upgrade_guide) { Rails.root.join('docs/pre-0-5-database-upgrade.md').read }
+    let(:testing_guide) { Rails.root.join('docs/testing.md').read }
+
+    it 'routes existing deployments through distinct bootstrap, migration, and runtime credentials' do
+      expect(deployment_guide).to include(
+        'BOOTSTRAP_DATABASE_URL',
+        'MIGRATION_DATABASE_URL',
+        'RUNTIME_DATABASE_URL',
+        'SOLID_QUEUE_DATABASE_URL'
+      )
+      expect(upgrade_guide).to include(
+        'compose/init-roles.sql',
+        'medtracker_migration',
+        'medtracker_runtime',
+        'WITH INHERIT FALSE, SET TRUE',
+        'db:migrate'
+      )
+    end
+
+    it 'documents the narrow bootstrap exception for fixture-backed tests' do
+      expect(testing_guide).to include('test-runner', 'bootstrap credential', 'fixture')
+      expect(testing_guide).to include('web-test', 'medtracker_runtime', 'migrate-test', 'medtracker_migration')
+    end
   end
 
-  it 'does not apply DATABASE_ROLE to development auxiliary databases' do
-    expect(config.dig('development', 'queue', 'variables')).to be_nil
-  end
+  context 'with live PostgreSQL login isolation' do
+    let(:database_uri) { URI.parse(ENV.fetch('DATABASE_URL')) }
 
-  it 'does not apply DATABASE_ROLE to production auxiliary databases' do
-    expect(config.dig('production', 'queue', 'variables')).to be_nil
-    expect(config.dig('production', 'cache', 'variables')).to be_nil
-    expect(config.dig('production', 'cable', 'variables')).to be_nil
-  end
+    it 'reapplies the bootstrap artifact with deployment-supplied passwords' do
+      output, status = run_role_bootstrap
 
-  def config
-    YAML.safe_load(ERB.new(Rails.root.join('config/database.yml').read).result, aliases: true)
+      expect(status).to be_success, output
+    end
+
+    it 'allows the runtime login to assume only the application role' do
+      with_connection('medtracker_runtime', 'local_runtime_only') do |connection|
+        expect_runtime_login_isolated(connection)
+      end
+    end
+
+    it 'allows the migration login to assume only the owner role' do
+      with_connection('medtracker_migration', 'local_migration_only') do |connection|
+        expect_migration_login_isolated(connection)
+      end
+    end
+
+    it 'denies the auxiliary login any connection to the primary database' do
+      expect { connect_as('medtracker_auxiliary', 'local_auxiliary_only') }
+        .to raise_error(PG::ConnectionBad, /permission denied for database/)
+    end
+
+    def run_role_bootstrap
+      Open3.capture2e(
+        'psql', ENV.fetch('DATABASE_URL'),
+        '--set=runtime_password=local_runtime_only',
+        '--set=migration_password=local_migration_only',
+        '--set=auxiliary_password=local_auxiliary_only',
+        '--file', Rails.root.join('compose/init-roles.sql').to_s
+      )
+    end
+
+    def expect_runtime_login_isolated(connection)
+      expect(login_attributes(connection)).to eq(safe_login_attributes)
+      expect(role_memberships(connection, 'medtracker_runtime')).to eq(
+        [{ 'role_name' => 'med_tracker_app', 'inherit_option' => 'false', 'set_option' => 'true' }]
+      )
+      expect { connection.exec('SET ROLE med_tracker_owner') }.to raise_error(PG::InsufficientPrivilege)
+
+      connection.exec('SET ROLE med_tracker_app')
+      expect_runtime_access(connection)
+    end
+
+    def expect_migration_login_isolated(connection)
+      expect(login_attributes(connection)).to eq(safe_login_attributes)
+      expect_migration_membership(connection)
+      expect_migration_access(connection)
+    end
+
+    def expect_migration_membership(connection)
+      expect(role_memberships(connection, 'medtracker_migration')).to eq(
+        [{ 'role_name' => 'med_tracker_owner', 'inherit_option' => 'false', 'set_option' => 'true' }]
+      )
+    end
+
+    def expect_migration_access(connection)
+      expect { connection.exec('SET ROLE med_tracker_app') }.to raise_error(PG::InsufficientPrivilege)
+
+      connection.exec('SET ROLE med_tracker_owner')
+      expect(connection.exec('SELECT current_user').getvalue(0, 0)).to eq('med_tracker_owner')
+    end
+
+    def expect_runtime_access(connection)
+      expect_runtime_identity(connection)
+      expect_runtime_data_access(connection)
+    end
+
+    def expect_runtime_identity(connection)
+      expect(connection.exec('SELECT current_user').getvalue(0, 0)).to eq('med_tracker_app')
+      expect(connection.exec("SELECT has_schema_privilege(current_user, 'public', 'CREATE')").getvalue(0, 0))
+        .to eq('f')
+    end
+
+    def expect_runtime_data_access(connection)
+      expect(connection.exec('SELECT COUNT(*) FROM schema_migrations').ntuples).to eq(1)
+      expect(connection.exec('SELECT med_tracker.current_household_id()').getvalue(0, 0)).to be_nil
+    end
+
+    def login_attributes(connection)
+      connection.exec(<<~SQL.squish).first
+        SELECT rolsuper::text,
+               rolcreaterole::text,
+               rolcreatedb::text,
+               rolreplication::text,
+               rolbypassrls::text
+        FROM pg_roles
+        WHERE rolname = session_user
+      SQL
+    end
+
+    def safe_login_attributes
+      {
+        'rolsuper' => 'false',
+        'rolcreaterole' => 'false',
+        'rolcreatedb' => 'false',
+        'rolreplication' => 'false',
+        'rolbypassrls' => 'false'
+      }
+    end
+
+    def with_connection(user, password)
+      connection = connect_as(user, password)
+      yield connection
+    ensure
+      connection&.close
+    end
+
+    def connect_as(user, password)
+      PG.connect(
+        host: database_uri.host,
+        port: database_uri.port,
+        dbname: database_uri.path.delete_prefix('/'),
+        user:,
+        password:
+      )
+    end
+
+    def role_memberships(connection, member_name)
+      connection.exec_params(<<~SQL.squish, [member_name]).to_a
+        SELECT granted.rolname AS role_name,
+               memberships.inherit_option::text,
+               memberships.set_option::text
+        FROM pg_auth_members memberships
+        JOIN pg_roles granted ON granted.oid = memberships.roleid
+        JOIN pg_roles member ON member.oid = memberships.member
+        WHERE member.rolname = $1
+        ORDER BY granted.rolname
+      SQL
+    end
   end
 end

--- a/spec/config/database_role_config_spec.rb
+++ b/spec/config/database_role_config_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 require 'erb'
 require 'open3'
 require 'pg'
+require 'securerandom'
+require 'tempfile'
 require 'uri'
 
 module DatabaseRoleConfig
@@ -88,6 +90,7 @@ RSpec.describe DatabaseRoleConfig do
     let(:deployment_guide) { Rails.root.join('docs/deployment.md').read }
     let(:upgrade_guide) { Rails.root.join('docs/pre-0-5-database-upgrade.md').read }
     let(:testing_guide) { Rails.root.join('docs/testing.md').read }
+    let(:root_testing_guide) { Rails.root.join('TESTING.md').read }
 
     it 'routes existing deployments through distinct bootstrap, migration, and runtime credentials' do
       expect(deployment_guide).to include(
@@ -109,6 +112,39 @@ RSpec.describe DatabaseRoleConfig do
       expect(testing_guide).to include('test-runner', 'bootstrap credential', 'fixture')
       expect(testing_guide).to include('web-test', 'medtracker_runtime', 'migrate-test', 'medtracker_migration')
     end
+
+    it 'uses environment-sourced secrets in fish-compatible bootstrap commands' do
+      expect(deployment_guide).to include('```fish', 'RUNTIME_DATABASE_PASSWORD', '--file compose/init-roles.sql')
+      expect(upgrade_guide).to include('```fish', 'RUNTIME_DATABASE_PASSWORD', '--file compose/init-roles.sql')
+      expect(deployment_guide).not_to match(/--set=.*password/i)
+      expect(upgrade_guide).not_to match(/--set=.*password/i)
+    end
+
+    it 'provides one fail-fast secret-safe CNPG bootstrap flow' do
+      expect(upgrade_guide).to include('kubectl port-forward', 'PGPASSFILE', '--file compose/init-roles.sql')
+      expect(upgrade_guide).to include(
+        'set namespace your-namespace',
+        'set rw_service your-cluster-rw',
+        'set database_name medtracker',
+        'set database_admin database-admin'
+      )
+      expect(upgrade_guide).not_to match(/```fish.*?<[^>]+>.*?```/m)
+      expect(upgrade_guide).not_to include('Paste the bootstrap SQL')
+    end
+
+    it 'documents the populated auxiliary database ownership upgrade' do
+      expect(deployment_guide).to include('existing auxiliary databases', 'compose/init-multiple-dbs.sh')
+      expect(upgrade_guide).to include('existing auxiliary databases', 'compose/init-multiple-dbs.sh')
+    end
+
+    it 'keeps the root testing guide on the separated runtime login' do
+      expect(root_testing_guide).to include(
+        'postgresql://medtracker_runtime:local_runtime_only@db-test:5432/medtracker'
+      )
+      expect(root_testing_guide).not_to include(
+        'DATABASE_URL: postgresql://medtracker:medtracker_password@db-test:5432/medtracker'
+      )
+    end
   end
 
   context 'with live PostgreSQL login isolation' do
@@ -118,6 +154,40 @@ RSpec.describe DatabaseRoleConfig do
       output, status = run_role_bootstrap
 
       expect(status).to be_success, output
+    end
+
+    it 'returns nonzero when a middle bootstrap statement fails' do
+      Tempfile.create(['role-bootstrap-fail-fast', '.sql']) do |file|
+        file.write(fail_fast_probe_sql)
+        file.flush
+
+        output, status = Open3.capture2e('psql', ENV.fetch('DATABASE_URL'), '--file', file.path)
+
+        expect(status).not_to be_success, output
+      end
+    end
+
+    it 'repairs legacy role attributes, memberships, and public schema creation' do
+      configure_unsafe_legacy_roles
+
+      output, status = run_role_bootstrap
+
+      expect(status).to be_success, output
+      expect_repaired_role_contract
+    ensure
+      restore_role_contract
+    end
+
+    it 'upgrades a populated auxiliary database without data loss' do
+      database_name = "medtracker_auxiliary_upgrade_#{SecureRandom.hex(5)}"
+      create_legacy_auxiliary_database(database_name)
+
+      output, status = run_auxiliary_upgrade(database_name)
+
+      expect(status).to be_success, output
+      expect_upgraded_auxiliary_database(database_name)
+    ensure
+      drop_database(database_name) if database_name
     end
 
     it 'allows the runtime login to assume only the application role' do
@@ -139,18 +209,183 @@ RSpec.describe DatabaseRoleConfig do
 
     def run_role_bootstrap
       Open3.capture2e(
+        {
+          'RUNTIME_DATABASE_PASSWORD' => 'local_runtime_only',
+          'MIGRATION_DATABASE_PASSWORD' => 'local_migration_only',
+          'AUXILIARY_DATABASE_PASSWORD' => 'local_auxiliary_only'
+        },
         'psql', ENV.fetch('DATABASE_URL'),
-        '--set=runtime_password=local_runtime_only',
-        '--set=migration_password=local_migration_only',
-        '--set=auxiliary_password=local_auxiliary_only',
         '--file', Rails.root.join('compose/init-roles.sql').to_s
       )
+    end
+
+    def fail_fast_probe_sql
+      directive = Rails.root.join('compose/init-roles.sql').read[/^\\set ON_ERROR_STOP on$/]
+      [directive, 'SELECT 1;', 'SELECT medtracker_missing_bootstrap_function();', 'SELECT 2;'].compact.join("\n")
+    end
+
+    def configure_unsafe_legacy_roles
+      bootstrap_connection.exec('CREATE ROLE medtracker_indirect_owner NOLOGIN')
+      bootstrap_connection.exec('GRANT med_tracker_owner TO medtracker_indirect_owner WITH SET TRUE')
+      bootstrap_connection.exec('GRANT medtracker_indirect_owner TO medtracker_runtime WITH SET TRUE')
+      bootstrap_connection.exec(
+        'GRANT med_tracker_app TO medtracker_runtime WITH ADMIN TRUE, INHERIT TRUE, SET TRUE'
+      )
+      bootstrap_connection.exec(
+        'GRANT med_tracker_app TO medtracker_migration WITH ADMIN TRUE, INHERIT TRUE, SET TRUE'
+      )
+      bootstrap_connection.exec(
+        'ALTER ROLE med_tracker_owner CREATEROLE CREATEDB REPLICATION BYPASSRLS'
+      )
+      bootstrap_connection.exec('GRANT CREATE ON SCHEMA public TO PUBLIC')
+    end
+
+    def expect_repaired_role_contract
+      expect_safe_group_role
+      expect_isolated_migration_membership
+      expect_legacy_access_paths_removed
+    end
+
+    def expect_safe_group_role
+      expect(group_role_attributes('med_tracker_owner')).to eq(safe_group_role_attributes)
+    end
+
+    def expect_isolated_migration_membership
+      expect(role_memberships(bootstrap_connection, 'medtracker_migration')).to eq(
+        [{ 'role_name' => 'med_tracker_owner', 'admin_option' => 'false',
+           'inherit_option' => 'false', 'set_option' => 'true' }]
+      )
+    end
+
+    def expect_legacy_access_paths_removed
+      expect(bootstrap_connection.exec(
+        "SELECT pg_has_role('medtracker_runtime', 'med_tracker_owner', 'SET')::text"
+      ).getvalue(0, 0)).to eq('false')
+      expect(bootstrap_connection.exec(
+        "SELECT has_schema_privilege('public', 'public', 'CREATE')::text"
+      ).getvalue(0, 0)).to eq('false')
+    end
+
+    def restore_role_contract
+      connection = bootstrap_connection
+      connection.exec('REVOKE med_tracker_app FROM medtracker_migration')
+      connection.exec('REVOKE medtracker_indirect_owner FROM medtracker_runtime')
+      connection.exec('DROP ROLE IF EXISTS medtracker_indirect_owner')
+      connection.exec(
+        'GRANT med_tracker_app TO medtracker_runtime WITH ADMIN FALSE, INHERIT FALSE, SET TRUE'
+      )
+      connection.exec(
+        'ALTER ROLE med_tracker_owner NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS'
+      )
+      connection.exec('REVOKE CREATE ON SCHEMA public FROM PUBLIC')
+    end
+
+    def create_legacy_auxiliary_database(database_name)
+      bootstrap_connection.exec("CREATE DATABASE #{PG::Connection.quote_ident(database_name)} OWNER medtracker")
+      with_database_connection('medtracker', 'medtracker_password', database_name) do |connection|
+        connection.exec('CREATE TABLE legacy_rows (value text NOT NULL)')
+        connection.exec("INSERT INTO legacy_rows (value) VALUES ('preserved')")
+        connection.exec('GRANT CREATE ON SCHEMA public TO PUBLIC')
+      end
+    end
+
+    def run_auxiliary_upgrade(database_name)
+      Open3.capture2e(
+        {
+          'POSTGRES_MULTIPLE_DATABASES' => database_name,
+          'POSTGRES_USER' => database_uri.user,
+          'PGHOST' => database_uri.host,
+          'PGPORT' => database_uri.port.to_s,
+          'PGPASSWORD' => database_uri.password
+        },
+        Rails.root.join('compose/init-multiple-dbs.sh').to_s
+      )
+    end
+
+    def expect_upgraded_auxiliary_database(database_name)
+      with_database_connection('medtracker_auxiliary', 'local_auxiliary_only', database_name) do |connection|
+        expect_auxiliary_data_preserved(connection)
+        expect_auxiliary_ownership(connection)
+        expect_public_schema_locked(connection)
+      end
+      expect(database_owner(database_name)).to eq('medtracker_auxiliary')
+    end
+
+    def expect_auxiliary_data_preserved(connection)
+      expect(connection.exec('SELECT value FROM legacy_rows').getvalue(0, 0)).to eq('preserved')
+    end
+
+    def expect_auxiliary_ownership(connection)
+      expect(object_owner(connection, 'legacy_rows')).to eq('medtracker_auxiliary')
+      expect(schema_owner(connection, 'public')).to eq('medtracker_auxiliary')
+    end
+
+    def expect_public_schema_locked(connection)
+      expect(connection.exec(
+        "SELECT has_schema_privilege('public', 'public', 'CREATE')::text"
+      ).getvalue(0, 0)).to eq('false')
+    end
+
+    def drop_database(database_name)
+      bootstrap_connection.exec_params(
+        'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1', [database_name]
+      )
+      bootstrap_connection.exec("DROP DATABASE IF EXISTS #{PG::Connection.quote_ident(database_name)}")
+    end
+
+    def bootstrap_connection
+      @bootstrap_connection ||= PG.connect(ENV.fetch('DATABASE_URL'))
+    end
+
+    def group_role_attributes(role_name)
+      bootstrap_connection.exec_params(<<~SQL.squish, [role_name]).first
+        SELECT rolcanlogin::text,
+               rolsuper::text,
+               rolcreaterole::text,
+               rolcreatedb::text,
+               rolreplication::text,
+               rolbypassrls::text
+        FROM pg_roles
+        WHERE rolname = $1
+      SQL
+    end
+
+    def safe_group_role_attributes
+      safe_login_attributes.merge('rolcanlogin' => 'false')
+    end
+
+    def database_owner(database_name)
+      bootstrap_connection.exec_params(<<~SQL.squish, [database_name]).getvalue(0, 0)
+        SELECT owner.rolname
+        FROM pg_database database
+        JOIN pg_roles owner ON owner.oid = database.datdba
+        WHERE database.datname = $1
+      SQL
+    end
+
+    def object_owner(connection, object_name)
+      connection.exec_params(<<~SQL.squish, [object_name]).getvalue(0, 0)
+        SELECT owner.rolname
+        FROM pg_class object
+        JOIN pg_roles owner ON owner.oid = object.relowner
+        WHERE object.relname = $1
+      SQL
+    end
+
+    def schema_owner(connection, schema_name)
+      connection.exec_params(<<~SQL.squish, [schema_name]).getvalue(0, 0)
+        SELECT owner.rolname
+        FROM pg_namespace schema
+        JOIN pg_roles owner ON owner.oid = schema.nspowner
+        WHERE schema.nspname = $1
+      SQL
     end
 
     def expect_runtime_login_isolated(connection)
       expect(login_attributes(connection)).to eq(safe_login_attributes)
       expect(role_memberships(connection, 'medtracker_runtime')).to eq(
-        [{ 'role_name' => 'med_tracker_app', 'inherit_option' => 'false', 'set_option' => 'true' }]
+        [{ 'role_name' => 'med_tracker_app', 'admin_option' => 'false',
+           'inherit_option' => 'false', 'set_option' => 'true' }]
       )
       expect { connection.exec('SET ROLE med_tracker_owner') }.to raise_error(PG::InsufficientPrivilege)
 
@@ -166,7 +401,8 @@ RSpec.describe DatabaseRoleConfig do
 
     def expect_migration_membership(connection)
       expect(role_memberships(connection, 'medtracker_migration')).to eq(
-        [{ 'role_name' => 'med_tracker_owner', 'inherit_option' => 'false', 'set_option' => 'true' }]
+        [{ 'role_name' => 'med_tracker_owner', 'admin_option' => 'false',
+           'inherit_option' => 'false', 'set_option' => 'true' }]
       )
     end
 
@@ -223,10 +459,21 @@ RSpec.describe DatabaseRoleConfig do
     end
 
     def connect_as(user, password)
+      connect_to_database(user, password, database_uri.path.delete_prefix('/'))
+    end
+
+    def with_database_connection(user, password, database_name)
+      connection = connect_to_database(user, password, database_name)
+      yield connection
+    ensure
+      connection&.close
+    end
+
+    def connect_to_database(user, password, database_name)
       PG.connect(
         host: database_uri.host,
         port: database_uri.port,
-        dbname: database_uri.path.delete_prefix('/'),
+        dbname: database_name,
         user:,
         password:
       )
@@ -235,6 +482,7 @@ RSpec.describe DatabaseRoleConfig do
     def role_memberships(connection, member_name)
       connection.exec_params(<<~SQL.squish, [member_name]).to_a
         SELECT granted.rolname AS role_name,
+               memberships.admin_option::text,
                memberships.inherit_option::text,
                memberships.set_option::text
         FROM pg_auth_members memberships

--- a/spec/config/database_role_config_spec.rb
+++ b/spec/config/database_role_config_spec.rb
@@ -281,8 +281,10 @@ RSpec.describe DatabaseRoleConfig do
     end
 
     def create_legacy_auxiliary_database(database_name)
-      bootstrap_connection.exec("CREATE DATABASE #{PG::Connection.quote_ident(database_name)} OWNER medtracker")
-      with_database_connection('medtracker', 'medtracker_password', database_name) do |connection|
+      bootstrap_connection.exec(
+        "CREATE DATABASE #{PG::Connection.quote_ident(database_name)} OWNER #{PG::Connection.quote_ident(database_uri.user)}"
+      )
+      with_database_connection(database_uri.user, database_uri.password, database_name) do |connection|
         connection.exec('CREATE TABLE legacy_rows (value text NOT NULL)')
         connection.exec("INSERT INTO legacy_rows (value) VALUES ('preserved')")
         connection.exec('GRANT CREATE ON SCHEMA public TO PUBLIC')

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -102,6 +102,17 @@ RSpec.describe 'Taskfiles' do
     expect(local_taskfile.dig('tasks', 'db:up').to_json).to include('compose/init-roles.sql')
   end
 
+  it 'bootstraps roles for an already-running local database container' do
+    bootstrap_task = local_taskfile.dig('tasks', 'db:bootstrap')
+
+    expect(bootstrap_task.fetch('deps')).to eq(['db:up'])
+    expect(bootstrap_task.fetch('cmds')).to include(
+      'docker exec -i {{.DB_CONTAINER}} psql --username {{.DB_USER}} --dbname {{.DB_NAME}} ' \
+      '--file /dev/stdin < {{.ROOT_DIR}}/compose/init-roles.sql'
+    )
+    expect(local_taskfile.dig('tasks', 'db:prepare', 'deps')).to eq(['db:bootstrap'])
+  end
+
   it 'defines a Vernier dashboard profiling task' do
     task = root_taskfile.dig('tasks', 'profile:dashboard')
     commands = task.fetch('cmds')

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe 'Taskfiles' do
     expect(test_taskfile.dig('tasks', 'rebuild', 'cmds', 3, 'vars', 'SERVICE')).to eq('test-runner')
   end
 
+  it 'runs arbitrary and asset-only test commands through the runtime login service' do
+    exec_services = test_taskfile.dig('tasks', 'exec', 'cmds').map { |command| command.dig('vars', 'SERVICE') }
+    asset_commands = test_taskfile.dig('tasks', 'assets-rebuild', 'cmds')
+    asset_services = asset_commands.map { |command| command.dig('vars', 'SERVICE') }
+
+    expect(exec_services).to all(eq('web-test'))
+    expect(asset_services).to all(eq('web-test'))
+  end
+
+  it 'separates local CI-like database credentials by command boundary' do
+    expect(local_taskfile['vars']).to include(local_database_urls)
+    expect(local_taskfile.dig('tasks', 'db:prepare', 'env')).to include(
+      'DATABASE_URL' => '{{.MIGRATION_DATABASE_URL}}',
+      'DATABASE_ROLE' => 'med_tracker_owner'
+    )
+    expect(local_taskfile.dig('tasks', 'test', 'env')).to include(
+      'DATABASE_URL' => '{{.BOOTSTRAP_DATABASE_URL}}',
+      'DATABASE_ROLE' => nil
+    )
+    expect(local_taskfile.dig('tasks', 'db:up').to_json).to include('compose/init-roles.sql')
+  end
+
   it 'defines a Vernier dashboard profiling task' do
     task = root_taskfile.dig('tasks', 'profile:dashboard')
     commands = task.fetch('cmds')
@@ -165,6 +187,21 @@ RSpec.describe 'Taskfiles' do
 
   def internal_taskfile
     YAML.safe_load(Rails.root.join('Taskfiles/internal.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def local_taskfile
+    YAML.safe_load(Rails.root.join('Taskfiles/local.yml').read, aliases: true, permitted_classes: [Symbol])
+  end
+
+  def local_database_urls
+    {
+      'BOOTSTRAP_DATABASE_URL' =>
+        'postgres://{{.DB_USER}}:{{.DB_PASSWORD}}@localhost:{{.DB_PORT}}/{{.DB_NAME}}',
+      'MIGRATION_DATABASE_URL' =>
+        'postgres://medtracker_migration:local_migration_only@localhost:{{.DB_PORT}}/{{.DB_NAME}}',
+      'RUNTIME_DATABASE_URL' =>
+        'postgres://medtracker_runtime:local_runtime_only@localhost:{{.DB_PORT}}/{{.DB_NAME}}'
+    }
   end
 
   def root_taskfile

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe 'Taskfiles' do
     )
   end
 
+  it 'runs database migrations through the migration login service' do
+    migration_task = internal_taskfile.dig('tasks', 'db-migrate')
+
+    expect(migration_task.dig('vars', 'MIGRATION_SERVICE')).to eq('migrate-{{ .ENVIRONMENT }}')
+    expect(migration_task.dig('cmds', 0)).to include('{{ .MIGRATION_SERVICE }} rails db:migrate')
+    expect(migration_task.to_json).not_to include('WEB_SERVICE')
+  end
+
+  it 'runs specs through the isolated test login service' do
+    test_task = root_taskfile.dig('tasks', 'test')
+
+    expect(test_task.dig('cmds', 0, 'vars', 'SERVICE')).to eq('test-runner')
+    expect(test_taskfile.dig('tasks', 'seed', 'cmds', 0, 'vars', 'SERVICE')).to eq('test-runner')
+    expect(test_taskfile.dig('tasks', 'rebuild', 'cmds', 3, 'vars', 'SERVICE')).to eq('test-runner')
+  end
+
   it 'defines a Vernier dashboard profiling task' do
     task = root_taskfile.dig('tasks', 'profile:dashboard')
     commands = task.fetch('cmds')

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe YAML do
   let(:compose_config) do
     described_class.safe_load(Rails.root.join('compose.yaml').read, aliases: true)
   end
+  let(:base_compose_config) do
+    described_class.safe_load(Rails.root.join('compose/base.yml').read, aliases: true)
+  end
   let(:init_roles_sql) { Rails.root.join('compose/init-roles.sql').read }
   let(:dockerfile) { Rails.root.join('Dockerfile').read }
   let(:deploy_config) { Rails.root.join('config/deploy.yml').read }
@@ -49,6 +52,25 @@ RSpec.describe YAML do
     expect(compose_config.dig('services', 'migrate-test', 'build', 'target')).to eq('test')
   end
 
+  it 'confines bootstrap fixture access to the ephemeral test runner', :aggregate_failures do
+    runner = compose_config.dig('services', 'test-runner')
+
+    expect(runner.dig('environment', 'DATABASE_URL'))
+      .to eq('postgresql://medtracker:medtracker_password@db-test:5432/medtracker')
+    expect(runner.dig('environment', 'DATABASE_ROLE')).to be_nil
+
+    %w[migrate-dev web-dev migrate-test web-test migrate-prod web-prod].each do |service_name|
+      expect(compose_config.dig('services', service_name, 'environment').to_json)
+        .not_to include('medtracker_password')
+    end
+  end
+
+  it 'prepares non-production databases and migrates production through the owner login' do
+    expect(compose_config.dig('services', 'migrate-dev', 'command')).to eq('bin/rails db:prepare')
+    expect(compose_config.dig('services', 'migrate-test', 'command')).to eq('bin/rails db:prepare')
+    expect(compose_config.dig('services', 'migrate-prod', 'command')).to eq('bin/rails db:migrate')
+  end
+
   it 'passes OIDC environment through to Rails containers used for local OIDC flows' do
     expected_keys = %w[
       APP_URL
@@ -74,13 +96,37 @@ RSpec.describe YAML do
     end
 
     expect(database_roles).to eq(
-      'migrate-dev' => '${DEV_MIGRATION_DATABASE_ROLE:-}',
-      'web-dev' => '${DEV_DATABASE_ROLE:-}',
-      'migrate-test' => '${TEST_MIGRATION_DATABASE_ROLE:-}',
-      'web-test' => '${TEST_DATABASE_ROLE:-}',
+      'migrate-dev' => '${DEV_MIGRATION_DATABASE_ROLE:-med_tracker_owner}',
+      'web-dev' => '${DEV_DATABASE_ROLE:-med_tracker_app}',
+      'migrate-test' => '${TEST_MIGRATION_DATABASE_ROLE:-med_tracker_owner}',
+      'web-test' => '${TEST_DATABASE_ROLE:-med_tracker_app}',
       'migrate-prod' => '${MIGRATION_DATABASE_ROLE:-med_tracker_owner}',
       'web-prod' => '${DATABASE_ROLE:-med_tracker_app}'
     )
+  end
+
+  it 'uses distinct non-superuser logins at every Rails database boundary', :aggregate_failures do
+    expected_database_urls.each do |service_name, urls|
+      expect(compose_config.dig('services', service_name, 'environment')).to include(urls)
+      expect(compose_config.dig('services', service_name, 'environment').to_json)
+        .not_to include('medtracker_password')
+    end
+    expect(base_compose_config.dig('services', 'postgres', 'environment', 'POSTGRES_PASSWORD'))
+      .to eq('medtracker_password')
+  end
+
+  it 'grants each primary login only its intended SET ROLE membership', :aggregate_failures do
+    expect_primary_login_memberships
+  end
+
+  it 'isolates the auxiliary login from the primary database', :aggregate_failures do
+    expect(init_roles_sql).to include(
+      '\\if :{?auxiliary_password}',
+      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'auxiliary_password'",
+      "format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database())"
+    )
+    expect(init_roles_sql).not_to match(/GRANT\s+CONNECT\s+ON\s+DATABASE.*TO[^;]*medtracker_auxiliary/i)
+    expect(init_multiple_databases).to include('CREATE DATABASE $db OWNER medtracker_auxiliary')
   end
 
   it 'keeps the production web container behind the runtime role after migrations complete' do
@@ -162,5 +208,146 @@ RSpec.describe YAML do
   it 'keeps development and test web host ports Docker-assigned for parallel worktrees' do
     expect(compose_config.dig('services', 'web-dev', 'ports')).to be_nil
     expect(compose_config.dig('services', 'web-test', 'ports')).to be_nil
+  end
+
+  context 'with CI database login routing' do
+    it 'bootstraps roles before migrating through the owner-only login' do
+      %w[test_non_system test_system mutation lighthouse].each do |job_name|
+        expect_ci_database_routing(job_name)
+      end
+    end
+
+    it 'uses bootstrap access only for CI test harness steps' do
+      ci_harness_steps.each do |job_name, step_name|
+        step = ci_workflow.dig(job_name, 'steps').find { |candidate| candidate['name'] == step_name }
+
+        expect(step.fetch('env')).to include(
+          'DATABASE_URL' => '${{ env.BOOTSTRAP_DATABASE_URL }}',
+          'DATABASE_ROLE' => nil
+        )
+      end
+    end
+
+    it 'starts the CI Rails server through the runtime-only login' do
+      server_step = ci_workflow.dig('lighthouse', 'steps').find { |step| step['name'] == 'Start Rails server' }
+
+      expect(server_step.fetch('env')).to include(
+        'DATABASE_URL' => '${{ env.RUNTIME_DATABASE_URL }}',
+        'DATABASE_ROLE' => 'med_tracker_app'
+      )
+    end
+  end
+
+  def expected_database_urls
+    {
+      'migrate-dev' => development_migration_urls,
+      'web-dev' => development_runtime_urls,
+      'migrate-test' => test_migration_urls,
+      'web-test' => test_runtime_urls,
+      'migrate-prod' => production_migration_urls,
+      'web-prod' => production_runtime_urls
+    }
+  end
+
+  def development_migration_urls
+    {
+      'DATABASE_URL' => 'postgresql://medtracker_migration:local_migration_only@db-dev:5432/medtracker',
+      'SOLID_QUEUE_DATABASE_URL' =>
+        'postgresql://medtracker_auxiliary:local_auxiliary_only@db-dev:5432/medtracker_queue'
+    }
+  end
+
+  def development_runtime_urls
+    development_migration_urls.merge(
+      'DATABASE_URL' => 'postgresql://medtracker_runtime:local_runtime_only@db-dev:5432/medtracker'
+    )
+  end
+
+  def test_migration_urls
+    { 'DATABASE_URL' => 'postgresql://medtracker_migration:local_migration_only@db-test:5432/medtracker' }
+  end
+
+  def test_runtime_urls
+    { 'DATABASE_URL' => 'postgresql://medtracker_runtime:local_runtime_only@db-test:5432/medtracker' }
+  end
+
+  def production_migration_urls
+    {
+      'DATABASE_URL' => 'postgresql://medtracker_migration:local_migration_only@db-prod:5432/medtracker',
+      'SOLID_QUEUE_DATABASE_URL' => auxiliary_production_url('queue'),
+      'SOLID_CACHE_DATABASE_URL' => auxiliary_production_url('cache'),
+      'SOLID_CABLE_DATABASE_URL' => auxiliary_production_url('cable')
+    }
+  end
+
+  def production_runtime_urls
+    production_migration_urls.merge(
+      'DATABASE_URL' => 'postgresql://medtracker_runtime:local_runtime_only@db-prod:5432/medtracker'
+    )
+  end
+
+  def auxiliary_production_url(database)
+    "postgresql://medtracker_auxiliary:local_auxiliary_only@db-prod:5432/medtracker_production_#{database}"
+  end
+
+  def expect_primary_login_memberships
+    expect(init_roles_sql).to include(
+      'GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;',
+      'GRANT med_tracker_owner TO medtracker_migration WITH INHERIT FALSE, SET TRUE;',
+      '\\if :{?runtime_password}',
+      '\\if :{?migration_password}',
+      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password'",
+      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password'",
+      'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public'
+    )
+    expect(init_roles_sql).not_to include(
+      'GRANT med_tracker_owner TO medtracker_runtime',
+      'GRANT med_tracker_app TO medtracker_migration',
+      'GRANT med_tracker_owner TO medtracker;',
+      'GRANT med_tracker_app TO medtracker;'
+    )
+  end
+
+  def init_multiple_databases
+    Rails.root.join('compose/init-multiple-dbs.sh').read
+  end
+
+  def ci_workflow
+    YAML.safe_load(Rails.root.join('.github/workflows/ci.yml').read, aliases: true).fetch('jobs')
+  end
+
+  def ci_harness_steps
+    {
+      'test_non_system' => 'Run non-browser tests',
+      'test_system' => 'Run browser tests (shard ${{ matrix.shard }}/2)',
+      'mutation' => 'Mutation test changed subjects (advisory)'
+    }
+  end
+
+  def expect_ci_database_routing(job_name)
+    job = ci_workflow.fetch(job_name)
+    expect_ci_database_urls(job)
+    expect_ci_database_steps(job)
+  end
+
+  def expect_ci_database_urls(job)
+    expect(job.fetch('env')).to include(
+      'MIGRATION_DATABASE_URL' =>
+        'postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test',
+      'RUNTIME_DATABASE_URL' =>
+        'postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test'
+    )
+    expect(job.fetch('env')).not_to include('DATABASE_URL')
+  end
+
+  def expect_ci_database_steps(job)
+    steps = job.fetch('steps').index_by { |step| step['name'] }
+
+    expect(steps.dig('Bootstrap database roles', 'run'))
+      .to eq('psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql')
+    expect(steps.dig('Set up database', 'env')).to include(
+      'DATABASE_URL' => '${{ env.MIGRATION_DATABASE_URL }}',
+      'DATABASE_ROLE' => 'med_tracker_owner'
+    )
   end
 end

--- a/spec/config/yaml_compose_spec.rb
+++ b/spec/config/yaml_compose_spec.rb
@@ -119,6 +119,23 @@ RSpec.describe YAML do
     expect_primary_login_memberships
   end
 
+  it 'repairs unsafe group roles and public schema creation', :aggregate_failures do
+    expect(init_roles_sql).to include(
+      'ALTER ROLE med_tracker_owner NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS;',
+      'ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS;',
+      'REVOKE CREATE ON SCHEMA public FROM PUBLIC;'
+    )
+  end
+
+  it 'loads deployment passwords from the environment and fails fast', :aggregate_failures do
+    expect(init_roles_sql).to start_with("\\set ON_ERROR_STOP on\n")
+    expect(init_roles_sql).to include(
+      '\\getenv runtime_password RUNTIME_DATABASE_PASSWORD',
+      '\\getenv migration_password MIGRATION_DATABASE_PASSWORD',
+      '\\getenv auxiliary_password AUXILIARY_DATABASE_PASSWORD'
+    )
+  end
+
   it 'isolates the auxiliary login from the primary database', :aggregate_failures do
     expect(init_roles_sql).to include(
       '\\if :{?auxiliary_password}',
@@ -126,7 +143,12 @@ RSpec.describe YAML do
       "format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database())"
     )
     expect(init_roles_sql).not_to match(/GRANT\s+CONNECT\s+ON\s+DATABASE.*TO[^;]*medtracker_auxiliary/i)
-    expect(init_multiple_databases).to include('CREATE DATABASE $db OWNER medtracker_auxiliary')
+    expect(init_multiple_databases).to include(
+      'CREATE DATABASE $db OWNER medtracker_auxiliary',
+      'ALTER DATABASE $db OWNER TO medtracker_auxiliary',
+      'ALTER SCHEMA public OWNER TO medtracker_auxiliary',
+      'REVOKE CREATE ON SCHEMA public FROM PUBLIC'
+    )
   end
 
   it 'keeps the production web container behind the runtime role after migrations complete' do
@@ -186,7 +208,9 @@ RSpec.describe YAML do
   end
 
   it 'bootstraps the deployed runtime role without owner or bypassrls privileges' do
-    expect(init_roles_sql).to include('ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOBYPASSRLS;')
+    expect(init_roles_sql).to include(
+      'ALTER ROLE med_tracker_app NOLOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS;'
+    )
     expect(init_roles_sql).to include('GRANT USAGE ON SCHEMA public TO med_tracker_app;')
     expect(init_roles_sql).not_to match(/GRANT\s+USAGE,\s+CREATE\s+ON\s+SCHEMA\s+public\s+TO\s+med_tracker_app/i)
   end
@@ -222,9 +246,18 @@ RSpec.describe YAML do
         step = ci_workflow.dig(job_name, 'steps').find { |candidate| candidate['name'] == step_name }
 
         expect(step.fetch('env')).to include(
-          'DATABASE_URL' => '${{ env.BOOTSTRAP_DATABASE_URL }}',
+          'DATABASE_URL' => ci_bootstrap_url,
           'DATABASE_ROLE' => nil
         )
+      end
+    end
+
+    it 'scopes each database credential to only the step that consumes it' do
+      %w[test_non_system test_system mutation lighthouse].each do |job_name|
+        expect(ci_workflow.fetch(job_name).fetch('env')).not_to include(
+          'BOOTSTRAP_DATABASE_URL', 'MIGRATION_DATABASE_URL', 'RUNTIME_DATABASE_URL', 'DATABASE_URL'
+        )
+        expect_ci_step_credentials(ci_workflow.fetch(job_name))
       end
     end
 
@@ -232,7 +265,7 @@ RSpec.describe YAML do
       server_step = ci_workflow.dig('lighthouse', 'steps').find { |step| step['name'] == 'Start Rails server' }
 
       expect(server_step.fetch('env')).to include(
-        'DATABASE_URL' => '${{ env.RUNTIME_DATABASE_URL }}',
+        'DATABASE_URL' => ci_runtime_url,
         'DATABASE_ROLE' => 'med_tracker_app'
       )
     end
@@ -291,21 +324,26 @@ RSpec.describe YAML do
   end
 
   def expect_primary_login_memberships
-    expect(init_roles_sql).to include(
-      'GRANT med_tracker_app TO medtracker_runtime WITH INHERIT FALSE, SET TRUE;',
-      'GRANT med_tracker_owner TO medtracker_migration WITH INHERIT FALSE, SET TRUE;',
-      '\\if :{?runtime_password}',
-      '\\if :{?migration_password}',
-      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password'",
-      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password'",
-      'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public'
-    )
+    expect(init_roles_sql).to include(*expected_primary_membership_statements)
     expect(init_roles_sql).not_to include(
       'GRANT med_tracker_owner TO medtracker_runtime',
       'GRANT med_tracker_app TO medtracker_migration',
       'GRANT med_tracker_owner TO medtracker;',
       'GRANT med_tracker_app TO medtracker;'
     )
+  end
+
+  def expected_primary_membership_statements
+    [
+      'GRANT med_tracker_app TO medtracker_runtime WITH ADMIN FALSE, INHERIT FALSE, SET TRUE;',
+      'GRANT med_tracker_owner TO medtracker_migration WITH ADMIN FALSE, INHERIT FALSE, SET TRUE;',
+      "WHERE member.rolname IN ('medtracker_auxiliary', 'medtracker_migration', 'medtracker_runtime')",
+      '\\if :{?runtime_password}',
+      '\\if :{?migration_password}',
+      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'runtime_password'",
+      "PASSWORD %L NOSUPERUSER NOCREATEROLE NOCREATEDB NOREPLICATION NOBYPASSRLS', :'migration_password'",
+      'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public'
+    ]
   end
 
   def init_multiple_databases
@@ -331,23 +369,61 @@ RSpec.describe YAML do
   end
 
   def expect_ci_database_urls(job)
-    expect(job.fetch('env')).to include(
-      'MIGRATION_DATABASE_URL' =>
-        'postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test',
-      'RUNTIME_DATABASE_URL' =>
-        'postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test'
+    expect(job.fetch('env')).not_to include(
+      'BOOTSTRAP_DATABASE_URL', 'MIGRATION_DATABASE_URL', 'RUNTIME_DATABASE_URL', 'DATABASE_URL'
     )
-    expect(job.fetch('env')).not_to include('DATABASE_URL')
   end
 
   def expect_ci_database_steps(job)
     steps = job.fetch('steps').index_by { |step| step['name'] }
 
-    expect(steps.dig('Bootstrap database roles', 'run'))
-      .to eq('psql "$BOOTSTRAP_DATABASE_URL" --file compose/init-roles.sql')
+    expect_ci_bootstrap_step(steps.fetch('Bootstrap database roles'))
     expect(steps.dig('Set up database', 'env')).to include(
-      'DATABASE_URL' => '${{ env.MIGRATION_DATABASE_URL }}',
+      'DATABASE_URL' => ci_migration_url,
       'DATABASE_ROLE' => 'med_tracker_owner'
     )
+  end
+
+  def expect_ci_bootstrap_step(step)
+    expect(step.fetch('run')).to eq('psql "$DATABASE_URL" --file compose/init-roles.sql')
+    expect(step.fetch('env')).to eq('DATABASE_URL' => ci_bootstrap_url)
+  end
+
+  def expect_ci_step_credentials(job)
+    job.fetch('steps').each do |step|
+      environment = step.fetch('env', {})
+      expected_url = ci_step_database_urls.fetch(step['name'], nil)
+
+      if expected_url
+        expect(environment.fetch('DATABASE_URL')).to eq(expected_url)
+      else
+        expect(environment.to_json).not_to include('medtracker_password', 'local_migration_only', 'local_runtime_only')
+      end
+    end
+  end
+
+  def ci_step_database_urls
+    {
+      'Bootstrap database roles' => ci_bootstrap_url,
+      'Set up database' => ci_migration_url,
+      'Precompile assets' => ci_runtime_url,
+      'Run non-browser tests' => ci_bootstrap_url,
+      'Run browser tests (shard ${{ matrix.shard }}/2)' => ci_bootstrap_url,
+      'Mutation test changed subjects (advisory)' => ci_bootstrap_url,
+      'Seed database' => ci_bootstrap_url,
+      'Start Rails server' => ci_runtime_url
+    }
+  end
+
+  def ci_bootstrap_url
+    'postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/medtracker_test'
+  end
+
+  def ci_migration_url
+    'postgres://medtracker_migration:local_migration_only@localhost:5432/medtracker_test'
+  end
+
+  def ci_runtime_url
+    'postgres://medtracker_runtime:local_runtime_only@localhost:5432/medtracker_test'
   end
 end

--- a/spec/migrations/configure_database_runtime_roles_spec.rb
+++ b/spec/migrations/configure_database_runtime_roles_spec.rb
@@ -71,11 +71,15 @@ RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
 
     def expect_source_audit_privileges
       %w[versions security_audit_events].each do |table_name|
-        expect(table_privilege(table_name, 'SELECT')).to be(true)
-        expect(table_privilege(table_name, 'INSERT')).to be(true)
-        expect(table_privilege(table_name, 'UPDATE')).to be(false)
-        expect(table_privilege(table_name, 'DELETE')).to be(false)
+        expect_source_audit_privileges_for(table_name)
       end
+    end
+
+    def expect_source_audit_privileges_for(table_name)
+      expect(table_privilege(table_name, 'SELECT')).to be(true)
+      expect(table_privilege(table_name, 'INSERT')).to be(true)
+      expect(table_privilege(table_name, 'UPDATE')).to be(false)
+      expect(table_privilege(table_name, 'DELETE')).to be(false)
     end
 
     def expect_household_audit_view_privilege

--- a/spec/migrations/configure_database_runtime_roles_spec.rb
+++ b/spec/migrations/configure_database_runtime_roles_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require Rails.root.join('db/migrate/20260715090000_refresh_database_runtime_privileges')
 
 RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
   it 'raises a pre-0.5 bootstrap error when runtime roles are missing and cannot be created' do
@@ -10,5 +11,47 @@ RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
 
     expect { migration.send(:ensure_runtime_roles_bootstrapped!) }
       .to raise_error(ActiveRecord::IrreversibleMigration, /pre-0.5 database upgrade/)
+  end
+
+  it 'does not widen a pre-provisioned migration login' do
+    migration = ConfigureDatabaseRuntimeRoles.new
+
+    allow(migration).to receive(:can_create_roles?).and_return(false)
+    allow(migration).to receive(:execute)
+
+    migration.send(:grant_roles_to_login)
+
+    expect(migration).not_to have_received(:execute)
+  end
+
+  describe RefreshDatabaseRuntimePrivileges do
+    it 'refreshes runtime data access without allowing migration metadata writes' do
+      migration = described_class.new
+      statements = []
+
+      allow(migration).to receive(:execute) { |sql| statements << sql.squish }
+
+      migration.up
+
+      expect(statements).to include(*expected_refresh_statements)
+    end
+
+    def expected_refresh_statements
+      [
+        'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO med_tracker_app;',
+        'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO med_tracker_app;',
+        'GRANT USAGE ON SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;',
+        'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA med_tracker TO med_tracker_owner, med_tracker_app;',
+        'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ' \
+        'ON TABLE schema_migrations, ar_internal_metadata FROM med_tracker_app;',
+        'GRANT SELECT ON TABLE schema_migrations, ar_internal_metadata TO med_tracker_app;',
+        'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public ' \
+        'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO med_tracker_app;',
+        'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA public ' \
+        'GRANT USAGE, SELECT ON SEQUENCES TO med_tracker_app;',
+        'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA med_tracker ' \
+        'GRANT EXECUTE ON FUNCTIONS TO med_tracker_app;'
+      ]
+    end
   end
 end

--- a/spec/migrations/configure_database_runtime_roles_spec.rb
+++ b/spec/migrations/configure_database_runtime_roles_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require Rails.root.join('db/migrate/20260709131100_enforce_audit_ledger_immutability')
 require Rails.root.join('db/migrate/20260715090000_refresh_database_runtime_privileges')
 
 RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
@@ -36,6 +37,14 @@ RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
       expect(statements).to include(*expected_refresh_statements)
     end
 
+    it 'preserves the final audit privilege contract after refreshing runtime privileges' do
+      described_class.new.up
+
+      expect_audit_privilege_contract
+    ensure
+      EnforceAuditLedgerImmutability.new.up
+    end
+
     def expected_refresh_statements
       [
         'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO med_tracker_app;',
@@ -52,6 +61,50 @@ RSpec.describe 'ConfigureDatabaseRuntimeRoles' do
         'ALTER DEFAULT PRIVILEGES FOR ROLE med_tracker_owner IN SCHEMA med_tracker ' \
         'GRANT EXECUTE ON FUNCTIONS TO med_tracker_app;'
       ]
+    end
+
+    def expect_audit_privilege_contract
+      expect_source_audit_privileges
+      expect_household_audit_view_privilege
+      expect_no_ledger_privileges
+    end
+
+    def expect_source_audit_privileges
+      %w[versions security_audit_events].each do |table_name|
+        expect(table_privilege(table_name, 'SELECT')).to be(true)
+        expect(table_privilege(table_name, 'INSERT')).to be(true)
+        expect(table_privilege(table_name, 'UPDATE')).to be(false)
+        expect(table_privilege(table_name, 'DELETE')).to be(false)
+      end
+    end
+
+    def expect_household_audit_view_privilege
+      expect(table_privilege('household_audit_ledger_entries', 'SELECT')).to be(true)
+      %w[INSERT UPDATE DELETE].each do |action|
+        expect(table_privilege('household_audit_ledger_entries', action)).to be(false)
+      end
+    end
+
+    def expect_no_ledger_privileges
+      EnforceAuditLedgerImmutability::LEDGER_TABLES.each do |table_name|
+        %w[SELECT INSERT UPDATE DELETE].each do |action|
+          expect(table_privilege(table_name, action)).to be(false)
+        end
+        expect(sequence_privilege("#{table_name}_id_seq", 'USAGE')).to be(false)
+        expect(sequence_privilege("#{table_name}_id_seq", 'SELECT')).to be(false)
+      end
+    end
+
+    def table_privilege(table_name, action)
+      ActiveRecord::Base.connection.select_value(
+        "SELECT has_table_privilege('med_tracker_app', '#{table_name}', '#{action}')"
+      )
+    end
+
+    def sequence_privilege(sequence_name, action)
+      ActiveRecord::Base.connection.select_value(
+        "SELECT has_sequence_privilege('med_tracker_app', '#{sequence_name}', '#{action}')"
+      )
     end
   end
 end

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -46,9 +46,16 @@ module DatabaseRuntimeRoleSetup
     AllowAccountScopedMembershipRlsBootstrap.new.up
     PartitionPaperTrailVersionsByHousehold.new.send(:enable_versions_rls)
     PartitionActiveStorageAttachmentsByHousehold.new.send(:enable_attachment_rls)
-    ConfigureDatabaseRuntimeRoles.new.up
+    apply_runtime_privileges
     AllowAccountLinkedPersonRlsLoginLookup.new.up
     AllowInvitationTokenRlsBootstrap.new.up
+  end
+
+  def self.apply_runtime_privileges
+    migration = ConfigureDatabaseRuntimeRoles.new
+    migration.send(:transfer_application_objects_to_owner)
+    migration.send(:grant_runtime_privileges)
+    migration.send(:configure_default_privileges)
   end
 
   def self.install_audit_ledger_database_objects

--- a/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
+++ b/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
@@ -36,9 +36,26 @@ RSpec.describe Rake::Task do
       .and output(/isolated role membership/).to_stderr
   end
 
-  def stub_preflight(memberships)
+  it 'aborts when a desired membership retains admin authority' do
+    stub_preflight(admin_membership)
+
+    expect { task.invoke }
+      .to raise_error(SystemExit)
+      .and output(/isolated role membership/).to_stderr
+  end
+
+  it 'aborts when a login has an indirect forbidden SET ROLE path' do
+    stub_preflight(isolated_memberships, paths: indirect_owner_path)
+
+    expect { task.invoke }
+      .to raise_error(SystemExit)
+      .and output(/isolated SET ROLE paths/).to_stderr
+  end
+
+  def stub_preflight(memberships, paths: isolated_set_paths)
     stub_role_rows
     stub_membership_rows(memberships)
+    stub_set_role_paths(paths)
     allow(connection).to receive(:select_value).with(/session_user/).and_return('medtracker_migration')
   end
 
@@ -48,6 +65,10 @@ RSpec.describe Rake::Task do
 
   def stub_membership_rows(memberships)
     allow(connection).to receive(:select_all).with(/FROM pg_auth_members/).and_return(memberships)
+  end
+
+  def stub_set_role_paths(paths)
+    allow(connection).to receive(:select_all).with(/pg_has_role/).and_return(paths)
   end
 
   def safe_role_rows
@@ -83,10 +104,42 @@ RSpec.describe Rake::Task do
     [membership_row('med_tracker_app', 'medtracker_migration')]
   end
 
-  def membership_row(granted_role, member_role)
+  def admin_membership
+    [
+      membership_row('med_tracker_app', 'medtracker_runtime', admin: true),
+      membership_row('med_tracker_owner', 'medtracker_migration')
+    ]
+  end
+
+  def isolated_set_paths
+    role_paths('medtracker_runtime' => 'med_tracker_app', 'medtracker_migration' => 'med_tracker_owner')
+  end
+
+  def indirect_owner_path
+    isolated_set_paths.map do |path|
+      next path unless path['login_role'] == 'medtracker_runtime' && path['granted_role'] == 'med_tracker_owner'
+
+      path.merge('can_set' => true)
+    end
+  end
+
+  def role_paths(expected_paths)
+    %w[medtracker_auxiliary medtracker_migration medtracker_runtime].product(
+      %w[med_tracker_app med_tracker_owner]
+    ).map do |login_role, granted_role|
+      {
+        'login_role' => login_role,
+        'granted_role' => granted_role,
+        'can_set' => expected_paths[login_role] == granted_role
+      }
+    end
+  end
+
+  def membership_row(granted_role, member_role, admin: false)
     {
       'granted_role' => granted_role,
       'member_role' => member_role,
+      'admin_option' => admin,
       'inherit_option' => false,
       'set_option' => true
     }

--- a/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
+++ b/spec/tasks/rake/task_pre_0_5_database_upgrade_preflight_spec.rb
@@ -14,16 +14,8 @@ RSpec.describe Rake::Task do
     allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
   end
 
-  it 'passes when runtime roles are bootstrapped for the app login' do
-    allow(connection).to receive(:select_all).and_return(
-      [
-        { 'rolname' => 'med_tracker_app', 'rolcanlogin' => false, 'rolsuper' => false, 'rolbypassrls' => false },
-        { 'rolname' => 'med_tracker_owner', 'rolcanlogin' => false, 'rolsuper' => false, 'rolbypassrls' => false }
-      ]
-    )
-    allow(connection).to receive(:quote) { |value| "'#{value}'" }
-    allow(connection).to receive(:select_value).with(/med_tracker_owner/).and_return(true)
-    allow(connection).to receive(:select_value).with(/med_tracker_app/).and_return(true)
+  it 'passes when migration and runtime logins have isolated role memberships' do
+    stub_preflight(isolated_memberships)
 
     expect { task.invoke }.to output(/pre-0.5 database upgrade preflight passed/i).to_stdout
   end
@@ -34,5 +26,69 @@ RSpec.describe Rake::Task do
     expect { task.invoke }
       .to raise_error(SystemExit)
       .and output(/pre-0.5 database upgrade/).to_stderr
+  end
+
+  it 'aborts when the migration login can assume the application role' do
+    stub_preflight(cross_membership)
+
+    expect { task.invoke }
+      .to raise_error(SystemExit)
+      .and output(/isolated role membership/).to_stderr
+  end
+
+  def stub_preflight(memberships)
+    stub_role_rows
+    stub_membership_rows(memberships)
+    allow(connection).to receive(:select_value).with(/session_user/).and_return('medtracker_migration')
+  end
+
+  def stub_role_rows
+    allow(connection).to receive(:select_all).with(/FROM pg_roles/).and_return(safe_role_rows)
+  end
+
+  def stub_membership_rows(memberships)
+    allow(connection).to receive(:select_all).with(/FROM pg_auth_members/).and_return(memberships)
+  end
+
+  def safe_role_rows
+    [
+      role_row('med_tracker_app', login: false),
+      role_row('med_tracker_owner', login: false),
+      role_row('medtracker_auxiliary', login: true),
+      role_row('medtracker_migration', login: true),
+      role_row('medtracker_runtime', login: true)
+    ]
+  end
+
+  def role_row(name, login:)
+    {
+      'rolname' => name,
+      'rolcanlogin' => login,
+      'rolsuper' => false,
+      'rolcreaterole' => false,
+      'rolcreatedb' => false,
+      'rolreplication' => false,
+      'rolbypassrls' => false
+    }
+  end
+
+  def isolated_memberships
+    [
+      membership_row('med_tracker_app', 'medtracker_runtime'),
+      membership_row('med_tracker_owner', 'medtracker_migration')
+    ]
+  end
+
+  def cross_membership
+    [membership_row('med_tracker_app', 'medtracker_migration')]
+  end
+
+  def membership_row(granted_role, member_role)
+    {
+      'granted_role' => granted_role,
+      'member_role' => member_role,
+      'inherit_option' => false,
+      'set_option' => true
+    }
   end
 end


### PR DESCRIPTION
## Summary

MedTracker previously gave web, job, and migration processes the same PostgreSQL bootstrap credential, then relied on SET ROLE to narrow it. That credential could still escape the intended boundary.

This change gives runtime, migration, and auxiliary databases distinct non-superuser logins with exact role memberships. It removes bootstrap credentials from normal workloads, repairs existing role and auxiliary-database ownership safely, and preserves audit-table immutability after privilege refreshes.

CI and local workflows now scope each credential to the process that needs it. The bootstrap login remains available only to fixture-backed test setup, where Rails must disable PostgreSQL system triggers; runtime and migration services never receive it.

Operators now have a fail-fast, secret-safe upgrade path for existing PostgreSQL and CloudNativePG deployments.

Closes #1662