### PR TITLE
fix(households): serialize purge cutoff

### DIFF
--- a/app/controllers/concerns/take_medication_guardable.rb
+++ b/app/controllers/concerns/take_medication_guardable.rb
@@ -13,7 +13,7 @@ module TakeMedicationGuardable
     when :out_of_stock, :cooldown, :paused, :overlapping_prescription_restriction
       default_message = take_medication_default_message(error)
       respond_take_medication_error(message: t("#{scope}.cannot_take_medication", default: default_message))
-    when :invalid_amount, :create_failed
+    when :invalid_amount, :create_failed, :household_unavailable
       respond_take_medication_invalid_dose(scope:)
     when :selection_required, :invalid_source
       respond_take_medication_stock_source_error(scope:, error:)

--- a/app/services/households/lifecycle_cutoff_lock.rb
+++ b/app/services/households/lifecycle_cutoff_lock.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Households
+  class LifecycleCutoffLock
+    LOCK_NAMESPACE = 'med_tracker.household_purge'
+
+    class << self
+      def with(household: nil, household_id: nil)
+        target_id = household_id || household&.id
+        connection = ActiveRecord::Base.connection
+        lock_key = "#{LOCK_NAMESPACE}:#{target_id}"
+        acquired = false
+
+        acquire(connection, lock_key)
+        acquired = true
+        yield
+      ensure
+        release(connection, lock_key) if acquired
+      end
+
+      private
+
+      def acquire(connection, lock_key)
+        connection.select_value(
+          ActiveRecord::Base.sanitize_sql_array(
+            [
+              'WITH lock_acquired AS MATERIALIZED (' \
+              'SELECT pg_advisory_lock(hashtextextended(?, 0))' \
+              ') SELECT 1 FROM lock_acquired',
+              lock_key
+            ]
+          )
+        )
+      end
+
+      def release(connection, lock_key)
+        connection.select_value(
+          ActiveRecord::Base.sanitize_sql_array(
+            ['SELECT pg_advisory_unlock(hashtextextended(?, 0))', lock_key]
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/services/households/offboarder.rb
+++ b/app/services/households/offboarder.rb
@@ -7,6 +7,15 @@ module Households
     class << self
       def call(household:, actor_account:)
         authorize_operator!(actor_account)
+        LifecycleCutoffLock.with(household: household) do
+          household = Household.find(household.id)
+          offboard(household, actor_account)
+        end
+      end
+
+      private
+
+      def offboard(household, actor_account)
         preserved_account_ids = accounts_with_other_operational_household(household, actor_account)
         TenantContext.with(account: actor_account, household: household) do
           ActiveRecord::Base.transaction do
@@ -20,8 +29,6 @@ module Households
           end
         end
       end
-
-      private
 
       def revoke_access!(household, actor_account, preserved_account_ids)
         memberships = household.household_memberships.to_a

--- a/app/services/households/purge_audit.rb
+++ b/app/services/households/purge_audit.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Households
+  class PurgeAudit
+    class << self
+      def attempt_started(run:, household:, actor_account:)
+        first_attempt = run.attempts == 1
+        record(
+          run: run,
+          household: household,
+          actor_account: actor_account,
+          event: {
+            type: first_attempt ? 'household.purge.initiated' : 'household.purge.retry_started',
+            outcome: first_attempt ? 'initiated' : 'retry_started'
+          }
+        )
+      end
+
+      def cutoff(run:, household:, actor_account:)
+        record(
+          run: run,
+          household: household,
+          actor_account: actor_account,
+          event: { type: 'household.purge.cutoff', outcome: 'cutoff' }
+        )
+      end
+
+      def failed(run:, household:, actor_account:, exception:)
+        record(
+          run: run,
+          household: household,
+          actor_account: actor_account,
+          event: {
+            type: 'household.purge.failed',
+            outcome: 'failed',
+            failure: {
+              exception_class: exception.class.name,
+              failure_code: run.failure_code
+            }
+          }
+        )
+      end
+
+      def completed(run:, household:, actor_account:)
+        record(
+          run: run,
+          household: household,
+          actor_account: actor_account,
+          event: { type: 'household.purge.completed', outcome: 'success' }
+        )
+      end
+
+      private
+
+      def record(run:, household:, actor_account:, event:)
+        Audit::Event.record!(
+          household: household,
+          actor_account: actor_account,
+          event_type: event.fetch(:type),
+          metadata: metadata(run, household, event.fetch(:outcome), event.fetch(:failure, {}))
+        )
+      end
+
+      def metadata(run, household, outcome, failure)
+        {
+          purge_run_id: run.id,
+          household_id: household.id,
+          attempt_number: run.attempts,
+          last_completed_table: run.last_completed_table,
+          outcome: outcome,
+          **failure
+        }.compact
+      end
+    end
+  end
+end

--- a/app/services/households/purger.rb
+++ b/app/services/households/purger.rb
@@ -44,11 +44,13 @@ module Households
         authorize_operator!(actor_account)
         LifecycleCutoffLock.with(household: household) do
           household = Household.find(household.id)
+          run = existing_purge_run(household)
+          next run if run&.completed?
+          raise InvalidLifecycle if household.purged?
+
           refuse_active_hold!(household, actor_account)
           household = Offboarder.call(household: household, actor_account: actor_account)
-          run = purge_run(household, actor_account)
-          next run if run.completed?
-          raise InvalidLifecycle if household.purged?
+          run ||= purge_run(household, actor_account)
 
           execute_purge!(run, household, actor_account, after_table)
           run
@@ -66,6 +68,10 @@ module Households
 
       def purge_run(household, actor_account)
         HouseholdPurgeRun.acquire!(household: household, requested_by_account: actor_account)
+      end
+
+      def existing_purge_run(household)
+        HouseholdPurgeRun.find_by(household: household)
       end
 
       def start_run!(run, household, actor_account)

--- a/app/services/households/purger.rb
+++ b/app/services/households/purger.rb
@@ -10,6 +10,12 @@ module Households
       end
     end
 
+    class InvalidLifecycle < StandardError
+      def initialize
+        super('Household is already purged without a completed purge run')
+      end
+    end
+
     PURGE_ORDER = %w[
       health_event_medications
       notification_events
@@ -33,16 +39,16 @@ module Households
       medications
       locations
     ].freeze
-    LOCK_NAMESPACE = 'med_tracker.household_purge'
-
     class << self
       def call(household:, actor_account:, after_table: nil)
         authorize_operator!(actor_account)
-        with_purge_lock(household) do
+        LifecycleCutoffLock.with(household: household) do
+          household = Household.find(household.id)
           refuse_active_hold!(household, actor_account)
-          Offboarder.call(household: household, actor_account: actor_account)
+          household = Offboarder.call(household: household, actor_account: actor_account)
           run = purge_run(household, actor_account)
           next run if run.completed?
+          raise InvalidLifecycle if household.purged?
 
           execute_purge!(run, household, actor_account, after_table)
           run
@@ -62,54 +68,28 @@ module Households
         HouseholdPurgeRun.acquire!(household: household, requested_by_account: actor_account)
       end
 
-      def with_purge_lock(household)
-        connection = ActiveRecord::Base.connection
-        lock_key = "#{LOCK_NAMESPACE}:#{household.id}"
-        acquire_purge_lock(connection, lock_key)
-        yield
-      ensure
-        release_purge_lock(connection, lock_key) if connection && lock_key
-      end
-
-      def acquire_purge_lock(connection, lock_key)
-        connection.select_value(
-          ActiveRecord::Base.sanitize_sql_array(
-            [
-              'WITH lock_acquired AS MATERIALIZED (' \
-              'SELECT pg_advisory_lock(hashtextextended(?, 0))' \
-              ') SELECT 1 FROM lock_acquired',
-              lock_key
-            ]
+      def start_run!(run, household, actor_account)
+        attempt_number = run.attempts + 1
+        TenantContext.with(account: actor_account, household: household) do
+          run.update!(
+            status: :running,
+            attempts: attempt_number,
+            started_at: run.started_at || Time.current,
+            failure_code: nil,
+            failed_at: nil
           )
-        )
-      end
-
-      def release_purge_lock(connection, lock_key)
-        connection.select_value(
-          ActiveRecord::Base.sanitize_sql_array(
-            ['SELECT pg_advisory_unlock(hashtextextended(?, 0))', lock_key]
-          )
-        )
-      end
-
-      def start_run!(run)
-        run.update!(
-          status: :running,
-          attempts: run.attempts + 1,
-          started_at: run.started_at || Time.current,
-          failure_code: nil,
-          failed_at: nil
-        )
+          PurgeAudit.attempt_started(run: run, household: household, actor_account: actor_account)
+        end
       end
 
       def execute_purge!(run, household, actor_account, after_table)
-        start_run!(run)
-        prepare_purge!(household, actor_account)
+        start_run!(run, household, actor_account)
+        prepare_purge!(run, household, actor_account)
         purge_dependencies!(run, household, actor_account, after_table)
         purge_inventory!(run, household, actor_account, after_table)
         complete_run!(run, household, actor_account)
       rescue StandardError => e
-        run.reload.update!(status: :failed, failure_code: e.class.name, failed_at: Time.current)
+        record_failure(run, household, actor_account, e)
         raise
       end
 
@@ -131,12 +111,18 @@ module Households
         end
       end
 
-      def prepare_purge!(household, actor_account)
+      def prepare_purge!(run, household, actor_account)
         TenantContext.with(account: actor_account, household: household) do
           household.lock!
           raise ActiveRetentionHold if household.household_retention_holds.active.exists?
+          return if household.purging?
 
-          household.update!(lifecycle_state: :purging) unless household.purging?
+          household.update!(lifecycle_state: :purging)
+          PurgeAudit.cutoff(
+            run: run,
+            household: household,
+            actor_account: actor_account
+          )
         end
       end
 
@@ -182,6 +168,8 @@ module Households
       end
 
       def delete_household_rows(table_name, household_id)
+        return purge_medication_takes(household_id) if table_name == 'medication_takes'
+
         connection = ActiveRecord::Base.connection
         connection.exec_delete(
           "DELETE FROM #{connection.quote_table_name(table_name)} " \
@@ -189,19 +177,32 @@ module Households
         )
       end
 
+      def purge_medication_takes(household_id)
+        ActiveRecord::Base.connection.select_value(
+          ActiveRecord::Base.sanitize_sql_array(
+            ['SELECT med_tracker.purge_medication_takes(?)', household_id]
+          )
+        ).to_i
+      end
+
       def record_completion(run, household, actor_account)
-        Audit::Event.record!(
+        PurgeAudit.completed(
+          run: run,
           household: household,
-          actor_account: actor_account,
-          event_type: 'household.purge.completed',
-          metadata: {
-            attempts: run.attempts,
-            household_id: household.id,
-            last_completed_table: run.last_completed_table,
-            outcome: 'success',
-            purge_run_id: run.id
-          }
+          actor_account: actor_account
         )
+      end
+
+      def record_failure(run, household, actor_account, exception)
+        TenantContext.with(account: actor_account, household: household) do
+          run.reload.update!(status: :failed, failure_code: exception.class.name, failed_at: Time.current)
+          PurgeAudit.failed(
+            run: run,
+            household: household,
+            actor_account: actor_account,
+            exception: exception
+          )
+        end
       end
 
       def ensure_inventory_empty!(household_id)

--- a/app/services/households/retention_hold_manager.rb
+++ b/app/services/households/retention_hold_manager.rb
@@ -13,24 +13,31 @@ module Households
     class << self
       def place!(household:, actor_account:, reason:, review_on:)
         authorize_operator!(actor_account)
-        TenantContext.with(account: actor_account, household: household) do
-          ActiveRecord::Base.transaction do
-            place_locked!(household, actor_account, reason, review_on)
+        LifecycleCutoffLock.with(household: household) do
+          household = Household.find(household.id)
+          TenantContext.with(account: actor_account, household: household) do
+            ActiveRecord::Base.transaction do
+              place_locked!(household, actor_account, reason, review_on)
+            end
           end
         end
       end
 
       def release!(hold:, actor_account:)
         authorize_operator!(actor_account)
-        TenantContext.with(account: actor_account, household: hold.household) do
-          ActiveRecord::Base.transaction do
-            hold.lock!
-            return hold if hold.released?
+        LifecycleCutoffLock.with(household_id: hold.household_id) do
+          hold = HouseholdRetentionHold.find(hold.id)
+          household = Household.find(hold.household_id)
+          TenantContext.with(account: actor_account, household: household) do
+            ActiveRecord::Base.transaction do
+              hold.lock!
+              return hold if hold.released?
 
-            hold.update!(status: :released, released_by_account: actor_account, released_at: Time.current)
-            hold.household.update!(lifecycle_state: :active) if hold.household.held?
-            record_event(hold, actor_account, 'released')
-            hold
+              hold.update!(status: :released, released_by_account: actor_account, released_at: Time.current)
+              household.update!(lifecycle_state: :active) if household.held?
+              record_event(hold, actor_account, 'released')
+              hold
+            end
           end
         end
       end

--- a/app/services/medication_administration/record_dose.rb
+++ b/app/services/medication_administration/record_dose.rb
@@ -38,6 +38,23 @@ module MedicationAdministration
     end
 
     def call(source:, amount_override:, taken_from_medication_id:, user:, **options)
+      Households::LifecycleCutoffLock.with(household_id: source.household_id) do
+        source = freshly_loaded_operational_source(source)
+        return failure(:household_unavailable) unless source
+
+        record_dose(
+          source: source,
+          amount_override: amount_override,
+          taken_from_medication_id: taken_from_medication_id,
+          user: user,
+          options: options
+        )
+      end
+    end
+
+    private
+
+    def record_dose(source:, amount_override:, taken_from_medication_id:, user:, options:)
       publish_take_metric('take_attempted.med_tracker', source:, user:, options:)
       prepared_take = prepare_take(
         source: source,
@@ -54,7 +71,12 @@ module MedicationAdministration
       success(take, source:, user:, options:)
     end
 
-    private
+    def freshly_loaded_operational_source(source)
+      source.reload
+      source if source.household&.operational?
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
 
     def failure(error)
       Result.new(success: false, take: nil, error: error)

--- a/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
+++ b/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
@@ -14,22 +14,52 @@ class CreateHouseholdMedicationTakePurgeFunction < ActiveRecord::Migration[8.1]
       DECLARE
         v_account_setting text := pg_catalog.current_setting('med_tracker.current_account_id', true);
         v_household_setting text := pg_catalog.current_setting('med_tracker.current_household_id', true);
+        v_account_id bigint;
+        v_household_id bigint;
         v_deleted_rows bigint;
       BEGIN
         IF v_household_setting IS NULL
-           OR v_household_setting !~ '^[0-9]+$'
-           OR v_household_setting::bigint IS DISTINCT FROM p_household_id THEN
+           OR v_household_setting !~ '^[0-9]+$' THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT104',
+            MESSAGE = 'household purge tenant context does not match target';
+        END IF;
+
+        BEGIN
+          v_household_id := v_household_setting::bigint;
+        EXCEPTION
+          WHEN numeric_value_out_of_range OR invalid_text_representation THEN
+            RAISE EXCEPTION USING
+              ERRCODE = 'MT104',
+              MESSAGE = 'household purge tenant context does not match target';
+        END;
+
+        IF v_household_id IS DISTINCT FROM p_household_id THEN
           RAISE EXCEPTION USING
             ERRCODE = 'MT104',
             MESSAGE = 'household purge tenant context does not match target';
         END IF;
 
         IF v_account_setting IS NULL
-           OR v_account_setting !~ '^[0-9]+$'
-           OR NOT EXISTS (
+           OR v_account_setting !~ '^[0-9]+$' THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT105',
+            MESSAGE = 'household purge operator context is invalid';
+        END IF;
+
+        BEGIN
+          v_account_id := v_account_setting::bigint;
+        EXCEPTION
+          WHEN numeric_value_out_of_range OR invalid_text_representation THEN
+            RAISE EXCEPTION USING
+              ERRCODE = 'MT105',
+              MESSAGE = 'household purge operator context is invalid';
+        END;
+
+        IF NOT EXISTS (
              SELECT 1
              FROM public.platform_admins
-             WHERE account_id = v_account_setting::bigint
+             WHERE account_id = v_account_id
                AND status = 'active'
            ) THEN
           RAISE EXCEPTION USING

--- a/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
+++ b/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+class CreateHouseholdMedicationTakePurgeFunction < ActiveRecord::Migration[8.1]
+  FUNCTION_SIGNATURE = 'med_tracker.purge_medication_takes(bigint)'
+
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION med_tracker.purge_medication_takes(p_household_id bigint)
+      RETURNS bigint
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = pg_catalog
+      AS $$
+      DECLARE
+        v_account_setting text := pg_catalog.current_setting('med_tracker.current_account_id', true);
+        v_household_setting text := pg_catalog.current_setting('med_tracker.current_household_id', true);
+        v_deleted_rows bigint;
+      BEGIN
+        IF v_household_setting IS NULL
+           OR v_household_setting !~ '^[0-9]+$'
+           OR v_household_setting::bigint IS DISTINCT FROM p_household_id THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT104',
+            MESSAGE = 'household purge tenant context does not match target';
+        END IF;
+
+        IF v_account_setting IS NULL
+           OR v_account_setting !~ '^[0-9]+$'
+           OR NOT EXISTS (
+             SELECT 1
+             FROM public.platform_admins
+             WHERE account_id = v_account_setting::bigint
+               AND status = 'active'
+           ) THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT105',
+            MESSAGE = 'household purge operator context is invalid';
+        END IF;
+
+        PERFORM 1
+        FROM public.households
+        WHERE id = p_household_id
+        FOR UPDATE;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT101',
+            MESSAGE = 'household purge target is invalid';
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1
+          FROM public.households
+          WHERE id = p_household_id
+            AND status = 'archived'
+            AND lifecycle_state = 'purging'
+            AND offboarded_at IS NOT NULL
+        ) THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT102',
+            MESSAGE = 'household purge lifecycle is invalid';
+        END IF;
+
+        IF EXISTS (
+          SELECT 1
+          FROM public.household_retention_holds
+          WHERE household_id = p_household_id
+            AND status = 'active'
+        ) THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT103',
+            MESSAGE = 'household purge retention hold is active';
+        END IF;
+
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_household_id',
+          p_household_id::text,
+          true
+        );
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_account_id',
+          v_account_setting,
+          true
+        );
+
+        DELETE FROM public.medication_takes
+        WHERE household_id = p_household_id;
+
+        GET DIAGNOSTICS v_deleted_rows = ROW_COUNT;
+
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_household_id',
+          coalesce(v_household_setting, ''),
+          true
+        );
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_account_id',
+          coalesce(v_account_setting, ''),
+          true
+        );
+
+        RETURN v_deleted_rows;
+      EXCEPTION
+        WHEN OTHERS THEN
+          PERFORM pg_catalog.set_config(
+            'med_tracker.current_household_id',
+            coalesce(v_household_setting, ''),
+            true
+          );
+          PERFORM pg_catalog.set_config(
+            'med_tracker.current_account_id',
+            coalesce(v_account_setting, ''),
+            true
+          );
+          RAISE;
+      END;
+      $$;
+
+      ALTER FUNCTION #{FUNCTION_SIGNATURE} OWNER TO med_tracker_owner;
+      REVOKE ALL ON FUNCTION #{FUNCTION_SIGNATURE} FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION #{FUNCTION_SIGNATURE} TO med_tracker_app;
+    SQL
+  end
+
+  def down
+    execute "DROP FUNCTION IF EXISTS #{FUNCTION_SIGNATURE};"
+  end
+end

--- a/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
+++ b/db/migrate/20260716120000_create_household_medication_take_purge_function.rb
@@ -116,9 +116,14 @@ class CreateHouseholdMedicationTakePurgeFunction < ActiveRecord::Migration[8.1]
       END;
       $$;
 
-      ALTER FUNCTION #{FUNCTION_SIGNATURE} OWNER TO med_tracker_owner;
       REVOKE ALL ON FUNCTION #{FUNCTION_SIGNATURE} FROM PUBLIC;
-      GRANT EXECUTE ON FUNCTION #{FUNCTION_SIGNATURE} TO med_tracker_app;
+      DO $purge_role_grant$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
+          GRANT EXECUTE ON FUNCTION #{FUNCTION_SIGNATURE} TO med_tracker_app;
+        END IF;
+      END
+      $purge_role_grant$;
     SQL
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1305,22 +1305,52 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_16_120000) do
     DECLARE
       v_account_setting text := pg_catalog.current_setting('med_tracker.current_account_id', true);
       v_household_setting text := pg_catalog.current_setting('med_tracker.current_household_id', true);
+      v_account_id bigint;
+      v_household_id bigint;
       v_deleted_rows bigint;
     BEGIN
       IF v_household_setting IS NULL
-         OR v_household_setting !~ '^[0-9]+$'
-         OR v_household_setting::bigint IS DISTINCT FROM p_household_id THEN
+         OR v_household_setting !~ '^[0-9]+$' THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT104',
+          MESSAGE = 'household purge tenant context does not match target';
+      END IF;
+
+      BEGIN
+        v_household_id := v_household_setting::bigint;
+      EXCEPTION
+        WHEN numeric_value_out_of_range OR invalid_text_representation THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT104',
+            MESSAGE = 'household purge tenant context does not match target';
+      END;
+
+      IF v_household_id IS DISTINCT FROM p_household_id THEN
         RAISE EXCEPTION USING
           ERRCODE = 'MT104',
           MESSAGE = 'household purge tenant context does not match target';
       END IF;
 
       IF v_account_setting IS NULL
-         OR v_account_setting !~ '^[0-9]+$'
-         OR NOT EXISTS (
+         OR v_account_setting !~ '^[0-9]+$' THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT105',
+          MESSAGE = 'household purge operator context is invalid';
+      END IF;
+
+      BEGIN
+        v_account_id := v_account_setting::bigint;
+      EXCEPTION
+        WHEN numeric_value_out_of_range OR invalid_text_representation THEN
+          RAISE EXCEPTION USING
+            ERRCODE = 'MT105',
+            MESSAGE = 'household purge operator context is invalid';
+      END;
+
+      IF NOT EXISTS (
            SELECT 1
            FROM public.platform_admins
-           WHERE account_id = v_account_setting::bigint
+           WHERE account_id = v_account_id
              AND status = 'active'
          ) THEN
         RAISE EXCEPTION USING

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1295,6 +1295,121 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_090000) do
       END IF;
     END
     $role_grant$;
+
+    CREATE OR REPLACE FUNCTION med_tracker.purge_medication_takes(p_household_id bigint)
+    RETURNS bigint
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $$
+    DECLARE
+      v_account_setting text := pg_catalog.current_setting('med_tracker.current_account_id', true);
+      v_household_setting text := pg_catalog.current_setting('med_tracker.current_household_id', true);
+      v_deleted_rows bigint;
+    BEGIN
+      IF v_household_setting IS NULL
+         OR v_household_setting !~ '^[0-9]+$'
+         OR v_household_setting::bigint IS DISTINCT FROM p_household_id THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT104',
+          MESSAGE = 'household purge tenant context does not match target';
+      END IF;
+
+      IF v_account_setting IS NULL
+         OR v_account_setting !~ '^[0-9]+$'
+         OR NOT EXISTS (
+           SELECT 1
+           FROM public.platform_admins
+           WHERE account_id = v_account_setting::bigint
+             AND status = 'active'
+         ) THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT105',
+          MESSAGE = 'household purge operator context is invalid';
+      END IF;
+
+      PERFORM 1
+      FROM public.households
+      WHERE id = p_household_id
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT101',
+          MESSAGE = 'household purge target is invalid';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM public.households
+        WHERE id = p_household_id
+          AND status = 'archived'
+          AND lifecycle_state = 'purging'
+          AND offboarded_at IS NOT NULL
+      ) THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT102',
+          MESSAGE = 'household purge lifecycle is invalid';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM public.household_retention_holds
+        WHERE household_id = p_household_id
+          AND status = 'active'
+      ) THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'MT103',
+          MESSAGE = 'household purge retention hold is active';
+      END IF;
+
+      PERFORM pg_catalog.set_config(
+        'med_tracker.current_household_id',
+        p_household_id::text,
+        true
+      );
+      PERFORM pg_catalog.set_config(
+        'med_tracker.current_account_id',
+        v_account_setting,
+        true
+      );
+
+      DELETE FROM public.medication_takes
+      WHERE household_id = p_household_id;
+
+      GET DIAGNOSTICS v_deleted_rows = ROW_COUNT;
+
+      PERFORM pg_catalog.set_config(
+        'med_tracker.current_household_id',
+        coalesce(v_household_setting, ''),
+        true
+      );
+      PERFORM pg_catalog.set_config(
+        'med_tracker.current_account_id',
+        coalesce(v_account_setting, ''),
+        true
+      );
+
+      RETURN v_deleted_rows;
+    EXCEPTION
+      WHEN OTHERS THEN
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_household_id',
+          coalesce(v_household_setting, ''),
+          true
+        );
+        PERFORM pg_catalog.set_config(
+          'med_tracker.current_account_id',
+          coalesce(v_account_setting, ''),
+          true
+        );
+        RAISE;
+    END;
+    $$;
+
+    ALTER FUNCTION med_tracker.purge_medication_takes(bigint) OWNER TO med_tracker_owner;
+    REVOKE ALL ON FUNCTION med_tracker.purge_medication_takes(bigint) FROM PUBLIC;
+    GRANT EXECUTE ON FUNCTION med_tracker.purge_medication_takes(bigint) TO med_tracker_app;
   SQL
 
   %w[

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1407,9 +1407,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_16_120000) do
     END;
     $$;
 
-    ALTER FUNCTION med_tracker.purge_medication_takes(bigint) OWNER TO med_tracker_owner;
     REVOKE ALL ON FUNCTION med_tracker.purge_medication_takes(bigint) FROM PUBLIC;
-    GRANT EXECUTE ON FUNCTION med_tracker.purge_medication_takes(bigint) TO med_tracker_app;
+    DO $purge_role_grant$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_app') THEN
+        GRANT EXECUTE ON FUNCTION med_tracker.purge_medication_takes(bigint) TO med_tracker_app;
+      END IF;
+    END
+    $purge_role_grant$;
   SQL
 
   %w[

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -20,8 +20,13 @@ The runtime application role can insert source events but cannot update or delet
 Household purge never updates or deletes either audit source table. Historical
 `actor_membership_id` values deliberately outlive purged membership domain rows, so
 the source payload and chained ledger remain byte-for-byte verifiable. A successful
-purge appends one `household.purge.completed` tombstone containing identifiers and
-status fields only.
+purge appends initiated, cutoff, retry, and failed attempt evidence as applicable,
+then one `household.purge.completed` tombstone containing identifiers and status
+fields only. Purge metadata is limited to the purge run and household identifiers,
+attempt number, last completed table, outcome, and exception class or failure code.
+The medication-take deletion step is a validated `SECURITY DEFINER` maintenance
+boundary for the existing shared login; it does not provide credential isolation or
+a general medication-history bypass.
 
 - `med_tracker_audit_exporter` reads ledger/checkpoint data, signs checkpoints through a one-way database function, and updates delivery receipts. It cannot read source or clinical tables or modify ledger history.
 - `med_tracker_audit_verifier` reads source and ledger evidence and may insert the audit event describing an export. It cannot read clinical tables or alter existing source, ledger, checkpoint, or delivery rows.

--- a/docs/operations/hosted-private-beta-runbook.md
+++ b/docs/operations/hosted-private-beta-runbook.md
@@ -197,6 +197,13 @@ Purge refuses an active retention hold before deleting anything. It is safe to
 retry after interruption: the durable purge run increments `attempts`, reports
 `last_completed_table`, repeats idempotent deletions, and finishes only after every
 purgeable `SchemaInventory` tenant table and household-owned attachment is empty.
+The `medication_takes` step crosses the validated
+`med_tracker.purge_medication_takes(bigint)` maintenance boundary. The function
+requires matching transaction-local household context and an active platform
+administrator account context, validates the archived/purging/offboarded lifecycle
+and retention hold state, and deletes only the target household's dose history.
+It is a `SECURITY DEFINER` boundary for the existing shared database login, not
+credential isolation or a general bypass for immutable medication history.
 Immutable `security_audit_events` and `versions` audit history are never updated or
 deleted. Tenant security events remain under tenant RLS. Historical actor-membership
 identifiers remain in the audit sources after the corresponding access-domain row is
@@ -204,10 +211,13 @@ purged. Completion appends one immutable `household.purge.completed` tombstone
 containing only the identifiers and status fields listed below. Purge never deletes
 another household's attachment or a blob still referenced elsewhere.
 Successful evidence contains `event_type`, `outcome`, `household_id`,
-`purge_run_id`, `attempts`, and `last_completed_table`. Failed commands emit
-`event_type`, `outcome`, and `failure_code`, exit non-zero, and do not claim
-completion. Investigate the application exception telemetry, correct the cause,
-then run the identical task command again.
+`purge_run_id`, `attempt_number`, and `last_completed_table`. The immutable sequence
+records `household.purge.initiated`, one `household.purge.cutoff`,
+`household.purge.failed` on failed attempts, `household.purge.retry_started` on
+later attempts, and one `household.purge.completed` tombstone after inventory is
+empty. Failed commands emit `event_type`, `outcome`, and `failure_code`, exit
+non-zero, and do not claim completion. Investigate the application exception
+telemetry, correct the cause, then run the identical task command again.
 
 Never retain free-text reasons, attachment contents, credentials, or health data in command output.
 

--- a/spec/config/shared_database_login_compatibility_spec.rb
+++ b/spec/config/shared_database_login_compatibility_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe SharedDatabaseLoginCompatibility do
     end
   end
 
+  it 'loads the purge function before optional runtime roles have been bootstrapped' do
+    migration_source = Rails.root.join(
+      'db/migrate/20260716120000_create_household_medication_take_purge_function.rb'
+    ).read
+    [migration_source, Rails.root.join('db/schema.rb').read].each do |source|
+      expect(source).not_to include('OWNER TO med_tracker_owner')
+      expect(source).to include('REVOKE ALL ON FUNCTION')
+      expect(source).to match(
+        /DO \$purge_role_grant\$.*?IF EXISTS .*?rolname = 'med_tracker_app'.*?GRANT EXECUTE ON FUNCTION/m
+      )
+    end
+  end
+
   def expect_compose_login(environment, login, *auxiliary_databases)
     services = %W[migrate-#{environment} web-#{environment}]
 

--- a/spec/migrations/create_household_medication_take_purge_function_spec.rb
+++ b/spec/migrations/create_household_medication_take_purge_function_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260716120000_create_household_medication_take_purge_function')
+
+RSpec.describe CreateHouseholdMedicationTakePurgeFunction do
+  delegate :connection, to: :'ActiveRecord::Base'
+
+  let(:operator) do
+    Account.create!(email: "purge-function-#{SecureRandom.hex(4)}@example.test", status: :verified).tap do |account|
+      PlatformAdmin.create!(account: account)
+    end
+  end
+  let(:household) { create(:household) }
+
+  before do
+    household.update!(status: :archived, lifecycle_state: :purging, offboarded_at: Time.current)
+  end
+
+  it 'installs the fixed-path security definer owned by the database owner' do
+    expect(function_contract).to include(
+      'prosecdef' => true,
+      'proconfig' => 'search_path=pg_catalog',
+      'lanname' => 'plpgsql',
+      'owner' => 'med_tracker_owner',
+      'result_type' => 'bigint'
+    )
+    expect(function_contract.fetch('definition')).to include('public.households', 'public.medication_takes')
+  end
+
+  def function_contract
+    connection.select_one(<<~SQL.squish)
+      SELECT p.prosecdef,
+             array_to_string(p.proconfig, ',') AS proconfig,
+             l.lanname,
+             r.rolname AS owner,
+             pg_get_function_result(p.oid) AS result_type,
+             pg_get_functiondef(p.oid) AS definition
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      JOIN pg_language l ON l.oid = p.prolang
+      JOIN pg_roles r ON r.oid = p.proowner
+      WHERE n.nspname = 'med_tracker'
+        AND p.proname = 'purge_medication_takes'
+        AND pg_get_function_identity_arguments(p.oid) = 'p_household_id bigint'
+    SQL
+  end
+
+  it 'revokes PUBLIC execution and grants med_tracker_app execution' do
+    privileges = connection.select_one(<<~SQL.squish)
+      SELECT p.proacl::text AS acl,
+             has_function_privilege(
+               'med_tracker_app',
+               'med_tracker.purge_medication_takes(bigint)',
+               'EXECUTE'
+             ) AS app_can_execute
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'med_tracker'
+        AND p.proname = 'purge_medication_takes'
+    SQL
+
+    expect(privileges.fetch('acl')).not_to match(/(?:\{|,)=X/)
+    expect(privileges.fetch('app_can_execute')).to be(true)
+  end
+
+  it 'deletes only target rows, returns the exact count, and returns zero on retry' do
+    target_takes = [create_take(household), create_take(household)]
+    other_household = create(:household)
+    other_take = create_take(other_household)
+
+    set_context(household_id: household.id, account_id: operator.id)
+
+    expect(call_function(household.id)).to eq(2)
+    expect(call_function(household.id)).to eq(0)
+    expect(MedicationTake.where(id: target_takes.map(&:id))).to be_empty
+    expect(MedicationTake.where(id: other_take.id)).to exist
+  end
+
+  it 'executes as med_tracker_app through the existing shared login' do
+    take = create_take(household)
+
+    connection.transaction(requires_new: true) do
+      connection.execute('SET LOCAL ROLE med_tracker_app')
+      set_context(household_id: household.id, account_id: operator.id)
+
+      expect(call_function(household.id)).to eq(1)
+      expect(MedicationTake.where(id: take.id)).not_to exist
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  it 'uses the stable invalid-target contract' do
+    missing_id = Household.maximum(:id) + 10_000
+    set_context(household_id: missing_id, account_id: operator.id)
+
+    expect_contract('MT101', 'household purge target is invalid') { call_function(missing_id) }
+  end
+
+  it 'uses the stable invalid-lifecycle contract' do
+    household.update!(lifecycle_state: :offboarded)
+    set_context(household_id: household.id, account_id: operator.id)
+
+    expect_contract('MT102', 'household purge lifecycle is invalid') { call_function(household.id) }
+  end
+
+  it 'uses the stable active-hold contract' do
+    HouseholdRetentionHold.create!(
+      household: household,
+      approved_by_account: operator,
+      reason: 'Protected test reason',
+      review_on: 1.month.from_now.to_date,
+      placed_at: Time.current
+    )
+    set_context(household_id: household.id, account_id: operator.id)
+
+    expect_contract('MT103', 'household purge retention hold is active') { call_function(household.id) }
+  end
+
+  it 'uses the stable tenant-context contract' do
+    other_household = create(:household)
+    set_context(household_id: other_household.id, account_id: operator.id)
+
+    expect_contract('MT104', 'household purge tenant context does not match target') do
+      call_function(household.id)
+    end
+  end
+
+  it 'uses the stable operator-context contract' do
+    ordinary_account = Account.create!(
+      email: "purge-function-ordinary-#{SecureRandom.hex(4)}@example.test",
+      status: :verified
+    )
+    set_context(household_id: household.id, account_id: ordinary_account.id)
+
+    expect_contract('MT105', 'household purge operator context is invalid') { call_function(household.id) }
+  end
+
+  it 'restores transaction-local tenant and operator settings after success' do
+    set_context(household_id: household.id, account_id: operator.id)
+
+    call_function(household.id)
+
+    expect(current_context).to eq([household.id.to_s, operator.id.to_s])
+  end
+
+  it 'restores transaction-local tenant and operator settings after failure' do
+    household.update!(lifecycle_state: :offboarded)
+    set_context(household_id: household.id, account_id: operator.id)
+    connection.execute(<<~SQL.squish)
+      DO $purge_context$
+      BEGIN
+        PERFORM med_tracker.purge_medication_takes(#{household.id});
+      EXCEPTION
+        WHEN SQLSTATE 'MT102' THEN NULL;
+      END
+      $purge_context$;
+    SQL
+
+    expect(current_context).to eq([household.id.to_s, operator.id.to_s])
+  end
+
+  def call_function(household_id)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ['SELECT med_tracker.purge_medication_takes(?)', household_id]
+      )
+    ).to_i
+  end
+
+  def create_take(target_household)
+    person = create(:person, household: target_household)
+    medication = create(:medication, household: target_household)
+    schedule = create(
+      :schedule,
+      household: target_household,
+      person: person,
+      medication: medication
+    )
+    create(:medication_take, :for_schedule, household: target_household, schedule: schedule)
+  end
+
+  def set_context(household_id:, account_id:)
+    connection.execute("SELECT set_config('med_tracker.current_household_id', '#{household_id}', true)")
+    connection.execute("SELECT set_config('med_tracker.current_account_id', '#{account_id}', true)")
+  end
+
+  def current_context
+    connection.select_rows(<<~SQL.squish).sole
+      SELECT current_setting('med_tracker.current_household_id', true),
+             current_setting('med_tracker.current_account_id', true)
+    SQL
+  end
+
+  def expect_contract(sqlstate, message, &)
+    error = database_error(&)
+
+    expect(error.cause.result.error_field(PG::Result::PG_DIAG_SQLSTATE)).to eq(sqlstate)
+    expect(error.cause.message).to include(message)
+  end
+
+  def database_error(&)
+    captured_error = nil
+    expect do
+      connection.transaction(requires_new: true, &)
+    end.to raise_error(ActiveRecord::StatementInvalid) { |exception| captured_error = exception }
+
+    captured_error
+  end
+end

--- a/spec/migrations/create_household_medication_take_purge_function_spec.rb
+++ b/spec/migrations/create_household_medication_take_purge_function_spec.rb
@@ -134,12 +134,27 @@ RSpec.describe CreateHouseholdMedicationTakePurgeFunction do
     end
   end
 
+  it 'uses the stable tenant-context contract for an oversized numeric setting' do
+    set_context(household_id: '9' * 100, account_id: operator.id)
+
+    expect_contract('MT104', 'household purge tenant context does not match target') do
+      call_function(household.id)
+    end
+  end
+
   it 'uses the stable operator-context contract' do
     ordinary_account = Account.create!(
       email: "purge-function-ordinary-#{SecureRandom.hex(4)}@example.test",
       status: :verified
     )
     set_context(household_id: household.id, account_id: ordinary_account.id)
+
+    expect_contract('MT105', 'household purge operator context is invalid') { call_function(household.id) }
+  end
+
+  it 'uses the stable operator-context contract for an oversized numeric setting' do
+    operator
+    set_context(household_id: household.id, account_id: '9' * 100)
 
     expect_contract('MT105', 'household purge operator context is invalid') { call_function(household.id) }
   end

--- a/spec/migrations/create_household_medication_take_purge_function_spec.rb
+++ b/spec/migrations/create_household_medication_take_purge_function_spec.rb
@@ -17,15 +17,23 @@ RSpec.describe CreateHouseholdMedicationTakePurgeFunction do
     household.update!(status: :archived, lifecycle_state: :purging, offboarded_at: Time.current)
   end
 
-  it 'installs the fixed-path security definer owned by the database owner' do
+  it 'installs the fixed-path security definer owned by the migration login' do
+    reinstall_function_as_migration_login
+
     expect(function_contract).to include(
       'prosecdef' => true,
       'proconfig' => 'search_path=pg_catalog',
       'lanname' => 'plpgsql',
-      'owner' => 'med_tracker_owner',
+      'owner' => connection.select_value('SELECT current_user'),
       'result_type' => 'bigint'
     )
     expect(function_contract.fetch('definition')).to include('public.households', 'public.medication_takes')
+  end
+
+  def reinstall_function_as_migration_login
+    migration = described_class.new
+    migration.migrate(:down)
+    migration.migrate(:up)
   end
 
   def function_contract

--- a/spec/services/households/lifecycle_cutoff_lock_spec.rb
+++ b/spec/services/households/lifecycle_cutoff_lock_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Households::LifecycleCutoffLock do
+  it 'uses the established household purge namespace' do
+    connection = instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+    allow(connection).to receive(:select_value).and_return(1, true)
+
+    described_class.with(household_id: 41) { nil }
+
+    expect(connection).to have_received(:select_value).with(include('med_tracker.household_purge:41')).twice
+  end
+
+  it 'releases the cutoff lock when the protected operation raises' do
+    connection = instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+    allow(connection).to receive(:select_value).and_return(1, true)
+
+    expect do
+      described_class.with(household_id: 42) { raise 'cutoff failure' }
+    end.to raise_error('cutoff failure')
+
+    expect(connection).to have_received(:select_value).with(include('pg_advisory_unlock')).once
+  end
+
+  it 'balances nested same-household acquisitions when the inner operation raises' do
+    connection = instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+    allow(connection).to receive(:select_value).and_return(1, true)
+
+    expect do
+      described_class.with(household_id: 43) do
+        described_class.with(household_id: 43) { raise 'nested cutoff failure' }
+      end
+    end.to raise_error('nested cutoff failure')
+
+    expect(connection).to have_received(:select_value).with(include('pg_advisory_lock')).twice
+    expect(connection).to have_received(:select_value).with(include('pg_advisory_unlock')).twice
+  end
+
+  it 'does not make an unrelated household wait for the held household key' do
+    first_key = 'med_tracker.household_purge:51'
+    second_key = 'med_tracker.household_purge:52'
+    first_connection, second_connection = pg_connections
+
+    first_connection.exec_params(acquire_sql, [first_key])
+
+    expect(second_connection.backend_pid).not_to eq(first_connection.backend_pid)
+    expect(try_lock?(second_connection, second_key)).to be(true)
+    expect(try_lock?(second_connection, first_key)).to be(false)
+  ensure
+    second_connection&.exec_params(unlock_sql, [second_key])
+    first_connection&.exec_params(unlock_sql, [first_key])
+    second_connection&.close
+    first_connection&.close
+  end
+
+  def acquire_sql
+    'WITH lock_acquired AS MATERIALIZED (' \
+      'SELECT pg_advisory_lock(hashtextextended($1, 0))' \
+      ') SELECT 1 FROM lock_acquired'
+  end
+
+  def try_lock_sql
+    'SELECT pg_try_advisory_lock(hashtextextended($1, 0))'
+  end
+
+  def unlock_sql
+    'SELECT pg_advisory_unlock(hashtextextended($1, 0))'
+  end
+
+  def pg_connections
+    parameters = ActiveRecord::Base.connection.raw_connection.conninfo_hash.compact_blank
+    [PG.connect(parameters), PG.connect(parameters)]
+  end
+
+  def try_lock?(connection, lock_key)
+    connection.exec_params(try_lock_sql, [lock_key]).getvalue(0, 0) == 't'
+  end
+end

--- a/spec/services/households/lifecycle_cutoff_lock_with_spec.rb
+++ b/spec/services/households/lifecycle_cutoff_lock_with_spec.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'timeout'
+
+RSpec.describe Households::LifecycleCutoffLock, '.with' do
+  self.use_transactional_tests = false
+
+  let(:workers) { [] }
+  let(:records) { PaperTrail.request(enabled: false) { concurrency_records } }
+
+  before do
+    allow(Audit::Event).to receive(:record!)
+    records
+  end
+
+  after do
+    terminate_workers
+    cleanup_records
+  end
+
+  it 'completes a dose inside the cutoff boundary before purging it' do
+    outcome = dose_first_outcome
+
+    expect(dose_first_state(outcome)).to eq(
+      dose_succeeded: true,
+      purge_completed: true,
+      take_exists: false,
+      household_purged: true
+    )
+  end
+
+  it 'blocks a dose behind purge cutoff without blocking an unrelated household' do
+    outcome = purge_first_outcome
+
+    expect(purge_first_state(outcome)).to eq(
+      unrelated_dose_succeeded: true,
+      unrelated_take_exists: true,
+      purge_completed: true,
+      target_error: :household_unavailable,
+      target_take_exists: false,
+      target_stock_mutated: false
+    )
+  end
+
+  def dose_first_outcome
+    dose_state = start_paused_dose
+    purge_worker = start_blocked_purge
+    dose_state.fetch(:release) << true
+
+    {
+      dose_result: join_worker(dose_state.fetch(:worker)),
+      purge_run: join_worker(purge_worker)
+    }
+  end
+
+  def start_paused_dose
+    inside_dose = Queue.new
+    release_dose = Queue.new
+    dose_service = paused_dose_service(inside_dose, release_dose)
+    dose_worker = worker { record_dose(records.fetch(:target), service: dose_service) }
+    wait_for(inside_dose, 'dose cutoff acquisition')
+    { worker: dose_worker, release: release_dose }
+  end
+
+  def start_blocked_purge
+    purge_pid = Queue.new
+    purge_worker = worker_with_pid(purge_pid) { purge_target(records) }
+    wait_for_advisory_wait(wait_for(purge_pid, 'purge database session'))
+    purge_worker
+  end
+
+  def paused_dose_service(inside_dose, release_dose)
+    MedicationAdministration::RecordDose.new.tap do |service|
+      original_record_dose = service.method(:record_dose)
+      allow(service).to receive(:record_dose) do |**arguments|
+        inside_dose << true
+        wait_for(release_dose, 'dose release')
+        original_record_dose.call(**arguments)
+      end
+    end
+  end
+
+  def dose_first_state(outcome)
+    dose_result = outcome.fetch(:dose_result)
+    {
+      dose_succeeded: dose_result.success,
+      purge_completed: outcome.fetch(:purge_run).completed?,
+      take_exists: MedicationTake.exists?(id: dose_result.take.id),
+      household_purged: Household.find(records.dig(:target, :household_id)).purged?
+    }
+  end
+
+  def purge_first_outcome
+    purge_state = start_paused_purge
+    target_dose_worker = start_blocked_target_dose
+    unrelated_dose_worker = worker { record_dose(records.fetch(:unrelated)) }
+    unrelated_result = join_worker(unrelated_dose_worker)
+    purge_state.fetch(:release) << true
+
+    purge_first_results(unrelated_result, purge_state, target_dose_worker)
+  end
+
+  def start_paused_purge
+    inside_purge = Queue.new
+    release_purge = Queue.new
+    target_stock_mutations = Queue.new
+    pause_purge(inside_purge, release_purge)
+    track_target_stock_mutations(target_stock_mutations)
+    purge_worker = worker { purge_target(records) }
+    wait_for(inside_purge, 'purge cutoff acquisition')
+    { worker: purge_worker, release: release_purge, stock_mutations: target_stock_mutations }
+  end
+
+  def start_blocked_target_dose
+    dose_pid = Queue.new
+    target_dose_worker = worker_with_pid(dose_pid) { record_dose(records.fetch(:target)) }
+    wait_for_advisory_wait(wait_for(dose_pid, 'dose database session'))
+    target_dose_worker
+  end
+
+  def purge_first_results(unrelated_result, purge_state, target_dose_worker)
+    {
+      unrelated_result: unrelated_result,
+      purge_run: join_worker(purge_state.fetch(:worker)),
+      target_result: join_worker(target_dose_worker),
+      target_stock_mutations: purge_state.fetch(:stock_mutations)
+    }
+  end
+
+  def pause_purge(inside_purge, release_purge)
+    original_execute_purge = Households::Purger.method(:execute_purge!)
+    allow(Households::Purger).to receive(:execute_purge!) do |*arguments|
+      inside_purge << true
+      wait_for(release_purge, 'purge release')
+      original_execute_purge.call(*arguments)
+    end
+  end
+
+  def track_target_stock_mutations(target_stock_mutations)
+    allow(MedicationTakeStockDecrement).to receive(:new).and_wrap_original do |original, take|
+      target_stock_mutations << take.id if take.household_id == records.dig(:target, :household_id)
+      original.call(take)
+    end
+  end
+
+  def purge_first_state(outcome)
+    unrelated_result = outcome.fetch(:unrelated_result)
+    {
+      unrelated_dose_succeeded: unrelated_result.success,
+      unrelated_take_exists: MedicationTake.exists?(id: unrelated_result.take.id),
+      purge_completed: outcome.fetch(:purge_run).completed?,
+      target_error: outcome.fetch(:target_result).error,
+      target_take_exists: MedicationTake.exists?(schedule_id: records.dig(:target, :schedule_id)),
+      target_stock_mutated: !outcome.fetch(:target_stock_mutations).empty?
+    }
+  end
+
+  def concurrency_records
+    token = SecureRandom.hex(6)
+    operator = Account.create!(email: "purge-concurrency-#{token}@example.test", status: :verified)
+    PlatformAdmin.create!(account: operator)
+    target_household = create(:household, name: "Purge Concurrency #{token}", slug: "purge-concurrency-#{token}")
+    unrelated_household = create(
+      :household,
+      name: "Unrelated Purge Concurrency #{token}",
+      slug: "unrelated-purge-concurrency-#{token}"
+    )
+
+    {
+      operator_id: operator.id,
+      target: dose_records(target_household, "target-#{token}"),
+      unrelated: dose_records(unrelated_household, "unrelated-#{token}")
+    }
+  end
+
+  def dose_records(household, token)
+    person = create(:person, household: household)
+    medication = create(:medication, household: household, current_supply: 10, supply_at_last_restock: 10)
+    schedule = create(:schedule, household: household, person: person, medication: medication)
+    user = User.create!(
+      person: person,
+      email_address: "#{token}@example.test",
+      password: 'password'
+    )
+    {
+      household_id: household.id,
+      schedule_id: schedule.id,
+      medication_id: medication.id,
+      user_id: user.id,
+      user_email: user.email_address
+    }
+  end
+
+  def worker(&)
+    thread = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        PaperTrail.request(enabled: false, &)
+      end
+    rescue StandardError => e
+      e
+    end
+    workers << thread
+    thread
+  end
+
+  def worker_with_pid(pid_queue, &)
+    worker do
+      pid_queue << ActiveRecord::Base.connection.select_value('SELECT pg_backend_pid()').to_i
+      yield
+    end
+  end
+
+  def join_worker(worker)
+    raise Timeout::Error, 'timed out waiting for concurrency worker' unless worker.join(thread_timeout)
+
+    worker.value.tap { raise it if it.is_a?(StandardError) }
+  end
+
+  def wait_for(queue, description)
+    Timeout.timeout(thread_timeout) { queue.pop }
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for #{description}"
+  end
+
+  def wait_for_advisory_wait(pid)
+    Timeout.timeout(thread_timeout) do
+      loop do
+        return if advisory_waiting?(pid)
+
+        Thread.pass
+      end
+    end
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for database session #{pid} to block on the cutoff lock"
+  end
+
+  def advisory_waiting?(pid)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = ? AND locktype = 'advisory' AND NOT granted)", pid]
+      )
+    )
+  end
+
+  def record_dose(records, service: MedicationAdministration::RecordDose.new)
+    service.call(
+      source: Schedule.find(records.fetch(:schedule_id)),
+      amount_override: nil,
+      taken_from_medication_id: records.fetch(:medication_id),
+      user: User.find(records.fetch(:user_id))
+    )
+  end
+
+  def purge_target(test_records)
+    Households::Purger.call(
+      household: Household.find(test_records.dig(:target, :household_id)),
+      actor_account: Account.find(test_records.fetch(:operator_id))
+    )
+  end
+
+  def cleanup_records
+    household_ids = record_household_ids
+    User.where(email_address: record_user_emails).delete_all
+    HouseholdPurgeRun.where(household_id: household_ids).delete_all
+    delete_global_dependencies(household_ids)
+    delete_household_inventory(household_ids)
+    Household.where(id: household_ids).delete_all
+    cleanup_operator
+  end
+
+  def cleanup_operator
+    operator_id = records.fetch(:operator_id)
+    PlatformAdmin.where(account_id: operator_id).delete_all
+    Account.where(id: operator_id).delete_all
+  end
+
+  def terminate_workers
+    workers.each do |worker|
+      worker.kill if worker.alive?
+      worker.join(1)
+    end
+  end
+
+  def record_household_ids
+    [records.dig(:target, :household_id), records.dig(:unrelated, :household_id)]
+  end
+
+  def record_user_emails
+    [records.dig(:target, :user_email), records.dig(:unrelated, :user_email)]
+  end
+
+  def delete_household_inventory(household_ids)
+    (Households::Purger::PURGE_ORDER + %w[household_memberships people]).each do |table_name|
+      delete_household_rows(table_name, household_ids)
+    end
+  end
+
+  def delete_global_dependencies(household_ids)
+    membership_ids = HouseholdMembership.where(household_id: household_ids).pluck(:id)
+    [ApiSession, ApiAppToken, OauthGrant].each do |model|
+      model.where(household_membership_id: membership_ids).delete_all
+    end
+  end
+
+  def delete_household_rows(table_name, household_ids)
+    connection = ActiveRecord::Base.connection
+    connection.exec_delete(
+      "DELETE FROM #{connection.quote_table_name(table_name)} " \
+      "WHERE household_id IN (#{household_ids.map { connection.quote(it) }.join(', ')})"
+    )
+  end
+
+  def thread_timeout = 10
+end

--- a/spec/services/households/purger_spec.rb
+++ b/spec/services/households/purger_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe Households::Purger do
     expect(household.reload).to be_purged
   end
 
+  it 'does not create a pending purge run when a household is already purged' do
+    household.update!(status: :archived, lifecycle_state: :purged, offboarded_at: Time.current)
+
+    expect do
+      described_class.call(household: household, actor_account: operator)
+    end.to raise_error(/already purged/)
+
+    expect(HouseholdPurgeRun.where(household: household)).to be_empty
+  end
+
+  it 'returns the completed purge run when the purge is repeated' do
+    completed_run = described_class.call(household: household, actor_account: operator)
+
+    expect(described_class.call(household: household, actor_account: operator)).to eq(completed_run)
+    expect(HouseholdPurgeRun.where(household: household).count).to eq(1)
+  end
+
   it 'ends active support access before purging the household' do
     support_session = SupportAccessSession.create!(
       platform_admin: operator.platform_admin,

--- a/spec/services/households/purger_spec.rb
+++ b/spec/services/households/purger_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe Households::Purger do
     end.to raise_error(Pundit::NotAuthorizedError)
   end
 
+  it 'rejects an incomplete purge run for a household already marked purged' do
+    household.update!(status: :archived, lifecycle_state: :purged, offboarded_at: Time.current)
+    HouseholdPurgeRun.create!(
+      household: household,
+      requested_by_account: operator,
+      status: :failed,
+      attempts: 1
+    )
+
+    expect do
+      described_class.call(household: household, actor_account: operator)
+    end.to raise_error(/already purged/)
+
+    expect(household.reload).to be_purged
+  end
+
   it 'ends active support access before purging the household' do
     support_session = SupportAccessSession.create!(
       platform_admin: operator.platform_admin,
@@ -47,6 +63,34 @@ RSpec.describe Households::Purger do
     end.to change { support_session.reload.ended_at }.from(nil)
 
     expect(household.reload).to be_lifecycle_purged
+  end
+
+  it 'preserves a completed dose before cutoff and removes it during purge' do
+    result = record_dose_before_purge
+
+    expect(result.success).to be(true)
+    expect { described_class.call(household: household, actor_account: operator) }
+      .to change { MedicationTake.exists?(id: result.take.id) }
+      .from(true)
+      .to(false)
+    expect(household.reload).to be_purged
+  end
+
+  def record_dose_before_purge
+    person = create(:person, household: household)
+    medication = create(:medication, household: household)
+    schedule = create(:schedule, household: household, person: person, medication: medication)
+    user = User.create!(
+      person: person,
+      email_address: "purge-dose-first-#{SecureRandom.hex(4)}@example.test",
+      password: 'password'
+    )
+    MedicationAdministration::RecordDose.new.call(
+      source: schedule,
+      amount_override: nil,
+      taken_from_medication_id: medication.id,
+      user: user
+    )
   end
 
   it 'preserves a shared login identity while invalidating prior API credentials under forced RLS',
@@ -206,7 +250,7 @@ RSpec.describe Households::Purger do
 
   def verify_purge_tombstone(run)
     expect(purge_tombstone.metadata).to eq(
-      'attempts' => 1,
+      'attempt_number' => 1,
       'household_id' => household.id,
       'last_completed_table' => 'people',
       'outcome' => 'success',
@@ -222,6 +266,37 @@ RSpec.describe Households::Purger do
     failed_run = verify_partial_progress(records)
     described_class.call(household:, actor_account: operator)
     verify_completed_purge(failed_run, records)
+  end
+
+  it 'appends initiated, cutoff, and failed evidence for an interrupted first attempt' do
+    expect do
+      interrupt_first_attempt
+    end.to raise_error('audit sequence interruption')
+
+    expect(failed_first_attempt_event_types).to eq(%w[
+                                                     household.purge.initiated
+                                                     household.purge.cutoff
+                                                     household.purge.failed
+                                                   ])
+  end
+
+  def interrupt_first_attempt
+    callback = lambda do |table_name|
+      raise 'audit sequence interruption' if table_name == 'medication_takes'
+    end
+    described_class.call(household: household, actor_account: operator, after_table: callback)
+  end
+
+  def failed_first_attempt_event_types
+    SecurityAuditEvent.where(household: household)
+                      .where(event_type: %w[
+                               household.purge.initiated
+                               household.purge.cutoff
+                               household.purge.failed
+                               household.purge.completed
+                             ])
+                      .order(:id)
+                      .pluck(:event_type)
   end
 
   def purge_records
@@ -286,9 +361,26 @@ RSpec.describe Households::Purger do
   end
 
   def verify_purge_evidence
+    expect_completion_evidence
+    expect_purge_attempt_sequence
+    expect_purge_metadata_allowlist
+  end
+
+  def expect_completion_evidence
     expect(SecurityAuditEvent.where(household: household)).to exist
     expect(SecurityAuditEvent.where(household: household, event_type: 'household.purge.completed').count).to eq(1)
     expect(ledger_events('household.purge.completed')).to exist
+  end
+
+  def expect_purge_attempt_sequence
+    expect(purge_event_types).to eq(%w[
+                                      household.purge.initiated
+                                      household.purge.cutoff
+                                      household.purge.failed
+                                      household.purge.retry_started
+                                      household.purge.completed
+                                    ])
+    expect(SecurityAuditEvent.where(household: household, event_type: 'household.purge.cutoff').count).to eq(1)
   end
 
   def verify_completed_state(failed_run)
@@ -321,6 +413,24 @@ RSpec.describe Households::Purger do
 
   def purge_tombstone
     SecurityAuditEvent.where(household: household, event_type: 'household.purge.completed').sole
+  end
+
+  def purge_event_types
+    SecurityAuditEvent.where(household: household)
+                      .where("event_type LIKE 'household.purge.%'")
+                      .order(:id)
+                      .pluck(:event_type)
+  end
+
+  def expect_purge_metadata_allowlist
+    allowed_keys = %w[
+      purge_run_id household_id attempt_number last_completed_table outcome exception_class failure_code
+    ]
+    SecurityAuditEvent.where(household: household)
+                      .where("event_type LIKE 'household.purge.%'")
+                      .find_each do |event|
+      expect(event.metadata.keys - allowed_keys).to be_empty
+    end
   end
 
   def with_runtime_role

--- a/spec/services/households/retention_hold_manager_spec.rb
+++ b/spec/services/households/retention_hold_manager_spec.rb
@@ -23,11 +23,14 @@ RSpec.describe Households::RetentionHoldManager do
 
   describe Households::RetentionHoldManager do
     it 'places and releases an audited hold while changing household availability', :aggregate_failures do
+      allow(Households::LifecycleCutoffLock).to receive(:with).and_call_original
       hold = place_hold('Regulatory preservation request')
       expect(hold).to be_active
       verify_placed_hold(hold)
       described_class.release!(hold: hold, actor_account: operator)
       verify_released_hold(hold)
+      expect(Households::LifecycleCutoffLock).to have_received(:with).with(household: household)
+      expect(Households::LifecycleCutoffLock).to have_received(:with).with(household_id: household.id)
     end
 
     def place_hold(reason)
@@ -90,6 +93,15 @@ RSpec.describe Households::RetentionHoldManager do
   end
 
   describe Households::Offboarder do
+    it 'holds the lifecycle cutoff lock around standalone offboarding' do
+      allow(Households::LifecycleCutoffLock).to receive(:with).and_call_original
+
+      described_class.call(household: household, actor_account: operator)
+
+      expect(Households::LifecycleCutoffLock).to have_received(:with).with(household: household)
+      expect(household.reload).to be_offboarded
+    end
+
     it 'atomically disables access and revokes every hosted credential and device surface', :aggregate_failures do
       records = offboarding_records
       other_records = preserved_household_records

--- a/spec/services/medication_administration/record_dose_spec.rb
+++ b/spec/services/medication_administration/record_dose_spec.rb
@@ -510,6 +510,25 @@ RSpec.describe MedicationAdministration::RecordDose do
     end
   end
 
+  describe 'household lifecycle cutoff' do
+    let(:schedule) { schedules(:john_paracetamol) }
+
+    before { travel_to Time.current.end_of_day - 1.minute }
+
+    it 'rejects a dose after purge cutoff without changing take history or stock' do
+      household = schedule.household
+      household.update!(status: :archived, lifecycle_state: :purging, offboarded_at: Time.current)
+      original_supply = schedule.medication.current_supply
+
+      expect do
+        result = call_service(source: schedule)
+        expect(result.error).to eq(:household_unavailable)
+      end.not_to change(MedicationTake, :count)
+
+      expect(schedule.medication.reload.current_supply).to eq(original_supply)
+    end
+  end
+
   describe 'medication take events' do
     def expect_metric_payload(payloads, source:, error: nil)
       expect(payloads).to contain_exactly(


### PR DESCRIPTION
## Summary

- add a narrowly validated database boundary that lets the existing application role delete medication takes only for an authorized household purge
- serialize purge, offboarding, retention holds, and dose recording at one household lifecycle cutoff so no dose or stock mutation can cross the purge boundary
- append non-PHI initiated, cutoff, retry, failed, and completed evidence while preserving durable purge resume behavior and immutable audit history

This keeps the shared-login deployment model intact and does not add credential isolation or a general medication-history bypass.

Closes #1692