### PR TITLE
fix(api): preserve idempotent response etags

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -252,6 +252,7 @@ module Api
 
         result = store.with_reservation(response: response, &action)
         if result.replayed
+          result.response_headers.each { |name, value| response.set_header(name, value) }
           response.set_header('Idempotency-Replayed', 'true')
           render json: result.record.response_body, status: result.record.response_status
         elsif result.conflict

--- a/app/services/api/idempotency_store.rb
+++ b/app/services/api/idempotency_store.rb
@@ -4,8 +4,9 @@ module Api
   class IdempotencyStore
     EXPIRY = 24.hours
     LOCK_NAMESPACE = 'med_tracker.api_idempotency.v1'
+    REPLAYABLE_RESPONSE_HEADERS = %w[ETag].freeze
 
-    Result = Data.define(:record, :replayed, :conflict)
+    Result = Data.define(:record, :replayed, :conflict, :response_headers)
 
     def initialize(request:, credential:, household:)
       @request = request
@@ -23,6 +24,7 @@ module Api
       result = nil
       ApiIdempotencyKey.transaction(requires_new: true) do
         acquire_reservation
+        discard_expired_record
         result = lookup
         next if result.record
 
@@ -34,9 +36,15 @@ module Api
 
     def lookup
       record = ApiIdempotencyKey.find_by(household: household, key: key)
-      return Result.new(record: nil, replayed: false, conflict: false) unless record
+      return Result.new(record: nil, replayed: false, conflict: false, response_headers: {}) unless record
 
-      Result.new(record: record, replayed: same_request?(record), conflict: !same_request?(record))
+      replayed = same_request?(record)
+      Result.new(
+        record: record,
+        replayed: replayed,
+        conflict: !replayed,
+        response_headers: replayed ? replayable_response_headers(record.response_headers) : {}
+      )
     end
 
     def store!(response)
@@ -61,6 +69,10 @@ module Api
       Digest::SHA256.digest(
         [LOCK_NAMESPACE, household.id, key].join("\0")
       ).unpack1('q>')
+    end
+
+    def discard_expired_record
+      ApiIdempotencyKey.where(household: household, key: key, expires_at: ..Time.current).delete_all
     end
 
     def persist_response!(response)
@@ -97,8 +109,13 @@ module Api
     def response_attributes(response)
       {
         response_status: response.status,
-        response_body: response_body(response)
+        response_body: response_body(response),
+        response_headers: replayable_response_headers(response.headers)
       }
+    end
+
+    def replayable_response_headers(headers)
+      REPLAYABLE_RESPONSE_HEADERS.index_with { |name| headers[name] }.compact
     end
 
     def key

--- a/db/migrate/20260728170000_add_response_headers_to_api_idempotency_keys.rb
+++ b/db/migrate/20260728170000_add_response_headers_to_api_idempotency_keys.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddResponseHeadersToApiIdempotencyKeys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :api_idempotency_keys, :response_headers, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_19_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_28_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_19_090000) do
     t.string "request_method", null: false
     t.string "request_path", null: false
     t.jsonb "response_body", default: {}, null: false
+    t.jsonb "response_headers", default: {}, null: false
     t.integer "response_status", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_api_idempotency_keys_on_account_id"

--- a/openspec/changes/preserve-idempotent-response-headers/.openspec.yaml
+++ b/openspec/changes/preserve-idempotent-response-headers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/preserve-idempotent-response-headers/design.md
+++ b/openspec/changes/preserve-idempotent-response-headers/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`Api::V1::BaseController#with_api_idempotency` delegates keyed mutations to `Api::IdempotencyStore#with_reservation`. The store opens a `requires_new` transaction, acquires a PostgreSQL transaction-scoped advisory lock for the `(household_id, key)` namespace, performs the post-lock lookup, runs the controller mutation on a miss, and persists response status/body before commit. A replay renders that stored status/body and adds `Idempotency-Replayed: true`.
+
+Resource responses are rendered through `BaseController#render_resource`, which sets an ETag derived from the record class, database ID, and `updated_at`. The OpenAPI contract requires ETag on successful create/update resource responses. `Retry-After` is the only other named OpenAPI response header, but Rack Attack produces it before the Rails controller and idempotency transaction; it is not part of a stored mutation response. Cookies, credentials, request identifiers, rate-limit metadata, cache controls, and arbitrary application headers must not enter the durable idempotency row.
+
+The table already records `expires_at` using a 24-hour retention value, but the reservation path does not currently remove an expired row before lookup. Adding a header column with an empty default keeps existing rows readable, but those rows cannot be backfilled because the original ETag was never captured.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the original ETag across normal and concurrent idempotent response replay.
+- Store and restore only explicitly allowlisted, non-sensitive response headers.
+- Keep response storage atomic with the mutation under the #1747 reservation transaction.
+- Give existing headerless rows a data-safe, bounded transition without re-running a completed mutation.
+- Preserve account matching, household isolation, conflict behavior, rollback, audit behavior, and exactly-once mutation side effects.
+
+**Non-Goals:**
+
+- General response caching or arbitrary/header-prefix persistence.
+- ETag reconstruction from stored JSON or endpoint-specific record lookup.
+- A background cleanup process or a different retention duration.
+- Persistence of `Retry-After`, `Set-Cookie`, `Authorization`, `X-Request-Id`, cache headers, or rate-limit headers.
+- Changes to medication-take `client_uuid` idempotency or any endpoint response body/schema.
+
+## Decisions
+
+### 1. Add a compatible JSONB response-header column
+
+Add `response_headers` to `api_idempotency_keys` as `jsonb`, `null: false`, with database default `{}`. The migration is an additive expansion that permits old and new application versions to coexist: old code ignores the column, while new code accepts empty hashes from legacy rows.
+
+Alternative considered: one nullable ETag string column. Rejected because the issue requires an explicit replayable-header contract that can grow deliberately without another schema migration, while JSONB still stores only allowlisted scalar values.
+
+Alternative considered: backfill ETags. Rejected because the generic row does not retain the record class/database ID pair required by `Api::RecordEtag`, and inferring it from paths or response JSON would be endpoint-specific and unsafe.
+
+### 2. Centralize a case-specific allowlist in the idempotency store
+
+`Api::IdempotencyStore` will define `REPLAYABLE_RESPONSE_HEADERS = %w[ETag].freeze`. When persisting a completed response, it will select only those exact names from `response.headers`; missing values are omitted. When returning a matching replay result, it will reapply the same allowlist to stored JSON before handing headers to the controller. This read-side filtering prevents manually altered or historical database content from bypassing the current allowlist.
+
+Alternative considered: store all headers except a denylist. Rejected because framework and middleware headers can contain cookies, request correlation data, cache policy, or future sensitive metadata that a denylist would fail to anticipate.
+
+Alternative considered: include `Retry-After`. Rejected because rate limiting occurs in Rack Attack before controller idempotency and a replayed completed mutation must not carry stale retry timing.
+
+### 3. Restore stored headers before rendering the replay body
+
+The replay result will expose an immutable header hash alongside the stored record and replay/conflict flags. `BaseController#with_api_idempotency` will set each returned header before rendering the stored JSON/status, then set `Idempotency-Replayed: true`. Conflict and miss results expose an empty header hash.
+
+This keeps durable-header selection inside the store while leaving HTTP response application at the controller boundary. The action is still skipped for a replay, and no new domain write, PaperTrail version, access grant, or audit mutation side effect occurs.
+
+### 4. Enforce existing expiry only after acquiring the reservation lock
+
+After acquiring the transaction-scoped advisory lock and before lookup, the store will delete a matching row only when `expires_at <= Time.current`. It will then perform the normal post-lock lookup and mutation/store flow. Deletion and replacement remain inside the same transaction and lock namespace, so two callers cannot both reopen the expired key.
+
+Fresh legacy rows with `{}` headers remain replayable without an invented ETag until their recorded expiry. This prioritizes exactly-once mutation safety over immediate header parity for responses created before deployment. Because expiry is enforced at the next keyed attempt, legacy rows age out within the already documented retention window without a background worker.
+
+Alternative considered: delete all existing rows in the migration. Rejected because a retry could execute an already committed mutation again.
+
+Alternative considered: return a new error for headerless rows. Rejected because that adds a public response contract and makes previously replayable requests fail even though the stored status/body remain valid.
+
+### 5. Verify public create, update, and concurrent replay
+
+Request coverage will prove a People create and update store the original ETag and return it unchanged on replay. Service coverage will prove non-allowlisted headers are omitted on write and read, legacy rows remain safe, expired rows can be replaced, and mismatched accounts receive no stored headers. The existing two-connection concurrency request spec will include ETag parity while retaining its exactly-one-mutation assertions.
+
+The People endpoint remains the public regression boundary because it exercises resource ETags, transactional delegation/access-grant side effects, PaperTrail, household routing, and the generic idempotency wrapper together.
+
+## Risks / Trade-offs
+
+- **[Fresh legacy rows can replay without ETag during the rollout window]** → Preserve the mutation result rather than risking duplicate execution; enforce the recorded 24-hour expiry so the window is bounded.
+- **[A future developer adds a sensitive header]** → Require an explicit constant change and retain write-side plus read-side allowlist tests.
+- **[Expired-key deletion weakens serialization]** → Perform it only after the existing advisory lock and inside the same `requires_new` transaction as replacement.
+- **[JSONB values are not guaranteed to be strings]** → Persist only values read from the response header interface and ignore non-allowlisted stored keys on replay.
+- **[Migration rollback while new code is deployed removes a required column]** → Roll application code back before reversing the schema migration; leaving the additive column in place is safe.
+
+## Migration Plan
+
+1. Deploy the additive `response_headers` JSONB column with default `{}` and `NOT NULL`.
+2. Deploy application code that writes/reads the allowlist and expires matching old rows under the reservation lock.
+3. Existing fresh rows continue their current status/body replay behavior; newly created rows include ETag where the response provides one.
+4. After the existing 24-hour retention window, every reusable row has passed through the new writer.
+5. Roll back application code first if needed. The unused additive column can remain; reverse the migration only after no deployed code references it.
+
+## Open Questions
+
+None. `ETag` is the only response header currently required by both a successful idempotent resource mutation and the generated-client concurrency contract.

--- a/openspec/changes/preserve-idempotent-response-headers/proposal.md
+++ b/openspec/changes/preserve-idempotent-response-headers/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The generic API idempotency store persists response status and JSON body but drops response headers, so an original successful mutation can include an `ETag` while a later replay of that same response does not. This breaks the optimistic-concurrency contract used by iOS and generated API clients and blocks reliable mobile retries.
+
+Originating issue: https://github.com/damacus/med-tracker/issues/1749
+
+## What Changes
+
+- Persist only an explicit, non-sensitive allowlist of response headers for completed idempotent mutations, beginning with `ETag`.
+- Restore the stored allowlisted headers before rendering a replayed response.
+- Add a compatible JSONB column whose empty default keeps existing idempotency rows readable without inventing unavailable historical header values.
+- Enforce the existing 24-hour idempotency expiry under the serialized reservation boundary so legacy headerless rows age out safely without reopening a fresh key concurrently.
+- Prove original and replayed create/update responses have matching ETag behavior while preserving account, household, conflict, rollback, and concurrent-serialization guarantees.
+- Keep `Retry-After`, rate-limit metadata, cookies, authentication headers, request identifiers, and every other non-allowlisted header out of stored replay data.
+
+Explicit non-goals:
+
+- General-purpose response caching or arbitrary header persistence.
+- Reconstructing historical ETags that were never stored.
+- Changing endpoint-specific idempotency such as medication-take `client_uuid`.
+- Changing the public response body, status, authorization, household isolation, or mutation semantics established by #1747.
+- Adding a background cleanup worker or changing the 24-hour retention period.
+
+## Capabilities
+
+### New Capabilities
+
+- `api-idempotent-response-headers`: Idempotent API mutation replays preserve explicitly allowlisted response headers and safely age out legacy headerless rows.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one compatible PostgreSQL JSONB column to `api_idempotency_keys`.
+- Extends `Api::IdempotencyStore` and `Api::V1::BaseController` without changing endpoint response schemas.
+- Adds focused service, migration, and API request coverage, including regression coverage around the serialized reservation boundary.
+- Unblocks iOS and generated API clients that require the original ETag after a lost-response retry.

--- a/openspec/changes/preserve-idempotent-response-headers/specs/api-idempotent-response-headers/spec.md
+++ b/openspec/changes/preserve-idempotent-response-headers/specs/api-idempotent-response-headers/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Replayed mutations preserve allowlisted response headers
+
+The system SHALL persist and restore only explicitly allowlisted, non-sensitive response headers for completed idempotent API mutations. The initial allowlist SHALL contain `ETag`.
+
+#### Scenario: A create replay returns the original ETag
+
+- **GIVEN** an authenticated account completes a keyed resource creation that returns an ETag
+- **WHEN** the same account repeats the matching request in the same household before expiry
+- **THEN** the system returns the stored status, body, and original ETag with `Idempotency-Replayed: true`
+- **AND** no additional resource or mutation side effect is created
+
+#### Scenario: An update replay returns the original ETag
+
+- **GIVEN** an authenticated account completes a keyed resource update that returns a new ETag
+- **WHEN** the same account repeats the matching request before expiry
+- **THEN** the system returns the stored status, body, and exact post-update ETag
+- **AND** it does not update the resource again
+
+#### Scenario: A concurrent waiter returns the committed ETag
+
+- **GIVEN** two matching authenticated mutations compete for the same household and idempotency key
+- **WHEN** the first request commits its mutation and response under the serialized reservation
+- **THEN** the waiting request returns the same status, body, and ETag with `Idempotency-Replayed: true`
+- **AND** exactly one mutation and one set of mutation side effects commit
+
+### Requirement: Replayable response headers use a strict allowlist
+
+The system MUST persist and restore response headers only when their names are present in the explicit replay allowlist. Stored headers SHALL contain no PHI, credentials, cookies, request identifiers, cache metadata, or rate-limit timing.
+
+#### Scenario: Sensitive and delivery-specific headers are excluded
+
+- **GIVEN** a completed keyed mutation response contains ETag plus non-allowlisted headers
+- **WHEN** the system persists and later replays that response
+- **THEN** the stored and replayed header set contains the ETag
+- **AND** it does not contain `Set-Cookie`, `Authorization`, `X-Request-Id`, `Cache-Control`, `Retry-After`, or rate-limit headers
+
+#### Scenario: Stored data cannot bypass the current allowlist
+
+- **GIVEN** an idempotency row contains a manually inserted non-allowlisted response-header key
+- **WHEN** a matching request replays the row
+- **THEN** the system does not add that header to the HTTP response
+
+### Requirement: Header replay preserves tenant and account boundaries
+
+The system SHALL expose stored allowlisted headers only when the authenticated account, household, method, path, and request digest match the completed idempotency row.
+
+#### Scenario: A different account cannot receive stored headers
+
+- **GIVEN** a completed idempotent response belongs to one account in a household
+- **WHEN** another account attempts to reuse the key in that household
+- **THEN** the system returns HTTP 409 `idempotency_key_reused`
+- **AND** it does not expose the stored status, body, or response headers
+
+#### Scenario: Households retain independent replay namespaces
+
+- **GIVEN** two households use the same raw idempotency key
+- **WHEN** each household completes and replays its own matching request
+- **THEN** each replay returns only its household's stored response and allowlisted headers
+
+### Requirement: Legacy headerless rows age out without duplicate mutation risk
+
+The system SHALL keep an unexpired legacy idempotency row with empty response headers replayable and SHALL remove an expired matching row only while holding the existing serialized reservation.
+
+#### Scenario: An unexpired legacy row remains replayable
+
+- **GIVEN** a matching pre-deployment row has stored status/body, empty response headers, and a future expiry
+- **WHEN** the authenticated account repeats the request
+- **THEN** the system replays the stored status/body without inventing an ETag
+- **AND** it does not execute the mutation again
+
+#### Scenario: An expired row is replaced under serialization
+
+- **GIVEN** a matching idempotency row has reached its recorded expiry
+- **WHEN** an authenticated mutation reuses the key
+- **THEN** the system removes the expired row after acquiring the reservation lock
+- **AND** it executes the mutation once and atomically stores the new response with its allowlisted headers
+
+#### Scenario: Concurrent callers cannot both reopen an expired key
+
+- **GIVEN** two matching requests encounter the same expired idempotency row
+- **WHEN** they compete for the existing reservation namespace
+- **THEN** one request replaces the expired row and the other replays the replacement
+- **AND** exactly one new mutation commits

--- a/openspec/changes/preserve-idempotent-response-headers/tasks.md
+++ b/openspec/changes/preserve-idempotent-response-headers/tasks.md
@@ -1,0 +1,27 @@
+## 1. Red: Specify Header and Legacy-Row Behavior
+
+- [x] 1.1 Extend `spec/services/api/idempotency_store_spec.rb` with failing examples for ETag-only persistence, read-side allowlisting, account-conflict non-disclosure, unexpired legacy replay, and expired-row replacement.
+- [x] 1.2 Extend `spec/requests/api/v1/people_controller_spec.rb` with failing create and update examples proving original and replayed ETags match without a second mutation.
+- [x] 1.3 Extend `spec/requests/api/v1/idempotency_concurrency_spec.rb` with a failing assertion that the concurrent waiter receives the committed ETag.
+- [x] 1.4 Run each focused spec through `task test TEST_FILE=...` and confirm the new examples fail for missing response-header persistence or expiry enforcement.
+
+## 2. Green: Add Compatible Header Storage
+
+- [x] 2.1 Add an additive Rails 8.1 migration for `api_idempotency_keys.response_headers` as JSONB with database default `{}` and `null: false`, then update `db/schema.rb` through the repository migration task.
+- [x] 2.2 Add the explicit `ETag` response-header allowlist to `Api::IdempotencyStore`, persist only allowlisted present values, and apply the allowlist again when building a matching replay result.
+- [x] 2.3 Restore replayable headers in `Api::V1::BaseController#with_api_idempotency` before rendering the stored response and adding `Idempotency-Replayed: true`.
+- [x] 2.4 Remove an expired matching idempotency row only after acquiring the existing advisory lock and before post-lock lookup, keeping deletion and replacement in the same reservation transaction.
+
+## 3. Refactor and Focused Verification
+
+- [x] 3.1 Make response doubles and replay results expose headers consistently without weakening verifying-double coverage.
+- [x] 3.2 Run the service, People request, and concurrency request specs together and confirm ETag parity, strict allowlisting, legacy behavior, account/household isolation, and exactly-once side effects.
+- [x] 3.3 Run directly related sync-safety and idempotency request/service specs to confirm #1747 serialization and conflict behavior remain green.
+- [x] 3.4 Run `task rubocop` and fix any offenses without broadening scope.
+
+## 4. Full Validation and Handoff
+
+- [x] 4.1 Run `task openspec:validate` and confirm the change artifacts are valid.
+- [x] 4.2 Run the full `task test` suite and record any expected pending examples separately from failures.
+- [x] 4.3 Review the final diff against issue #1749 and the OpenSpec requirements, including the 24-hour legacy transition and exclusion of all non-allowlisted headers.
+- [x] 4.4 Commit with a Conventional Commit message, push the branch, open a focused pull request linked to #1749, and monitor every required check to green.

--- a/spec/requests/api/v1/idempotency_concurrency_spec.rb
+++ b/spec/requests/api/v1/idempotency_concurrency_spec.rb
@@ -27,26 +27,109 @@ RSpec.describe 'API v1 idempotency concurrency' do
   end
 
   it 'serializes concurrent People creates before mutation side effects' do
+    responses, person = perform_concurrent_people_creates
+
+    expect_serialized_create(responses, person)
+  end
+
+  it 'serializes replacement when concurrent callers encounter an expired response' do
+    expired_record = create_expired_idempotency_record
+
+    responses, person = perform_concurrent_people_creates
+    replacement = ApiIdempotencyKey.find_by!(
+      household_id: records.fetch(:household_id),
+      key: records.fetch(:key)
+    )
+
+    expect_serialized_create(responses, person)
+    expect(replacement.id).not_to eq(expired_record.id)
+    expect(replacement.response_headers.fetch('ETag')).to eq(responses.first.fetch(:etag))
+  end
+
+  def perform_concurrent_people_creates
     pause_first_assignment
+    first, second = start_concurrent_requests
+    wait_for_competing_request(second)
+    release_assignment << true
+    [collect_responses(first, second), created_person]
+  end
+
+  def start_concurrent_requests
     sessions = Array.new(2) { ActionDispatch::Integration::Session.new(Rails.application) }
     first = start_request(sessions.first, records.fetch(:tokens).first)
     wait_for(assignment_entered, 'first People assignment')
     second = start_request(sessions.second, records.fetch(:tokens).second)
+    [first, second]
+  end
+
+  def wait_for_competing_request(second)
     second_pid = wait_for(second.fetch(:pid), 'second request database session')
     wait_for_advisory_wait(second_pid)
+  end
 
-    release_assignment << true
-    responses = [join_worker(first.fetch(:worker)), join_worker(second.fetch(:worker))]
-    person = Person.find_by!(household_id: records.fetch(:household_id), name: records.fetch(:name))
+  def collect_responses(first, second)
+    [join_worker(first.fetch(:worker)), join_worker(second.fetch(:worker))]
+  end
 
+  def created_person
+    Person.find_by!(household_id: records.fetch(:household_id), name: records.fetch(:name))
+  end
+
+  def expect_serialized_create(responses, person)
+    expect_response_parity(responses)
+    expect_person_side_effects(person)
+    expect_audit_and_idempotency(person)
+  end
+
+  def expect_response_parity(responses)
+    expect_status_and_body_parity(responses)
+    expect_etag_and_replay_parity(responses)
+  end
+
+  def expect_status_and_body_parity(responses)
     expect(responses.map { it.fetch(:status) }).to eq([201, 201])
     expect(responses.map { it.fetch(:body) }.uniq.one?).to be true
+  end
+
+  def expect_etag_and_replay_parity(responses)
+    expect(responses.map { it.fetch(:etag) }.uniq.one?).to be true
+    expect(responses.first.fetch(:etag)).to be_present
     expect(responses.count { it.fetch(:replayed) }).to eq(1)
+  end
+
+  def expect_person_side_effects(person)
+    expect_single_person
+    expect_delegation_side_effects(person)
+  end
+
+  def expect_single_person
     expect(Person.where(household_id: records.fetch(:household_id), name: records.fetch(:name)).count).to eq(1)
+  end
+
+  def expect_delegation_side_effects(person)
     expect(CarerRelationship.where(patient: person).count).to eq(1)
     expect(PersonAccessGrant.where(person: person, revoked_at: nil).count).to eq(1)
+  end
+
+  def expect_audit_and_idempotency(person)
     expect(PaperTrail::Version.where(item_type: 'Person', item_id: person.id, event: 'create').count).to eq(1)
     expect(ApiIdempotencyKey.where(household_id: records.fetch(:household_id), key: records.fetch(:key)).count).to eq(1)
+  end
+
+  def create_expired_idempotency_record
+    ApiIdempotencyKey.create!(
+      household_id: records.fetch(:household_id),
+      account_id: records.fetch(:account_id),
+      api_session_id: records.fetch(:session_ids).first,
+      key: records.fetch(:key),
+      request_method: 'POST',
+      request_path: api_v1_household_people_path(records.fetch(:household_id)),
+      request_digest: 'expired-response',
+      response_status: 201,
+      response_body: { 'expired' => true },
+      response_headers: {},
+      expires_at: 1.minute.ago
+    )
   end
 
   def pause_first_assignment
@@ -103,6 +186,7 @@ RSpec.describe 'API v1 idempotency concurrency' do
     {
       status: request_response.status,
       body: request_response.parsed_body,
+      etag: request_response.headers['ETag'],
       replayed: request_response.headers['Idempotency-Replayed'] == 'true'
     }
   end

--- a/spec/requests/api/v1/people_controller_spec.rb
+++ b/spec/requests/api/v1/people_controller_spec.rb
@@ -51,6 +51,41 @@ RSpec.describe Api::V1::PeopleController do
   end
 
   describe 'POST /api/v1/households/:household_id/people' do
+    it 'replays a lost create response with the original ETag' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token')).merge('Idempotency-Key' => SecureRandom.uuid)
+      payload = {
+        person: {
+          name: "Durable adult #{SecureRandom.hex(4)}",
+          date_of_birth: 30.years.ago.to_date,
+          person_type: 'adult'
+        }
+      }
+
+      expect do
+        post api_v1_household_people_path(household_id), params: payload, headers: headers, as: :json
+      end.to change(Person, :count).by(1)
+      first_body = response.parsed_body
+      first_etag = response.headers.fetch('ETag')
+      stored_response = ApiIdempotencyKey.find_by!(key: headers.fetch('Idempotency-Key'))
+
+      expect(stored_response.response_headers).to eq('ETag' => first_etag)
+      replay_login = api_login(user, household_id: household_id)
+      replay_headers = api_auth_headers(replay_login.fetch('access_token')).merge(
+        'Idempotency-Key' => headers.fetch('Idempotency-Key')
+      )
+
+      expect do
+        post api_v1_household_people_path(household_id), params: payload, headers: replay_headers, as: :json
+      end.not_to change(Person, :count)
+
+      expect(response).to have_http_status(:created)
+      expect(response.headers['Idempotency-Replayed']).to eq('true')
+      expect(response.headers['ETag']).to eq(first_etag)
+      expect(response.parsed_body).to eq(first_body)
+    end
+
     it 'creates a dependent through the transactional care delegation workflow' do
       login_data = api_login(user)
       household_id = login_data.dig('household', 'id')
@@ -150,6 +185,41 @@ RSpec.describe Api::V1::PeopleController do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.parsed_body).to eq(first_body)
       expect(response.headers['Idempotency-Replayed']).to eq('true')
+    end
+  end
+
+  describe 'PATCH /api/v1/households/:household_id/people/:id' do
+    it 'replays a lost update response with the original ETag' do
+      login_data = api_login(user)
+      household_id = login_data.dig('household', 'id')
+      person = people(:child_patient)
+      payload = { person: { name: "Durable fresh name #{SecureRandom.hex(4)}" } }
+      headers = api_auth_headers(login_data.fetch('access_token')).merge(
+        'Idempotency-Key' => SecureRandom.uuid,
+        'If-Match' => Api::RecordEtag.for(person)
+      )
+
+      patch api_v1_household_person_path(household_id, person.id),
+            params: payload,
+            headers: headers,
+            as: :json
+      first_body = response.parsed_body
+      first_etag = response.headers.fetch('ETag')
+      stored_response = ApiIdempotencyKey.find_by!(key: headers.fetch('Idempotency-Key'))
+
+      expect(stored_response.response_headers).to eq('ETag' => first_etag)
+
+      expect do
+        patch api_v1_household_person_path(household_id, person.id),
+              params: payload,
+              headers: headers,
+              as: :json
+      end.not_to(change { person.reload.updated_at })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['Idempotency-Replayed']).to eq('true')
+      expect(response.headers['ETag']).to eq(first_etag)
+      expect(response.parsed_body).to eq(first_body)
     end
   end
 

--- a/spec/services/api/idempotency_store_spec.rb
+++ b/spec/services/api/idempotency_store_spec.rb
@@ -37,11 +37,16 @@ RSpec.describe Api::IdempotencyStore do
     expect(result.record).to be_nil
     expect(result.replayed).to be false
     expect(result.conflict).to be false
+    expect(result.response_headers).to eq({})
   end
 
-  it 'rejects replay from a different authenticated account' do
+  it 'rejects replay headers from a different authenticated account' do
     request = request_double(method: 'POST', key: 'account-scoped-key')
-    response = response_double(status: 201, body: '{"data":{"name":"Private result"}}')
+    response = response_double(
+      status: 201,
+      body: '{"data":{"name":"Private result"}}',
+      headers: { 'ETag' => '"private-etag"' }
+    )
     described_class.new(request: request, credential: api_session, household: household).store!(response)
     other_session = api_session_for(create_account_with_membership(household))
 
@@ -49,6 +54,7 @@ RSpec.describe Api::IdempotencyStore do
 
     expect(result.replayed).to be false
     expect(result.conflict).to be true
+    expect(result.response_headers).to eq({})
   end
 
   it 'derives a stable opaque reservation id from household and key' do
@@ -64,20 +70,58 @@ RSpec.describe Api::IdempotencyStore do
 
   it 'stores non-PHI response metadata and normalises invalid JSON response bodies' do
     request = request_double(method: 'POST', key: 'store-key')
-    response = response_double(status: 201, body: 'not-json')
 
     expect do
-      described_class.new(request: request, credential: api_session, household: household).store!(response)
+      described_class.new(request: request, credential: api_session, household: household).store!(private_response)
     end.to change(ApiIdempotencyKey, :count).by(1)
 
     key = ApiIdempotencyKey.order(:id).last
-    expect(key).to have_attributes(
-      household: household,
-      account: account,
-      api_session: api_session,
-      response_status: 201,
-      response_body: {}
+    expect(key).to have_attributes(stored_response_attributes)
+  end
+
+  it 'applies the current allowlist when reading stored response headers' do
+    store = store_for('read-allowlist-key')
+    store.store!(
+      response_double(status: 201, body: '{"ok":true}', headers: { 'ETag' => '"stored-etag"' })
     )
+    ApiIdempotencyKey.find_by!(household: household, key: 'read-allowlist-key').update!(
+      response_headers: { 'ETag' => '"stored-etag"', 'Set-Cookie' => 'private=value' }
+    )
+
+    result = store.lookup
+
+    expect(result.replayed).to be true
+    expect(result.response_headers).to eq('ETag' => '"stored-etag"')
+  end
+
+  it 'replays an unexpired legacy response without inventing headers' do
+    store = store_for('legacy-headerless-key')
+    store.store!(response_double(status: 201, body: '{"legacy":true}'))
+    executed = false
+
+    result = store.with_reservation(
+      response: response_double(status: 201, body: '{"replacement":true}', headers: { 'ETag' => '"new-etag"' })
+    ) { executed = true }
+
+    expect(executed).to be false
+    expect(result.replayed).to be true
+    expect(result.response_headers).to eq({})
+  end
+
+  it 'replaces an expired response while holding the reservation' do
+    store = store_for('expired-key')
+    store.store!(response_double(status: 201, body: '{"expired":true}'))
+    expired_record = ApiIdempotencyKey.find_by!(household: household, key: 'expired-key')
+    expired_record.update!(expires_at: 1.minute.ago)
+    name = replace_expired_response(store)
+    replacement = ApiIdempotencyKey.find_by!(household: household, key: 'expired-key')
+
+    expect(replacement.id).not_to eq(expired_record.id)
+    expect(replacement).to have_attributes(
+      response_body: { 'replacement' => true },
+      response_headers: { 'ETag' => '"replacement-etag"' }
+    )
+    expect(Person.exists?(household: household, name: name)).to be true
   end
 
   it 'stores app-token idempotency attribution' do
@@ -146,17 +190,20 @@ RSpec.describe Api::IdempotencyStore do
 
   it 'allows the same key to be stored independently in different households' do
     request = request_double(method: 'POST', key: 'household-scoped-key')
-    response = response_double(status: 201, body: '{"ok":true}')
     other_household = Household.create!(
       name: 'Other Idempotency Store Spec',
       slug: "other-idempotency-store-#{SecureRandom.hex(4)}"
     )
     other_session = api_session_for(create_account_with_membership(other_household))
+    first_store = described_class.new(request: request, credential: api_session, household: household)
+    second_store = described_class.new(request: request, credential: other_session, household: other_household)
 
-    described_class.new(request: request, credential: api_session, household: household).store!(response)
-    described_class.new(request: request, credential: other_session, household: other_household).store!(response)
+    store_household_response(first_store, number: 1)
+    store_household_response(second_store, number: 2)
 
     expect(ApiIdempotencyKey.where(key: 'household-scoped-key').count).to eq(2)
+    expect(first_store.lookup.response_headers).to eq('ETag' => '"household-one"')
+    expect(second_store.lookup.response_headers).to eq('ETag' => '"household-two"')
   end
 
   def request_double(method:, key:)
@@ -173,8 +220,53 @@ RSpec.describe Api::IdempotencyStore do
     )
   end
 
-  def response_double(status:, body:)
-    instance_double(ActionDispatch::Response, status: status, body: body)
+  def response_double(status:, body:, headers: {})
+    instance_double(ActionDispatch::Response, status: status, body: body, headers: headers)
+  end
+
+  def private_response
+    response_double(
+      status: 201,
+      body: 'not-json',
+      headers: {
+        'ETag' => '"record-etag"',
+        'Set-Cookie' => 'private=value',
+        'X-Request-Id' => 'delivery-specific',
+        'Retry-After' => '30'
+      }
+    )
+  end
+
+  def stored_response_attributes
+    {
+      household: household,
+      account: account,
+      api_session: api_session,
+      response_status: 201,
+      response_body: {},
+      response_headers: { 'ETag' => '"record-etag"' }
+    }
+  end
+
+  def replace_expired_response(store)
+    name = "Replacement Person #{SecureRandom.hex(4)}"
+    response = response_double(
+      status: 201,
+      body: '{"replacement":true}',
+      headers: { 'ETag' => '"replacement-etag"' }
+    )
+    store.with_reservation(response: response) { create_unowned_person(name) }
+    name
+  end
+
+  def store_household_response(store, number:)
+    store.store!(
+      response_double(
+        status: 201,
+        body: %({"household":#{number}}),
+        headers: { 'ETag' => %("household-#{number == 1 ? 'one' : 'two'}") }
+      )
+    )
   end
 
   def store_for(key)


### PR DESCRIPTION
## Summary

- Preserve the original `ETag` when a mobile client retries an idempotent API mutation, so the replayed response remains usable as the next write precondition.
- Store and restore only the explicitly allowlisted `ETag` header; request IDs, cookies, rate-limit metadata, and other response headers are never replayed.
- Replace expired idempotency records under the existing advisory lock, preserving exactly-once mutation behavior during concurrent retries.
- Keep fresh legacy rows compatible: they continue replaying without an invented ETag until their existing 24-hour lifetime expires.

## Why

The response body and status were already replay-safe, but losing the original ETag left iOS clients without the version token required for the next mutation. This completes the idempotency contract without widening the stored response surface.

Closes #1749
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->