### PR TITLE
🎨 Palette: Update admin users pagination to use aria-labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-03-05 - Add Descriptive Placeholders for Better Guidance
 **Learning:** Form fields lacking `placeholder` attributes (such as the Medication form inputs) can cause user friction since it’s not immediately clear what expected format or type of data to provide, especially on larger, empty textareas like `warnings` or `description`. Adding placeholder text does not break existing test locators compared to changing ARIA labels.
 **Action:** When working with forms or input fields via `RubyUI::Input` or `RubyUI::Textarea`, add a corresponding translated placeholder where appropriate to guide users effectively without cluttering the UI with additional helper text.
+
+## 2024-05-18 - ARIA labels on disabled <span> elements
+**Learning:** According to W3C ARIA specifications, `aria-label` is generally ignored by screen readers when applied to non-interactive generic elements like `<span>` or `<div>` unless they have a designated widget role. When rendering disabled states of links or buttons using plain `<span>` tags, moving a nested `.sr-only` text label to an `aria-label` attribute on the outer `<span>` causes an accessibility regression, leaving screen reader users without context.
+**Action:** Retain the nested `<span class="sr-only">` pattern for accessible text when styling disabled interactive elements as generic `<span>` tags, or give the outer span appropriate ARIA semantics (e.g., `role="link" aria-disabled="true"`) to ensure the `aria-label` is announced.

--- a/app/components/admin/users/pagination.rb
+++ b/app/components/admin/users/pagination.rb
@@ -92,9 +92,9 @@ module Components
               href: page_url(pagy_obj.previous),
               variant: :link,
               class: nav_button_class('rounded-l-md'),
+              aria_label: t('admin.users.pagination.previous'),
               data: { turbo_frame: 'admin-users-frame' }
             ) do
-              span(class: 'sr-only') { t('admin.users.pagination.previous') }
               plain '‹'
             end
           else
@@ -111,9 +111,9 @@ module Components
               href: page_url(pagy_obj.next),
               variant: :link,
               class: nav_button_class('rounded-r-md'),
+              aria_label: t('admin.users.pagination.next'),
               data: { turbo_frame: 'admin-users-frame' }
             ) do
-              span(class: 'sr-only') { t('admin.users.pagination.next') }
               plain '›'
             end
           else

--- a/spec/components/admin/users/pagination_spec.rb
+++ b/spec/components/admin/users/pagination_spec.rb
@@ -46,13 +46,14 @@ RSpec.describe Components::Admin::Users::Pagination, type: :component do
       prev_span = rendered.css('span.sr-only').find { |s| s.text == 'Previous' }
       expect(prev_span).to be_present
       prev_container = prev_span.parent
+      expect(prev_container).to be_present
       expect(prev_container['class']).to include('cursor-not-allowed')
     end
 
     it 'enables next button when there is a next page' do
       rendered = render_inline(described_class.new(pagy: pagy))
 
-      next_links = rendered.css('a').select { |a| a.css('.sr-only').any? { |s| s.text == 'Next' } }
+      next_links = rendered.css('a[aria-label="Next"]')
       expect(next_links).to be_present
     end
   end
@@ -92,7 +93,7 @@ RSpec.describe Components::Admin::Users::Pagination, type: :component do
     it 'enables previous button' do
       rendered = render_inline(described_class.new(pagy: pagy))
 
-      prev_links = rendered.css('a').select { |a| a.css('.sr-only').any? { |s| s.text == 'Previous' } }
+      prev_links = rendered.css('a[aria-label="Previous"]')
       expect(prev_links).to be_present
     end
   end
@@ -141,12 +142,12 @@ RSpec.describe Components::Admin::Users::Pagination, type: :component do
       expect(nav).to be_present
     end
 
-    it 'renders sr-only text for previous and next buttons' do
+    it 'renders aria-labels for previous and next buttons' do
       rendered = render_inline(described_class.new(pagy: pagy))
 
-      sr_only = rendered.css('.sr-only').map(&:text)
-      expect(sr_only).to include('Previous')
-      expect(sr_only).to include('Next')
+      aria_labels = rendered.css('[aria-label]').map { |el| el['aria-label'] }
+      expect(aria_labels).to include('Previous')
+      expect(aria_labels).to include('Next')
     end
   end
 end

--- a/spec/components/admin/users/pagination_spec.rb
+++ b/spec/components/admin/users/pagination_spec.rb
@@ -145,9 +145,10 @@ RSpec.describe Components::Admin::Users::Pagination, type: :component do
     it 'renders aria-labels for previous and next buttons' do
       rendered = render_inline(described_class.new(pagy: pagy))
 
-      aria_labels = rendered.css('[aria-label]').map { |el| el['aria-label'] }
-      expect(aria_labels).to include('Previous')
-      expect(aria_labels).to include('Next')
+      aria_labels = rendered.css('[aria-label]').pluck('aria-label')
+      expect(aria_labels).to include('Pagination')
+      expect(rendered.css('a[aria-label="Previous"]')).to be_present
+      expect(rendered.css('a[aria-label="Next"]')).to be_present
     end
   end
 end


### PR DESCRIPTION
💡 What: Updated the Admin Users Pagination component to rely on the `aria-label` attribute on the interactive 'Previous' and 'Next' links rather than nesting a visually hidden `<span class="sr-only">`. It retains the `sr-only` spans for the non-interactive disabled states where `aria-label` wouldn't be reliably announced.

🎯 Why: Following internal UX conventions from the journal, icon-only interactive components should preferably define their accessible names directly via `aria_label:` prop on the component/link rather than nesting `sr-only` spans.

📸 Before/After: Visuals are unchanged (only screen-reader text representations changed).

♿ Accessibility: Preserves disabled-state accessibility while simplifying the markup for active states by attaching the label directly to the link wrapper instead of requiring screen-readers to descend into child DOM elements.

---
*PR created automatically by Jules for task [7208006763210276852](https://jules.google.com/task/7208006763210276852) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->