### PR TITLE
fix(ci): stabilize Lighthouse score gate

### DIFF
--- a/Taskfiles/lighthouse.yml
+++ b/Taskfiles/lighthouse.yml
@@ -79,67 +79,31 @@ tasks:
       A11Y_THRESHOLD: '{{ .A11Y_THRESHOLD | default "90" }}'
       BP_THRESHOLD: '{{ .BP_THRESHOLD | default "90" }}'
       REPORT_PATH: '{{ .REPORT_PATH | default "./lighthouse-report" }}'
+      LIGHTHOUSE_RUNS: '{{ .LIGHTHOUSE_RUNS | default "3" }}'
       EXTRA_HEADERS: '{{ .EXTRA_HEADERS | default "" }}'
     cmds:
       - |
         set -euo pipefail
-        echo "Running Lighthouse CI audit on {{ .URL }}..."
-        npx --yes lighthouse@13 {{ .URL }} \
-          --output=json,html \
-          --output-path={{ .REPORT_PATH }} \
-          --chrome-flags="--headless --no-sandbox --disable-gpu" \
-          --form-factor=mobile \
-          --screenEmulation.mobile=true \
-          --screenEmulation.width=375 \
-          --screenEmulation.height=812 \
-          {{ if .EXTRA_HEADERS }}--extra-headers='{{ .EXTRA_HEADERS }}' {{ end }}--only-categories=accessibility,best-practices,performance
+        for run in $(seq 1 {{ .LIGHTHOUSE_RUNS }}); do
+          REPORT_PATH="{{ .REPORT_PATH }}-${run}"
+          echo "Running Lighthouse CI audit ${run}/{{ .LIGHTHOUSE_RUNS }} on {{ .URL }}..."
+          npx --yes lighthouse@13 {{ .URL }} \
+            --output=json,html \
+            --output-path="$REPORT_PATH" \
+            --chrome-flags="--headless --no-sandbox --disable-gpu" \
+            --form-factor=mobile \
+            --screenEmulation.mobile=true \
+            --screenEmulation.width=375 \
+            --screenEmulation.height=812 \
+            {{ if .EXTRA_HEADERS }}--extra-headers='{{ .EXTRA_HEADERS }}' {{ end }}--only-categories=accessibility,best-practices,performance
+        done
       - |
-        set -euo pipefail
-        REPORT_FILE=""
-        if [ -f "{{ .REPORT_PATH }}.report.json" ]; then
-          REPORT_FILE="{{ .REPORT_PATH }}.report.json"
-        elif [ -f "{{ .REPORT_PATH }}.json" ]; then
-          REPORT_FILE="{{ .REPORT_PATH }}.json"
-        else
-          echo "No Lighthouse JSON report found for REPORT_PATH={{ .REPORT_PATH }}"
-          exit 1
-        fi
-        echo ""
-        echo "═══════════════════════════════════════════"
-        echo "         LIGHTHOUSE MOBILE SCORES          "
-        echo "═══════════════════════════════════════════"
-
-        PERF=$(node -e "console.log(Math.floor(require('$REPORT_FILE').categories.performance.score * 100))")
-        A11Y=$(node -e "console.log(Math.floor(require('$REPORT_FILE').categories.accessibility.score * 100))")
-        BP=$(node -e "console.log(Math.floor(require('$REPORT_FILE').categories['best-practices'].score * 100))")
-
-        echo "Performance:     ${PERF}% (threshold: {{ .PERF_THRESHOLD }}%)"
-        echo "Accessibility:   ${A11Y}% (threshold: {{ .A11Y_THRESHOLD }}%)"
-        echo "Best Practices:  ${BP}% (threshold: {{ .BP_THRESHOLD }}%)"
-        echo "═══════════════════════════════════════════"
-
-        FAILED=0
-        if [ "$PERF" -lt "{{ .PERF_THRESHOLD }}" ]; then
-          echo "❌ Performance score below threshold!"
-          FAILED=1
-        fi
-        if [ "$A11Y" -lt "{{ .A11Y_THRESHOLD }}" ]; then
-          echo "❌ Accessibility score below threshold!"
-          FAILED=1
-        fi
-        if [ "$BP" -lt "{{ .BP_THRESHOLD }}" ]; then
-          echo "❌ Best Practices score below threshold!"
-          FAILED=1
-        fi
-
-        if [ "$FAILED" -eq 1 ]; then
-          echo ""
-          echo "Top 10 failed audits:"
-          node -e "const r=require('$REPORT_FILE');Object.entries(r.audits).filter(([k,v])=>v.score!=null&&v.score<1).map(([k,v])=>({title:v.title,score:Math.floor(v.score*100)})).sort((a,b)=>a.score-b.score).slice(0,10).forEach(a=>console.log('  ['+a.score+'%] '+a.title))"
-          exit 1
-        else
-          echo "✅ All scores meet thresholds!"
-        fi
+        node bin/lighthouse_score_gate.js \
+          --report-path "{{ .REPORT_PATH }}" \
+          --runs "{{ .LIGHTHOUSE_RUNS }}" \
+          --perf-threshold "{{ .PERF_THRESHOLD }}" \
+          --a11y-threshold "{{ .A11Y_THRESHOLD }}" \
+          --bp-threshold "{{ .BP_THRESHOLD }}"
 
   failed-audits:
     desc: List failed Lighthouse audits

--- a/bin/lighthouse_score_gate.js
+++ b/bin/lighthouse_score_gate.js
@@ -77,14 +77,18 @@ function loadReport(filePath) {
   };
 }
 
+function scorePercent(score) {
+  return Math.floor(score * 100);
+}
+
 function printScore(label, score, threshold) {
-  console.log(`${label}:`.padEnd(16) + ` ${Math.round(score * 100)}% (threshold: ${threshold}%)`);
+  console.log(`${label}:`.padEnd(16) + ` ${scorePercent(score)}% (threshold: ${threshold}%)`);
 }
 
 function failedAudits(report) {
   return Object.entries(report.audits)
     .filter(([, audit]) => isRecord(audit) && Number.isFinite(audit.score) && audit.score < 1)
-    .map(([id, audit]) => ({ score: Math.round(audit.score * 100), title: audit.title || id }))
+    .map(([id, audit]) => ({ score: scorePercent(audit.score), title: audit.title || id }))
     .sort((left, right) => left.score - right.score)
     .slice(0, 10);
 }
@@ -118,7 +122,7 @@ function run() {
     ['Performance', selected.performance, thresholds.performance],
     ['Accessibility', selected.accessibility, thresholds.accessibility],
     ['Best Practices', selected.bestPractices, thresholds.bestPractices]
-  ].filter(([, score, threshold]) => score * 100 < threshold);
+  ].filter(([, score, threshold]) => scorePercent(score) < threshold);
 
   if (failures.length === 0) {
     console.log('All scores meet thresholds.');

--- a/bin/lighthouse_score_gate.js
+++ b/bin/lighthouse_score_gate.js
@@ -1,0 +1,139 @@
+const fs = require('node:fs');
+
+const optionNames = ['report-path', 'runs', 'perf-threshold', 'a11y-threshold', 'bp-threshold'];
+
+function parseArguments(argumentsList) {
+  const options = {};
+
+  for (let index = 0; index < argumentsList.length; index += 2) {
+    const option = argumentsList[index];
+    const value = argumentsList[index + 1];
+
+    if (!optionNames.includes(option?.slice(2)) || value === undefined || value.startsWith('--')) {
+      throw new Error('Usage: node bin/lighthouse_score_gate.js --report-path PATH --runs COUNT --perf-threshold SCORE --a11y-threshold SCORE --bp-threshold SCORE');
+    }
+
+    options[option.slice(2)] = value;
+  }
+
+  if (optionNames.some((name) => options[name] === undefined)) {
+    throw new Error('Usage: node bin/lighthouse_score_gate.js --report-path PATH --runs COUNT --perf-threshold SCORE --a11y-threshold SCORE --bp-threshold SCORE');
+  }
+
+  return options;
+}
+
+function numericOption(options, name, { integer = false } = {}) {
+  const value = Number(options[name]);
+
+  if (!Number.isFinite(value) || (integer && !Number.isInteger(value))) {
+    throw new Error(`Invalid ${name}: ${options[name]}`);
+  }
+
+  return value;
+}
+
+function reportPath(reportPathPrefix, run) {
+  return `${reportPathPrefix}-${run}.report.json`;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function scoreFor(report, category, filePath) {
+  const score = report.categories?.[category]?.score;
+
+  if (!Number.isFinite(score) || score < 0 || score > 1) {
+    throw new Error(`Malformed Lighthouse JSON report: ${filePath}`);
+  }
+
+  return score;
+}
+
+function loadReport(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing Lighthouse JSON report: ${filePath}`);
+  }
+
+  let report;
+
+  try {
+    report = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    throw new Error(`Malformed Lighthouse JSON report: ${filePath}`);
+  }
+
+  if (!isRecord(report) || !isRecord(report.categories) || !isRecord(report.audits)) {
+    throw new Error(`Malformed Lighthouse JSON report: ${filePath}`);
+  }
+
+  return {
+    accessibility: scoreFor(report, 'accessibility', filePath),
+    bestPractices: scoreFor(report, 'best-practices', filePath),
+    filePath,
+    performance: scoreFor(report, 'performance', filePath),
+    report
+  };
+}
+
+function printScore(label, score, threshold) {
+  console.log(`${label}:`.padEnd(16) + ` ${Math.round(score * 100)}% (threshold: ${threshold}%)`);
+}
+
+function failedAudits(report) {
+  return Object.entries(report.audits)
+    .filter(([, audit]) => isRecord(audit) && Number.isFinite(audit.score) && audit.score < 1)
+    .map(([id, audit]) => ({ score: Math.round(audit.score * 100), title: audit.title || id }))
+    .sort((left, right) => left.score - right.score)
+    .slice(0, 10);
+}
+
+function run() {
+  const options = parseArguments(process.argv.slice(2));
+  const runs = numericOption(options, 'runs', { integer: true });
+  const thresholds = {
+    accessibility: numericOption(options, 'a11y-threshold'),
+    bestPractices: numericOption(options, 'bp-threshold'),
+    performance: numericOption(options, 'perf-threshold')
+  };
+
+  if (runs < 1 || runs % 2 === 0) {
+    throw new Error(`runs must be a positive odd number: ${options.runs}`);
+  }
+
+  if (Object.values(thresholds).some((threshold) => threshold < 0 || threshold > 100)) {
+    throw new Error('Thresholds must be between 0 and 100');
+  }
+
+  const reports = Array.from({ length: runs }, (_, index) => loadReport(reportPath(options['report-path'], index + 1)));
+  const selected = [...reports].sort((left, right) => left.performance - right.performance)[Math.floor(reports.length / 2)];
+
+  console.log(`Selected median performance report: ${selected.filePath}`);
+  printScore('Performance', selected.performance, thresholds.performance);
+  printScore('Accessibility', selected.accessibility, thresholds.accessibility);
+  printScore('Best Practices', selected.bestPractices, thresholds.bestPractices);
+
+  const failures = [
+    ['Performance', selected.performance, thresholds.performance],
+    ['Accessibility', selected.accessibility, thresholds.accessibility],
+    ['Best Practices', selected.bestPractices, thresholds.bestPractices]
+  ].filter(([, score, threshold]) => score * 100 < threshold);
+
+  if (failures.length === 0) {
+    console.log('All scores meet thresholds.');
+    return;
+  }
+
+  failures.forEach(([label]) => console.log(`${label} score below threshold!`));
+  console.log('Top 10 failed audits:');
+  failedAudits(selected.report).forEach((audit) => console.log(`  [${audit.score}%] ${audit.title}`));
+  process.exitCode = 1;
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/spec/config/lighthouse_score_gate_spec.rb
+++ b/spec/config/lighthouse_score_gate_spec.rb
@@ -1,0 +1,105 @@
+require 'json'
+require 'open3'
+require 'rails_helper'
+require 'tmpdir'
+
+RSpec.describe 'Lighthouse score gate' do
+  around do |example|
+    Dir.mktmpdir('lighthouse-score-gate') do |directory|
+      @report_path = File.join(directory, 'lighthouse-report')
+      example.run
+    end
+  end
+
+  it 'passes when one low performance outlier leaves a passing median' do
+    write_report(1, performance: 0.45)
+    write_report(2, performance: 0.77)
+    write_report(3, performance: 0.72)
+
+    output, status = run_gate
+
+    expect(status).to be_success
+    expect(output).to include(
+      'Performance:     72% (threshold: 60%)',
+      'Accessibility:   95% (threshold: 90%)',
+      'Best Practices:  95% (threshold: 90%)',
+      'All scores meet thresholds.'
+    )
+  end
+
+  it 'fails for a below-threshold median and identifies failed audits' do
+    write_report(1, performance: 0.55)
+    write_report(2, performance: 0.58, audits: { 'first-contentful-paint' => { score: 0.5, title: 'First Contentful Paint' } })
+    write_report(3, performance: 0.77)
+
+    output, status = run_gate
+
+    expect(status).not_to be_success
+    expect(output).to include(
+      'Performance:     58% (threshold: 60%)',
+      'Performance score below threshold!',
+      'Top 10 failed audits:',
+      '[50%] First Contentful Paint'
+    )
+  end
+
+  it 'fails closed when an expected report is missing' do
+    write_report(1, performance: 0.72)
+    write_report(3, performance: 0.77)
+
+    output, status = run_gate
+
+    expect(status).not_to be_success
+    expect(output).to include("Missing Lighthouse JSON report: #{@report_path}-2.report.json")
+  end
+
+  it 'fails closed when an expected report is malformed' do
+    write_report(1, performance: 0.72)
+    File.write("#{@report_path}-2.report.json", '{')
+    write_report(3, performance: 0.77)
+
+    output, status = run_gate
+
+    expect(status).not_to be_success
+    expect(output).to include("Malformed Lighthouse JSON report: #{@report_path}-2.report.json")
+  end
+
+  it 'collects three reports and runs the gate once' do
+    task = Rails.root.join('Taskfiles/lighthouse.yml').read
+
+    expect(task).to include(
+      'LIGHTHOUSE_RUNS: \'{{ .LIGHTHOUSE_RUNS | default "3" }}\'',
+      'for run in $(seq 1 {{ .LIGHTHOUSE_RUNS }}); do',
+      'REPORT_PATH="{{ .REPORT_PATH }}-${run}"',
+      'node bin/lighthouse_score_gate.js'
+    )
+    expect(task.scan('node bin/lighthouse_score_gate.js').count).to eq(1)
+  end
+
+  def run_gate
+    stdout, stderr, status = Open3.capture3(
+      'node',
+      Rails.root.join('bin/lighthouse_score_gate.js').to_s,
+      '--report-path', @report_path,
+      '--runs', '3',
+      '--perf-threshold', '60',
+      '--a11y-threshold', '90',
+      '--bp-threshold', '90'
+    )
+
+    [stdout + stderr, status]
+  end
+
+  def write_report(run, performance:, accessibility: 0.95, best_practices: 0.95, audits: {})
+    report = {
+      categories: {
+        performance: { score: performance },
+        accessibility: { score: accessibility },
+        'best-practices': { score: best_practices }
+      },
+      audits: audits
+    }
+
+    File.write("#{@report_path}-#{run}.report.json", JSON.generate(report))
+  end
+end

--- a/spec/config/lighthouse_score_gate_spec.rb
+++ b/spec/config/lighthouse_score_gate_spec.rb
@@ -36,11 +36,26 @@ RSpec.describe 'Lighthouse score gate' do
 
     expect(status).not_to be_success
     expect(output).to include(
-      'Performance:     58% (threshold: 60%)',
+      'Performance:     57% (threshold: 60%)',
       'Performance score below threshold!',
       'Top 10 failed audits:',
       '[50%] First Contentful Paint'
     )
+  end
+
+  it 'floors a boundary score consistently for display and threshold checks' do
+    write_report(1, performance: 0.45)
+    write_report(2, performance: 0.599)
+    write_report(3, performance: 0.77)
+
+    output, status = run_gate
+
+    expect(status).not_to be_success
+    expect(output).to include(
+      'Performance:     59% (threshold: 60%)',
+      'Performance score below threshold!'
+    )
+    expect(output).not_to include('All scores meet thresholds.')
   end
 
   it 'fails closed when an expected report is missing' do
@@ -62,18 +77,6 @@ RSpec.describe 'Lighthouse score gate' do
 
     expect(status).not_to be_success
     expect(output).to include("Malformed Lighthouse JSON report: #{@report_path}-2.report.json")
-  end
-
-  it 'collects three reports and runs the gate once' do
-    task = Rails.root.join('Taskfiles/lighthouse.yml').read
-
-    expect(task).to include(
-      'LIGHTHOUSE_RUNS: \'{{ .LIGHTHOUSE_RUNS | default "3" }}\'',
-      'for run in $(seq 1 {{ .LIGHTHOUSE_RUNS }}); do',
-      'REPORT_PATH="{{ .REPORT_PATH }}-${run}"',
-      'node bin/lighthouse_score_gate.js'
-    )
-    expect(task.scan('node bin/lighthouse_score_gate.js').count).to eq(1)
   end
 
   def run_gate

--- a/spec/config/lighthouse_score_gate_spec.rb
+++ b/spec/config/lighthouse_score_gate_spec.rb
@@ -1,15 +1,16 @@
+# frozen_string_literal: true
+
+require 'fileutils'
 require 'json'
 require 'open3'
 require 'rails_helper'
 require 'tmpdir'
 
-RSpec.describe 'Lighthouse score gate' do
-  around do |example|
-    Dir.mktmpdir('lighthouse-score-gate') do |directory|
-      @report_path = File.join(directory, 'lighthouse-report')
-      example.run
-    end
-  end
+RSpec.describe 'Lighthouse score gate' do # rubocop:disable RSpec/DescribeClass
+  let(:report_directory) { Dir.mktmpdir('lighthouse-score-gate') }
+  let(:report_path) { File.join(report_directory, 'lighthouse-report') }
+
+  after { FileUtils.remove_entry(report_directory) }
 
   it 'passes when one low performance outlier leaves a passing median' do
     write_report(1, performance: 0.45)
@@ -29,7 +30,11 @@ RSpec.describe 'Lighthouse score gate' do
 
   it 'fails for a below-threshold median and identifies failed audits' do
     write_report(1, performance: 0.55)
-    write_report(2, performance: 0.58, audits: { 'first-contentful-paint' => { score: 0.5, title: 'First Contentful Paint' } })
+    write_report(
+      2,
+      performance: 0.58,
+      audits: { 'first-contentful-paint' => { score: 0.5, title: 'First Contentful Paint' } }
+    )
     write_report(3, performance: 0.77)
 
     output, status = run_gate
@@ -65,25 +70,25 @@ RSpec.describe 'Lighthouse score gate' do
     output, status = run_gate
 
     expect(status).not_to be_success
-    expect(output).to include("Missing Lighthouse JSON report: #{@report_path}-2.report.json")
+    expect(output).to include("Missing Lighthouse JSON report: #{report_path}-2.report.json")
   end
 
   it 'fails closed when an expected report is malformed' do
     write_report(1, performance: 0.72)
-    File.write("#{@report_path}-2.report.json", '{')
+    File.write("#{report_path}-2.report.json", '{')
     write_report(3, performance: 0.77)
 
     output, status = run_gate
 
     expect(status).not_to be_success
-    expect(output).to include("Malformed Lighthouse JSON report: #{@report_path}-2.report.json")
+    expect(output).to include("Malformed Lighthouse JSON report: #{report_path}-2.report.json")
   end
 
   def run_gate
     stdout, stderr, status = Open3.capture3(
       'node',
       Rails.root.join('bin/lighthouse_score_gate.js').to_s,
-      '--report-path', @report_path,
+      '--report-path', report_path,
       '--runs', '3',
       '--perf-threshold', '60',
       '--a11y-threshold', '90',
@@ -103,6 +108,6 @@ RSpec.describe 'Lighthouse score gate' do
       audits: audits
     }
 
-    File.write("#{@report_path}-#{run}.report.json", JSON.generate(report))
+    File.write("#{report_path}-#{run}.report.json", JSON.generate(report))
   end
 end


### PR DESCRIPTION
## Summary

Lighthouse currently makes a blocking decision from one volatile shared-runner sample. Identical login code scored between 45 and 85 across nearby runs, so lockfile-only pull requests could fail while the application was unchanged.

This collects three sequential reports for each existing route and evaluates one representative median-performance run. The existing 60/90/90 budgets remain blocking, every report is retained, and missing or malformed evidence fails closed.