### PR TITLE
fix(api): serialize idempotent mutations

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -243,26 +243,21 @@ module Api
         Api::RecordEtag.for(record)
       end
 
-      def with_api_idempotency
+      def with_api_idempotency(&action)
         store = Api::IdempotencyStore.new(request: request, credential: current_api_session, household: current_household)
         unless store.active?
-          yield
+          action.call
           return
         end
 
-        result = store.lookup
+        result = store.with_reservation(response: response, &action)
         if result.replayed
           response.set_header('Idempotency-Replayed', 'true')
           render json: result.record.response_body, status: result.record.response_status
-          return
+        elsif result.conflict
+          render_conflict('Idempotency key has already been used for a different request',
+                          code: 'idempotency_key_reused')
         end
-        if result.conflict
-          return render_conflict('Idempotency key has already been used for a different request',
-                                 code: 'idempotency_key_reused')
-        end
-
-        yield
-        store.store!(response) unless performed? && response.status == 409
       end
     end
   end

--- a/app/services/api/idempotency_store.rb
+++ b/app/services/api/idempotency_store.rb
@@ -3,6 +3,7 @@
 module Api
   class IdempotencyStore
     EXPIRY = 24.hours
+    LOCK_NAMESPACE = 'med_tracker.api_idempotency.v1'
 
     Result = Data.define(:record, :replayed, :conflict)
 
@@ -16,6 +17,21 @@ module Api
       key.present? && mutating_request? && household.present? && credential.present?
     end
 
+    def with_reservation(response:)
+      return yield unless active?
+
+      result = nil
+      ApiIdempotencyKey.transaction(requires_new: true) do
+        acquire_reservation
+        result = lookup
+        next if result.record
+
+        yield
+        persist_response!(response)
+      end
+      result
+    end
+
     def lookup
       record = ApiIdempotencyKey.find_by(household: household, key: key)
       return Result.new(record: nil, replayed: false, conflict: false) unless record
@@ -27,13 +43,32 @@ module Api
       return unless active? && response.status < 500
 
       ApiIdempotencyKey.create!(idempotency_attributes(response))
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-      nil
     end
 
     private
 
     attr_reader :request, :credential, :household
+
+    def acquire_reservation
+      ApiIdempotencyKey.connection.execute(
+        ActiveRecord::Base.sanitize_sql_array(
+          ['SELECT pg_advisory_xact_lock(?)', reservation_id]
+        )
+      )
+    end
+
+    def reservation_id
+      Digest::SHA256.digest(
+        [LOCK_NAMESPACE, household.id, key].join("\0")
+      ).unpack1('q>')
+    end
+
+    def persist_response!(response)
+      raise ActiveRecord::Rollback if response.status >= 500
+      return if response.status == 409
+
+      store!(response)
+    end
 
     def idempotency_attributes(response)
       credential_attributes.merge(request_attributes).merge(response_attributes(response)).merge(
@@ -75,7 +110,8 @@ module Api
     end
 
     def same_request?(record)
-      record.request_method == request.request_method &&
+      record.account_id == credential.account_id &&
+        record.request_method == request.request_method &&
         record.request_path == request.path &&
         record.request_digest == request_digest
     end

--- a/app/services/medication_administration/record_dose.rb
+++ b/app/services/medication_administration/record_dose.rb
@@ -42,7 +42,7 @@ module MedicationAdministration
         source = freshly_loaded_operational_source(source)
         return failure(:household_unavailable) unless source
 
-        record_dose(
+        record_dose_with_savepoint(
           source: source,
           amount_override: amount_override,
           taken_from_medication_id: taken_from_medication_id,
@@ -53,6 +53,12 @@ module MedicationAdministration
     end
 
     private
+
+    def record_dose_with_savepoint(**arguments)
+      return record_dose(**arguments) unless ActiveRecord::Base.connection.transaction_open?
+
+      ActiveRecord::Base.transaction(requires_new: true) { record_dose(**arguments) }
+    end
 
     def record_dose(source:, amount_override:, taken_from_medication_id:, user:, options:)
       publish_take_metric('take_attempted.med_tracker', source:, user:, options:)

--- a/openspec/changes/serialize-concurrent-api-idempotency/.openspec.yaml
+++ b/openspec/changes/serialize-concurrent-api-idempotency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/serialize-concurrent-api-idempotency/design.md
+++ b/openspec/changes/serialize-concurrent-api-idempotency/design.md
@@ -1,0 +1,119 @@
+## Context
+
+`Api::V1::BaseController#with_api_idempotency` currently performs an unlocked `Api::IdempotencyStore#lookup`, yields to the controller action, and then calls `store!`. The unique index on `(household_id, key)` prevents two stored responses, but it runs after both requests may have created domain records, PaperTrail versions, access grants, and other side effects. `store!` then rescues the uniqueness failure, hiding the race without undoing the losing mutation.
+
+People creation is the regression boundary because it writes a Person inside a controller transaction and also creates either delegated access or a household access grant. Person changes are audited through PaperTrail. A deterministic two-connection test can therefore prove that the generic middleware serializes both the primary record and its mutation side effects.
+
+The idempotency table already stores household, account, credential attribution, method, path, digest, response status/body, and a 24-hour expiry. Its unique index defines the strongest current key namespace as `(household_id, key)`. The design must preserve that database invariant while preventing a response from being replayed to a different account.
+
+`with_api_request_context` remains the outer API boundary. It authenticates and binds the tenant before idempotency runs, and it records an `api.request` security event for every HTTP delivery. Those per-delivery security events are intentionally distinct from mutation audit side effects: two HTTP attempts remain two access events even though only one Person mutation and one Person PaperTrail version may commit.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Serialize competing generic idempotent mutations before any domain write.
+- Commit a successful mutation, its database side effects, and its stored response atomically.
+- Let a waiter observe the committed response and replay it without executing the controller action.
+- Preserve request-digest conflicts, tenant isolation, account isolation, the response policy, and PHI-safe errors.
+- Release failed or abandoned attempts automatically so an iOS client can retry.
+- Prove the behavior with real PostgreSQL connections rather than mocks or sequential calls.
+
+**Non-Goals:**
+
+- Changing endpoint-specific identities such as `MedicationTake.client_uuid`.
+- Changing People authorization, fields, serialization, or delegation behavior.
+- Changing the 24-hour expiry or introducing a general background reservation reconciler.
+- Deduplicating per-delivery `api.request` security events.
+- Adding response-header persistence; the existing generic store persists status and JSON body, while header parity remains a separate API-contract concern.
+
+## Decisions
+
+### 1. Use a PostgreSQL transaction-scoped advisory lock
+
+`Api::IdempotencyStore` will expose one execution boundary that opens an Active Record transaction, acquires a PostgreSQL transaction-scoped advisory lock, performs lookup, yields the controller mutation when needed, and stores the response before commit. `BaseController` will use that boundary rather than coordinating separate `lookup` and `store!` calls.
+
+The lock identity will be a versioned, one-way 64-bit digest of the routed `household_id` and raw idempotency key. It deliberately matches the table's existing `(household_id, key)` uniqueness namespace. Method, path, digest, and account are checked after the lock is held; they must not be part of the lock identity because competing reuse of the same database-unique key must serialize before conflict detection. The raw key and request content will not be logged.
+
+The lock query and all application work must use the same checked-out database connection and transaction. PostgreSQL releases the lock automatically on commit, rollback, connection loss, or process failure. A hash collision can only serialize unrelated requests temporarily; the exact database lookup still decides replay or conflict.
+
+Alternative considered: add pending/completed reservation states to `api_idempotency_keys`. Rejected because it requires a migration, nullable response fields, ownership/lease semantics, stale-reservation recovery, and a cleanup path even though PostgreSQL can provide lifecycle-safe serialization.
+
+Alternative considered: rely on `INSERT ... ON CONFLICT` immediately before the action. Rejected because a placeholder row needs a durable pending state and a waiter protocol, and an insert inside the same transaction is invisible to waiters until commit.
+
+Alternative considered: use a Ruby mutex. Rejected because it cannot coordinate multiple Rails processes or hosts.
+
+### 2. Re-check replay or conflict only after serialization
+
+Once the lock is held, the store will query `(household_id, key)` again:
+
+- Matching account, method, path, and digest: render the stored status/body and set `Idempotency-Replayed: true`.
+- Any account, method, path, or digest mismatch: render HTTP 409 `idempotency_key_reused` without running the action.
+- No stored row: run the action exactly once inside the transaction.
+
+Authenticated account is the durable credential scope. It survives access-token rotation while preventing another account in the same household from receiving a response that may contain health data. Existing session/app-token attribution remains stored for audit context. The database key namespace stays household-wide, so a different account reusing the same key receives a conflict rather than creating an independent row.
+
+Alternative considered: scope replay to the exact `ApiSession` or `ApiAppToken` row. Rejected because a legitimate client retry should survive token rotation and because OAuth grants are not currently represented by a dedicated idempotency-table foreign key.
+
+Alternative considered: migrate the unique index to account, method, and path. Rejected as an unnecessary contract expansion for #1747; retaining the existing household-wide key namespace is backward-compatible and safer for unknown clients.
+
+### 3. Make response persistence part of the mutation transaction
+
+For a new request, the action runs under the idempotency transaction. An eligible response is persisted before that transaction commits. `store!` must no longer swallow `RecordInvalid` or `RecordNotUnique`: after serialization, either indicates a violated invariant, and propagating it rolls back the mutation instead of leaving an un-replayable success.
+
+Existing completed-response policy remains:
+
+- HTTP responses below 500 are eligible for storage, except the middleware's own 409 key-reuse conflict, which never replaces the original row.
+- Stored 4xx responses replay deterministically and must have no committed mutation side effect.
+- HTTP 500-or-higher responses are not stored. Their database work is rolled back before returning the response, leaving the key retryable.
+- Raised exceptions roll back automatically and are handled by the existing API exception path.
+
+For a rendered server error, the wrapper will mark the transaction for rollback while preserving the rendered response. This prevents a controller that rendered a 5xx after partial work from committing that work.
+
+Alternative considered: store the response after committing the action. Rejected because it recreates the crash window and duplicate-side-effect race that this change exists to remove.
+
+Alternative considered: cache 5xx responses. Rejected because a transient failure would poison the key for the retention period and prevent a native client from recovering.
+
+### 4. Test through the public People endpoint with two connections
+
+The regression spec will use two independent Active Record connection-pool leases, thread barriers, and a bounded join/timeout. It will pause the first request after the post-lock miss but before the People mutation, start the second request, then release the first. The synchronization point will be a narrow test-only collaboration at the store boundary, not a production sleep.
+
+Assertions will cover:
+
+- one response is original and one has `Idempotency-Replayed: true`;
+- both responses have the same status and JSON body;
+- one Person exists;
+- only one expected access grant or carer relationship exists;
+- one Person PaperTrail create version exists; and
+- no duplicate mutation side effect is present.
+
+The spec will not expect one `api.request` security event, because access auditing correctly records both authenticated HTTP attempts. It will explicitly count the Person mutation audit version instead.
+
+Alternative considered: unit-test two sequential `lookup` calls. Rejected because it cannot prove blocking, transaction visibility, connection ownership, or the absence of a real race.
+
+Alternative considered: use sleeps to create the race. Rejected because timing-based concurrency tests are nondeterministic in local Docker and CI.
+
+### 5. Keep authorization, tenancy, and privacy outside the lock mechanism
+
+Authentication and household binding continue before the idempotency wrapper, so the lock is never acquired for an unauthenticated or unbound request. Tenant context and RLS stay active throughout the transaction. A different household derives a different lock identity and queries only its own idempotency row.
+
+Conflict responses remain generic and do not echo the key, digest, request parameters, account, or stored response. Diagnostics may identify the error class and hashed lock version, but not raw identifiers or PHI.
+
+## Risks / Trade-offs
+
+- **[A slow mutation holds a database transaction and advisory lock]** → Scope locking only to keyed mutating requests, rely on existing database/request timeouts, and avoid external I/O inside keyed controller actions.
+- **[A malformed controller path renders a 4xx after writing data]** → The generic boundary makes the entire request transactional; focused tests assert that stored 4xx outcomes leave no mutation side effects.
+- **[An advisory-lock hash collision serializes unrelated keys]** → Use a versioned 64-bit cryptographic digest; exact lookup after locking prevents incorrect replay or conflict.
+- **[Connection-pool pressure increases while duplicate requests wait]** → Native retries for the same key are expected to be rare and short; the waiting request trades one occupied connection for prevention of duplicate health-data writes.
+- **[Changing `store!` from best-effort to atomic can expose latent persistence failures]** → Treat failure to persist a replayable success as a correctness failure and roll back; cover normal credential types and response bodies in focused service specs.
+- **[Account-scoped replay differs from today's account-blind lookup]** → This closes a response-disclosure risk while retaining key reuse as a safe generic 409.
+
+## Migration Plan
+
+No database migration or backfill is required. Deploy the transaction/locking boundary and its regression coverage together. Existing completed idempotency rows remain readable and retain their expiry.
+
+Rollback is code-only: restore the previous unlocked wrapper. No persisted data needs conversion, although rollback would reintroduce the concurrency race and should be reserved for an operational emergency.
+
+## Open Questions
+
+None. Response-header replay, including preservation of `ETag`, is deliberately not folded into #1747 and should be tracked as a separate public contract change if the iOS generated client requires it.

--- a/openspec/changes/serialize-concurrent-api-idempotency/proposal.md
+++ b/openspec/changes/serialize-concurrent-api-idempotency/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The generic API idempotency middleware checks for a stored response before a mutation and stores the response afterward, so concurrent requests can both execute before either result exists. Native clients therefore cannot safely retry People or other API writes without risking duplicate records and mutation side effects.
+
+Origin: [GitHub issue #1747](https://github.com/damacus/med-tracker/issues/1747)
+
+## What Changes
+
+- Serialize requests that compete for the same idempotency scope before any controller mutation or mutation side effect runs.
+- Make concurrent matching requests converge on one committed mutation and one stored response; waiting and later callers replay that response with `Idempotency-Replayed: true`.
+- Preserve HTTP 409 `idempotency_key_reused` behavior when a key is reused outside its original request digest or authenticated account scope.
+- Keep failed or abandoned attempts retryable: server failures and raised exceptions roll back the mutation, release serialization, and do not leave a permanent reservation.
+- Define deterministic handling for successful, client-error, conflict, and server-error responses.
+- Add a deterministic two-connection People-create regression proving that only one Person and one set of mutation side effects are committed.
+
+### Non-goals
+
+- Changing People fields, authorization, household isolation, or the public create response shape.
+- Replacing endpoint-specific idempotency such as medication-take `client_uuid`.
+- Generalizing all API writes into a new command framework.
+- Changing the 24-hour idempotency retention period.
+- Making separate accounts inside one household share a replayable response.
+
+## Capabilities
+
+### New Capabilities
+
+- `api-mutation-idempotency`: Authenticated mutating API requests are serialized and replayed safely across concurrent deliveries.
+
+### Modified Capabilities
+
+None. This repository does not yet contain a generic API idempotency capability.
+
+## Impact
+
+- Changes the execution boundary in `Api::V1::BaseController` and `Api::IdempotencyStore`.
+- Uses PostgreSQL transaction semantics to cover mutation, audit/change side effects, and response persistence as one idempotent attempt.
+- Extends service and request coverage, including a real two-database-connection concurrency example against People creation.
+- Preserves the existing `Idempotency-Key`, `Idempotency-Replayed`, response body/status, expiry, and PHI-safe conflict contracts.

--- a/openspec/changes/serialize-concurrent-api-idempotency/specs/api-mutation-idempotency/spec.md
+++ b/openspec/changes/serialize-concurrent-api-idempotency/specs/api-mutation-idempotency/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Matching concurrent mutations execute once
+The system SHALL serialize authenticated mutating API requests before controller mutation when they have the same routed household, authenticated account scope, request path, HTTP method, and `Idempotency-Key`. After the first request commits, every matching waiter SHALL replay its stored status and body with `Idempotency-Replayed: true` without executing the mutation again.
+
+#### Scenario: Concurrent People creates converge
+- **GIVEN** two database connections submit the same valid People create for the same household and authenticated account with the same path, method, key, and request digest
+- **WHEN** both requests pass the initial idempotency boundary concurrently
+- **THEN** one request performs the create and stores its response
+- **AND** the other request waits, then returns the stored status and body with `Idempotency-Replayed: true`
+- **AND** exactly one Person, one applicable access grant or carer relationship, and one Person mutation audit version are committed
+
+#### Scenario: A later retry replays the committed response
+- **GIVEN** a matching idempotent mutation has committed successfully
+- **WHEN** the same authenticated account later repeats the request within the retention period
+- **THEN** the system returns the stored status and body with `Idempotency-Replayed: true`
+- **AND** it produces no additional mutation or mutation side effect
+
+### Requirement: Mutation and idempotency response commit atomically
+The system SHALL hold serialization across the post-lock lookup, controller mutation, mutation side effects, and response storage. A successful mutation SHALL NOT commit unless its replayable response also commits.
+
+#### Scenario: Response storage fails
+- **GIVEN** a keyed People create has produced a successful response but its idempotency response cannot be stored
+- **WHEN** the idempotent attempt finishes
+- **THEN** the Person and every access, audit, and other mutation side effect are rolled back
+- **AND** the key remains retryable
+
+#### Scenario: Successful response storage releases the waiter
+- **GIVEN** a matching request is waiting for the active idempotent attempt
+- **WHEN** the first mutation and stored response commit
+- **THEN** serialization is released
+- **AND** the waiter observes the committed response before deciding to replay
+
+### Requirement: Key reuse conflicts remain scoped and PHI-safe
+The system SHALL replay a stored response only when the authenticated account scope, HTTP method, request path, and request digest match the stored request. Reuse outside that request identity SHALL return HTTP 409 with error code `idempotency_key_reused` and SHALL NOT reveal the stored request or response.
+
+#### Scenario: Same key with a different request digest conflicts
+- **GIVEN** an idempotency key has a stored response for one request body
+- **WHEN** the same account reuses the key with different filtered parameters
+- **THEN** the system returns HTTP 409 with error code `idempotency_key_reused`
+- **AND** neither request's submitted values or stored response data are disclosed
+- **AND** no second mutation runs
+
+#### Scenario: A different account cannot replay the response
+- **GIVEN** an account has stored a keyed response inside a household
+- **WHEN** another authorized account in that household submits the same key and request
+- **THEN** the system returns HTTP 409 with error code `idempotency_key_reused`
+- **AND** it does not return the first account's response or run a mutation
+
+#### Scenario: The same key is independent across households
+- **GIVEN** two authenticated accounts are routed to different households
+- **WHEN** each submits the same key, method, path shape, and request body in its own household
+- **THEN** each household may execute and store its own mutation
+- **AND** neither request can observe the other household's response or health data
+
+### Requirement: Failed attempts do not poison an idempotency key
+The system SHALL release transaction-scoped serialization on commit, rollback, database disconnect, or raised exception. Responses below HTTP 500 MAY be stored as completed outcomes under the existing response policy; HTTP 500 responses and raised exceptions SHALL NOT store a completed response and SHALL leave the key retryable.
+
+#### Scenario: A deterministic client error is replayed
+- **GIVEN** a keyed mutation completes with a deterministic HTTP 4xx response that is eligible for storage
+- **WHEN** a matching request repeats within the retention period
+- **THEN** the system replays the stored error status and body with `Idempotency-Replayed: true`
+- **AND** no mutation side effect exists
+
+#### Scenario: An exception rolls back and releases the key
+- **GIVEN** a keyed mutation raises after starting database work
+- **WHEN** the idempotent attempt exits
+- **THEN** all mutation and response-storage work is rolled back
+- **AND** serialization is released automatically
+- **AND** a later matching request may attempt the mutation again
+
+#### Scenario: A server-error response is retryable
+- **GIVEN** a keyed mutation returns HTTP 500 or higher
+- **WHEN** the attempt finishes
+- **THEN** no completed response is stored
+- **AND** the key is not permanently reserved
+- **AND** a later matching request may attempt the mutation again
+
+### Requirement: Serialization metadata remains non-sensitive
+The system SHALL derive its serialization identity without including request bodies, filtered parameters, person details, medication details, or other protected health information in database locks, application logs, or public errors.
+
+#### Scenario: A lock wait or failure is reported safely
+- **GIVEN** an idempotent request waits for serialization or fails while holding it
+- **WHEN** the condition is logged or returned as an error
+- **THEN** diagnostics contain no raw idempotency key, submitted health data, or stored response body
+- **AND** the public response uses the existing generic API error envelope

--- a/openspec/changes/serialize-concurrent-api-idempotency/tasks.md
+++ b/openspec/changes/serialize-concurrent-api-idempotency/tasks.md
@@ -1,0 +1,33 @@
+## 1. Red: Prove the generic race and failure contracts
+
+- [ ] 1.1 Extend `spec/services/api/idempotency_store_spec.rb` with failing examples for account-scoped replay, cross-account conflict, transaction-scoped serialization, exact post-lock lookup, and non-sensitive lock identity.
+- [ ] 1.2 Add a deterministic request concurrency spec using two checked-out PostgreSQL connections and barriers to submit the same keyed People create concurrently.
+- [ ] 1.3 Assert the concurrency regression produces one Person, one applicable access grant or carer relationship, one Person PaperTrail create version, identical response status/body, and exactly one replay marker.
+- [ ] 1.4 Add failure examples proving response-storage errors and raised exceptions roll back all mutation side effects, rendered 5xx responses are not stored, and the same key can be retried afterward.
+- [ ] 1.5 Add request examples proving deterministic stored 4xx replay, same-key different-digest conflict, different-account conflict without response disclosure, and independent behavior across households.
+- [ ] 1.6 Run `task test TEST_FILE=spec/services/api/idempotency_store_spec.rb` and each new focused request spec; confirm the new examples fail for the intended unlocked behavior.
+
+## 2. Green: Serialize lookup, mutation, and response storage
+
+- [ ] 2.1 Add a versioned, one-way advisory-lock identity derived only from household ID and idempotency key, without logging the raw key or request content.
+- [ ] 2.2 Refactor `Api::IdempotencyStore` to acquire the transaction-scoped PostgreSQL advisory lock and perform the post-lock lookup on the same checked-out connection and transaction.
+- [ ] 2.3 Require household, authenticated account, method, path, and request digest to match before replay; return the existing PHI-safe `idempotency_key_reused` conflict for every mismatch.
+- [ ] 2.4 Move new-request execution and eligible response storage into the serialized transaction so a stored success and every mutation side effect commit or roll back together.
+- [ ] 2.5 Stop swallowing idempotency persistence failures after serialization; propagate them so the transaction rolls back instead of committing an un-replayable mutation.
+- [ ] 2.6 Preserve stored sub-500 outcomes and middleware conflict behavior, while rolling back and leaving the key retryable for rendered 5xx responses and raised exceptions.
+- [ ] 2.7 Update `Api::V1::BaseController#with_api_idempotency` to use the store's single execution boundary and keep `Idempotency-Replayed: true` on replay.
+- [ ] 2.8 Run the focused store, People, sync-safety, tenancy, authorization, audit, and concurrency specs until green.
+
+## 3. Refactor: Keep the boundary narrow and auditable
+
+- [ ] 3.1 Remove obsolete split lookup/store coordination while keeping authentication, tenant binding, controller authorization, and per-delivery `api.request` auditing outside the serialization mechanism.
+- [ ] 3.2 Confirm replay responses cannot cross authenticated accounts or households and all lock, conflict, exception, and diagnostic paths omit raw keys, parameters, response bodies, and PHI.
+- [ ] 3.3 Confirm no reservation-state migration, background cleanup worker, endpoint-specific idempotency change, or OpenAPI request/response shape change was introduced.
+- [ ] 3.4 Run `task rubocop` and correct any offenses without unrelated formatting.
+
+## 4. Verification and handoff
+
+- [ ] 4.1 Run `task openspec:validate` and verify the implementation still matches the approved proposal, specification, and design.
+- [ ] 4.2 Run `task test` and confirm the full Docker-backed Rails suite passes.
+- [ ] 4.3 Run `task brakeman` and review any finding against the advisory-lock SQL, account/household replay boundary, and PHI-safe diagnostics.
+- [ ] 4.4 Review the final diff against issue #1747, confirm PR #1744 medication-take behavior is unchanged, and record response-header replay as separate follow-up work if the iOS client requires `ETag` parity.

--- a/openspec/changes/serialize-concurrent-api-idempotency/tasks.md
+++ b/openspec/changes/serialize-concurrent-api-idempotency/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Red: Prove the generic race and failure contracts
 
-- [ ] 1.1 Extend `spec/services/api/idempotency_store_spec.rb` with failing examples for account-scoped replay, cross-account conflict, transaction-scoped serialization, exact post-lock lookup, and non-sensitive lock identity.
-- [ ] 1.2 Add a deterministic request concurrency spec using two checked-out PostgreSQL connections and barriers to submit the same keyed People create concurrently.
-- [ ] 1.3 Assert the concurrency regression produces one Person, one applicable access grant or carer relationship, one Person PaperTrail create version, identical response status/body, and exactly one replay marker.
-- [ ] 1.4 Add failure examples proving response-storage errors and raised exceptions roll back all mutation side effects, rendered 5xx responses are not stored, and the same key can be retried afterward.
-- [ ] 1.5 Add request examples proving deterministic stored 4xx replay, same-key different-digest conflict, different-account conflict without response disclosure, and independent behavior across households.
-- [ ] 1.6 Run `task test TEST_FILE=spec/services/api/idempotency_store_spec.rb` and each new focused request spec; confirm the new examples fail for the intended unlocked behavior.
+- [x] 1.1 Extend `spec/services/api/idempotency_store_spec.rb` with failing examples for account-scoped replay, cross-account conflict, transaction-scoped serialization, exact post-lock lookup, and non-sensitive lock identity.
+- [x] 1.2 Add a deterministic request concurrency spec using two checked-out PostgreSQL connections and barriers to submit the same keyed People create concurrently.
+- [x] 1.3 Assert the concurrency regression produces one Person, one applicable access grant or carer relationship, one Person PaperTrail create version, identical response status/body, and exactly one replay marker.
+- [x] 1.4 Add failure examples proving response-storage errors and raised exceptions roll back all mutation side effects, rendered 5xx responses are not stored, and the same key can be retried afterward.
+- [x] 1.5 Add request examples proving deterministic stored 4xx replay, same-key different-digest conflict, different-account conflict without response disclosure, and independent behavior across households.
+- [x] 1.6 Run `task test TEST_FILE=spec/services/api/idempotency_store_spec.rb` and each new focused request spec; confirm the new examples fail for the intended unlocked behavior.
 
 ## 2. Green: Serialize lookup, mutation, and response storage
 
-- [ ] 2.1 Add a versioned, one-way advisory-lock identity derived only from household ID and idempotency key, without logging the raw key or request content.
-- [ ] 2.2 Refactor `Api::IdempotencyStore` to acquire the transaction-scoped PostgreSQL advisory lock and perform the post-lock lookup on the same checked-out connection and transaction.
-- [ ] 2.3 Require household, authenticated account, method, path, and request digest to match before replay; return the existing PHI-safe `idempotency_key_reused` conflict for every mismatch.
-- [ ] 2.4 Move new-request execution and eligible response storage into the serialized transaction so a stored success and every mutation side effect commit or roll back together.
-- [ ] 2.5 Stop swallowing idempotency persistence failures after serialization; propagate them so the transaction rolls back instead of committing an un-replayable mutation.
-- [ ] 2.6 Preserve stored sub-500 outcomes and middleware conflict behavior, while rolling back and leaving the key retryable for rendered 5xx responses and raised exceptions.
-- [ ] 2.7 Update `Api::V1::BaseController#with_api_idempotency` to use the store's single execution boundary and keep `Idempotency-Replayed: true` on replay.
-- [ ] 2.8 Run the focused store, People, sync-safety, tenancy, authorization, audit, and concurrency specs until green.
+- [x] 2.1 Add a versioned, one-way advisory-lock identity derived only from household ID and idempotency key, without logging the raw key or request content.
+- [x] 2.2 Refactor `Api::IdempotencyStore` to acquire the transaction-scoped PostgreSQL advisory lock and perform the post-lock lookup on the same checked-out connection and transaction.
+- [x] 2.3 Require household, authenticated account, method, path, and request digest to match before replay; return the existing PHI-safe `idempotency_key_reused` conflict for every mismatch.
+- [x] 2.4 Move new-request execution and eligible response storage into the serialized transaction so a stored success and every mutation side effect commit or roll back together.
+- [x] 2.5 Stop swallowing idempotency persistence failures after serialization; propagate them so the transaction rolls back instead of committing an un-replayable mutation.
+- [x] 2.6 Preserve stored sub-500 outcomes and middleware conflict behavior, while rolling back and leaving the key retryable for rendered 5xx responses and raised exceptions.
+- [x] 2.7 Update `Api::V1::BaseController#with_api_idempotency` to use the store's single execution boundary and keep `Idempotency-Replayed: true` on replay.
+- [x] 2.8 Run the focused store, People, sync-safety, tenancy, authorization, audit, and concurrency specs until green.
 
 ## 3. Refactor: Keep the boundary narrow and auditable
 
-- [ ] 3.1 Remove obsolete split lookup/store coordination while keeping authentication, tenant binding, controller authorization, and per-delivery `api.request` auditing outside the serialization mechanism.
-- [ ] 3.2 Confirm replay responses cannot cross authenticated accounts or households and all lock, conflict, exception, and diagnostic paths omit raw keys, parameters, response bodies, and PHI.
-- [ ] 3.3 Confirm no reservation-state migration, background cleanup worker, endpoint-specific idempotency change, or OpenAPI request/response shape change was introduced.
-- [ ] 3.4 Run `task rubocop` and correct any offenses without unrelated formatting.
+- [x] 3.1 Remove obsolete split lookup/store coordination while keeping authentication, tenant binding, controller authorization, and per-delivery `api.request` auditing outside the serialization mechanism.
+- [x] 3.2 Confirm replay responses cannot cross authenticated accounts or households and all lock, conflict, exception, and diagnostic paths omit raw keys, parameters, response bodies, and PHI.
+- [x] 3.3 Confirm no reservation-state migration, background cleanup worker, endpoint-specific idempotency change, or OpenAPI request/response shape change was introduced.
+- [x] 3.4 Run `task rubocop` and correct any offenses without unrelated formatting.
 
 ## 4. Verification and handoff
 
-- [ ] 4.1 Run `task openspec:validate` and verify the implementation still matches the approved proposal, specification, and design.
-- [ ] 4.2 Run `task test` and confirm the full Docker-backed Rails suite passes.
-- [ ] 4.3 Run `task brakeman` and review any finding against the advisory-lock SQL, account/household replay boundary, and PHI-safe diagnostics.
-- [ ] 4.4 Review the final diff against issue #1747, confirm PR #1744 medication-take behavior is unchanged, and record response-header replay as separate follow-up work if the iOS client requires `ETag` parity.
+- [x] 4.1 Run `task openspec:validate` and verify the implementation still matches the approved proposal, specification, and design.
+- [x] 4.2 Run `task test` and confirm the full Docker-backed Rails suite passes.
+- [x] 4.3 Run `task brakeman` and review any finding against the advisory-lock SQL, account/household replay boundary, and PHI-safe diagnostics.
+- [x] 4.4 Review the final diff against issue #1747, confirm PR #1744 medication-take behavior is unchanged, and record response-header replay as separate follow-up work if the iOS client requires `ETag` parity.

--- a/spec/requests/api/v1/idempotency_concurrency_spec.rb
+++ b/spec/requests/api/v1/idempotency_concurrency_spec.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'timeout'
+
+RSpec.describe 'API v1 idempotency concurrency' do
+  self.use_transactional_tests = false
+
+  let(:workers) { [] }
+  let(:assignment_entered) { Queue.new }
+  let(:release_assignment) { Queue.new }
+  let(:records) { concurrency_records }
+
+  before do
+    version_ledger_trigger(:disable)
+    allow(Audit::Event).to receive(:record!)
+    allow(AuthTokenAuditLogger).to receive(:new)
+      .and_return(instance_double(AuthTokenAuditLogger, record: nil))
+    records
+  end
+
+  after do
+    release_assignment << true
+    terminate_workers
+    cleanup_records
+    version_ledger_trigger(:enable)
+  end
+
+  it 'serializes concurrent People creates before mutation side effects' do
+    pause_first_assignment
+    sessions = Array.new(2) { ActionDispatch::Integration::Session.new(Rails.application) }
+    first = start_request(sessions.first, records.fetch(:tokens).first)
+    wait_for(assignment_entered, 'first People assignment')
+    second = start_request(sessions.second, records.fetch(:tokens).second)
+    second_pid = wait_for(second.fetch(:pid), 'second request database session')
+    wait_for_advisory_wait(second_pid)
+
+    release_assignment << true
+    responses = [join_worker(first.fetch(:worker)), join_worker(second.fetch(:worker))]
+    person = Person.find_by!(household_id: records.fetch(:household_id), name: records.fetch(:name))
+
+    expect(responses.map { it.fetch(:status) }).to eq([201, 201])
+    expect(responses.map { it.fetch(:body) }.uniq.one?).to be true
+    expect(responses.count { it.fetch(:replayed) }).to eq(1)
+    expect(Person.where(household_id: records.fetch(:household_id), name: records.fetch(:name)).count).to eq(1)
+    expect(CarerRelationship.where(patient: person).count).to eq(1)
+    expect(PersonAccessGrant.where(person: person, revoked_at: nil).count).to eq(1)
+    expect(PaperTrail::Version.where(item_type: 'Person', item_id: person.id, event: 'create').count).to eq(1)
+    expect(ApiIdempotencyKey.where(household_id: records.fetch(:household_id), key: records.fetch(:key)).count).to eq(1)
+  end
+
+  def pause_first_assignment
+    gate = Mutex.new
+    paused = false
+    allow(CareDelegation::Assign).to receive(:new).and_wrap_original do |original, *arguments, **keywords|
+      service = original.call(*arguments, **keywords)
+      should_pause = gate.synchronize do
+        next false if paused
+
+        paused = true
+      end
+      pause_assignment(service) if should_pause
+      service
+    end
+  end
+
+  def pause_assignment(service)
+    original_call = service.method(:call)
+    allow(service).to receive(:call) do
+      assignment_entered << true
+      wait_for(release_assignment, 'People assignment release')
+      original_call.call
+    end
+  end
+
+  def start_request(session, token)
+    pid = Queue.new
+    worker = Thread.new { perform_request(session, token, pid) }
+    workers << worker
+    { worker: worker, pid: pid }
+  end
+
+  def perform_request(session, token, pid)
+    ActiveRecord::Base.connection_pool.with_connection do
+      pid << ActiveRecord::Base.connection.select_value('SELECT pg_backend_pid()').to_i
+      post_person(session, token)
+      response_result(session.response)
+    end
+  rescue StandardError => e
+    e
+  end
+
+  def post_person(session, token)
+    session.post(
+      api_v1_household_people_path(records.fetch(:household_id)),
+      params: person_payload,
+      headers: api_auth_headers(token).merge('Idempotency-Key' => records.fetch(:key)),
+      as: :json
+    )
+  end
+
+  def response_result(request_response)
+    {
+      status: request_response.status,
+      body: request_response.parsed_body,
+      replayed: request_response.headers['Idempotency-Replayed'] == 'true'
+    }
+  end
+
+  def join_worker(worker)
+    raise Timeout::Error, 'timed out waiting for idempotency request' unless worker.join(thread_timeout)
+
+    worker.value.tap { raise it if it.is_a?(StandardError) }
+  end
+
+  def wait_for(queue, description)
+    Timeout.timeout(thread_timeout) { queue.pop }
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for #{description}"
+  end
+
+  def wait_for_advisory_wait(pid)
+    Timeout.timeout(thread_timeout) do
+      loop do
+        return if advisory_waiting?(pid)
+
+        Thread.pass
+      end
+    end
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for database session #{pid} to block on idempotency"
+  end
+
+  def advisory_waiting?(pid)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = ? AND locktype = 'advisory' AND NOT granted)", pid]
+      )
+    )
+  end
+
+  def concurrency_records
+    household = create_concurrency_household
+    account = create_concurrency_account
+    person = create_concurrency_owner(account, household)
+    create_concurrency_user(account, person)
+    membership = create_concurrency_membership(account, person, household)
+    sessions_and_tokens = issue_sessions(account, membership)
+    {
+      household_id: household.id,
+      account_id: account.id,
+      key: SecureRandom.uuid,
+      name: "Concurrent API Dependent #{SecureRandom.hex(4)}",
+      session_ids: sessions_and_tokens.map(&:first),
+      tokens: sessions_and_tokens.map(&:last)
+    }
+  end
+
+  def create_concurrency_household
+    Household.create!(
+      name: 'Idempotency Concurrency Household',
+      slug: "idempotency-concurrency-#{SecureRandom.hex(4)}"
+    )
+  end
+
+  def create_concurrency_account
+    Account.create!(
+      email: "idempotency-concurrency-#{SecureRandom.hex(4)}@example.test",
+      status: :verified
+    )
+  end
+
+  def create_concurrency_owner(account, household)
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'Idempotency Concurrency Owner',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+
+  def create_concurrency_user(account, person)
+    User.create!(
+      person: person,
+      email_address: account.email,
+      password: 'password',
+      active: true
+    )
+  end
+
+  def create_concurrency_membership(account, person, household)
+    household.household_memberships.create!(
+      account: account,
+      person: person,
+      role: :owner,
+      status: :active
+    )
+  end
+
+  def issue_sessions(account, membership)
+    Array.new(2) do
+      session, token = ApiSession.issue_for(
+        account: account,
+        household_membership: membership,
+        device_name: 'RSpec idempotency client'
+      )
+      [session.id, token]
+    end
+  end
+
+  def person_payload
+    {
+      person: {
+        name: records.fetch(:name),
+        date_of_birth: 8.years.ago.to_date,
+        person_type: 'minor'
+      }
+    }
+  end
+
+  def version_ledger_trigger(action)
+    ActiveRecord::Base.connection.execute(
+      "ALTER TABLE versions #{action.to_s.upcase} TRIGGER append_versions_to_audit_ledger"
+    )
+  end
+
+  def terminate_workers
+    workers.each do |worker|
+      worker.kill if worker.alive?
+      worker.join(1)
+    end
+  end
+
+  def cleanup_records
+    created_people = Person.where(household_id: records.fetch(:household_id))
+    person_ids = created_people.ids
+    user_ids = User.where(person_id: person_ids).ids
+    ApiChangeEvent.where(household_id: records.fetch(:household_id)).delete_all
+    cleanup_person_records(person_ids)
+    cleanup_request_records
+    cleanup_identity_records(created_people, user_ids)
+  end
+
+  def cleanup_identity_records(created_people, user_ids)
+    cleanup_versions
+    cleanup_people(created_people, user_ids)
+    cleanup_household
+  end
+
+  def cleanup_versions
+    PaperTrail::Version.where(household_id: records.fetch(:household_id)).delete_all
+  end
+
+  def cleanup_people(created_people, user_ids)
+    HouseholdMembership.where(household_id: records.fetch(:household_id)).delete_all
+    User.where(id: user_ids).delete_all
+    created_people.delete_all
+  end
+
+  def cleanup_household
+    Location.where(household_id: records.fetch(:household_id)).delete_all
+    Household.where(id: records.fetch(:household_id)).delete_all
+    Account.where(id: records.fetch(:account_id)).delete_all
+  end
+
+  def cleanup_person_records(person_ids)
+    PersonAccessGrant.where(person_id: person_ids).delete_all
+    CarerRelationship.where(patient_id: person_ids).or(CarerRelationship.where(carer_id: person_ids)).delete_all
+    LocationMembership.where(person_id: person_ids).delete_all
+  end
+
+  def cleanup_request_records
+    ApiIdempotencyKey.where(household_id: records.fetch(:household_id), key: records.fetch(:key)).delete_all
+    ApiSession.where(id: records.fetch(:session_ids)).delete_all
+  end
+
+  def thread_timeout = 10
+end

--- a/spec/requests/api/v1/people_controller_spec.rb
+++ b/spec/requests/api/v1/people_controller_spec.rb
@@ -100,6 +100,57 @@ RSpec.describe Api::V1::PeopleController do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.parsed_body.dig('error', 'errors', 'base')).to include('Delegated access is invalid')
     end
+
+    it 'rolls back a created dependent when idempotency response storage fails' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      name = "Unstored API Dependent #{SecureRandom.hex(4)}"
+      invalid_key = ApiIdempotencyKey.new
+      invalid_key.errors.add(:base, 'Response storage failed')
+      allow(ApiIdempotencyKey).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(invalid_key))
+
+      expect do
+        post api_v1_household_people_path(household_id),
+             params: {
+               person: {
+                 name: name,
+                 date_of_birth: 8.years.ago.to_date,
+                 person_type: 'minor'
+               }
+             },
+             headers: api_auth_headers(login_data.fetch('access_token'))
+                      .merge('Idempotency-Key' => SecureRandom.uuid),
+             as: :json
+      end.not_to change(Person, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(Person.exists?(name: name)).to be false
+    end
+
+    it 'stores and replays a deterministic validation failure' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+                .merge('Idempotency-Key' => SecureRandom.uuid)
+      payload = {
+        person: {
+          name: '',
+          date_of_birth: 8.years.ago.to_date,
+          person_type: 'adult'
+        }
+      }
+
+      post api_v1_household_people_path(household_id), params: payload, headers: headers, as: :json
+      first_body = response.parsed_body
+
+      expect do
+        post api_v1_household_people_path(household_id), params: payload, headers: headers, as: :json
+      end.not_to change(Person, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body).to eq(first_body)
+      expect(response.headers['Idempotency-Replayed']).to eq('true')
+    end
   end
 
   describe 'GET /api/v1/households/:household_id/people household grants' do

--- a/spec/requests/api/v1/sync_medication_takes_concurrency_spec.rb
+++ b/spec/requests/api/v1/sync_medication_takes_concurrency_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
 
   fixtures :accounts, :people, :users, :locations, :location_memberships, :medications, :dosages, :schedules
 
+  let(:worker_state) do
+    { workers: [], first_lock_released: Queue.new, release_first_request: Queue.new }
+  end
   let(:record_state) { { loaded: false } }
   let(:records) do
     PaperTrail.request(enabled: false) { concurrency_records }.tap { record_state[:loaded] = true }
@@ -24,6 +27,8 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
   end
 
   after do
+    release_first_request << true
+    terminate_workers
     cleanup_records(records) if record_state[:loaded]
   ensure
     version_ledger_trigger(:enable)
@@ -54,19 +59,20 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
   end
 
   it 'converges concurrent batch retries on one take and one set of side effects' do
-    ready = Queue.new
-    release = Queue.new
     gate = Mutex.new
-    counter = { calls: 0 }
-    pause_initial_dose_calls(ready, release, gate, counter)
+    state = { paused: false }
+    pause_first_lock_after_release(gate, state)
     initial_supply = medication.current_supply
 
     sessions = Array.new(2) { ActionDispatch::Integration::Session.new(Rails.application) }
-    workers = sessions.map { |session| start_request(session) }
+    first = start_request(sessions.first)
+    wait_for(first_lock_released, 'first request to release the household lock')
+    second = start_request(sessions.second)
+    second_pid = wait_for(second.fetch(:pid), 'second request database session')
+    wait_for_transaction_lock(second_pid)
 
-    2.times { Timeout.timeout(10) { ready.pop } }
-    2.times { release << true }
-    responses = workers.map { |worker| join_worker(worker) }
+    release_first_request << true
+    responses = [join_worker(first.fetch(:worker)), join_worker(second.fetch(:worker))]
 
     expect(responses.map { |result| result.fetch(:status) }).to eq([201, 201])
     results = responses.map { |result| result.dig(:body, 'data', 'results', 0) }
@@ -79,31 +85,47 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
     expect(ApiChangeEvent.where(record_type: 'MedicationTake', record_id: take.id).count).to eq(1)
   end
 
-  def pause_initial_dose_calls(ready, release, gate, counter)
-    allow(MedicationAdministration::RecordDose).to receive(:new).and_wrap_original do |original, *arguments|
-      pause_dose_service(original.call(*arguments), ready, release, gate, counter)
+  def pause_first_lock_after_release(gate, state)
+    lock = Households::LifecycleCutoffLock
+    allow(lock).to receive(:with).and_wrap_original do |original, *arguments, **keywords, &operation|
+      result = original.call(*arguments, **keywords, &operation)
+      should_pause = gate.synchronize do
+        next false if state[:paused]
+
+        state[:paused] = true
+      end
+      if should_pause
+        first_lock_released << true
+        wait_for(release_first_request, 'first request transaction release')
+      end
+      result
     end
   end
 
-  def pause_dose_service(service, ready, release, gate, counter)
-    original_call = service.method(:call)
-    allow(service).to receive(:call) do |**keywords|
-      pause_dose_call(ready, release) if initial_dose_call?(gate, counter)
-      original_call.call(**keywords)
+  def wait_for_transaction_lock(pid)
+    Timeout.timeout(10) do
+      loop do
+        return if transaction_lock_waiting?(pid)
+
+        Thread.pass
+      end
     end
-    service
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for database session #{pid} to block on a transaction"
   end
 
-  def initial_dose_call?(gate, counter)
-    gate.synchronize do
-      counter[:calls] += 1
-      counter[:calls] <= 2
-    end
+  def transaction_lock_waiting?(pid)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = ? AND locktype = 'transactionid' AND NOT granted)", pid]
+      )
+    )
   end
 
-  def pause_dose_call(ready, release)
-    ready << true
-    Timeout.timeout(10) { release.pop }
+  def wait_for(queue, description)
+    Timeout.timeout(10) { queue.pop }
+  rescue Timeout::Error
+    raise Timeout::Error, "timed out waiting for #{description}"
   end
 
   def concurrency_records
@@ -174,19 +196,25 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
   def client_uuid = records.fetch(:client_uuid)
 
   def start_request(session)
-    Thread.new do
-      ActiveRecord::Base.connection_pool.with_connection do
-        session.post(
-          api_v1_household_sync_batches_path(household_id),
-          params: batch_payload,
-          headers: headers,
-          as: :json
-        )
-        { status: session.response.status, body: session.response.parsed_body }
-      end
-    rescue StandardError => e
-      e
+    pid = Queue.new
+    worker = Thread.new { perform_request(session, pid) }
+    workers << worker
+    { worker: worker, pid: pid }
+  end
+
+  def perform_request(session, pid)
+    ActiveRecord::Base.connection_pool.with_connection do
+      pid << ActiveRecord::Base.connection.select_value('SELECT pg_backend_pid()').to_i
+      session.post(
+        api_v1_household_sync_batches_path(household_id),
+        params: batch_payload,
+        headers: headers,
+        as: :json
+      )
+      { status: session.response.status, body: session.response.parsed_body }
     end
+  rescue StandardError => e
+    e
   end
 
   def join_worker(worker)
@@ -194,6 +222,17 @@ RSpec.describe 'API v1 medication-take sync concurrency' do
 
     worker.value.tap { raise it if it.is_a?(StandardError) }
   end
+
+  def terminate_workers
+    workers.each do |worker|
+      worker.kill if worker.alive?
+      worker.join(1)
+    end
+  end
+
+  def workers = worker_state.fetch(:workers)
+  def first_lock_released = worker_state.fetch(:first_lock_released)
+  def release_first_request = worker_state.fetch(:release_first_request)
 
   def batch_payload
     { batch: { operations: [batch_operation] } }

--- a/spec/requests/api/v1/sync_safety_spec.rb
+++ b/spec/requests/api/v1/sync_safety_spec.rb
@@ -63,6 +63,73 @@ RSpec.describe 'API v1 sync safety primitives' do
     expect(response.parsed_body.dig('error', 'code')).to eq('idempotency_key_reused')
   end
 
+  it 'rejects replay to a different authenticated account in the same household' do
+    idempotency_headers = headers.merge('Idempotency-Key' => SecureRandom.uuid)
+    payload = {
+      medication: {
+        name: 'API Account Scoped Result',
+        location_id: locations(:home).id,
+        dose_amount: 5,
+        dose_unit: 'ml'
+      }
+    }
+    post api_v1_household_medications_path(household_id),
+         params: payload,
+         headers: idempotency_headers,
+         as: :json
+    first_body = response.parsed_body
+    other_token = issue_other_account_token(Household.find(household_id))
+
+    post api_v1_household_medications_path(household_id),
+         params: payload,
+         headers: api_auth_headers(other_token).merge(
+           'Idempotency-Key' => idempotency_headers.fetch('Idempotency-Key')
+         ),
+         as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(response.parsed_body.dig('error', 'code')).to eq('idempotency_key_reused')
+    expect(response.parsed_body).not_to eq(first_body)
+  end
+
+  it 'allows the same idempotency key to be used independently in different households' do
+    key = SecureRandom.uuid
+    first_household = Household.find(household_id)
+    second_household = Household.create!(
+      name: 'Other Idempotency Household',
+      slug: "other-idempotency-household-#{SecureRandom.hex(4)}"
+    )
+    second_token = issue_other_account_token(second_household)
+    payload = {
+      person: {
+        name: "Household Scoped Person #{SecureRandom.hex(4)}",
+        date_of_birth: 30.years.ago.to_date,
+        person_type: 'adult'
+      }
+    }
+
+    post api_v1_household_people_path(first_household),
+         params: payload,
+         headers: headers.merge('Idempotency-Key' => key),
+         as: :json
+    expect(response).to have_http_status(:created)
+
+    post api_v1_household_people_path(second_household),
+         params: payload,
+         headers: api_auth_headers(second_token).merge('Idempotency-Key' => key),
+         as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(Person.where(name: payload.dig(:person, :name)).pluck(:household_id)).to contain_exactly(
+      first_household.id,
+      second_household.id
+    )
+    expect(ApiIdempotencyKey.where(key: key).pluck(:household_id)).to contain_exactly(
+      first_household.id,
+      second_household.id
+    )
+  end
+
   it 'finds resources by portable id without leaking cross-household records' do
     medication = medications(:paracetamol)
     other_household = Household.create!(name: 'Other Portable Household', slug: 'other-portable-household')
@@ -132,5 +199,49 @@ RSpec.describe 'API v1 sync safety primitives' do
       action: 'update'
     )
     expect(event.metadata.to_json).not_to include('Sensitive API Medicine')
+  end
+
+  def issue_other_account_token(household)
+    account = create_other_account
+    person = create_other_person(account, household)
+    create_other_user(person, account)
+    membership = create_other_membership(account, person, household)
+    ApiSession.issue_for(account: account, household_membership: membership).second
+  end
+
+  def create_other_account
+    Account.create!(
+      email: "api-idempotency-other-#{SecureRandom.hex(4)}@example.test",
+      status: :verified
+    )
+  end
+
+  def create_other_person(account, household)
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'API Idempotency Other Owner',
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+
+  def create_other_user(person, account)
+    User.create!(
+      person: person,
+      email_address: account.email,
+      password: 'password',
+      active: true
+    )
+  end
+
+  def create_other_membership(account, person, household)
+    household.household_memberships.create!(
+      account: account,
+      person: person,
+      role: :owner,
+      status: :active
+    )
   end
 end

--- a/spec/services/api/idempotency_store_spec.rb
+++ b/spec/services/api/idempotency_store_spec.rb
@@ -39,9 +39,32 @@ RSpec.describe Api::IdempotencyStore do
     expect(result.conflict).to be false
   end
 
+  it 'rejects replay from a different authenticated account' do
+    request = request_double(method: 'POST', key: 'account-scoped-key')
+    response = response_double(status: 201, body: '{"data":{"name":"Private result"}}')
+    described_class.new(request: request, credential: api_session, household: household).store!(response)
+    other_session = api_session_for(create_account_with_membership(household))
+
+    result = described_class.new(request: request, credential: other_session, household: household).lookup
+
+    expect(result.replayed).to be false
+    expect(result.conflict).to be true
+  end
+
+  it 'derives a stable opaque reservation id from household and key' do
+    first = store_for('private-key-material')
+    matching = store_for('private-key-material')
+    different = store_for('different-key-material')
+
+    expect(first.send(:reservation_id)).to be_a(Integer)
+    expect(first.send(:reservation_id)).to eq(matching.send(:reservation_id))
+    expect(first.send(:reservation_id)).not_to eq(different.send(:reservation_id))
+    expect(first.send(:reservation_id).to_s).not_to include('private-key-material')
+  end
+
   it 'stores non-PHI response metadata and normalises invalid JSON response bodies' do
     request = request_double(method: 'POST', key: 'store-key')
-    response = instance_double(ActionDispatch::Response, status: 201, body: 'not-json')
+    response = response_double(status: 201, body: 'not-json')
 
     expect do
       described_class.new(request: request, credential: api_session, household: household).store!(response)
@@ -64,7 +87,7 @@ RSpec.describe Api::IdempotencyStore do
       name: 'Idempotency app token'
     ).first
     request = request_double(method: 'PATCH', key: 'app-token-key')
-    response = instance_double(ActionDispatch::Response, status: 200, body: '{"ok":true}')
+    response = response_double(status: 200, body: '{"ok":true}')
 
     described_class.new(request: request, credential: app_token, household: household).store!(response)
 
@@ -75,7 +98,7 @@ RSpec.describe Api::IdempotencyStore do
 
   it 'does not store inactive or failed responses' do
     inactive_request = request_double(method: 'GET', key: 'inactive-key')
-    failed_response = instance_double(ActionDispatch::Response, status: 500, body: '{}')
+    failed_response = response_double(status: 500, body: '{}')
 
     expect do
       described_class.new(
@@ -88,14 +111,52 @@ RSpec.describe Api::IdempotencyStore do
     end.not_to change(ApiIdempotencyKey, :count)
   end
 
-  it 'ignores duplicate stores for the same key' do
+  it 'raises when a response cannot be stored uniquely' do
     request = request_double(method: 'POST', key: 'duplicate-key')
-    response = instance_double(ActionDispatch::Response, status: 201, body: '{"ok":true}')
+    response = response_double(status: 201, body: '{"ok":true}')
     store = described_class.new(request: request, credential: api_session, household: household)
+    store.store!(response)
 
-    expect do
-      2.times { store.store!(response) }
-    end.to change(ApiIdempotencyKey, :count).by(1)
+    expect { store.store!(response) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'rolls back a rendered server error and leaves the key retryable' do
+    request = request_double(method: 'POST', key: 'server-error-key')
+    store = described_class.new(request: request, credential: api_session, household: household)
+    name = "Rolled Back Person #{SecureRandom.hex(4)}"
+
+    mutate_person(store, status: 500, name: name)
+    expect(Person.exists?(household: household, name: name)).to be false
+    expect(ApiIdempotencyKey.exists?(household: household, key: 'server-error-key')).to be false
+
+    mutate_person(store, status: 201, name: name)
+    expect(Person.exists?(household: household, name: name)).to be true
+    expect(ApiIdempotencyKey.exists?(household: household, key: 'server-error-key')).to be true
+  end
+
+  it 'rolls back a raised exception and leaves the key retryable' do
+    request = request_double(method: 'POST', key: 'exception-key')
+    store = described_class.new(request: request, credential: api_session, household: household)
+    name = "Exception Person #{SecureRandom.hex(4)}"
+
+    expect { mutate_person_then_raise(store, name) }.to raise_error('mutation failed')
+    expect(Person.exists?(household: household, name: name)).to be false
+    expect(ApiIdempotencyKey.exists?(household: household, key: 'exception-key')).to be false
+  end
+
+  it 'allows the same key to be stored independently in different households' do
+    request = request_double(method: 'POST', key: 'household-scoped-key')
+    response = response_double(status: 201, body: '{"ok":true}')
+    other_household = Household.create!(
+      name: 'Other Idempotency Store Spec',
+      slug: "other-idempotency-store-#{SecureRandom.hex(4)}"
+    )
+    other_session = api_session_for(create_account_with_membership(other_household))
+
+    described_class.new(request: request, credential: api_session, household: household).store!(response)
+    described_class.new(request: request, credential: other_session, household: other_household).store!(response)
+
+    expect(ApiIdempotencyKey.where(key: 'household-scoped-key').count).to eq(2)
   end
 
   def request_double(method:, key:)
@@ -110,6 +171,59 @@ RSpec.describe Api::IdempotencyStore do
       put?: method == 'PUT',
       delete?: method == 'DELETE'
     )
+  end
+
+  def response_double(status:, body:)
+    instance_double(ActionDispatch::Response, status: status, body: body)
+  end
+
+  def store_for(key)
+    described_class.new(
+      request: request_double(method: 'POST', key: key),
+      credential: api_session,
+      household: household
+    )
+  end
+
+  def mutate_person(store, status:, name:)
+    store.with_reservation(response: response_double(status: status, body: '{"ok":true}')) do
+      create_unowned_person(name)
+    end
+  end
+
+  def mutate_person_then_raise(store, name)
+    store.with_reservation(response: response_double(status: 201, body: '{"ok":true}')) do
+      create_unowned_person(name)
+      raise 'mutation failed'
+    end
+  end
+
+  def create_unowned_person(name)
+    Person.create!(
+      household: household,
+      name: name,
+      date_of_birth: 30.years.ago.to_date,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+
+  def create_account_with_membership(target_household)
+    other_account = Account.create!(
+      email: "idempotency-other-#{SecureRandom.hex(4)}@example.test",
+      status: :verified
+    )
+    other_person = create_person_for(other_account, target_household)
+    target_household.household_memberships.create!(
+      account: other_account,
+      person: other_person,
+      role: :owner,
+      status: :active
+    )
+  end
+
+  def api_session_for(target_membership)
+    ApiSession.issue_for(account: target_membership.account, household_membership: target_membership).first
   end
 
   def create_person_for(account, household)


### PR DESCRIPTION
## Summary

- Serializes matching API mutations with a transaction-scoped PostgreSQL advisory lock before controller side effects begin.
- Commits domain writes and the replayable response atomically, while leaving failed or server-error attempts retryable.
- Prevents cross-account response replay and adds deterministic two-connection coverage through the public People endpoint.

## Verification

- task test — 4,775 examples, 0 failures (1 expected OIDC pending)
- task rubocop — 1,660 files, no offenses
- task brakeman — 0 warnings
- task openspec:validate — 2 changes passed

## Risks / follow-ups

- No migration or public API shape change is included.
- Response-header replay, including ETag, remains separate in #1749.

Closes #1747
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->