### PR TITLE
refactor(ai): remove stale lint suppression

### DIFF
--- a/app/services/ai_medication/audit_logger.rb
+++ b/app/services/ai_medication/audit_logger.rb
@@ -5,9 +5,7 @@ module AiMedication
     ITEM_TYPE = 'AiMedicationSuggestion'
 
     def record(user:, medication_identity:, suggestion:)
-      # rubocop:disable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
       Audit::VersionEvent.record!(**version_attrs(user:, medication_identity:, suggestion:))
-      # rubocop:enable Rails/SkipsModelValidations, Lint/RedundantCopDisableDirective
     rescue StandardError => e
       Rails.logger.error("AiMedication::AuditLogger failed: #{e.class}: #{e.message}")
     end


### PR DESCRIPTION
## Summary

- Removes an obsolete RuboCop disable/enable pair from `AiMedication::AuditLogger`.
- Keeps the audit call and all executable behavior unchanged.
- Leaves the valid `Rails/SkipsModelValidations` suppression at the actual `PaperTrail::Version.insert` call inside `Audit::VersionEvent`.

## Verification

- `git diff --cached --check` — passed before commit.
- `task test:preflight` — Docker is reachable, but the shared test image rebuild is still contending with concurrent MedTracker worktrees.
- GitHub CI is the verification authority for RuboCop and the full test suite.

## Risks / follow-ups

- No executable code changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->