### PR TITLE
fix(audit): repair incomplete ledger upgrades

### DIFF
--- a/app/services/audit/entry_filter.rb
+++ b/app/services/audit/entry_filter.rb
@@ -21,6 +21,10 @@ module Audit
       value?('FROM') || value?('TO')
     end
 
+    def household_id
+      integer_filter('HOUSEHOLD_ID') if value?('HOUSEHOLD_ID')
+    end
+
     private
 
     attr_reader :environment, :relation

--- a/app/services/audit/verification/command.rb
+++ b/app/services/audit/verification/command.rb
@@ -35,6 +35,8 @@ module Audit
       def verification_result
         raise ConfigurationError, "unsupported scope: #{scope}" unless SCOPES.include?(scope)
 
+        validate_filter_compatibility!
+
         case scope
         when 'database' then resolved_database_verifier.call
         when 'worm' then resolved_worm_verifier.call
@@ -44,7 +46,7 @@ module Audit
 
       def resolved_database_verifier
         database_verifier || DatabaseVerifier.new(entries: entry_filter.call,
-                                                  verify_heads: !entry_filter.time_filtered?)
+                                                  household_id: entry_filter.household_id)
       end
 
       def resolved_worm_verifier
@@ -57,6 +59,12 @@ module Audit
 
       def scope
         @scope ||= environment.fetch('SCOPE', 'database').downcase
+      end
+
+      def validate_filter_compatibility!
+        return if scope == 'worm' || !entry_filter.time_filtered?
+
+        raise ConfigurationError, 'time filters are unsupported for database verification'
       end
 
       def combine(database_result, worm_result)

--- a/app/services/audit/verification/database_authority.rb
+++ b/app/services/audit/verification/database_authority.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class DatabaseAuthority
+      REQUIRED_SELECT_TABLES = %w[
+        audit_chain_heads audit_ledger_entries audit_signing_keys audit_checkpoints security_audit_events versions
+      ].freeze
+      VERIFIER_ROLE = 'med_tracker_audit_verifier'
+      VERIFIER_POLICY = 'audit_verifier_complete_visibility'
+
+      def initialize(connection: ActiveRecord::Base.connection)
+        @connection = connection
+      end
+
+      def verify!
+        raise ConfigurationError, "database verification requires #{VERIFIER_ROLE}" unless current_user == VERIFIER_ROLE
+        raise ConfigurationError, 'database verifier role has unsafe row-security authority' unless verifier_role_safe?
+
+        missing_tables = REQUIRED_SELECT_TABLES.reject { |table_name| select_privilege?(table_name) }
+        if missing_tables.any?
+          raise ConfigurationError, "database verifier lacks required SELECT privilege: #{missing_tables.join(', ')}"
+        end
+        return if complete_visibility_policy?
+
+        raise ConfigurationError, 'database verifier complete RLS policy is missing or invalid'
+      end
+
+      private
+
+      attr_reader :connection
+
+      def current_user
+        connection.select_value('SELECT current_user')
+      end
+
+      def verifier_role_safe?
+        connection.select_value(<<~SQL.squish)
+          SELECT NOT rolsuper AND NOT rolbypassrls
+          FROM pg_roles
+          WHERE rolname = current_user
+        SQL
+      end
+
+      def select_privilege?(table_name)
+        connection.select_value(<<~SQL.squish)
+          SELECT has_table_privilege(current_user, #{connection.quote(table_name)}, 'SELECT')
+        SQL
+      end
+
+      def complete_visibility_policy?
+        connection.select_value(<<~SQL.squish)
+          SELECT relations.relrowsecurity AND relations.relforcerowsecurity AND COUNT(policies.*) = 1
+          FROM pg_class relations
+          LEFT JOIN pg_policies policies
+            ON policies.schemaname = 'public'
+            AND policies.tablename = relations.relname
+            AND policies.policyname = #{connection.quote(VERIFIER_POLICY)}
+            AND policies.permissive = 'PERMISSIVE'
+            AND policies.roles = ARRAY[#{connection.quote(VERIFIER_ROLE)}]::name[]
+            AND policies.cmd = 'SELECT'
+            AND policies.qual = 'true'
+            AND policies.with_check IS NULL
+          WHERE relations.oid = 'security_audit_events'::regclass
+          GROUP BY relations.relrowsecurity, relations.relforcerowsecurity
+        SQL
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/database_authority.rb
+++ b/app/services/audit/verification/database_authority.rb
@@ -63,11 +63,15 @@ module Audit
       end
 
       def verify_forbidden_role_memberships!
-        memberships = connection.select_values(<<~SQL.squish)
-          SELECT role_name
-          FROM unnest(ARRAY[#{quoted_list(FORBIDDEN_ROLES)}]::text[]) AS forbidden(role_name)
-          WHERE pg_has_role(current_user, role_name, 'MEMBER')
-        SQL
+        memberships = connection.select_values(
+          <<~SQL.squish,
+            SELECT role_name
+            FROM jsonb_array_elements_text($1::jsonb) AS forbidden(role_name)
+            WHERE pg_has_role(current_user, role_name, 'MEMBER')
+          SQL
+          'Audit forbidden role memberships',
+          [text_array_bind('forbidden_roles', FORBIDDEN_ROLES)]
+        )
         return if memberships.empty?
 
         raise ConfigurationError, "database verifier has forbidden role membership: #{memberships.join(', ')}"
@@ -83,46 +87,61 @@ module Audit
       end
 
       def table_mutation_privileges
-        connection.select_values(<<~SQL.squish)
-          SELECT DISTINCT relations.relname || ':' || privileges.name
-          FROM pg_class relations
-          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-          CROSS JOIN unnest(ARRAY[#{quoted_list(MUTATION_PRIVILEGES)}]::text[]) AS privileges(name)
-          WHERE namespaces.nspname = 'public'
-            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES)})
-            AND has_table_privilege(current_user, relations.oid, privileges.name)
-          ORDER BY 1
-        SQL
+        connection.select_values(
+          <<~SQL.squish,
+            SELECT DISTINCT relations.relname || ':' || privileges.name
+            FROM pg_class relations
+            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+            CROSS JOIN jsonb_array_elements_text($1::jsonb) AS privileges(name)
+            WHERE namespaces.nspname = 'public'
+              AND relations.relname IN (SELECT jsonb_array_elements_text($2::jsonb))
+              AND has_table_privilege(current_user, relations.oid, privileges.name)
+            ORDER BY 1
+          SQL
+          'Audit table mutation privileges',
+          text_array_binds(mutation_privileges: MUTATION_PRIVILEGES, approved_tables: APPROVED_SELECT_TABLES)
+        )
       end
 
       def column_mutation_privileges
-        connection.select_values(<<~SQL.squish)
-          SELECT DISTINCT relations.relname || ':column-' || privileges.name
-          FROM pg_class relations
-          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-          CROSS JOIN unnest(ARRAY[#{quoted_list(COLUMN_MUTATION_PRIVILEGES)}]::text[]) AS privileges(name)
-          WHERE namespaces.nspname = 'public'
-            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES)})
-            AND has_any_column_privilege(current_user, relations.oid, privileges.name)
-            AND NOT has_table_privilege(current_user, relations.oid, privileges.name)
-          ORDER BY 1
-        SQL
+        connection.select_values(
+          <<~SQL.squish,
+            SELECT DISTINCT relations.relname || ':column-' || privileges.name
+            FROM pg_class relations
+            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+            CROSS JOIN jsonb_array_elements_text($1::jsonb) AS privileges(name)
+            WHERE namespaces.nspname = 'public'
+              AND relations.relname IN (SELECT jsonb_array_elements_text($2::jsonb))
+              AND has_any_column_privilege(current_user, relations.oid, privileges.name)
+              AND NOT has_table_privilege(current_user, relations.oid, privileges.name)
+            ORDER BY 1
+          SQL
+          'Audit column mutation privileges',
+          text_array_binds(
+            column_mutation_privileges: COLUMN_MUTATION_PRIVILEGES,
+            approved_tables: APPROVED_SELECT_TABLES
+          )
+        )
       end
 
       def sequence_mutation_privileges
-        connection.select_values(<<~SQL.squish)
-          SELECT relations.relname || ':sequence-mutation'
-          FROM pg_class relations
-          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-          WHERE namespaces.nspname = 'public'
-            AND relations.relkind = 'S'
-            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES.map { |name| "#{name}_id_seq" })})
-            AND (
-              has_sequence_privilege(current_user, relations.oid, 'USAGE')
-              OR has_sequence_privilege(current_user, relations.oid, 'UPDATE')
-            )
-          ORDER BY 1
-        SQL
+        connection.select_values(
+          <<~SQL.squish,
+            SELECT relations.relname || ':sequence-mutation'
+            FROM pg_class relations
+            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+            WHERE namespaces.nspname = 'public'
+              AND relations.relkind = 'S'
+              AND relations.relname IN (SELECT jsonb_array_elements_text($1::jsonb))
+              AND (
+                has_sequence_privilege(current_user, relations.oid, 'USAGE')
+                OR has_sequence_privilege(current_user, relations.oid, 'UPDATE')
+              )
+            ORDER BY 1
+          SQL
+          'Audit sequence mutation privileges',
+          [text_array_bind('approved_sequences', APPROVED_SELECT_TABLES.map { |name| "#{name}_id_seq" })]
+        )
       end
 
       def audit_function_privileges
@@ -138,16 +157,20 @@ module Audit
       end
 
       def verify_unapproved_select_privileges!
-        tables = connection.select_values(<<~SQL.squish)
-          SELECT relations.relname
-          FROM pg_class relations
-          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-          WHERE namespaces.nspname = 'public'
-            AND relations.relkind IN ('r', 'p', 'v', 'm', 'f')
-            AND relations.relname NOT IN (#{quoted_list(APPROVED_SELECT_TABLES)})
-            AND has_any_column_privilege(current_user, relations.oid, 'SELECT')
-          ORDER BY relations.relname
-        SQL
+        tables = connection.select_values(
+          <<~SQL.squish,
+            SELECT relations.relname
+            FROM pg_class relations
+            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+            WHERE namespaces.nspname = 'public'
+              AND relations.relkind IN ('r', 'p', 'v', 'm', 'f')
+              AND relations.relname NOT IN (SELECT jsonb_array_elements_text($1::jsonb))
+              AND has_any_column_privilege(current_user, relations.oid, 'SELECT')
+            ORDER BY relations.relname
+          SQL
+          'Audit unapproved select privileges',
+          [text_array_bind('approved_tables', APPROVED_SELECT_TABLES)]
+        )
         return if tables.empty?
 
         raise ConfigurationError, "database verifier has unapproved SELECT privilege: #{tables.join(', ')}"
@@ -174,8 +197,12 @@ module Audit
         SQL
       end
 
-      def quoted_list(values)
-        values.map { |value| connection.quote(value) }.join(', ')
+      def text_array_binds(values_by_name)
+        values_by_name.map { |name, values| text_array_bind(name.to_s, values) }
+      end
+
+      def text_array_bind(name, values)
+        ActiveRecord::Relation::QueryAttribute.new(name, values.to_json, ActiveRecord::Type::String.new)
       end
     end
   end

--- a/app/services/audit/verification/database_authority.rb
+++ b/app/services/audit/verification/database_authority.rb
@@ -6,6 +6,10 @@ module Audit
       REQUIRED_SELECT_TABLES = %w[
         audit_chain_heads audit_ledger_entries audit_signing_keys audit_checkpoints security_audit_events versions
       ].freeze
+      APPROVED_SELECT_TABLES = (REQUIRED_SELECT_TABLES + %w[audit_export_deliveries]).freeze
+      FORBIDDEN_ROLES = %w[med_tracker_app med_tracker_owner med_tracker_audit_exporter].freeze
+      MUTATION_PRIVILEGES = %w[INSERT UPDATE DELETE TRUNCATE REFERENCES TRIGGER].freeze
+      COLUMN_MUTATION_PRIVILEGES = %w[INSERT UPDATE REFERENCES].freeze
       VERIFIER_ROLE = 'med_tracker_audit_verifier'
       VERIFIER_POLICY = 'audit_verifier_complete_visibility'
 
@@ -17,13 +21,20 @@ module Audit
         raise ConfigurationError, "database verification requires #{VERIFIER_ROLE}" unless current_user == VERIFIER_ROLE
         raise ConfigurationError, 'database verifier role has unsafe row-security authority' unless verifier_role_safe?
 
+        verify_forbidden_role_memberships!
+
         missing_tables = REQUIRED_SELECT_TABLES.reject { |table_name| select_privilege?(table_name) }
         if missing_tables.any?
           raise ConfigurationError, "database verifier lacks required SELECT privilege: #{missing_tables.join(', ')}"
         end
-        return if complete_visibility_policy?
 
-        raise ConfigurationError, 'database verifier complete RLS policy is missing or invalid'
+        verify_mutation_privileges!
+        verify_unapproved_select_privileges!
+        unless complete_visibility_policy?
+          raise ConfigurationError, 'database verifier complete RLS policy is missing or invalid'
+        end
+
+        verify_competing_visibility_policies!
       end
 
       private
@@ -48,6 +59,97 @@ module Audit
         SQL
       end
 
+      def verify_forbidden_role_memberships!
+        memberships = connection.select_values(<<~SQL.squish)
+          SELECT role_name
+          FROM unnest(ARRAY[#{quoted_list(FORBIDDEN_ROLES)}]::text[]) AS forbidden(role_name)
+          WHERE pg_has_role(current_user, role_name, 'MEMBER')
+        SQL
+        return if memberships.empty?
+
+        raise ConfigurationError, "database verifier has forbidden role membership: #{memberships.join(', ')}"
+      end
+
+      def verify_mutation_privileges!
+        privileges = table_mutation_privileges + column_mutation_privileges + sequence_mutation_privileges +
+                     audit_function_privileges
+        privileges = privileges.uniq.sort
+        return if privileges.empty?
+
+        raise ConfigurationError, "database verifier has effective audit mutation privilege: #{privileges.join(', ')}"
+      end
+
+      def table_mutation_privileges
+        connection.select_values(<<~SQL.squish)
+          SELECT DISTINCT relations.relname || ':' || privileges.name
+          FROM pg_class relations
+          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+          CROSS JOIN unnest(ARRAY[#{quoted_list(MUTATION_PRIVILEGES)}]::text[]) AS privileges(name)
+          WHERE namespaces.nspname = 'public'
+            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES)})
+            AND has_table_privilege(current_user, relations.oid, privileges.name)
+          ORDER BY 1
+        SQL
+      end
+
+      def column_mutation_privileges
+        connection.select_values(<<~SQL.squish)
+          SELECT DISTINCT relations.relname || ':column-' || privileges.name
+          FROM pg_class relations
+          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+          CROSS JOIN unnest(ARRAY[#{quoted_list(COLUMN_MUTATION_PRIVILEGES)}]::text[]) AS privileges(name)
+          WHERE namespaces.nspname = 'public'
+            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES)})
+            AND has_any_column_privilege(current_user, relations.oid, privileges.name)
+            AND NOT has_table_privilege(current_user, relations.oid, privileges.name)
+          ORDER BY 1
+        SQL
+      end
+
+      def sequence_mutation_privileges
+        connection.select_values(<<~SQL.squish)
+          SELECT relations.relname || ':sequence-mutation'
+          FROM pg_class relations
+          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+          WHERE namespaces.nspname = 'public'
+            AND relations.relkind = 'S'
+            AND relations.relname IN (#{quoted_list(APPROVED_SELECT_TABLES.map { |name| "#{name}_id_seq" })})
+            AND (
+              has_sequence_privilege(current_user, relations.oid, 'USAGE')
+              OR has_sequence_privilege(current_user, relations.oid, 'UPDATE')
+            )
+          ORDER BY 1
+        SQL
+      end
+
+      def audit_function_privileges
+        connection.select_values(<<~SQL.squish)
+          SELECT procedures.oid::regprocedure::text || ':execute'
+          FROM pg_proc procedures
+          JOIN pg_namespace namespaces ON namespaces.oid = procedures.pronamespace
+          WHERE namespaces.nspname = 'public'
+            AND procedures.proname LIKE 'audit_%'
+            AND has_function_privilege(current_user, procedures.oid, 'EXECUTE')
+          ORDER BY 1
+        SQL
+      end
+
+      def verify_unapproved_select_privileges!
+        tables = connection.select_values(<<~SQL.squish)
+          SELECT relations.relname
+          FROM pg_class relations
+          JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+          WHERE namespaces.nspname = 'public'
+            AND relations.relkind IN ('r', 'p', 'v', 'm', 'f')
+            AND relations.relname NOT IN (#{quoted_list(APPROVED_SELECT_TABLES)})
+            AND has_any_column_privilege(current_user, relations.oid, 'SELECT')
+          ORDER BY relations.relname
+        SQL
+        return if tables.empty?
+
+        raise ConfigurationError, "database verifier has unapproved SELECT privilege: #{tables.join(', ')}"
+      end
+
       def complete_visibility_policy?
         connection.select_value(<<~SQL.squish)
           SELECT relations.relrowsecurity AND relations.relforcerowsecurity AND COUNT(policies.*) = 1
@@ -64,6 +166,27 @@ module Audit
           WHERE relations.oid = 'security_audit_events'::regclass
           GROUP BY relations.relrowsecurity, relations.relforcerowsecurity
         SQL
+      end
+
+      def verify_competing_visibility_policies!
+        policies = connection.select_values(<<~SQL.squish)
+          SELECT policyname
+          FROM pg_policies
+          WHERE schemaname = 'public'
+            AND tablename = 'security_audit_events'
+            AND permissive = 'PERMISSIVE'
+            AND cmd IN ('SELECT', 'ALL')
+            AND qual = 'true'
+            AND roles <> ARRAY[#{connection.quote(VERIFIER_ROLE)}]::name[]
+          ORDER BY policyname
+        SQL
+        return if policies.empty?
+
+        raise ConfigurationError, "database verifier has competing unrestricted RLS policy: #{policies.join(', ')}"
+      end
+
+      def quoted_list(values)
+        values.map { |value| connection.quote(value) }.join(', ')
       end
     end
   end

--- a/app/services/audit/verification/database_authority.rb
+++ b/app/services/audit/verification/database_authority.rb
@@ -11,7 +11,14 @@ module Audit
       MUTATION_PRIVILEGES = %w[INSERT UPDATE DELETE TRUNCATE REFERENCES TRIGGER].freeze
       COLUMN_MUTATION_PRIVILEGES = %w[INSERT UPDATE REFERENCES].freeze
       VERIFIER_ROLE = 'med_tracker_audit_verifier'
-      VERIFIER_POLICY = 'audit_verifier_complete_visibility'
+      EXPECTED_SECURITY_EVENT_POLICIES = [
+        ['audit_verifier_complete_visibility', 'PERMISSIVE', '{med_tracker_audit_verifier}', 'SELECT', 'true', nil],
+        [
+          'household_tenant_isolation', 'PERMISSIVE', '{public}', 'ALL',
+          '(household_id = med_tracker.current_household_id())',
+          '(household_id = med_tracker.current_household_id())'
+        ]
+      ].freeze
 
       def initialize(connection: ActiveRecord::Base.connection)
         @connection = connection
@@ -30,11 +37,7 @@ module Audit
 
         verify_mutation_privileges!
         verify_unapproved_select_privileges!
-        unless complete_visibility_policy?
-          raise ConfigurationError, 'database verifier complete RLS policy is missing or invalid'
-        end
-
-        verify_competing_visibility_policies!
+        verify_security_event_policy_set!
       end
 
       private
@@ -150,39 +153,25 @@ module Audit
         raise ConfigurationError, "database verifier has unapproved SELECT privilege: #{tables.join(', ')}"
       end
 
-      def complete_visibility_policy?
-        connection.select_value(<<~SQL.squish)
-          SELECT relations.relrowsecurity AND relations.relforcerowsecurity AND COUNT(policies.*) = 1
-          FROM pg_class relations
-          LEFT JOIN pg_policies policies
-            ON policies.schemaname = 'public'
-            AND policies.tablename = relations.relname
-            AND policies.policyname = #{connection.quote(VERIFIER_POLICY)}
-            AND policies.permissive = 'PERMISSIVE'
-            AND policies.roles = ARRAY[#{connection.quote(VERIFIER_ROLE)}]::name[]
-            AND policies.cmd = 'SELECT'
-            AND policies.qual = 'true'
-            AND policies.with_check IS NULL
-          WHERE relations.oid = 'security_audit_events'::regclass
-          GROUP BY relations.relrowsecurity, relations.relforcerowsecurity
-        SQL
-      end
-
-      def verify_competing_visibility_policies!
-        policies = connection.select_values(<<~SQL.squish)
-          SELECT policyname
+      def verify_security_event_policy_set!
+        policy_rows = connection.select_rows(<<~SQL.squish)
+          SELECT policyname, permissive, roles::text, cmd, qual, with_check
           FROM pg_policies
           WHERE schemaname = 'public'
             AND tablename = 'security_audit_events'
-            AND permissive = 'PERMISSIVE'
-            AND cmd IN ('SELECT', 'ALL')
-            AND qual = 'true'
-            AND roles <> ARRAY[#{connection.quote(VERIFIER_ROLE)}]::name[]
           ORDER BY policyname
         SQL
-        return if policies.empty?
+        return if security_events_forced_rls? && policy_rows == EXPECTED_SECURITY_EVENT_POLICIES
 
-        raise ConfigurationError, "database verifier has competing unrestricted RLS policy: #{policies.join(', ')}"
+        raise ConfigurationError, 'database verifier security-event RLS policy set is invalid'
+      end
+
+      def security_events_forced_rls?
+        connection.select_value(<<~SQL.squish)
+          SELECT relrowsecurity AND relforcerowsecurity
+          FROM pg_class
+          WHERE oid = 'security_audit_events'::regclass
+        SQL
       end
 
       def quoted_list(values)

--- a/app/services/audit/verification/database_authority.rb
+++ b/app/services/audit/verification/database_authority.rb
@@ -19,6 +19,40 @@ module Audit
           '(household_id = med_tracker.current_household_id())'
         ]
       ].freeze
+      COLUMN_MUTATION_PRIVILEGES_SQL = <<~SQL.squish
+        SELECT DISTINCT relations.relname || ':column-' || privileges.name
+        FROM pg_class relations
+        JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+        CROSS JOIN jsonb_array_elements_text($1::jsonb) AS privileges(name)
+        WHERE namespaces.nspname = 'public'
+          AND relations.relname IN (SELECT jsonb_array_elements_text($2::jsonb))
+          AND has_any_column_privilege(current_user, relations.oid, privileges.name)
+          AND NOT has_table_privilege(current_user, relations.oid, privileges.name)
+        ORDER BY 1
+      SQL
+      SEQUENCE_MUTATION_PRIVILEGES_SQL = <<~SQL.squish
+        SELECT relations.relname || ':sequence-mutation'
+        FROM pg_class relations
+        JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+        WHERE namespaces.nspname = 'public'
+          AND relations.relkind = 'S'
+          AND relations.relname IN (SELECT jsonb_array_elements_text($1::jsonb))
+          AND (
+            has_sequence_privilege(current_user, relations.oid, 'USAGE')
+            OR has_sequence_privilege(current_user, relations.oid, 'UPDATE')
+          )
+        ORDER BY 1
+      SQL
+      UNAPPROVED_SELECT_PRIVILEGES_SQL = <<~SQL.squish
+        SELECT relations.relname
+        FROM pg_class relations
+        JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
+        WHERE namespaces.nspname = 'public'
+          AND relations.relkind IN ('r', 'p', 'v', 'm', 'f')
+          AND relations.relname NOT IN (SELECT jsonb_array_elements_text($1::jsonb))
+          AND has_any_column_privilege(current_user, relations.oid, 'SELECT')
+        ORDER BY relations.relname
+      SQL
 
       def initialize(connection: ActiveRecord::Base.connection)
         @connection = connection
@@ -105,17 +139,7 @@ module Audit
 
       def column_mutation_privileges
         connection.select_values(
-          <<~SQL.squish,
-            SELECT DISTINCT relations.relname || ':column-' || privileges.name
-            FROM pg_class relations
-            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-            CROSS JOIN jsonb_array_elements_text($1::jsonb) AS privileges(name)
-            WHERE namespaces.nspname = 'public'
-              AND relations.relname IN (SELECT jsonb_array_elements_text($2::jsonb))
-              AND has_any_column_privilege(current_user, relations.oid, privileges.name)
-              AND NOT has_table_privilege(current_user, relations.oid, privileges.name)
-            ORDER BY 1
-          SQL
+          COLUMN_MUTATION_PRIVILEGES_SQL,
           'Audit column mutation privileges',
           text_array_binds(
             column_mutation_privileges: COLUMN_MUTATION_PRIVILEGES,
@@ -126,19 +150,7 @@ module Audit
 
       def sequence_mutation_privileges
         connection.select_values(
-          <<~SQL.squish,
-            SELECT relations.relname || ':sequence-mutation'
-            FROM pg_class relations
-            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-            WHERE namespaces.nspname = 'public'
-              AND relations.relkind = 'S'
-              AND relations.relname IN (SELECT jsonb_array_elements_text($1::jsonb))
-              AND (
-                has_sequence_privilege(current_user, relations.oid, 'USAGE')
-                OR has_sequence_privilege(current_user, relations.oid, 'UPDATE')
-              )
-            ORDER BY 1
-          SQL
+          SEQUENCE_MUTATION_PRIVILEGES_SQL,
           'Audit sequence mutation privileges',
           [text_array_bind('approved_sequences', APPROVED_SELECT_TABLES.map { |name| "#{name}_id_seq" })]
         )
@@ -158,16 +170,7 @@ module Audit
 
       def verify_unapproved_select_privileges!
         tables = connection.select_values(
-          <<~SQL.squish,
-            SELECT relations.relname
-            FROM pg_class relations
-            JOIN pg_namespace namespaces ON namespaces.oid = relations.relnamespace
-            WHERE namespaces.nspname = 'public'
-              AND relations.relkind IN ('r', 'p', 'v', 'm', 'f')
-              AND relations.relname NOT IN (SELECT jsonb_array_elements_text($1::jsonb))
-              AND has_any_column_privilege(current_user, relations.oid, 'SELECT')
-            ORDER BY relations.relname
-          SQL
+          UNAPPROVED_SELECT_PRIVILEGES_SQL,
           'Audit unapproved select privileges',
           [text_array_bind('approved_tables', APPROVED_SELECT_TABLES)]
         )

--- a/app/services/audit/verification/database_verifier.rb
+++ b/app/services/audit/verification/database_verifier.rb
@@ -22,14 +22,17 @@ module Audit
         WHERE source_row.id = $1
       SQL
 
-      def initialize(entries: AuditLedgerEntry.all, verify_heads: true)
+      def initialize(entries: AuditLedgerEntry.all, verify_heads: true, household_id: nil)
         @entries_source = entries
         @verify_heads = verify_heads
+        @household_id = household_id
         @issues = []
       end
 
       def call
+        DatabaseAuthority.new.verify!
         verify_entries
+        issues.concat(SourceCompletenessVerifier.new(household_id:).call)
         verify_chain_heads if verify_heads
         checked_checkpoints = verify_checkpoints
         Result.new(
@@ -40,7 +43,7 @@ module Audit
 
       private
 
-      attr_reader :entries_source, :issues, :verify_heads
+      attr_reader :entries_source, :household_id, :issues, :verify_heads
 
       def entries
         @entries ||= entries_source.to_a.sort_by { |entry| [entry.chain_key, entry.chain_epoch, entry.sequence] }

--- a/app/services/audit/verification/database_verifier.rb
+++ b/app/services/audit/verification/database_verifier.rb
@@ -11,16 +11,6 @@ module Audit
       HASH_DOMAIN = 'medtracker.audit.ledger.v1'
       CHECKPOINT_DOMAIN = 'medtracker.audit.checkpoint.v1'
       SEPARATOR = "\u001F"
-      SECURITY_EVENT_SOURCE_SQL = <<~SQL.squish.freeze
-        SELECT (to_jsonb(source_row.*) - 'updated_at')::text
-        FROM security_audit_events source_row
-        WHERE source_row.id = $1
-      SQL
-      VERSION_SOURCE_SQL = <<~SQL.squish.freeze
-        SELECT (to_jsonb(source_row.*) - 'updated_at')::text
-        FROM versions source_row
-        WHERE source_row.id = $1
-      SQL
 
       def initialize(entries: AuditLedgerEntry.all, verify_heads: true, household_id: nil)
         @entries_source = entries
@@ -117,23 +107,10 @@ module Audit
           return
         end
 
-        current_payload = source_payload(entry)
+        current_payload = SourcePayloadReader.new.call(entry)
         code = current_payload ? 'source_payload_mismatch' : 'source_row_missing'
         message = current_payload ? 'source row no longer matches the ledger' : 'source row is missing'
         add_issue(code, message, entry) unless current_payload == entry.source_payload
-      end
-
-      def source_payload(entry)
-        sql = case entry.source_table
-              when 'versions' then VERSION_SOURCE_SQL
-              when 'security_audit_events' then SECURITY_EVENT_SOURCE_SQL
-              end
-        value = connection.select_value(sql, 'Audit source', [source_id_bind(entry.source_id)])
-        JSON.parse(value) if value
-      end
-
-      def source_id_bind(source_id)
-        ActiveRecord::Relation::QueryAttribute.new('source_id', source_id, ActiveRecord::Type::Integer.new)
       end
 
       def verify_chain_heads
@@ -249,10 +226,6 @@ module Audit
 
       def sorted_issues
         issues.sort_by { |issue| [issue.chain_key.to_s, issue.sequence.to_i, issue.code] }
-      end
-
-      def connection
-        ActiveRecord::Base.connection
       end
     end
   end

--- a/app/services/audit/verification/database_verifier.rb
+++ b/app/services/audit/verification/database_verifier.rb
@@ -46,7 +46,8 @@ module Audit
       attr_reader :entries_source, :household_id, :issues, :verify_heads
 
       def entries
-        @entries ||= entries_source.to_a.sort_by { |entry| [entry.chain_key, entry.chain_epoch, entry.sequence] }
+        @entries ||= scoped_records(entries_source)
+                     .sort_by { |entry| [entry.chain_key, entry.chain_epoch, entry.sequence] }
       end
 
       def verify_entries
@@ -69,7 +70,7 @@ module Audit
       def stored_predecessor(entry)
         return if entry.sequence == 1
 
-        AuditLedgerEntry.find_by(
+        scoped_relation(AuditLedgerEntry.all).find_by(
           chain_key: entry.chain_key, chain_epoch: entry.chain_epoch, sequence: entry.sequence - 1
         )
       end
@@ -140,7 +141,7 @@ module Audit
       end
 
       def relevant_chain_heads
-        heads = AuditChainHead.all.to_a
+        heads = scoped_relation(AuditChainHead.all).to_a
         return heads if entries.empty?
 
         chain_keys = entries.map(&:chain_key).uniq
@@ -175,9 +176,20 @@ module Audit
 
       def checkpoints_for_entries
         keys = entries.to_h { |entry| [[entry.chain_key, entry.chain_epoch, entry.sequence], true] }
-        AuditCheckpoint.includes(:audit_signing_key).select do |checkpoint|
+        scoped_relation(AuditCheckpoint.includes(:audit_signing_key)).select do |checkpoint|
           keys.key?([checkpoint.chain_key, checkpoint.chain_epoch, checkpoint.sequence])
         end
+      end
+
+      def scoped_records(source)
+        return source.to_a unless household_id
+        return source.where(household_id:).to_a if source.respond_to?(:where)
+
+        source.to_a.select { |record| record.household_id == household_id }
+      end
+
+      def scoped_relation(relation)
+        household_id ? relation.where(household_id:) : relation
       end
 
       def verify_checkpoint(checkpoint)

--- a/app/services/audit/verification/result.rb
+++ b/app/services/audit/verification/result.rb
@@ -4,9 +4,13 @@ module Audit
   module Verification
     class ConfigurationError < StandardError; end
 
-    Issue = Data.define(:code, :message, :chain_key, :sequence) do
+    Issue = Data.define(:code, :message, :chain_key, :sequence, :metadata) do
+      def initialize(code:, message:, chain_key:, sequence:, metadata: nil)
+        super
+      end
+
       def to_h
-        { code:, message:, chain_key:, sequence: }.compact
+        { code:, message:, chain_key:, sequence:, metadata: }.compact
       end
     end
 

--- a/app/services/audit/verification/source_completeness_verifier.rb
+++ b/app/services/audit/verification/source_completeness_verifier.rb
@@ -50,7 +50,7 @@ module Audit
 
       def household_id_bind
         ActiveRecord::Relation::QueryAttribute.new(
-          'household_id', household_id, ActiveRecord::Type::Integer.new
+          'household_id', household_id, AuditLedgerEntry.type_for_attribute('household_id')
         )
       end
     end

--- a/app/services/audit/verification/source_completeness_verifier.rb
+++ b/app/services/audit/verification/source_completeness_verifier.rb
@@ -32,7 +32,13 @@ module Audit
       def incomplete_source_count(source_table)
         household_predicate = household_id ? 'WHERE source_row.household_id = $1' : ''
         binds = household_id ? [household_id_bind] : []
-        sql = <<~SQL.squish
+        connection.select_value(
+          incomplete_source_sql(source_table, household_predicate), 'Audit source completeness', binds
+        ).to_i
+      end
+
+      def incomplete_source_sql(source_table, household_predicate)
+        <<~SQL.squish
           SELECT COUNT(*)
           FROM (
             SELECT source_row.id
@@ -46,7 +52,6 @@ module Audit
             HAVING COUNT(ledger_entry.id) <> 1
           ) incomplete_sources
         SQL
-        connection.select_value(sql, 'Audit source completeness', binds).to_i
       end
 
       def household_id_bind

--- a/app/services/audit/verification/source_completeness_verifier.rb
+++ b/app/services/audit/verification/source_completeness_verifier.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class SourceCompletenessVerifier
+      SOURCE_TABLES = %w[security_audit_events versions].freeze
+
+      def initialize(household_id: nil, connection: ActiveRecord::Base.connection)
+        @household_id = household_id
+        @connection = connection
+      end
+
+      def call
+        SOURCE_TABLES.filter_map do |source_table|
+          missing_count = incomplete_source_count(source_table)
+          next if missing_count.zero?
+
+          Issue.new(
+            code: 'source_ledger_entry_missing',
+            message: 'source rows do not have exactly one ledger entry',
+            chain_key: nil,
+            sequence: nil,
+            metadata: { source_table:, missing_count: }
+          )
+        end
+      end
+
+      private
+
+      attr_reader :connection, :household_id
+
+      def incomplete_source_count(source_table)
+        household_predicate = household_id ? 'WHERE source_row.household_id = $1' : ''
+        binds = household_id ? [household_id_bind] : []
+        sql = <<~SQL.squish
+          SELECT COUNT(*)
+          FROM (
+            SELECT source_row.id
+            FROM #{source_table} source_row
+            LEFT JOIN audit_ledger_entries ledger_entry
+              ON ledger_entry.source_table = #{connection.quote(source_table)}
+              AND ledger_entry.source_id = source_row.id
+            #{household_predicate}
+            GROUP BY source_row.id
+            HAVING COUNT(ledger_entry.id) <> 1
+          ) incomplete_sources
+        SQL
+        connection.select_value(sql, 'Audit source completeness', binds).to_i
+      end
+
+      def household_id_bind
+        ActiveRecord::Relation::QueryAttribute.new(
+          'household_id', household_id, ActiveRecord::Type::Integer.new
+        )
+      end
+    end
+  end
+end

--- a/app/services/audit/verification/source_completeness_verifier.rb
+++ b/app/services/audit/verification/source_completeness_verifier.rb
@@ -40,6 +40,7 @@ module Audit
             LEFT JOIN audit_ledger_entries ledger_entry
               ON ledger_entry.source_table = #{connection.quote(source_table)}
               AND ledger_entry.source_id = source_row.id
+              AND ledger_entry.household_id IS NOT DISTINCT FROM source_row.household_id
             #{household_predicate}
             GROUP BY source_row.id
             HAVING COUNT(ledger_entry.id) <> 1

--- a/app/services/audit/verification/source_payload_reader.rb
+++ b/app/services/audit/verification/source_payload_reader.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Audit
+  module Verification
+    class SourcePayloadReader
+      SOURCE_SQL = {
+        'security_audit_events' => <<~SQL.squish,
+          SELECT (to_jsonb(source_row.*) - 'updated_at')::text
+          FROM security_audit_events source_row
+          WHERE source_row.id = $1
+            AND source_row.household_id IS NOT DISTINCT FROM $2
+        SQL
+        'versions' => <<~SQL.squish
+          SELECT (to_jsonb(source_row.*) - 'updated_at')::text
+          FROM versions source_row
+          WHERE source_row.id = $1
+            AND source_row.household_id IS NOT DISTINCT FROM $2
+        SQL
+      }.freeze
+
+      def call(entry)
+        value = connection.select_value(SOURCE_SQL.fetch(entry.source_table), 'Audit source', binds(entry))
+        JSON.parse(value) if value
+      end
+
+      private
+
+      def binds(entry)
+        [query_attribute('source_id', entry.source_id),
+         query_attribute('source_household_id', entry.household_id, type: 'household_id')]
+      end
+
+      def query_attribute(name, value, type: name)
+        ActiveRecord::Relation::QueryAttribute.new(name, value, AuditLedgerEntry.type_for_attribute(type))
+      end
+
+      def connection
+        ActiveRecord::Base.connection
+      end
+    end
+  end
+end

--- a/db/migrate/20260717120000_repair_rls_hidden_audit_sources.rb
+++ b/db/migrate/20260717120000_repair_rls_hidden_audit_sources.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+class RepairRlsHiddenAuditSources < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      LOCK TABLE versions, security_audit_events IN SHARE MODE;
+
+      CREATE POLICY repair_rls_hidden_audit_sources_select ON versions
+        FOR SELECT TO med_tracker_owner USING (true);
+      CREATE POLICY repair_rls_hidden_audit_sources_select ON security_audit_events
+        FOR SELECT TO med_tracker_owner USING (true);
+
+      INSERT INTO audit_chain_heads (chain_key, household_id, epoch_kind, created_at, updated_at)
+      SELECT DISTINCT sources.chain_key, sources.household_id, 'live', clock_timestamp(), clock_timestamp()
+      FROM (
+        SELECT COALESCE('household:' || household_id::text, 'global') chain_key,
+               household_id, 'versions'::text source_table, id source_id
+        FROM versions
+        UNION ALL
+        SELECT COALESCE('household:' || household_id::text, 'global'),
+               household_id, 'security_audit_events'::text, id
+        FROM security_audit_events
+      ) sources
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM audit_ledger_entries entries
+        WHERE entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+      )
+      ON CONFLICT (chain_key) DO NOTHING;
+
+      DO $$
+      DECLARE
+        chain_row record;
+        source_row record;
+        chain_head audit_chain_heads%ROWTYPE;
+      BEGIN
+        FOR chain_row IN
+          SELECT sources.chain_key, sources.household_id
+          FROM (
+            SELECT COALESCE('household:' || household_id::text, 'global') chain_key,
+                   household_id, 'versions'::text source_table, id source_id
+            FROM versions
+            UNION ALL
+            SELECT COALESCE('household:' || household_id::text, 'global'),
+                   household_id, 'security_audit_events'::text, id
+            FROM security_audit_events
+          ) sources
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM audit_ledger_entries entries
+            WHERE entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+          )
+          GROUP BY sources.chain_key, sources.household_id
+          ORDER BY sources.chain_key
+        LOOP
+          SELECT * INTO STRICT chain_head
+          FROM audit_chain_heads
+          WHERE chain_key = chain_row.chain_key
+          FOR UPDATE;
+
+          IF chain_head.epoch_kind = 'live' AND chain_head.last_sequence > 0 THEN
+            INSERT INTO audit_checkpoints (
+              household_id, chain_key, chain_epoch, checkpoint_kind, sequence, entry_hash,
+              created_at, updated_at
+            ) VALUES (
+              chain_head.household_id, chain_head.chain_key, chain_head.chain_epoch, 'pre-legacy-repair',
+              chain_head.last_sequence, chain_head.last_hash, clock_timestamp(), clock_timestamp()
+            )
+            ON CONFLICT (chain_key, chain_epoch, sequence) DO NOTHING;
+          END IF;
+
+          UPDATE audit_chain_heads
+          SET chain_epoch = gen_random_uuid(), epoch_kind = 'legacy-repair',
+              last_sequence = 0, last_hash = NULL, updated_at = clock_timestamp()
+          WHERE id = chain_head.id;
+
+          FOR source_row IN
+            SELECT source_table, source_id, household_id, source_payload, occurred_at
+            FROM (
+              SELECT 'versions'::text source_table, id source_id, household_id,
+                     to_jsonb(versions.*) source_payload, created_at occurred_at
+              FROM versions
+              UNION ALL
+              SELECT 'security_audit_events'::text, id, household_id,
+                     to_jsonb(security_audit_events.*), created_at
+              FROM security_audit_events
+            ) sources
+            WHERE COALESCE('household:' || household_id::text, 'global') = chain_row.chain_key
+              AND NOT EXISTS (
+                SELECT 1
+                FROM audit_ledger_entries entries
+                WHERE entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+              )
+            ORDER BY occurred_at, source_table, source_id
+          LOOP
+            PERFORM audit_append_ledger_entry(
+              source_row.source_table, source_row.source_id, source_row.household_id,
+              source_row.source_payload, source_row.occurred_at
+            );
+          END LOOP;
+
+          SELECT * INTO STRICT chain_head
+          FROM audit_chain_heads
+          WHERE id = chain_head.id;
+
+          INSERT INTO audit_checkpoints (
+            household_id, chain_key, chain_epoch, checkpoint_kind, sequence, entry_hash,
+            created_at, updated_at
+          ) VALUES (
+            chain_head.household_id, chain_head.chain_key, chain_head.chain_epoch, 'legacy-repair',
+            chain_head.last_sequence, chain_head.last_hash, clock_timestamp(), clock_timestamp()
+          );
+
+          UPDATE audit_chain_heads
+          SET chain_epoch = gen_random_uuid(), epoch_kind = 'live',
+              last_sequence = 0, last_hash = NULL, updated_at = clock_timestamp()
+          WHERE id = chain_head.id;
+        END LOOP;
+
+        IF EXISTS (
+          SELECT 1
+          FROM (
+            SELECT sources.source_table, sources.source_id
+            FROM (
+              SELECT 'versions'::text source_table, id source_id FROM versions
+              UNION ALL
+              SELECT 'security_audit_events'::text, id FROM security_audit_events
+            ) sources
+            LEFT JOIN audit_ledger_entries entries
+              ON entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+            GROUP BY sources.source_table, sources.source_id
+            HAVING COUNT(entries.id) <> 1
+          ) incomplete_sources
+        ) THEN
+          RAISE EXCEPTION 'audit ledger repair did not produce exactly one entry per supported source row';
+        END IF;
+      END
+      $$;
+
+      DROP POLICY repair_rls_hidden_audit_sources_select ON versions;
+      DROP POLICY repair_rls_hidden_audit_sources_select ON security_audit_events;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'Repaired audit evidence is append-only'
+  end
+end

--- a/db/migrate/20260717120000_repair_rls_hidden_audit_sources.rb
+++ b/db/migrate/20260717120000_repair_rls_hidden_audit_sources.rb
@@ -67,6 +67,18 @@ class RepairRlsHiddenAuditSources < ActiveRecord::Migration[8.1]
               chain_head.last_sequence, chain_head.last_hash, clock_timestamp(), clock_timestamp()
             )
             ON CONFLICT (chain_key, chain_epoch, sequence) DO NOTHING;
+
+            IF NOT EXISTS (
+              SELECT 1
+              FROM audit_checkpoints checkpoints
+              WHERE checkpoints.chain_key = chain_head.chain_key
+                AND checkpoints.chain_epoch = chain_head.chain_epoch
+                AND checkpoints.sequence = chain_head.last_sequence
+                AND checkpoints.household_id IS NOT DISTINCT FROM chain_head.household_id
+                AND checkpoints.entry_hash = chain_head.last_hash
+            ) THEN
+              RAISE EXCEPTION 'existing checkpoint does not match the pre-repair live tail';
+            END IF;
           END IF;
 
           UPDATE audit_chain_heads

--- a/db/migrate/20260717130000_grant_audit_verifier_complete_visibility.rb
+++ b/db/migrate/20260717130000_grant_audit_verifier_complete_visibility.rb
@@ -7,6 +7,11 @@ class GrantAuditVerifierCompleteVisibility < ActiveRecord::Migration[8.1]
     audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
     versions security_audit_events
   ].freeze
+  AUDIT_FUNCTIONS = [
+    'audit_append_ledger_entry(text, bigint, bigint, jsonb, timestamptz)',
+    'audit_capture_source_row()',
+    'audit_record_signed_checkpoint(text, text, text, uuid, bigint, text, text, timestamptz, text)'
+  ].freeze
 
   def up
     return unless role_exists?
@@ -40,5 +45,6 @@ class GrantAuditVerifierCompleteVisibility < ActiveRecord::Migration[8.1]
       FROM #{VERIFIER_ROLE};
     SQL
     execute "REVOKE ALL PRIVILEGES ON SEQUENCE security_audit_events_id_seq FROM #{VERIFIER_ROLE};"
+    execute "REVOKE ALL ON FUNCTION #{AUDIT_FUNCTIONS.join(', ')} FROM PUBLIC, #{VERIFIER_ROLE};"
   end
 end

--- a/db/migrate/20260717130000_grant_audit_verifier_complete_visibility.rb
+++ b/db/migrate/20260717130000_grant_audit_verifier_complete_visibility.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class GrantAuditVerifierCompleteVisibility < ActiveRecord::Migration[8.1]
+  VERIFIER_ROLE = 'med_tracker_audit_verifier'
+  POLICY_NAME = 'audit_verifier_complete_visibility'
+  AUDIT_TABLES = %w[
+    audit_chain_heads audit_ledger_entries audit_export_deliveries audit_signing_keys audit_checkpoints
+    versions security_audit_events
+  ].freeze
+
+  def up
+    return unless role_exists?
+
+    revoke_mutation_privileges
+    execute "GRANT SELECT ON TABLE #{AUDIT_TABLES.join(', ')} TO #{VERIFIER_ROLE};"
+    execute "DROP POLICY IF EXISTS #{POLICY_NAME} ON security_audit_events;"
+    execute <<~SQL
+      CREATE POLICY #{POLICY_NAME} ON security_audit_events
+      FOR SELECT TO #{VERIFIER_ROLE}
+      USING (true);
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS #{POLICY_NAME} ON security_audit_events;"
+  end
+
+  private
+
+  def role_exists?
+    select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*) FROM pg_roles WHERE rolname = #{quote(VERIFIER_ROLE)}
+    SQL
+  end
+
+  def revoke_mutation_privileges
+    execute <<~SQL
+      REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+      ON TABLE #{AUDIT_TABLES.join(', ')}
+      FROM #{VERIFIER_ROLE};
+    SQL
+    execute "REVOKE ALL PRIVILEGES ON SEQUENCE security_audit_events_id_seq FROM #{VERIFIER_ROLE};"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_16_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_17_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1514,4 +1514,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_16_120000) do
   execute 'DROP POLICY IF EXISTS household_tenant_isolation ON versions;'
   execute 'ALTER TABLE versions NO FORCE ROW LEVEL SECURITY;'
   execute 'ALTER TABLE versions DISABLE ROW LEVEL SECURITY;'
+
+  execute <<~SQL
+    DO $audit_verifier_visibility$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_audit_verifier') THEN
+        DROP POLICY IF EXISTS audit_verifier_complete_visibility ON security_audit_events;
+        CREATE POLICY audit_verifier_complete_visibility ON security_audit_events
+          FOR SELECT TO med_tracker_audit_verifier
+          USING (true);
+      END IF;
+    END
+    $audit_verifier_visibility$;
+  SQL
 end

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -29,13 +29,25 @@ boundary for the existing shared login; it does not provide credential isolation
 a general medication-history bypass.
 
 - `med_tracker_audit_exporter` reads ledger/checkpoint data, signs checkpoints through a one-way database function, and updates delivery receipts. It cannot read source or clinical tables or modify ledger history.
-- `med_tracker_audit_verifier` reads source and ledger evidence and may insert the audit event describing an export. It cannot read clinical tables or alter existing source, ledger, checkpoint, or delivery rows.
+- `med_tracker_audit_verifier` is read-only. It needs complete visibility of
+  both audit sources and ledger evidence, but no clinical-table access or
+  authority to alter source, ledger, checkpoint, or delivery rows. It checks
+  ledger-to-source equality and source-to-ledger completeness. If that
+  visibility or isolation is insufficient, verification fails as a
+  configuration error rather than reporting valid evidence.
 
 Database-owner access remains a break-glass capability. PostgreSQL cannot independently audit a malicious database owner who controls the database and its logs. Every owner-level audit-table operation therefore requires an incident or approved change record in a separate system.
 
 ## Existing history
 
 Rows that existed when the ledger was installed are chained in a distinct `legacy-baseline` epoch. A signed baseline manifest proves the bytes exported at that point and detects later changes. It does not prove that pre-migration history was complete or unmodified before the baseline. Documentation and exports must retain that label.
+
+Affected old-database upgrades also append previously omitted `versions` and
+`security_audit_events` rows in a distinct `legacy-repair` epoch. Existing
+evidence is not rewritten. The repair creates `pre-legacy-repair` and
+`legacy-repair` checkpoints; evidence omitted before repair was not protected
+before repair, and integrity is established from the new repair checkpoint
+onward.
 
 ## Object Lock evidence
 
@@ -60,13 +72,15 @@ Inputs are supplied as environment variables:
 | `SCOPE` | `database`, `worm`, or `combined` |
 | `FORMAT` | `human` or `json` |
 | `HOUSEHOLD_ID` | Optional numeric household filter |
-| `FROM` / `TO` | Optional ISO 8601 time bounds |
+| `FROM` / `TO` | Optional ISO 8601 bounds for WORM-only verification; unsupported for `database` and `combined` completeness verification |
 
 Exit status `0` means all selected evidence is valid, `1` means an integrity failure was found, and `2` means verification could not run because of configuration or runtime failure.
 
 Database verification checks source-row equality, canonical payload parsing, sequence continuity, every previous-hash link, recomputed entry hashes, live chain heads, checkpoint targets, Ed25519 signatures, and retained public keys. WORM verification checks delivery completeness, object key/checksum/version, retention mode/date, missing objects, and duplicate versions.
 
-Time-bounded verification validates selected entries and their predecessor links but does not compare a filtered range with the current chain head. Scheduled full verification is still required to detect tail truncation.
+`HOUSEHOLD_ID` remains supported for every scope. `FROM` and `TO` remain
+available for WORM-only verification; database and combined completeness
+verification reject time filters rather than reporting a valid partial result.
 
 ## Export
 
@@ -79,6 +93,13 @@ task audit:export
 Set `OUTPUT`, optional `HOUSEHOLD_ID`, `FROM`, `TO`, and `FHIR=true` as required. The export contains deterministic native NDJSON and a signed manifest. `FHIR=true` also writes a FHIR R4 `Bundle` of `AuditEvent` resources. The native envelope remains authoritative for integrity; FHIR is an interoperability representation. FHIR defines AuditEvent as a security log and advises servers not to support update/delete because that compromises audit integrity: <https://hl7.org/fhir/R4/auditevent.html>.
 
 Creating an export is itself written to `security_audit_events` without recording output paths or clinical content.
+
+After a `legacy-repair` upgrade, sign and export the new
+`pre-legacy-repair` and `legacy-repair` checkpoints, drain pending delivery
+records, then rerun database, WORM, and combined verification before accepting
+the evidence. Keep an external change or incident record with the deployment
+version, migration time, checkpoint, key, manifest, and object identifiers,
+verification output, and operator.
 
 ## Retention
 

--- a/docs/operations/audit-evidence-runbook.md
+++ b/docs/operations/audit-evidence-runbook.md
@@ -20,6 +20,30 @@ The capacity record must include peak audited writes per second, p95 insert late
 
 Immediately after migration, sign every `legacy-baseline` checkpoint and export the native evidence and manifest to Object Lock. Record the manifest checksum, object version, public key ID, deployment version, migration time, and external change reference. State that integrity is proven from the baseline onward only.
 
+## Legacy-repair acceptance
+
+Affected old-database upgrades append previously omitted `versions` and
+`security_audit_events` rows in a `legacy-repair` epoch. They do not rewrite
+existing evidence. Omitted evidence was not protected before repair; integrity
+is established from the new repair checkpoint onward.
+
+Before accepting repaired evidence:
+
+1. Sign and export every new `pre-legacy-repair` and `legacy-repair`
+   checkpoint.
+2. Drain pending delivery records.
+3. Rerun database, WORM, and combined verification.
+4. Record the deployment version, migration time, checkpoint, key, manifest,
+   and object identifiers, verification output, and operator in an external
+   change or incident record.
+
+The dedicated verifier is read-only. It must see all audit source and ledger
+rows, but no clinical tables. It verifies both ledger-to-source equality and
+source-to-ledger completeness; incomplete authority is a configuration failure,
+not valid evidence. `HOUSEHOLD_ID` remains supported. `FROM` and `TO` are
+unsupported for database and combined completeness verification; WORM-only
+time filtering is unchanged.
+
 ## Signing-key rotation
 
 1. Generate Ed25519 key material in the approved key-management system.

--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -159,6 +159,23 @@ ORDER BY table_name;
 
 Every `null_household_id` count should be `0`.
 
+## Audit evidence repair
+
+Affected upgrades automatically append previously omitted `versions` and
+`security_audit_events` rows in a separate `legacy-repair` epoch. Existing
+ledger entries and source evidence are not rewritten. The repair creates a
+`pre-legacy-repair` checkpoint before the new epoch and a `legacy-repair`
+checkpoint after it.
+
+Evidence that was omitted before this repair was not protected before repair.
+Integrity is established from the new repair checkpoint onward.
+
+Before accepting the repaired audit evidence, operators must sign and export
+both checkpoints, drain pending delivery records, and rerun database, WORM,
+and combined verification. Record the deployment version, migration time,
+checkpoint, key, manifest, and object identifiers, verification output, and
+operator in an external change or incident record.
+
 Verify the account access bootstrap:
 
 ```sql

--- a/spec/migrations/configure_audit_verifier_role_spec.rb
+++ b/spec/migrations/configure_audit_verifier_role_spec.rb
@@ -2,12 +2,13 @@
 
 require 'rails_helper'
 require Rails.root.join('db/migrate/20260709150000_configure_audit_verifier_role')
+require Rails.root.join('db/migrate/20260717130000_grant_audit_verifier_complete_visibility')
 
 RSpec.describe ConfigureAuditVerifierRole do
-  it 'can read audit evidence and record exports without reading clinical tables' do
+  it 'can read audit evidence without reading clinical tables' do
     expect(privilege('audit_ledger_entries', 'SELECT')).to be(true)
     expect(privilege('security_audit_events', 'SELECT')).to be(true)
-    expect(privilege('security_audit_events', 'INSERT')).to be(true)
+    expect(privilege('security_audit_events', 'INSERT')).to be(false)
     expect(privilege('versions', 'SELECT')).to be(true)
     expect(privilege('medications', 'SELECT')).to be(false)
   end
@@ -29,6 +30,7 @@ RSpec.describe ConfigureAuditVerifierRole do
     expect(privilege('security_audit_events', 'INSERT')).to be(false)
   ensure
     migration&.lock_verifier_privileges
+    GrantAuditVerifierCompleteVisibility.new.up
   end
 
   def privilege(table_name, action)

--- a/spec/migrations/grant_audit_verifier_complete_visibility_spec.rb
+++ b/spec/migrations/grant_audit_verifier_complete_visibility_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe GrantAuditVerifierCompleteVisibility do
     expect(privilege('security_audit_events', 'UPDATE')).to be(false)
     expect(privilege('security_audit_events', 'DELETE')).to be(false)
     expect(privilege('audit_ledger_entries', 'UPDATE')).to be(false)
+    function_signature = 'audit_append_ledger_entry(text,bigint,bigint,jsonb,timestamp with time zone)'
+    expect(function_privilege(function_signature)).to be(false)
   end
 
   it 'removes and restores only the complete-visibility policy across rollback' do
@@ -74,6 +76,12 @@ RSpec.describe GrantAuditVerifierCompleteVisibility do
       FROM pg_policies
       WHERE tablename = 'security_audit_events'
         AND policyname = 'audit_verifier_complete_visibility'
+    SQL
+  end
+
+  def function_privilege(signature)
+    connection.select_value(<<~SQL.squish)
+      SELECT has_function_privilege('med_tracker_audit_verifier', '#{signature}', 'EXECUTE')
     SQL
   end
 end

--- a/spec/migrations/grant_audit_verifier_complete_visibility_spec.rb
+++ b/spec/migrations/grant_audit_verifier_complete_visibility_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260717130000_grant_audit_verifier_complete_visibility')
+
+RSpec.describe GrantAuditVerifierCompleteVisibility do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:migration) { described_class.new }
+
+  it 'gives only the verifier complete read visibility while FORCE RLS remains enabled' do
+    policy = connection.select_one(<<~SQL.squish)
+      SELECT cmd, roles, qual, with_check
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename = 'security_audit_events'
+        AND policyname = 'audit_verifier_complete_visibility'
+    SQL
+
+    expect(policy).to eq(
+      'cmd' => 'SELECT', 'roles' => '{med_tracker_audit_verifier}', 'qual' => 'true', 'with_check' => nil
+    )
+    expect(connection.select_value(<<~SQL.squish)).to be(true)
+      SELECT relrowsecurity AND relforcerowsecurity
+      FROM pg_class
+      WHERE oid = 'security_audit_events'::regclass
+    SQL
+  end
+
+  it 'does not grant clinical reads or row-security bypass' do
+    expect(privilege('medications', 'SELECT')).to be(false)
+    expect(connection.select_value(<<~SQL.squish)).to be(true)
+      SELECT NOT rolsuper AND NOT rolbypassrls
+      FROM pg_roles
+      WHERE rolname = 'med_tracker_audit_verifier'
+    SQL
+  end
+
+  it 'does not grant audit mutation' do
+    expect(privilege('security_audit_events', 'INSERT')).to be(false)
+    expect(privilege('security_audit_events', 'UPDATE')).to be(false)
+    expect(privilege('security_audit_events', 'DELETE')).to be(false)
+    expect(privilege('audit_ledger_entries', 'UPDATE')).to be(false)
+  end
+
+  it 'removes and restores only the complete-visibility policy across rollback' do
+    migration.down
+
+    expect(policy_exists?).to be(false)
+    expect(privilege('security_audit_events', 'INSERT')).to be(false)
+
+    migration.up
+    expect(policy_exists?).to be(true)
+  ensure
+    migration&.up unless policy_exists?
+  end
+
+  it 'keeps schema loading safe when the optional verifier role is absent' do
+    schema = Rails.root.join('db/schema.rb').read
+
+    expect(schema).to include("IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'med_tracker_audit_verifier')")
+    expect(schema).to include('CREATE POLICY audit_verifier_complete_visibility')
+    expect(schema).to include('FOR SELECT TO med_tracker_audit_verifier')
+  end
+
+  def privilege(table_name, action)
+    connection.select_value(<<~SQL.squish)
+      SELECT has_table_privilege('med_tracker_audit_verifier', '#{table_name}', '#{action}')
+    SQL
+  end
+
+  def policy_exists?
+    connection.select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_policies
+      WHERE tablename = 'security_audit_events'
+        AND policyname = 'audit_verifier_complete_visibility'
+    SQL
+  end
+end

--- a/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
+++ b/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
@@ -8,39 +8,16 @@ require Rails.root.join('db/migrate/20260717120000_repair_rls_hidden_audit_sourc
 RSpec.describe RepairRlsHiddenAuditSources do
   fixtures :accounts, :people, :users
 
-  POLICY_NAME = 'repair_rls_hidden_audit_sources_select'
-  SHARED_LOGIN = 'audit_repair_shared_login'
-
   let(:connection) { ActiveRecord::Base.connection }
   let(:household) { users(:admin).person.household }
   let(:migration) { described_class.new }
 
   it 'repairs forced-RLS omissions without changing existing audit evidence' do
     with_historical_omission do |event_id, version_id|
-      expect(missing_entry?('security_audit_events', event_id)).to be(true)
-      expect(missing_entry?('versions', version_id)).to be(true)
-
-      expected_order = add_ordering_sources(event_id, version_id)
-      expect(household_source_times(expected_order).uniq.size).to be > 1
-      live_entry = create_live_tail
-      preserved_records = preserve_existing_audit_records
-
-      as_med_tracker_owner { migration.migrate(:up) }
-
-      repaired_entries = entries_for(expected_order).order(:id)
-      expect(repaired_entries.pluck(:chain_key, :source_table, :source_id)).to eq(expected_order)
-      expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
-      expect_repair_checkpoints(repaired_entries)
-      expect_pending_deliveries(repaired_entries)
-      expect_live_tail_checkpoint(live_entry)
-      expect_existing_audit_records_unchanged(preserved_records)
-      expect_complete_source_coverage
-      expect_clean_rls_state
-
-      repaired_state = repair_state
-      as_med_tracker_owner { migration.migrate(:up) }
-      expect(repair_state).to eq(repaired_state)
-      expect_clean_rls_state
+      expect_hidden_sources(event_id, version_id)
+      expected_order = expected_repair_order(event_id, version_id)
+      expect_distinct_household_source_times(expected_order)
+      verify_repair_preserves_existing_audit_evidence(expected_order)
     end
   end
 
@@ -50,12 +27,8 @@ RSpec.describe RepairRlsHiddenAuditSources do
       install_repair_checkpoint_failure
       state_before_repair = repair_state
 
-      expect { migrate_in_new_transaction }.to raise_error(
-        ActiveRecord::StatementInvalid, /injected failure after repaired entry and delivery/
-      )
-
-      expect(repair_state).to eq(state_before_repair)
-      expect_clean_rls_state
+      expect_repair_to_fail(/injected failure after repaired entry and delivery/)
+      expect_failed_repair_to_preserve(state_before_repair)
     end
   end
 
@@ -65,12 +38,8 @@ RSpec.describe RepairRlsHiddenAuditSources do
       create_live_tail_checkpoint(live_entry, entry_hash: "\0".b * 32)
       state_before_repair = repair_state
 
-      expect { migrate_in_new_transaction }.to raise_error(
-        ActiveRecord::StatementInvalid, /existing checkpoint does not match the pre-repair live tail/
-      )
-
-      expect(repair_state).to eq(state_before_repair)
-      expect_clean_rls_state
+      expect_repair_to_fail(/existing checkpoint does not match the pre-repair live tail/)
+      expect_failed_repair_to_preserve(state_before_repair)
     end
   end
 
@@ -82,24 +51,14 @@ RSpec.describe RepairRlsHiddenAuditSources do
 
       as_med_tracker_owner { migration.migrate(:up) }
 
-      expect(checkpoint.reload.attributes).to eq(attributes)
-      expect_complete_source_coverage
-      expect_clean_rls_state
+      expect_repair_to_preserve_checkpoint(checkpoint, attributes)
     end
   end
 
   it 'runs through the shared login without DATABASE_ROLE' do
     with_historical_omission do |event_id, version_id|
-      as_restricted_shared_login do
-        expect_restricted_shared_login
-        without_database_role { migration.migrate(:up) }
-        expect_restricted_shared_login
-      end
-
-      expect(missing_entry?('security_audit_events', event_id)).to be(false)
-      expect(missing_entry?('versions', version_id)).to be(false)
-      expect_complete_source_coverage
-      expect_clean_rls_state
+      migrate_as_restricted_shared_login
+      expect_repaired_sources(event_id, version_id)
     end
   end
 
@@ -152,17 +111,36 @@ RSpec.describe RepairRlsHiddenAuditSources do
     SQL
   end
 
-  def add_ordering_sources(event_id, version_id)
-    occurred_at = connection.select_value(<<~SQL.squish)
+  def expected_repair_order(event_id, version_id)
+    source_ids = ordering_source_ids(event_id)
+    expected_order(source_ids, event_id, version_id)
+  end
+
+  def ordering_source_ids(event_id)
+    occurred_at = event_occurred_at(event_id)
+    connection.execute('ALTER TABLE versions DISABLE TRIGGER append_versions_to_audit_ledger')
+    insert_ordering_versions(occurred_at)
+  ensure
+    connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
+  end
+
+  def event_occurred_at(event_id)
+    connection.select_value(<<~SQL.squish)
       SELECT created_at FROM security_audit_events WHERE id = #{event_id}
     SQL
-    connection.execute('ALTER TABLE versions DISABLE TRIGGER append_versions_to_audit_ledger')
-    earlier_version_id = insert_version_for(occurred_at - 2.hours, household.id)
-    second_version_id = insert_version_for(occurred_at, household.id)
-    later_version_id = insert_version_for(occurred_at + 2.hours, household.id)
-    global_version_id = insert_version_for(occurred_at + 4.hours, nil)
-    connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
+  end
 
+  def insert_ordering_versions(occurred_at)
+    [
+      insert_version_for(occurred_at - 2.hours, household.id),
+      insert_version_for(occurred_at, household.id),
+      insert_version_for(occurred_at + 2.hours, household.id),
+      insert_version_for(occurred_at + 4.hours, nil)
+    ]
+  end
+
+  def expected_order(source_ids, event_id, version_id)
+    earlier_version_id, second_version_id, later_version_id, global_version_id = source_ids
     [
       ['global', 'versions', global_version_id],
       ["household:#{household.id}", 'versions', earlier_version_id],
@@ -171,8 +149,6 @@ RSpec.describe RepairRlsHiddenAuditSources do
       ["household:#{household.id}", 'versions', second_version_id],
       ["household:#{household.id}", 'versions', later_version_id]
     ]
-  ensure
-    connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
   end
 
   def create_live_tail
@@ -187,9 +163,13 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def preserve_existing_audit_records
-    [AuditLedgerEntry, AuditCheckpoint, AuditExportDelivery, AuditSigningKey].to_h do |model|
-      [model, model.order(:id).to_h { |record| [record.id, record.attributes] }]
+    audit_models.index_with do |model|
+      model.order(:id).index_by(&:id).transform_values(&:attributes)
     end
+  end
+
+  def audit_models
+    [AuditLedgerEntry, AuditCheckpoint, AuditExportDelivery, AuditSigningKey]
   end
 
   def expect_existing_audit_records_unchanged(preserved_records)
@@ -255,7 +235,7 @@ RSpec.describe RepairRlsHiddenAuditSources do
     expect(forced_rls?('versions')).to be(true)
     expect(forced_rls?('security_audit_events')).to be(true)
     expect(connection.select_value(<<~SQL.squish)).to eq(0)
-      SELECT COUNT(*) FROM pg_policies WHERE policyname = #{connection.quote(POLICY_NAME)}
+      SELECT COUNT(*) FROM pg_policies WHERE policyname = #{connection.quote(repair_policy_name)}
     SQL
   end
 
@@ -302,6 +282,11 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def install_repair_checkpoint_failure
+    create_repair_checkpoint_failure_function
+    create_repair_checkpoint_failure_trigger
+  end
+
+  def create_repair_checkpoint_failure_function
     connection.execute <<~SQL
       CREATE FUNCTION spec_fail_legacy_repair_checkpoint() RETURNS trigger
       LANGUAGE plpgsql
@@ -324,6 +309,11 @@ RSpec.describe RepairRlsHiddenAuditSources do
       END;
       $$;
 
+    SQL
+  end
+
+  def create_repair_checkpoint_failure_trigger
+    connection.execute <<~SQL
       CREATE TRIGGER spec_fail_legacy_repair_checkpoint
       BEFORE INSERT ON audit_checkpoints
       FOR EACH ROW EXECUTE FUNCTION spec_fail_legacy_repair_checkpoint();
@@ -385,19 +375,19 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def as_restricted_shared_login
-    quoted_role = connection.quote_table_name(SHARED_LOGIN)
+    quoted_role = connection.quote_table_name(shared_login)
     connection.execute("CREATE ROLE #{quoted_role} LOGIN NOSUPERUSER NOBYPASSRLS INHERIT")
     connection.execute("GRANT med_tracker_owner TO #{quoted_role} WITH INHERIT TRUE, SET TRUE")
-    connection.execute("SET LOCAL SESSION AUTHORIZATION #{connection.quote(SHARED_LOGIN)}")
+    connection.execute("SET LOCAL SESSION AUTHORIZATION #{connection.quote(shared_login)}")
     yield
   ensure
     connection.execute('RESET SESSION AUTHORIZATION')
-    connection.execute("DROP ROLE IF EXISTS #{connection.quote_table_name(SHARED_LOGIN)}")
+    connection.execute("DROP ROLE IF EXISTS #{connection.quote_table_name(shared_login)}")
   end
 
   def expect_restricted_shared_login
-    expect(connection.select_value('SELECT current_user')).to eq(SHARED_LOGIN)
-    expect(connection.select_value('SELECT session_user')).to eq(SHARED_LOGIN)
+    expect(connection.select_value('SELECT current_user')).to eq(shared_login)
+    expect(connection.select_value('SELECT session_user')).to eq(shared_login)
     expect(connection.select_value(<<~SQL.squish)).to be(true)
       SELECT rolcanlogin AND NOT rolsuper AND NOT rolbypassrls
       FROM pg_roles
@@ -406,5 +396,79 @@ RSpec.describe RepairRlsHiddenAuditSources do
     expect(connection.select_value(<<~SQL.squish)).to be(true)
       SELECT pg_has_role(current_user, 'med_tracker_owner', 'MEMBER')
     SQL
+  end
+
+  def expect_hidden_sources(event_id, version_id)
+    expect(missing_entry?('security_audit_events', event_id)).to be(true)
+    expect(missing_entry?('versions', version_id)).to be(true)
+  end
+
+  def expect_distinct_household_source_times(expected_order)
+    expect(household_source_times(expected_order).uniq.size).to be > 1
+  end
+
+  def verify_repair_preserves_existing_audit_evidence(expected_order)
+    live_entry = create_live_tail
+    preserved_records = preserve_existing_audit_records
+    as_med_tracker_owner { migration.migrate(:up) }
+    expect_repaired_audit_evidence(expected_order, live_entry, preserved_records)
+    expect_repair_to_be_idempotent
+  end
+
+  def expect_repaired_audit_evidence(expected_order, live_entry, preserved_records)
+    repaired_entries = entries_for(expected_order).order(:id)
+    expect(repaired_entries.pluck(:chain_key, :source_table, :source_id)).to eq(expected_order)
+    expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
+    expect_repair_checkpoints(repaired_entries)
+    expect_pending_deliveries(repaired_entries)
+    expect_live_tail_checkpoint(live_entry)
+    expect_existing_audit_records_unchanged(preserved_records)
+    expect_complete_source_coverage
+    expect_clean_rls_state
+  end
+
+  def expect_repair_to_be_idempotent
+    repaired_state = repair_state
+    as_med_tracker_owner { migration.migrate(:up) }
+    expect(repair_state).to eq(repaired_state)
+    expect_clean_rls_state
+  end
+
+  def expect_repair_to_fail(message)
+    expect { migrate_in_new_transaction }.to raise_error(ActiveRecord::StatementInvalid, message)
+  end
+
+  def expect_failed_repair_to_preserve(state_before_repair)
+    expect(repair_state).to eq(state_before_repair)
+    expect_clean_rls_state
+  end
+
+  def expect_repair_to_preserve_checkpoint(checkpoint, attributes)
+    expect(checkpoint.reload.attributes).to eq(attributes)
+    expect_complete_source_coverage
+    expect_clean_rls_state
+  end
+
+  def migrate_as_restricted_shared_login
+    as_restricted_shared_login do
+      expect_restricted_shared_login
+      without_database_role { migration.migrate(:up) }
+      expect_restricted_shared_login
+    end
+  end
+
+  def expect_repaired_sources(event_id, version_id)
+    expect(missing_entry?('security_audit_events', event_id)).to be(false)
+    expect(missing_entry?('versions', version_id)).to be(false)
+    expect_complete_source_coverage
+    expect_clean_rls_state
+  end
+
+  def repair_policy_name
+    'repair_rls_hidden_audit_sources_select'
+  end
+
+  def shared_login
+    'audit_repair_shared_login'
   end
 end

--- a/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
+++ b/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260709131000_create_tamper_evident_audit_ledger')
+require Rails.root.join('db/migrate/20260709143000_configure_audit_object_lock_exporter')
+require Rails.root.join('db/migrate/20260717120000_repair_rls_hidden_audit_sources')
+
+RSpec.describe RepairRlsHiddenAuditSources do
+  fixtures :accounts, :people, :users
+
+  POLICY_NAME = 'repair_rls_hidden_audit_sources_select'
+
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:household) { users(:admin).person.household }
+  let(:migration) { described_class.new }
+
+  it 'repairs forced-RLS omissions without changing existing audit evidence' do
+    with_historical_omission do |event_id, version_id|
+      expect(missing_entry?('security_audit_events', event_id)).to be(true)
+      expect(missing_entry?('versions', version_id)).to be(true)
+
+      live_entry = create_live_tail
+      preserved_records = preserve_existing_audit_records
+
+      as_med_tracker_owner { migration.migrate(:up) }
+
+      repaired_entries = AuditLedgerEntry.where(source_table: 'security_audit_events', source_id: event_id)
+        .or(AuditLedgerEntry.where(source_table: 'versions', source_id: version_id))
+        .order(:sequence)
+      expect(repaired_entries.pluck(:source_table, :source_id)).to eq([
+        ['security_audit_events', event_id],
+        ['versions', version_id]
+      ])
+      expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
+      expect(repaired_entries.pluck(:chain_epoch).uniq.one?).to be(true)
+      expect_repair_checkpoint(repaired_entries.last)
+      expect_pending_deliveries(repaired_entries)
+      expect_live_tail_checkpoint(live_entry)
+      expect_existing_audit_records_unchanged(preserved_records)
+      expect_complete_source_coverage
+      expect_clean_rls_state
+
+      repaired_state = repair_state
+      as_med_tracker_owner { migration.migrate(:up) }
+      expect(repair_state).to eq(repaired_state)
+      expect_clean_rls_state
+    end
+  end
+
+  it 'rolls back its transient policies when the repair cannot finish' do
+    with_historical_omission do
+      live_entry = create_live_tail
+      connection.execute(<<~SQL.squish)
+        UPDATE audit_chain_heads SET last_hash = NULL WHERE chain_key = #{connection.quote(live_entry.chain_key)}
+      SQL
+
+      expect { migrate_in_new_transaction }.to raise_error(ActiveRecord::StatementInvalid)
+
+      expect_clean_rls_state
+    end
+  end
+
+  it 'runs through the shared login without DATABASE_ROLE' do
+    with_historical_omission do |event_id, version_id|
+      expect(connection.select_value('SELECT current_user')).to eq(connection.select_value('SELECT session_user'))
+
+      without_database_role { migration.migrate(:up) }
+
+      expect(missing_entry?('security_audit_events', event_id)).to be(false)
+      expect(missing_entry?('versions', version_id)).to be(false)
+      expect_complete_source_coverage
+      expect_clean_rls_state
+    end
+  end
+
+  private
+
+  def with_historical_omission
+    connection.transaction(requires_new: true) do
+      event_id, version_id = rebuild_ledger_with_hidden_sources
+      yield event_id, version_id
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def rebuild_ledger_with_hidden_sources
+    ActiveRecord::Migration.suppress_messages do
+      ConfigureAuditObjectLockExporter.new.down
+      CreateTamperEvidentAuditLedger.new.down
+      force_source_rls
+      event_id, version_id = insert_hidden_sources
+      clear_current_household
+      as_med_tracker_owner { CreateTamperEvidentAuditLedger.new.up }
+      remove_ledger_entry('versions', version_id)
+      ConfigureAuditObjectLockExporter.new.up
+      [event_id, version_id]
+    end
+  end
+
+  def insert_hidden_sources
+    set_current_household
+    event = Audit::Event.record!(
+      household:,
+      event_type: 'audit.legacy.hidden',
+      metadata: { outcome: 'success' }
+    )
+    [event.id, insert_version(event.created_at)]
+  end
+
+  def insert_version(occurred_at)
+    connection.select_value(<<~SQL.squish)
+      INSERT INTO versions (item_type, item_id, event, object, created_at, audit_context, household_id)
+      VALUES (
+        'LegacyAudit', 1, 'legacy.test', '{"outcome":"success"}',
+        #{connection.quote(occurred_at)}, '{}', #{household.id}
+      )
+      RETURNING id
+    SQL
+  end
+
+  def create_live_tail
+    set_current_household
+    event = Audit::Event.record!(
+      household:,
+      event_type: 'audit.live.before_repair',
+      metadata: { outcome: 'success' }
+    )
+    clear_current_household
+    AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+  end
+
+  def preserve_existing_audit_records
+    [AuditLedgerEntry, AuditCheckpoint, AuditExportDelivery, AuditSigningKey].to_h do |model|
+      [model, model.order(:id).to_h { |record| [record.id, record.attributes] }]
+    end
+  end
+
+  def expect_existing_audit_records_unchanged(preserved_records)
+    preserved_records.each do |model, records|
+      records.each do |id, attributes|
+        expect(model.find(id).attributes).to eq(attributes)
+      end
+    end
+  end
+
+  def expect_repair_checkpoint(entry)
+    expect(AuditCheckpoint.find_by!(chain_epoch: entry.chain_epoch)).to have_attributes(
+      checkpoint_kind: 'legacy-repair',
+      sequence: entry.sequence,
+      entry_hash: entry.entry_hash,
+      signature: nil,
+      audit_signing_key_id: nil
+    )
+  end
+
+  def expect_pending_deliveries(entries)
+    entries.each do |entry|
+      expect(AuditExportDelivery.find_by!(audit_ledger_entry: entry)).to have_attributes(
+        status: 'pending',
+        attempts: 0,
+        object_key: nil,
+        checksum_sha256: nil,
+        object_version_id: nil,
+        delivered_at: nil
+      )
+    end
+  end
+
+  def expect_live_tail_checkpoint(entry)
+    expect(AuditCheckpoint.find_by!(chain_epoch: entry.chain_epoch, sequence: entry.sequence)).to have_attributes(
+      checkpoint_kind: 'pre-legacy-repair',
+      entry_hash: entry.entry_hash
+    )
+  end
+
+  def expect_complete_source_coverage
+    expect(connection.select_value(<<~SQL.squish)).to eq(0)
+      SELECT COUNT(*)
+      FROM (
+        SELECT sources.source_table, sources.source_id
+        FROM (
+          SELECT 'versions'::text source_table, id source_id FROM versions
+          UNION ALL
+          SELECT 'security_audit_events'::text, id FROM security_audit_events
+        ) sources
+        LEFT JOIN audit_ledger_entries entries
+          ON entries.source_table = sources.source_table AND entries.source_id = sources.source_id
+        GROUP BY sources.source_table, sources.source_id
+        HAVING COUNT(entries.id) <> 1
+      ) incomplete_sources
+    SQL
+  end
+
+  def expect_clean_rls_state
+    expect(forced_rls?('versions')).to be(true)
+    expect(forced_rls?('security_audit_events')).to be(true)
+    expect(connection.select_value(<<~SQL.squish)).to eq(0)
+      SELECT COUNT(*) FROM pg_policies WHERE policyname = #{connection.quote(POLICY_NAME)}
+    SQL
+  end
+
+  def repair_state
+    {
+      heads: AuditChainHead.order(:id).pluck(:id, :chain_epoch, :epoch_kind, :last_sequence, :last_hash),
+      entries: AuditLedgerEntry.order(:id).pluck(:id, :chain_epoch, :epoch_kind, :sequence, :entry_hash),
+      checkpoints: AuditCheckpoint.order(:id).pluck(:id, :chain_epoch, :checkpoint_kind, :sequence, :entry_hash),
+      deliveries: AuditExportDelivery.order(:id).pluck(:id, :audit_ledger_entry_id, :status, :attempts)
+    }
+  end
+
+  def missing_entry?(source_table, source_id)
+    !AuditLedgerEntry.exists?(source_table:, source_id:)
+  end
+
+  def remove_ledger_entry(source_table, source_id)
+    entry = AuditLedgerEntry.find_by!(source_table:, source_id:)
+    connection.execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
+    connection.execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
+  end
+
+  def force_source_rls
+    connection.execute('ALTER TABLE versions FORCE ROW LEVEL SECURITY')
+    connection.execute('ALTER TABLE security_audit_events FORCE ROW LEVEL SECURITY')
+  end
+
+  def forced_rls?(table_name)
+    connection.select_value(<<~SQL.squish)
+      SELECT relforcerowsecurity
+      FROM pg_class
+      WHERE oid = #{connection.quote(table_name)}::regclass
+    SQL
+  end
+
+  def set_current_household
+    connection.execute("SELECT set_config('med_tracker.current_household_id', '#{household.id}', true)")
+  end
+
+  def clear_current_household
+    connection.execute("SELECT set_config('med_tracker.current_household_id', '', true)")
+  end
+
+  def as_med_tracker_owner
+    connection.execute('SET LOCAL ROLE med_tracker_owner')
+    yield
+  ensure
+    connection.execute('RESET ROLE')
+  end
+
+  def migrate_in_new_transaction
+    connection.transaction(requires_new: true) do
+      connection.execute('SET LOCAL ROLE med_tracker_owner')
+      migration.migrate(:up)
+    end
+  ensure
+    connection.execute('RESET ROLE')
+  end
+
+  def without_database_role
+    database_role = ENV.delete('DATABASE_ROLE')
+    yield
+  ensure
+    ENV['DATABASE_ROLE'] = database_role if database_role
+  end
+end

--- a/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
+++ b/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RepairRlsHiddenAuditSources do
   fixtures :accounts, :people, :users
 
   POLICY_NAME = 'repair_rls_hidden_audit_sources_select'
+  SHARED_LOGIN = 'audit_repair_shared_login'
 
   let(:connection) { ActiveRecord::Base.connection }
   let(:household) { users(:admin).person.household }
@@ -19,21 +20,16 @@ RSpec.describe RepairRlsHiddenAuditSources do
       expect(missing_entry?('security_audit_events', event_id)).to be(true)
       expect(missing_entry?('versions', version_id)).to be(true)
 
+      expected_order = add_ordering_sources(event_id, version_id)
       live_entry = create_live_tail
       preserved_records = preserve_existing_audit_records
 
       as_med_tracker_owner { migration.migrate(:up) }
 
-      repaired_entries = AuditLedgerEntry.where(source_table: 'security_audit_events', source_id: event_id)
-        .or(AuditLedgerEntry.where(source_table: 'versions', source_id: version_id))
-        .order(:sequence)
-      expect(repaired_entries.pluck(:source_table, :source_id)).to eq([
-        ['security_audit_events', event_id],
-        ['versions', version_id]
-      ])
+      repaired_entries = entries_for(expected_order).order(:id)
+      expect(repaired_entries.pluck(:chain_key, :source_table, :source_id)).to eq(expected_order)
       expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
-      expect(repaired_entries.pluck(:chain_epoch).uniq.one?).to be(true)
-      expect_repair_checkpoint(repaired_entries.last)
+      expect_repair_checkpoints(repaired_entries)
       expect_pending_deliveries(repaired_entries)
       expect_live_tail_checkpoint(live_entry)
       expect_existing_audit_records_unchanged(preserved_records)
@@ -49,22 +45,55 @@ RSpec.describe RepairRlsHiddenAuditSources do
 
   it 'rolls back its transient policies when the repair cannot finish' do
     with_historical_omission do
+      create_live_tail
+      install_repair_checkpoint_failure
+      state_before_repair = repair_state
+
+      expect { migrate_in_new_transaction }.to raise_error(
+        ActiveRecord::StatementInvalid, /injected failure after repaired entry and delivery/
+      )
+
+      expect(repair_state).to eq(state_before_repair)
+      expect_clean_rls_state
+    end
+  end
+
+  it 'rejects a conflicting existing live-tail checkpoint before rotation' do
+    with_historical_omission do
       live_entry = create_live_tail
-      connection.execute(<<~SQL.squish)
-        UPDATE audit_chain_heads SET last_hash = NULL WHERE chain_key = #{connection.quote(live_entry.chain_key)}
-      SQL
+      create_live_tail_checkpoint(live_entry, entry_hash: "\0".b * 32)
+      state_before_repair = repair_state
 
-      expect { migrate_in_new_transaction }.to raise_error(ActiveRecord::StatementInvalid)
+      expect { migrate_in_new_transaction }.to raise_error(
+        ActiveRecord::StatementInvalid, /existing checkpoint does not match the pre-repair live tail/
+      )
 
+      expect(repair_state).to eq(state_before_repair)
+      expect_clean_rls_state
+    end
+  end
+
+  it 'preserves a matching existing live-tail checkpoint' do
+    with_historical_omission do
+      live_entry = create_live_tail
+      checkpoint = create_live_tail_checkpoint(live_entry, entry_hash: live_entry.entry_hash)
+      attributes = checkpoint.attributes
+
+      as_med_tracker_owner { migration.migrate(:up) }
+
+      expect(checkpoint.reload.attributes).to eq(attributes)
+      expect_complete_source_coverage
       expect_clean_rls_state
     end
   end
 
   it 'runs through the shared login without DATABASE_ROLE' do
     with_historical_omission do |event_id, version_id|
-      expect(connection.select_value('SELECT current_user')).to eq(connection.select_value('SELECT session_user'))
-
-      without_database_role { migration.migrate(:up) }
+      as_restricted_shared_login do
+        expect_restricted_shared_login
+        without_database_role { migration.migrate(:up) }
+        expect_restricted_shared_login
+      end
 
       expect(missing_entry?('security_audit_events', event_id)).to be(false)
       expect(missing_entry?('versions', version_id)).to be(false)
@@ -108,14 +137,37 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def insert_version(occurred_at)
+    insert_version_for(occurred_at, household.id)
+  end
+
+  def insert_version_for(occurred_at, household_id)
     connection.select_value(<<~SQL.squish)
       INSERT INTO versions (item_type, item_id, event, object, created_at, audit_context, household_id)
       VALUES (
         'LegacyAudit', 1, 'legacy.test', '{"outcome":"success"}',
-        #{connection.quote(occurred_at)}, '{}', #{household.id}
+        #{connection.quote(occurred_at)}, '{}', #{connection.quote(household_id)}
       )
       RETURNING id
     SQL
+  end
+
+  def add_ordering_sources(event_id, version_id)
+    occurred_at = connection.select_value(<<~SQL.squish)
+      SELECT created_at FROM security_audit_events WHERE id = #{event_id}
+    SQL
+    connection.execute('ALTER TABLE versions DISABLE TRIGGER append_versions_to_audit_ledger')
+    second_version_id = insert_version_for(occurred_at, household.id)
+    global_version_id = insert_version_for(occurred_at, nil)
+    connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
+
+    [
+      ['global', 'versions', global_version_id],
+      ["household:#{household.id}", 'security_audit_events', event_id],
+      ["household:#{household.id}", 'versions', version_id],
+      ["household:#{household.id}", 'versions', second_version_id]
+    ]
+  ensure
+    connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
   end
 
   def create_live_tail
@@ -143,14 +195,17 @@ RSpec.describe RepairRlsHiddenAuditSources do
     end
   end
 
-  def expect_repair_checkpoint(entry)
-    expect(AuditCheckpoint.find_by!(chain_epoch: entry.chain_epoch)).to have_attributes(
-      checkpoint_kind: 'legacy-repair',
-      sequence: entry.sequence,
-      entry_hash: entry.entry_hash,
-      signature: nil,
-      audit_signing_key_id: nil
-    )
+  def expect_repair_checkpoints(entries)
+    entries.group_by(&:chain_epoch).each_value do |epoch_entries|
+      entry = epoch_entries.max_by(&:sequence)
+      expect(AuditCheckpoint.find_by!(chain_epoch: entry.chain_epoch)).to have_attributes(
+        checkpoint_kind: 'legacy-repair',
+        sequence: entry.sequence,
+        entry_hash: entry.entry_hash,
+        signature: nil,
+        audit_signing_key_id: nil
+      )
+    end
   end
 
   def expect_pending_deliveries(entries)
@@ -201,11 +256,63 @@ RSpec.describe RepairRlsHiddenAuditSources do
 
   def repair_state
     {
-      heads: AuditChainHead.order(:id).pluck(:id, :chain_epoch, :epoch_kind, :last_sequence, :last_hash),
-      entries: AuditLedgerEntry.order(:id).pluck(:id, :chain_epoch, :epoch_kind, :sequence, :entry_hash),
-      checkpoints: AuditCheckpoint.order(:id).pluck(:id, :chain_epoch, :checkpoint_kind, :sequence, :entry_hash),
-      deliveries: AuditExportDelivery.order(:id).pluck(:id, :audit_ledger_entry_id, :status, :attempts)
+      heads: AuditChainHead.order(:id).map(&:attributes),
+      entries: AuditLedgerEntry.order(:id).map(&:attributes),
+      checkpoints: AuditCheckpoint.order(:id).map(&:attributes),
+      deliveries: AuditExportDelivery.order(:id).map(&:attributes),
+      policies: connection.select_rows(<<~SQL.squish)
+        SELECT tablename, policyname, roles, cmd, qual
+        FROM pg_policies
+        WHERE tablename IN ('versions', 'security_audit_events')
+        ORDER BY tablename, policyname
+      SQL
     }
+  end
+
+  def entries_for(expected_order)
+    expected_order.reduce(AuditLedgerEntry.none) do |entries, (_chain_key, source_table, source_id)|
+      entries.or(AuditLedgerEntry.where(source_table:, source_id:))
+    end
+  end
+
+  def create_live_tail_checkpoint(entry, entry_hash:)
+    AuditCheckpoint.create!(
+      household_id: entry.household_id,
+      chain_key: entry.chain_key,
+      chain_epoch: entry.chain_epoch,
+      checkpoint_kind: 'periodic',
+      sequence: entry.sequence,
+      entry_hash:
+    )
+  end
+
+  def install_repair_checkpoint_failure
+    connection.execute <<~SQL
+      CREATE FUNCTION spec_fail_legacy_repair_checkpoint() RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NEW.checkpoint_kind = 'legacy-repair' THEN
+          IF NOT EXISTS (
+            SELECT 1
+            FROM audit_ledger_entries entries
+            JOIN audit_export_deliveries deliveries ON deliveries.audit_ledger_entry_id = entries.id
+            WHERE entries.chain_epoch = NEW.chain_epoch
+              AND entries.epoch_kind = 'legacy-repair'
+              AND deliveries.status = 'pending'
+          ) THEN
+            RAISE EXCEPTION 'repair checkpoint reached before repaired entry and delivery';
+          END IF;
+          RAISE EXCEPTION 'injected failure after repaired entry and delivery';
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+
+      CREATE TRIGGER spec_fail_legacy_repair_checkpoint
+      BEFORE INSERT ON audit_checkpoints
+      FOR EACH ROW EXECUTE FUNCTION spec_fail_legacy_repair_checkpoint();
+    SQL
   end
 
   def missing_entry?(source_table, source_id)
@@ -260,5 +367,29 @@ RSpec.describe RepairRlsHiddenAuditSources do
     yield
   ensure
     ENV['DATABASE_ROLE'] = database_role if database_role
+  end
+
+  def as_restricted_shared_login
+    quoted_role = connection.quote_table_name(SHARED_LOGIN)
+    connection.execute("CREATE ROLE #{quoted_role} LOGIN NOSUPERUSER NOBYPASSRLS INHERIT")
+    connection.execute("GRANT med_tracker_owner TO #{quoted_role} WITH INHERIT TRUE, SET TRUE")
+    connection.execute("SET LOCAL SESSION AUTHORIZATION #{connection.quote(SHARED_LOGIN)}")
+    yield
+  ensure
+    connection.execute('RESET SESSION AUTHORIZATION')
+    connection.execute("DROP ROLE IF EXISTS #{connection.quote_table_name(SHARED_LOGIN)}")
+  end
+
+  def expect_restricted_shared_login
+    expect(connection.select_value('SELECT current_user')).to eq(SHARED_LOGIN)
+    expect(connection.select_value('SELECT session_user')).to eq(SHARED_LOGIN)
+    expect(connection.select_value(<<~SQL.squish)).to be(true)
+      SELECT rolcanlogin AND NOT rolsuper AND NOT rolbypassrls
+      FROM pg_roles
+      WHERE rolname = current_user
+    SQL
+    expect(connection.select_value(<<~SQL.squish)).to be(true)
+      SELECT pg_has_role(current_user, 'med_tracker_owner', 'MEMBER')
+    SQL
   end
 end

--- a/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
+++ b/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
@@ -287,33 +287,46 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def create_repair_checkpoint_failure_function
-    connection.execute <<~SQL
+    connection.execute(repair_checkpoint_failure_function_sql)
+  end
+
+  def repair_checkpoint_failure_function_sql
+    <<~SQL.squish
       CREATE FUNCTION spec_fail_legacy_repair_checkpoint() RETURNS trigger
       LANGUAGE plpgsql
       AS $$
       BEGIN
-        IF NEW.checkpoint_kind = 'legacy-repair' THEN
-          IF NOT EXISTS (
-            SELECT 1
-            FROM audit_ledger_entries entries
-            JOIN audit_export_deliveries deliveries ON deliveries.audit_ledger_entry_id = entries.id
-            WHERE entries.chain_epoch = NEW.chain_epoch
-              AND entries.epoch_kind = 'legacy-repair'
-              AND deliveries.status = 'pending'
-          ) THEN
-            RAISE EXCEPTION 'repair checkpoint reached before repaired entry and delivery';
-          END IF;
-          RAISE EXCEPTION 'injected failure after repaired entry and delivery';
-        END IF;
+        #{repair_checkpoint_failure_body_sql}
         RETURN NEW;
       END;
       $$;
+    SQL
+  end
 
+  def repair_checkpoint_failure_body_sql
+    <<~SQL.squish
+      IF NEW.checkpoint_kind = 'legacy-repair' THEN
+        IF NOT EXISTS (#{pending_repair_delivery_sql}) THEN
+          RAISE EXCEPTION 'repair checkpoint reached before repaired entry and delivery';
+        END IF;
+        RAISE EXCEPTION 'injected failure after repaired entry and delivery';
+      END IF;
+    SQL
+  end
+
+  def pending_repair_delivery_sql
+    <<~SQL.squish
+      SELECT 1
+      FROM audit_ledger_entries entries
+      JOIN audit_export_deliveries deliveries ON deliveries.audit_ledger_entry_id = entries.id
+      WHERE entries.chain_epoch = NEW.chain_epoch
+        AND entries.epoch_kind = 'legacy-repair'
+        AND deliveries.status = 'pending'
     SQL
   end
 
   def create_repair_checkpoint_failure_trigger
-    connection.execute <<~SQL
+    connection.execute <<~SQL.squish
       CREATE TRIGGER spec_fail_legacy_repair_checkpoint
       BEFORE INSERT ON audit_checkpoints
       FOR EACH ROW EXECUTE FUNCTION spec_fail_legacy_repair_checkpoint();
@@ -375,19 +388,39 @@ RSpec.describe RepairRlsHiddenAuditSources do
   end
 
   def as_restricted_shared_login
+    create_restricted_shared_login
+    assume_restricted_shared_login
+    yield
+  ensure
+    remove_restricted_shared_login
+  end
+
+  def create_restricted_shared_login
     quoted_role = connection.quote_table_name(shared_login)
     connection.execute("CREATE ROLE #{quoted_role} LOGIN NOSUPERUSER NOBYPASSRLS INHERIT")
     connection.execute("GRANT med_tracker_owner TO #{quoted_role} WITH INHERIT TRUE, SET TRUE")
+  end
+
+  def assume_restricted_shared_login
     connection.execute("SET LOCAL SESSION AUTHORIZATION #{connection.quote(shared_login)}")
-    yield
-  ensure
+  end
+
+  def remove_restricted_shared_login
     connection.execute('RESET SESSION AUTHORIZATION')
     connection.execute("DROP ROLE IF EXISTS #{connection.quote_table_name(shared_login)}")
   end
 
   def expect_restricted_shared_login
+    expect_shared_login_identity
+    expect_shared_login_permissions
+  end
+
+  def expect_shared_login_identity
     expect(connection.select_value('SELECT current_user')).to eq(shared_login)
     expect(connection.select_value('SELECT session_user')).to eq(shared_login)
+  end
+
+  def expect_shared_login_permissions
     expect(connection.select_value(<<~SQL.squish)).to be(true)
       SELECT rolcanlogin AND NOT rolsuper AND NOT rolbypassrls
       FROM pg_roles
@@ -417,14 +450,22 @@ RSpec.describe RepairRlsHiddenAuditSources do
 
   def expect_repaired_audit_evidence(expected_order, live_entry, preserved_records)
     repaired_entries = entries_for(expected_order).order(:id)
-    expect(repaired_entries.pluck(:chain_key, :source_table, :source_id)).to eq(expected_order)
-    expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
-    expect_repair_checkpoints(repaired_entries)
-    expect_pending_deliveries(repaired_entries)
-    expect_live_tail_checkpoint(live_entry)
+    expect_repaired_entries(repaired_entries, expected_order)
+    expect_repair_artifacts(repaired_entries, live_entry)
     expect_existing_audit_records_unchanged(preserved_records)
     expect_complete_source_coverage
     expect_clean_rls_state
+  end
+
+  def expect_repaired_entries(repaired_entries, expected_order)
+    expect(repaired_entries.pluck(:chain_key, :source_table, :source_id)).to eq(expected_order)
+    expect(repaired_entries.pluck(:epoch_kind).uniq).to eq(['legacy-repair'])
+  end
+
+  def expect_repair_artifacts(repaired_entries, live_entry)
+    expect_repair_checkpoints(repaired_entries)
+    expect_pending_deliveries(repaired_entries)
+    expect_live_tail_checkpoint(live_entry)
   end
 
   def expect_repair_to_be_idempotent

--- a/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
+++ b/spec/migrations/repair_rls_hidden_audit_sources_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe RepairRlsHiddenAuditSources do
       expect(missing_entry?('versions', version_id)).to be(true)
 
       expected_order = add_ordering_sources(event_id, version_id)
+      expect(household_source_times(expected_order).uniq.size).to be > 1
       live_entry = create_live_tail
       preserved_records = preserve_existing_audit_records
 
@@ -156,15 +157,19 @@ RSpec.describe RepairRlsHiddenAuditSources do
       SELECT created_at FROM security_audit_events WHERE id = #{event_id}
     SQL
     connection.execute('ALTER TABLE versions DISABLE TRIGGER append_versions_to_audit_ledger')
+    earlier_version_id = insert_version_for(occurred_at - 2.hours, household.id)
     second_version_id = insert_version_for(occurred_at, household.id)
-    global_version_id = insert_version_for(occurred_at, nil)
+    later_version_id = insert_version_for(occurred_at + 2.hours, household.id)
+    global_version_id = insert_version_for(occurred_at + 4.hours, nil)
     connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
 
     [
       ['global', 'versions', global_version_id],
+      ["household:#{household.id}", 'versions', earlier_version_id],
       ["household:#{household.id}", 'security_audit_events', event_id],
       ["household:#{household.id}", 'versions', version_id],
-      ["household:#{household.id}", 'versions', second_version_id]
+      ["household:#{household.id}", 'versions', second_version_id],
+      ["household:#{household.id}", 'versions', later_version_id]
     ]
   ensure
     connection.execute('ALTER TABLE versions ENABLE TRIGGER append_versions_to_audit_ledger')
@@ -272,6 +277,16 @@ RSpec.describe RepairRlsHiddenAuditSources do
   def entries_for(expected_order)
     expected_order.reduce(AuditLedgerEntry.none) do |entries, (_chain_key, source_table, source_id)|
       entries.or(AuditLedgerEntry.where(source_table:, source_id:))
+    end
+  end
+
+  def household_source_times(expected_order)
+    expected_order.filter_map do |chain_key, source_table, source_id|
+      next unless chain_key == "household:#{household.id}"
+
+      connection.select_value(<<~SQL.squish)
+        SELECT created_at FROM #{connection.quote_table_name(source_table)} WHERE id = #{source_id}
+      SQL
     end
   end
 

--- a/spec/services/audit/verification/command_spec.rb
+++ b/spec/services/audit/verification/command_spec.rb
@@ -43,5 +43,36 @@ RSpec.describe Audit::Verification::Command do
 
     expect(exit_code).to eq(2)
     expect(error_output.string).to include('audit verification could not run: invalid FROM')
+    expect(output.string).not_to include('VALID')
+  end
+
+  it 'rejects time filters for database and combined verification without reporting valid evidence' do
+    %w[database combined].each do |scope|
+      output.truncate(0)
+      error_output.truncate(0)
+
+      exit_code = described_class.new(
+        environment: { 'SCOPE' => scope, 'FROM' => '2026-07-01T00:00:00Z' },
+        output:, error_output:
+      ).call
+
+      expect(exit_code).to eq(2)
+      expect(output.string).not_to include('VALID')
+      expect(error_output.string).to include('time filters are unsupported for database verification')
+    end
+  end
+
+  it 'preserves time filtering for WORM-only verification' do
+    result = Audit::Verification::Result.new(scope: 'worm', checked_entries: 0, checked_checkpoints: 0,
+                                             checked_objects: 1, issues: [])
+    verifier = instance_double(Audit::Verification::WormVerifier, call: result)
+
+    exit_code = described_class.new(
+      environment: { 'SCOPE' => 'worm', 'FROM' => '2026-07-01T00:00:00Z' },
+      output:, error_output:, worm_verifier: verifier
+    ).call
+
+    expect(exit_code).to eq(0)
+    expect(output.string).to include('VALID')
   end
 end

--- a/spec/services/audit/verification/database_verifier_spec.rb
+++ b/spec/services/audit/verification/database_verifier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     second = ledger_entry_for('audit.verify.second')
     signer.sign(second)
 
-    result = described_class.new(entries: AuditLedgerEntry.where(id: [first.id, second.id])).call
+    result = verify(entries: AuditLedgerEntry.where(id: [first.id, second.id]))
 
     expect(result).to be_valid
     expect(result.checked_entries).to eq(2)
@@ -23,7 +23,7 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     entry = ledger_entry_for('audit.verify.hash')
     execute("UPDATE audit_ledger_entries SET entry_hash = decode('#{'00' * 32}', 'hex') WHERE id = #{entry.id}")
 
-    result = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    result = verify(entries: AuditLedgerEntry.where(id: entry.id))
 
     expect(result.issue_codes).to include('entry_hash_mismatch', 'chain_head_mismatch')
     expect(result.exit_code).to eq(1)
@@ -33,9 +33,82 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     entry = ledger_entry_for('audit.verify.source')
     execute("UPDATE security_audit_events SET event_type = 'audit.verify.changed' WHERE id = #{entry.source_id}")
 
-    result = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    result = verify(entries: AuditLedgerEntry.where(id: entry.id))
 
     expect(result.issue_codes).to include('source_payload_mismatch')
+  end
+
+  it 'reports a source row with no matching ledger entry without exposing its payload' do
+    event = Audit::Event.record!(household:, event_type: 'audit.verify.missing', metadata: { outcome: 'success' })
+    entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+    execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
+    execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
+
+    result = verify(entries: AuditLedgerEntry.where(household:))
+
+    issue = result.issues.find { |candidate| candidate.code == 'source_ledger_entry_missing' }
+    expect(issue&.to_h).to include(
+      code: 'source_ledger_entry_missing',
+      metadata: { source_table: 'security_audit_events', missing_count: 1 }
+    )
+    expect(issue.to_h.to_s).not_to include(event.event_type)
+  end
+
+  it 'reports a version row with no matching ledger entry' do
+    version_id = insert_version('audit.verify.version.missing', household.id)
+    remove_ledger_entry('versions', version_id)
+
+    result = verify(entries: AuditLedgerEntry.where(household:))
+
+    expect(result.issues.map(&:to_h)).to include(
+      hash_including(
+        code: 'source_ledger_entry_missing',
+        metadata: { source_table: 'versions', missing_count: 1 }
+      )
+    )
+  end
+
+  it 'limits source completeness to the requested household' do
+    own_event = Audit::Event.record!(household:, event_type: 'audit.verify.household.missing', metadata: {})
+    other_household = Household.create!(name: 'Unrelated verifier household')
+    other_event = Audit::Event.record!(household: other_household, event_type: 'audit.verify.unrelated', metadata: {})
+    remove_ledger_entry('security_audit_events', own_event.id)
+    remove_ledger_entry('security_audit_events', other_event.id)
+
+    result = verify(entries: AuditLedgerEntry.where(household:), household_id: household.id)
+
+    expect(result.issues.map(&:to_h)).to include(
+      hash_including(
+        code: 'source_ledger_entry_missing',
+        metadata: { source_table: 'security_audit_events', missing_count: 1 }
+      )
+    )
+  end
+
+  it 'requires the dedicated verifier database role' do
+    expect do
+      described_class.new(entries: AuditLedgerEntry.none).call
+    end.to raise_error(Audit::Verification::ConfigurationError, /med_tracker_audit_verifier/)
+  end
+
+  it 'requires every read privilege used by verification' do
+    execute('REVOKE SELECT ON versions FROM med_tracker_audit_verifier')
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /SELECT privilege/)
+  ensure
+    execute('GRANT SELECT ON versions TO med_tracker_audit_verifier')
+  end
+
+  it 'requires the complete verifier RLS policy' do
+    execute('DROP POLICY audit_verifier_complete_visibility ON security_audit_events')
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /RLS policy/)
+  ensure
+    install_verifier_visibility_policy
   end
 
   it 'reports missing or duplicated sequence positions' do
@@ -46,8 +119,8 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     duplicate = second.dup
     duplicate.sequence = first.sequence
 
-    missing_result = described_class.new(entries: [missing], verify_heads: false).call
-    duplicated = described_class.new(entries: [first, duplicate], verify_heads: false).call
+    missing_result = verify(entries: [missing], verify_heads: false)
+    duplicated = verify(entries: [first, duplicate], verify_heads: false)
 
     expect(missing_result.issue_codes).to include('sequence_gap')
     expect(duplicated.issue_codes).to include('sequence_gap')
@@ -60,7 +133,7 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
                                  metadata: { outcome: 'success' })
     second = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
 
-    result = described_class.new(entries: [second, first]).call
+    result = verify(entries: [second, first])
 
     expect(result).to be_valid
   end
@@ -70,7 +143,7 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
     execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
 
-    result = described_class.new(entries: AuditLedgerEntry.none).call
+    result = verify(entries: AuditLedgerEntry.none)
 
     expect(result.issue_codes).to include('chain_head_mismatch')
   end
@@ -82,12 +155,12 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
       checkpoint_kind: 'periodic', sequence: entry.sequence, entry_hash: entry.entry_hash
     )
 
-    unsigned = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    unsigned = verify(entries: AuditLedgerEntry.where(id: entry.id))
     expect(unsigned.issue_codes).to include('checkpoint_unsigned')
 
     signer.sign(entry)
     execute("UPDATE audit_checkpoints SET signature = decode('00', 'hex') WHERE id = #{checkpoint.id}")
-    invalid = described_class.new(entries: AuditLedgerEntry.where(id: entry.id)).call
+    invalid = verify(entries: AuditLedgerEntry.where(id: entry.id))
     expect(invalid.issue_codes).to include('checkpoint_signature_invalid')
   end
 
@@ -106,5 +179,43 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
 
   def execute(sql)
     ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def verify(entries:, verify_heads: true, household_id: nil)
+    with_audit_verifier_role do
+      described_class.new(entries:, verify_heads:, household_id:).call
+    end
+  end
+
+  def remove_ledger_entry(source_table, source_id)
+    entry = AuditLedgerEntry.find_by!(source_table:, source_id:)
+    execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
+    execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
+  end
+
+  def insert_version(event, household_id)
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      INSERT INTO versions (item_type, item_id, event, object, created_at, audit_context, household_id)
+      VALUES ('VerifierSpec', 1, #{ActiveRecord::Base.connection.quote(event)}, '{}', clock_timestamp(), '{}',
+              #{household_id})
+      RETURNING id
+    SQL
+  end
+
+  def install_verifier_visibility_policy
+    execute <<~SQL.squish
+      CREATE POLICY audit_verifier_complete_visibility ON security_audit_events
+      FOR SELECT TO med_tracker_audit_verifier
+      USING (true)
+    SQL
+  end
+
+  def with_audit_verifier_role
+    execute("SELECT set_config('med_tracker.current_household_id', '#{household.id}', true)")
+    execute('SET LOCAL ROLE med_tracker_audit_verifier')
+    yield
+  ensure
+    execute('RESET ROLE')
+    execute("SELECT set_config('med_tracker.current_household_id', '', true)")
   end
 end

--- a/spec/services/audit/verification/database_verifier_spec.rb
+++ b/spec/services/audit/verification/database_verifier_spec.rb
@@ -101,6 +101,21 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     )
   end
 
+  %w[legacy-baseline legacy-repair].product(%i[wrong null]).each do |epoch_kind, household_mismatch|
+    it "reports a completed #{epoch_kind} source whose ledger household is #{household_mismatch}" do
+      event = Audit::Event.record!(
+        household:, event_type: "audit.verify.#{epoch_kind}.#{household_mismatch}", metadata: {}
+      )
+      entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+      ledger_household_id = Household.create!(name: 'Wrong ledger household').id if household_mismatch == :wrong
+      complete_legacy_epoch(entry, epoch_kind:, ledger_household_id:)
+
+      result = verify(entries: AuditLedgerEntry.all, household_id: household.id)
+
+      expect(result.issue_codes).to contain_exactly('source_ledger_entry_missing')
+    end
+  end
+
   it 'scopes every verification phase when the requested household has no ledger entries' do
     requested_household = Household.create!(name: 'Empty requested verifier household')
     unrelated_entry, unrelated_event = corrupt_unrelated_audit_evidence
@@ -292,6 +307,24 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     entry = AuditLedgerEntry.find_by!(source_table:, source_id:)
     execute("DELETE FROM audit_export_deliveries WHERE audit_ledger_entry_id = #{entry.id}")
     execute("DELETE FROM audit_ledger_entries WHERE id = #{entry.id}")
+  end
+
+  def complete_legacy_epoch(entry, epoch_kind:, ledger_household_id:)
+    AuditCheckpoint.create!(
+      household:, chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+      checkpoint_kind: epoch_kind, sequence: entry.sequence, entry_hash: entry.entry_hash
+    )
+    connection = ActiveRecord::Base.connection
+    execute <<~SQL.squish
+      UPDATE audit_ledger_entries
+      SET household_id = #{connection.quote(ledger_household_id)}, epoch_kind = #{connection.quote(epoch_kind)}
+      WHERE id = #{entry.id}
+    SQL
+    execute <<~SQL.squish
+      UPDATE audit_chain_heads
+      SET chain_epoch = gen_random_uuid(), epoch_kind = 'live', last_sequence = 0, last_hash = NULL
+      WHERE chain_key = #{connection.quote(entry.chain_key)}
+    SQL
   end
 
   def insert_version(event, household_id)

--- a/spec/services/audit/verification/database_verifier_spec.rb
+++ b/spec/services/audit/verification/database_verifier_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     expect(result.issue_codes).to include('source_payload_mismatch')
   end
 
+  it 'does not follow a forged source reference into another household' do
+    entry = ledger_entry_for('audit.verify.cross-household.source')
+    other_household = Household.create!(name: 'Cross-household source reference')
+    other_event = Audit::Event.record!(
+      household: other_household, event_type: 'audit.verify.cross-household.secret', metadata: {}
+    )
+    remove_ledger_entry('security_audit_events', other_event.id)
+    execute("UPDATE audit_ledger_entries SET source_id = #{other_event.id} WHERE id = #{entry.id}")
+
+    result = verify(entries: AuditLedgerEntry.where(id: entry.id), household_id: household.id)
+
+    expect(result.issue_codes).to include('source_row_missing')
+    expect(result.issue_codes).not_to include('source_payload_mismatch')
+    expect(result.to_h.to_s).not_to include(other_event.event_type)
+  end
+
   it 'reports a source row with no matching ledger entry without exposing its payload' do
     event = Audit::Event.record!(household:, event_type: 'audit.verify.missing', metadata: { outcome: 'success' })
     entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
@@ -168,18 +184,32 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     end
   end
 
-  it 'rejects competing unrestricted security-event policies for other roles' do
+  it 'rejects a non-literal unrestricted security-event policy' do
     execute <<~SQL.squish
       CREATE POLICY audit_verifier_competing_visibility ON security_audit_events
       FOR SELECT TO med_tracker_app
-      USING (true)
+      USING (current_user IS NOT NULL)
     SQL
 
     expect do
       verify(entries: AuditLedgerEntry.none)
-    end.to raise_error(Audit::Verification::ConfigurationError, /competing unrestricted RLS policy/)
+    end.to raise_error(Audit::Verification::ConfigurationError, /RLS policy set/)
   ensure
     execute('DROP POLICY IF EXISTS audit_verifier_competing_visibility ON security_audit_events')
+  end
+
+  it 'rejects any unexpected security-event policy' do
+    execute <<~SQL.squish
+      CREATE POLICY audit_verifier_unexpected_policy ON security_audit_events
+      FOR SELECT TO med_tracker_app
+      USING (household_id = 123)
+    SQL
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /RLS policy set/)
+  ensure
+    execute('DROP POLICY IF EXISTS audit_verifier_unexpected_policy ON security_audit_events')
   end
 
   it 'reports missing or duplicated sequence positions' do

--- a/spec/services/audit/verification/database_verifier_spec.rb
+++ b/spec/services/audit/verification/database_verifier_spec.rb
@@ -85,6 +85,31 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     )
   end
 
+  it 'scopes every verification phase when the requested household has no ledger entries' do
+    requested_household = Household.create!(name: 'Empty requested verifier household')
+    unrelated_entry, unrelated_event = corrupt_unrelated_audit_evidence
+
+    result = verify(entries: AuditLedgerEntry.all, household_id: requested_household.id)
+
+    expect(result).to be_valid
+    expect(result.checked_entries).to eq(0)
+    expect(result.checked_checkpoints).to eq(0)
+    expect(result.to_h.to_s).not_to include(unrelated_entry.chain_key, unrelated_event.event_type)
+  end
+
+  it 'binds household completeness filters as bigint values' do
+    large_household_id = 4_294_967_296
+    large_household = Household.create!(id: large_household_id, name: 'Bigint verifier household')
+    event = Audit::Event.record!(household: large_household, event_type: 'audit.verify.bigint', metadata: {})
+    remove_ledger_entry('security_audit_events', event.id)
+
+    result = verify(entries: AuditLedgerEntry.where(household: large_household), household_id: large_household_id)
+
+    expect(result.issues.map(&:to_h)).to include(
+      hash_including(metadata: { source_table: 'security_audit_events', missing_count: 1 })
+    )
+  end
+
   it 'requires the dedicated verifier database role' do
     expect do
       described_class.new(entries: AuditLedgerEntry.none).call
@@ -109,6 +134,52 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
     end.to raise_error(Audit::Verification::ConfigurationError, /RLS policy/)
   ensure
     install_verifier_visibility_policy
+  end
+
+  it 'rejects effective audit mutation privileges' do
+    execute('GRANT INSERT ON audit_ledger_entries TO med_tracker_audit_verifier')
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /mutation privilege/)
+  ensure
+    execute('REVOKE INSERT ON audit_ledger_entries FROM med_tracker_audit_verifier')
+  end
+
+  it 'rejects effective reads on unapproved public tables' do
+    execute('GRANT SELECT ON medications TO med_tracker_audit_verifier')
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /unapproved SELECT privilege/)
+  ensure
+    execute('REVOKE SELECT ON medications FROM med_tracker_audit_verifier')
+  end
+
+  it 'rejects membership in runtime, owner, or exporter roles' do
+    %w[med_tracker_app med_tracker_owner med_tracker_audit_exporter].each do |role_name|
+      execute("GRANT #{role_name} TO med_tracker_audit_verifier")
+
+      expect do
+        verify(entries: AuditLedgerEntry.none)
+      end.to raise_error(Audit::Verification::ConfigurationError, /forbidden role membership/)
+    ensure
+      execute("REVOKE #{role_name} FROM med_tracker_audit_verifier")
+    end
+  end
+
+  it 'rejects competing unrestricted security-event policies for other roles' do
+    execute <<~SQL.squish
+      CREATE POLICY audit_verifier_competing_visibility ON security_audit_events
+      FOR SELECT TO med_tracker_app
+      USING (true)
+    SQL
+
+    expect do
+      verify(entries: AuditLedgerEntry.none)
+    end.to raise_error(Audit::Verification::ConfigurationError, /competing unrestricted RLS policy/)
+  ensure
+    execute('DROP POLICY IF EXISTS audit_verifier_competing_visibility ON security_audit_events')
   end
 
   it 'reports missing or duplicated sequence positions' do
@@ -200,6 +271,24 @@ RSpec.describe Audit::Verification::DatabaseVerifier do
               #{household_id})
       RETURNING id
     SQL
+  end
+
+  def corrupt_unrelated_audit_evidence
+    unrelated_household = Household.create!(name: 'Corrupted unrelated verifier household')
+    event = Audit::Event.record!(
+      household: unrelated_household, event_type: 'audit.verify.unrelated.secret', metadata: {}
+    )
+    entry = AuditLedgerEntry.find_by!(source_table: 'security_audit_events', source_id: event.id)
+    AuditCheckpoint.create!(
+      household: unrelated_household, chain_key: entry.chain_key, chain_epoch: entry.chain_epoch,
+      checkpoint_kind: 'periodic', sequence: entry.sequence, entry_hash: entry.entry_hash
+    )
+    execute(<<~SQL.squish)
+      UPDATE audit_chain_heads
+      SET last_hash = decode('#{'00' * 32}', 'hex')
+      WHERE household_id = #{unrelated_household.id}
+    SQL
+    [entry, event]
   end
 
   def install_verifier_visibility_policy

--- a/spec/services/audit/verification/issue_spec.rb
+++ b/spec/services/audit/verification/issue_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::Verification::Issue do
+  it 'omits metadata when absent and includes it when present' do
+    issue = described_class.new(code: 'entry_hash_mismatch', message: 'entry hash differs',
+                                chain_key: 'global', sequence: 1)
+    completeness_issue = described_class.new(
+      code: 'source_ledger_entry_missing', message: 'source rows are missing ledger entries',
+      chain_key: nil, sequence: nil, metadata: { source_table: 'versions', missing_count: 2 }
+    )
+
+    expect(issue.to_h).to eq(
+      code: 'entry_hash_mismatch', message: 'entry hash differs', chain_key: 'global', sequence: 1
+    )
+    expect(completeness_issue.to_h).to include(
+      metadata: { source_table: 'versions', missing_count: 2 }
+    )
+  end
+end

--- a/spec/support/database_runtime_role_setup.rb
+++ b/spec/support/database_runtime_role_setup.rb
@@ -14,6 +14,7 @@ module DatabaseRuntimeRoleSetup
     db/migrate/20260709143000_configure_audit_object_lock_exporter.rb
     db/migrate/20260709143100_enforce_recent_household_row_level_security.rb
     db/migrate/20260709150000_configure_audit_verifier_role.rb
+    db/migrate/20260717130000_grant_audit_verifier_complete_visibility.rb
     db/migrate/20260713190100_allow_invitation_token_rls_bootstrap.rb
   ].freeze
 
@@ -69,6 +70,7 @@ module DatabaseRuntimeRoleSetup
     migration = ConfigureAuditVerifierRole.new
     migration.install_verifier_role
     migration.lock_verifier_privileges
+    GrantAuditVerifierCompleteVisibility.new.up
   end
 end
 


### PR DESCRIPTION
## Summary

Upgrades that passed through the original audit-ledger migration could silently omit tenant-scoped audit source rows because forced RLS hid them from the backfill. This PR adds a forward-only repair that appends the missing evidence in honest `legacy-repair` epochs, creates pending delivery records, and refuses to finish unless both supported audit sources have exactly one ledger entry each.

Database verification now proves the relationship in both directions. It uses a dedicated read-only verifier authority with complete audit-source visibility, fails closed when that authority is not exact, and keeps household-scoped verification bound to matching source and ledger ownership. Existing ledger entries, checkpoints, signed evidence, and delivered WORM objects are left unchanged.

The operator guidance now explains how to sign and export repaired checkpoints, drain deliveries, and re-run database and WORM verification before accepting upgraded evidence.

A disposable PostgreSQL 18 rehearsal upgraded the production `0.5.7` image to this branch with the existing shared login. It reproduced the hidden source row before upgrade, repaired it to one ledger entry and one pending delivery, preserved people and medication takes, retained forced RLS and tenant isolation, and completed database verification successfully.

Closes #1693
