### PR TITLE
fix(dmd): accept current release archive

### DIFF
--- a/app/services/nhs_dmd/release_archive_extractor.rb
+++ b/app/services/nhs_dmd/release_archive_extractor.rb
@@ -8,7 +8,7 @@ module NhsDmd
     class Error < StandardError; end
 
     MAX_ENTRIES = 200
-    MAX_ENTRY_BYTES = 100.megabytes
+    MAX_ENTRY_BYTES = 150.megabytes
     MAX_TOTAL_BYTES = 500.megabytes
 
     def extract(zip_path, destination, pattern: nil)

--- a/spec/services/nhs_dmd/release_archive_extractor_spec.rb
+++ b/spec/services/nhs_dmd/release_archive_extractor_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe NhsDmd::ReleaseArchiveExtractor do
       expect(destination.join('nested/f_gtin2_0000000.xml').read).to eq('<GTIN />')
     end
 
+    it 'accepts the AMPP entry size in the current NHSBSA release' do
+      current_release_entry_size = 120_269_530
+
+      expect(described_class::MAX_ENTRY_BYTES).to be >= current_release_entry_size
+    end
+
     it 'rejects traversal entries before writing files' do
       write_zip('../escape.txt' => 'owned', 'f_ampp2_3000000.xml' => '<AMPP />')
 


### PR DESCRIPTION
The current NHSBSA dm+d release contains a 120,269,530-byte AMPP XML entry, so the existing 100 MiB per-entry safety limit rejects an otherwise valid archive after upload. This raises only that bounded per-entry limit to 150 MiB. The 500 MiB total extraction limit, entry-count limit, path traversal checks, and symlink checks remain unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->