### PR TITLE
fix(medications): preserve search results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,24 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  production_image_medication_search:
+    runs-on: [ubuntu-latest]
+    name: Production Image Medication Search
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.52.0
+          repo-token: ${{ github.token }}
+
+      - name: Exercise medication search from the final app image
+        run: task prod:medication-search-smoke
+
   mutation:
     runs-on: [ubuntu-latest]
     name: Mutation Testing (advisory, changed subjects)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,9 @@ jobs:
           version: 3.52.0
           repo-token: ${{ github.token }}
 
+      - name: Install Fish
+        run: sudo apt-get update && sudo apt-get install --yes fish
+
       - name: Exercise medication search from the final app image
         run: task prod:medication-search-smoke
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,8 @@ COPY --chown=ruby:ruby --from=assets /app/app /app/app
 COPY --chown=ruby:ruby --from=assets /app/bin /app/bin
 COPY --chown=ruby:ruby --from=assets /app/config /app/config
 COPY --chown=ruby:ruby --from=assets /app/db /app/db
-COPY --chown=ruby:ruby --from=assets /app/data /app/data
+COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/openfda_labels.json /app/data/medication_reviews/openfda_labels.json
+COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/rxclass_terminology.json /app/data/medication_reviews/rxclass_terminology.json
 COPY --chown=ruby:ruby --from=assets /app/lib /app/lib
 COPY --chown=ruby:ruby --from=assets /app/public /app/public
 COPY --chown=ruby:ruby --from=assets /app/config.ru /app/Rakefile /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,7 @@ COPY --chown=ruby:ruby --from=assets /app/app /app/app
 COPY --chown=ruby:ruby --from=assets /app/bin /app/bin
 COPY --chown=ruby:ruby --from=assets /app/config /app/config
 COPY --chown=ruby:ruby --from=assets /app/db /app/db
+COPY --chown=ruby:ruby --from=assets /app/data /app/data
 COPY --chown=ruby:ruby --from=assets /app/lib /app/lib
 COPY --chown=ruby:ruby --from=assets /app/public /app/public
 COPY --chown=ruby:ruby --from=assets /app/config.ru /app/Rakefile /app/

--- a/Taskfiles/prod.yml
+++ b/Taskfiles/prod.yml
@@ -23,6 +23,19 @@ tasks:
           NO_CACHE: '{{ .NO_CACHE | default "" }}'
           APP_IMAGE_REF: '{{ .APP_IMAGE_REF | default "med-tracker:local-production-build" }}'
 
+  medication-search-smoke:
+    desc: Verify medication search from the final production image
+    summary: |
+      Build the final app target and exercise medication search without an app source mount.
+      Usage: task prod:medication-search-smoke
+    vars:
+      IMAGE_REF: '{{ .APP_IMAGE_REF | default "med-tracker:medication-search-smoke" }}'
+    cmds:
+      - task: build
+        vars:
+          APP_IMAGE_REF: '{{ .IMAGE_REF }}'
+      - ./scripts/production_medication_search_smoke.fish '{{ .IMAGE_REF }}'
+
   up:
     desc: Start production server (local validation)
     summary: |

--- a/app/components/medications/finder_view.rb
+++ b/app/components/medications/finder_view.rb
@@ -17,6 +17,7 @@ module Components
               idleText: t('medications.finder.idle_text'),
               unavailableTitle: t('medications.finder.unavailable_title'),
               unavailableMessage: t('medications.finder.unavailable_message'),
+              reviewGuidanceUnavailable: t('medications.finder.review_guidance_unavailable'),
               noResultsTitle: t('medications.finder.no_results_title'),
               noResultsMessage: t('medications.finder.no_results_message'),
               resultsTitle: t('medications.finder.results_title'),

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -41,7 +41,13 @@ export default class extends Controller {
       } else {
         const barcode = data.barcode || this.barcodeQuery(query)
         const displayQuery = barcode || query
-        this.showResults(displayQuery, data.results, barcode, data.permissions || {})
+        this.showResults(
+          displayQuery,
+          data.results,
+          barcode,
+          data.permissions || {},
+          data.review_guidance || {}
+        )
       }
     } catch (error) {
       this.showError(this.t("unavailableMessage"))
@@ -95,7 +101,7 @@ export default class extends Controller {
     `
   }
 
-  showResults(query, results, barcode, permissions = {}) {
+  showResults(query, results, barcode, permissions = {}, reviewGuidance = {}) {
     if (results.length === 0) {
       this.resultsTarget.innerHTML = `
         <div class="text-center py-12 text-on-surface-variant" data-testid="no-results">
@@ -122,16 +128,16 @@ export default class extends Controller {
     `
 
     const items = results.map(result => this.renderResultCard(result, barcode, permissions)).join('')
-    const reviewGuidanceWarning = results.some((result) => result.review_prompt_status === "unavailable")
+    const reviewGuidanceWarning = reviewGuidance.status === "unavailable"
       ? `
-        <div class="mb-3 rounded-lg border border-warning/50 bg-warning-container/20 p-3 text-sm text-on-warning-container" role="status" data-testid="review-guidance-warning">
+        <div class="mb-3 rounded-lg border border-warning/50 bg-warning-container/20 p-3 text-sm text-on-warning-container" role="status" aria-controls="medication-search-results-list" data-testid="review-guidance-warning">
           ${this.escapeHtml(this.t("reviewGuidanceUnavailable"))}
         </div>
       `
       : ''
 
     this.resultsTarget.innerHTML = reviewGuidanceWarning + header +
-      `<div class="space-y-2" data-testid="results-list">${items}</div>`
+      `<div id="medication-search-results-list" class="space-y-2" data-testid="results-list">${items}</div>`
   }
 
   renderResultCard(result, barcode, permissions = {}) {

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -122,8 +122,16 @@ export default class extends Controller {
     `
 
     const items = results.map(result => this.renderResultCard(result, barcode, permissions)).join('')
+    const reviewGuidanceWarning = results.some((result) => result.review_prompt_status === "unavailable")
+      ? `
+        <div class="mb-3 rounded-lg border border-warning/50 bg-warning-container/20 p-3 text-sm text-on-warning-container" role="status" data-testid="review-guidance-warning">
+          ${this.escapeHtml(this.t("reviewGuidanceUnavailable"))}
+        </div>
+      `
+      : ''
 
-    this.resultsTarget.innerHTML = header + `<div class="space-y-2" data-testid="results-list">${items}</div>`
+    this.resultsTarget.innerHTML = reviewGuidanceWarning + header +
+      `<div class="space-y-2" data-testid="results-list">${items}</div>`
   }
 
   renderResultCard(result, barcode, permissions = {}) {

--- a/app/services/medication_finder_search_responder.rb
+++ b/app/services/medication_finder_search_responder.rb
@@ -12,6 +12,7 @@ class MedicationFinderSearchResponder
 
   def call(query:, form: nil, strength: nil, permissions: {})
     @review_enrichment_unavailable = false
+    @review_enrichment_failure_logged = false
     normalized_query = query.to_s.strip
     return Result.new(body: { results: [], permissions: permissions }, status: :ok) if normalized_query.blank?
 
@@ -28,22 +29,27 @@ class MedicationFinderSearchResponder
   private
 
   def successful_response(query:, result:, form:, strength:, permissions:)
+    Result.new(
+      body: successful_response_body(query:, result:, form:, strength:, permissions:),
+      status: :ok
+    )
+  end
+
+  def successful_response_body(query:, result:, form:, strength:, permissions:)
     normalized_form = NhsDmd::DosageFormFilter.normalize(form)
     normalized_strength = NhsDmd::StrengthFilter.normalize(strength)
     results = filtered_results(result.results, form:, strength:)
 
-    Result.new(
-      body: {
-        results: results.map { |search_result| result_payload(search_result, result.barcode) },
-        query: result.resolved_query.presence || query,
-        barcode: result.barcode,
-        barcode_resolution: barcode_resolution(result),
-        form: normalized_form,
-        strength: normalized_strength,
-        permissions: permissions
-      },
-      status: :ok
-    )
+    {
+      results: results.map { |search_result| result_payload(search_result, result.barcode) },
+      review_guidance: review_guidance_payload,
+      query: result.resolved_query.presence || query,
+      barcode: result.barcode,
+      barcode_resolution: barcode_resolution(result),
+      form: normalized_form,
+      strength: normalized_strength,
+      permissions: permissions
+    }
   end
 
   def unavailable_response
@@ -73,26 +79,33 @@ class MedicationFinderSearchResponder
   end
 
   def review_prompt_payload(search_result)
-    return unavailable_review_prompt_payload if @review_enrichment_unavailable
-
     review_result = @interaction_lookup.call(search_result)
     {
       review_prompts: review_result.visible_prompts,
-      review_prompt_filter: { hidden_count: review_result.hidden_count },
-      review_prompt_status: 'available'
+      review_prompt_filter: { hidden_count: review_result.hidden_count }
     }
   rescue StandardError => e
     @review_enrichment_unavailable = true
-    Rails.logger.error("Medication review enrichment failed: #{e.class}")
+    log_review_enrichment_failure(e)
     unavailable_review_prompt_payload
   end
 
   def unavailable_review_prompt_payload
     {
       review_prompts: [],
-      review_prompt_filter: { hidden_count: 0 },
-      review_prompt_status: 'unavailable'
+      review_prompt_filter: { hidden_count: 0 }
     }
+  end
+
+  def review_guidance_payload
+    { status: @review_enrichment_unavailable ? 'unavailable' : 'available' }
+  end
+
+  def log_review_enrichment_failure(error)
+    return if @review_enrichment_failure_logged
+
+    @review_enrichment_failure_logged = true
+    Rails.logger.error("Medication review enrichment failed: #{error.class}")
   end
 
   def existing_medication_for(search_result, barcode)

--- a/app/services/medication_finder_search_responder.rb
+++ b/app/services/medication_finder_search_responder.rb
@@ -11,6 +11,7 @@ class MedicationFinderSearchResponder
   end
 
   def call(query:, form: nil, strength: nil, permissions: {})
+    @review_enrichment_unavailable = false
     normalized_query = query.to_s.strip
     return Result.new(body: { results: [], permissions: permissions }, status: :ok) if normalized_query.blank?
 
@@ -66,11 +67,32 @@ class MedicationFinderSearchResponder
   def result_payload(search_result, barcode)
     search_result.to_h.tap do |payload|
       medication = existing_medication_for(search_result, barcode)
-      review_result = @interaction_lookup.call(search_result)
       payload[:existing_medication] = existing_medication_payload(medication) if medication
-      payload[:review_prompts] = review_result.visible_prompts
-      payload[:review_prompt_filter] = { hidden_count: review_result.hidden_count }
+      payload.merge!(review_prompt_payload(search_result))
     end
+  end
+
+  def review_prompt_payload(search_result)
+    return unavailable_review_prompt_payload if @review_enrichment_unavailable
+
+    review_result = @interaction_lookup.call(search_result)
+    {
+      review_prompts: review_result.visible_prompts,
+      review_prompt_filter: { hidden_count: review_result.hidden_count },
+      review_prompt_status: 'available'
+    }
+  rescue StandardError => e
+    @review_enrichment_unavailable = true
+    Rails.logger.error("Medication review enrichment failed: #{e.class}")
+    unavailable_review_prompt_payload
+  end
+
+  def unavailable_review_prompt_payload
+    {
+      review_prompts: [],
+      review_prompt_filter: { hidden_count: 0 },
+      review_prompt_status: 'unavailable'
+    }
   end
 
   def existing_medication_for(search_result, barcode)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -837,8 +837,8 @@ cy:
       unavailable_title: Chwiliad ddim ar gael
       unavailable_message: Methu cysylltu â'r gronfa ddata meddyginiaethau. Rhowch
         gynnig arall.
-      review_guidance_unavailable: Nid yw canllawiau adolygu meddyginiaeth ar gael
-        dros dro. Mae canlyniadau chwilio ar gael o hyd.
+      review_guidance_unavailable: Nid yw gwybodaeth adolygu meddyginiaeth ar gael
+        dros dro. Efallai na fydd canlyniadau chwilio yn cynnwys canllawiau rhyngweithio.
       no_results_title: Ni chanfuwyd meddyginiaethau
       no_results_message: Ceisiwch chwilio gyda thelerau gwahanol neu gwiriwch yr
         orgraff.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -837,6 +837,8 @@ cy:
       unavailable_title: Chwiliad ddim ar gael
       unavailable_message: Methu cysylltu â'r gronfa ddata meddyginiaethau. Rhowch
         gynnig arall.
+      review_guidance_unavailable: Nid yw canllawiau adolygu meddyginiaeth ar gael
+        dros dro. Mae canlyniadau chwilio ar gael o hyd.
       no_results_title: Ni chanfuwyd meddyginiaethau
       no_results_message: Ceisiwch chwilio gyda thelerau gwahanol neu gwiriwch yr
         orgraff.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -791,8 +791,8 @@ en:
       unavailable_title: Search unavailable
       unavailable_message: Unable to connect to the medication database. Please try
         again.
-      review_guidance_unavailable: Medication review guidance is temporarily unavailable.
-        Search results are still available.
+      review_guidance_unavailable: Medication review information is temporarily unavailable.
+        Search results may not include interaction guidance.
       no_results_title: No medications found
       no_results_message: Try searching with different terms or check the spelling.
       results_title: Search Results

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -791,6 +791,8 @@ en:
       unavailable_title: Search unavailable
       unavailable_message: Unable to connect to the medication database. Please try
         again.
+      review_guidance_unavailable: Medication review guidance is temporarily unavailable.
+        Search results are still available.
       no_results_title: No medications found
       no_results_message: Try searching with different terms or check the spelling.
       results_title: Search Results

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -846,6 +846,8 @@ es:
       unavailable_title: Búsqueda no disponible
       unavailable_message: No se pudo conectar con la base de datos de medicamentos.
         Inténtelo de nuevo.
+      review_guidance_unavailable: La orientación para la revisión de medicamentos
+        no está disponible temporalmente. Los resultados de búsqueda siguen disponibles.
       no_results_title: No se encontraron medicamentos
       no_results_message: Pruebe con otros términos o revise la ortografía.
       results_title: Resultados de la búsqueda

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -846,8 +846,9 @@ es:
       unavailable_title: Búsqueda no disponible
       unavailable_message: No se pudo conectar con la base de datos de medicamentos.
         Inténtelo de nuevo.
-      review_guidance_unavailable: La orientación para la revisión de medicamentos
-        no está disponible temporalmente. Los resultados de búsqueda siguen disponibles.
+      review_guidance_unavailable: La información sobre la revisión de medicamentos
+        no está disponible temporalmente. Es posible que los resultados de búsqueda
+        no incluyan orientación sobre interacciones.
       no_results_title: No se encontraron medicamentos
       no_results_message: Pruebe con otros términos o revise la ortografía.
       results_title: Resultados de la búsqueda

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -841,8 +841,8 @@ ga:
       unavailable_title: Cuardach neamhfhaighte
       unavailable_message: Ní féidir ceangal leis an mbunachar sonraí leigheas. Bain
         triail eile as.
-      review_guidance_unavailable: Níl treoir athbhreithnithe cógais ar fáil go sealadach.
-        Tá torthaí cuardaigh ar fáil fós.
+      review_guidance_unavailable: Níl faisnéis athbhreithnithe cógais ar fáil go sealadach.
+        Seans nach mbeidh treoir idirghníomhaíochta sna torthaí cuardaigh.
       no_results_title: Níor aimsíodh aon leigheasanna
       no_results_message: Bain triail as téarmaí éagsúla nó seiceáil an litriú.
       results_title: Torthaí Cuardaigh

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -841,6 +841,8 @@ ga:
       unavailable_title: Cuardach neamhfhaighte
       unavailable_message: Ní féidir ceangal leis an mbunachar sonraí leigheas. Bain
         triail eile as.
+      review_guidance_unavailable: Níl treoir athbhreithnithe cógais ar fáil go sealadach.
+        Tá torthaí cuardaigh ar fáil fós.
       no_results_title: Níor aimsíodh aon leigheasanna
       no_results_message: Bain triail as téarmaí éagsúla nó seiceáil an litriú.
       results_title: Torthaí Cuardaigh

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -844,6 +844,8 @@ pt:
       unavailable_title: Pesquisa indisponível
       unavailable_message: Não foi possível ligar à base de dados de medicamentos.
         Tente novamente.
+      review_guidance_unavailable: A orientação para revisão de medicamentos está
+        temporariamente indisponível. Os resultados da pesquisa continuam disponíveis.
       no_results_title: Nenhum medicamento encontrado
       no_results_message: Tente pesquisar com termos diferentes ou verifique a ortografia.
       results_title: Resultados da pesquisa

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -844,8 +844,9 @@ pt:
       unavailable_title: Pesquisa indisponível
       unavailable_message: Não foi possível ligar à base de dados de medicamentos.
         Tente novamente.
-      review_guidance_unavailable: A orientação para revisão de medicamentos está
-        temporariamente indisponível. Os resultados da pesquisa continuam disponíveis.
+      review_guidance_unavailable: A informação sobre a revisão de medicamentos está
+        temporariamente indisponível. Os resultados da pesquisa podem não incluir
+        orientações sobre interações.
       no_results_title: Nenhum medicamento encontrado
       no_results_message: Tente pesquisar com termos diferentes ou verifique a ortografia.
       results_title: Resultados da pesquisa

--- a/scripts/production_medication_search_smoke.fish
+++ b/scripts/production_medication_search_smoke.fish
@@ -1,0 +1,271 @@
+#!/usr/bin/env fish
+
+if test (count $argv) -ne 1
+    echo "Usage: production_medication_search_smoke.fish IMAGE_REF" >&2
+    exit 2
+end
+
+for command_name in docker curl jq openssl
+    if not command -q $command_name
+        echo "Required command is unavailable: $command_name" >&2
+        exit 2
+    end
+end
+
+set -g MEDICATION_SEARCH_SMOKE_IMAGE $argv[1]
+set -g MEDICATION_SEARCH_SMOKE_ROOT (realpath (dirname (status filename))/..)
+set -g MEDICATION_SEARCH_SMOKE_TMP (mktemp -d)
+set -g MEDICATION_SEARCH_SMOKE_SUFFIX (random)
+set -g MEDICATION_SEARCH_SMOKE_PREFIX "medication-search-smoke-$MEDICATION_SEARCH_SMOKE_SUFFIX"
+set -g MEDICATION_SEARCH_SMOKE_NETWORK "$MEDICATION_SEARCH_SMOKE_PREFIX-network"
+set -g MEDICATION_SEARCH_SMOKE_DB "$MEDICATION_SEARCH_SMOKE_PREFIX-db"
+set -g MEDICATION_SEARCH_SMOKE_NHS "$MEDICATION_SEARCH_SMOKE_PREFIX-nhs"
+set -g MEDICATION_SEARCH_SMOKE_STORAGE "$MEDICATION_SEARCH_SMOKE_PREFIX-storage"
+set -g MEDICATION_SEARCH_SMOKE_NORMAL "$MEDICATION_SEARCH_SMOKE_PREFIX-normal"
+set -g MEDICATION_SEARCH_SMOKE_UNAVAILABLE "$MEDICATION_SEARCH_SMOKE_PREFIX-unavailable"
+
+function cleanup_medication_search_smoke --on-event fish_exit
+    docker rm -f \
+        $MEDICATION_SEARCH_SMOKE_NORMAL \
+        $MEDICATION_SEARCH_SMOKE_UNAVAILABLE \
+        $MEDICATION_SEARCH_SMOKE_NHS \
+        $MEDICATION_SEARCH_SMOKE_DB >/dev/null 2>&1
+    docker network rm $MEDICATION_SEARCH_SMOKE_NETWORK >/dev/null 2>&1
+    docker volume rm $MEDICATION_SEARCH_SMOKE_STORAGE >/dev/null 2>&1
+    if test -d $MEDICATION_SEARCH_SMOKE_TMP
+        and string match -qr '^/(tmp|private/tmp|private/var/folders)/' $MEDICATION_SEARCH_SMOKE_TMP
+        rm -rf -- $MEDICATION_SEARCH_SMOKE_TMP
+    end
+end
+
+string join \n \
+    '[req]' \
+    'distinguished_name = subject' \
+    'x509_extensions = extensions' \
+    'prompt = no' \
+    '[subject]' \
+    'CN = fake-nhs' \
+    '[extensions]' \
+    'subjectAltName = DNS:fake-nhs' \
+    'basicConstraints = critical,CA:TRUE' \
+    'keyUsage = critical,digitalSignature,keyEncipherment,keyCertSign' \
+    >$MEDICATION_SEARCH_SMOKE_TMP/openssl.cnf
+
+openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+    -config $MEDICATION_SEARCH_SMOKE_TMP/openssl.cnf \
+    -keyout $MEDICATION_SEARCH_SMOKE_TMP/fake-nhs.key \
+    -out $MEDICATION_SEARCH_SMOKE_TMP/fake-nhs.crt >/dev/null 2>&1
+or exit 1
+
+string join \n \
+    'events {}' \
+    'http {' \
+    '  server {' \
+    '    listen 443 ssl;' \
+    '    server_name fake-nhs;' \
+    '    ssl_certificate /etc/nginx/fake-nhs.crt;' \
+    '    ssl_certificate_key /etc/nginx/fake-nhs.key;' \
+    '    location = /token {' \
+    '      default_type application/json;' \
+    '      return 200 '"'"'{"access_token":"smoke-token","expires_in":3600}'"'"';' \
+    '    }' \
+    '    location /fhir/ValueSet/ {' \
+    '      default_type application/json;' \
+    '      return 200 '"'"'{"expansion":{"contains":[{"code":"32223611000001104","display":"Paracetamol 500mg tablets","system":"https://dmd.nhs.uk","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/valueset-concept-comments","valueString":"VMP"}]}]}}'"'"';' \
+    '    }' \
+    '  }' \
+    '}' \
+    >$MEDICATION_SEARCH_SMOKE_TMP/nginx.conf
+
+docker network create $MEDICATION_SEARCH_SMOKE_NETWORK >/dev/null
+or exit 1
+docker volume create $MEDICATION_SEARCH_SMOKE_STORAGE >/dev/null
+or exit 1
+
+docker run --detach \
+    --name $MEDICATION_SEARCH_SMOKE_DB \
+    --network $MEDICATION_SEARCH_SMOKE_NETWORK \
+    --env POSTGRES_USER=medtracker \
+    --env POSTGRES_PASSWORD=medtracker_password \
+    --env POSTGRES_DB=medtracker \
+    --env POSTGRES_MULTIPLE_DATABASES=medtracker_production_queue,medtracker_production_cache,medtracker_production_cable \
+    --volume "$MEDICATION_SEARCH_SMOKE_ROOT/compose/init-roles.sql:/docker-entrypoint-initdb.d/001-init-roles.sql:ro" \
+    --volume "$MEDICATION_SEARCH_SMOKE_ROOT/compose/init-multiple-dbs.sh:/docker-entrypoint-initdb.d/002-init-multiple-dbs.sh:ro" \
+    postgres:18-alpine >/dev/null
+or exit 1
+
+for attempt in (seq 1 60)
+    if docker exec $MEDICATION_SEARCH_SMOKE_DB pg_isready -U medtracker -d medtracker >/dev/null 2>&1
+        break
+    end
+    if test $attempt -eq 60
+        docker logs $MEDICATION_SEARCH_SMOKE_DB
+        echo "PostgreSQL did not become ready" >&2
+        exit 1
+    end
+    sleep 1
+end
+
+docker run --detach \
+    --name $MEDICATION_SEARCH_SMOKE_NHS \
+    --network $MEDICATION_SEARCH_SMOKE_NETWORK \
+    --network-alias fake-nhs \
+    --volume "$MEDICATION_SEARCH_SMOKE_TMP/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    --volume "$MEDICATION_SEARCH_SMOKE_TMP/fake-nhs.crt:/etc/nginx/fake-nhs.crt:ro" \
+    --volume "$MEDICATION_SEARCH_SMOKE_TMP/fake-nhs.key:/etc/nginx/fake-nhs.key:ro" \
+    nginx:1.29-alpine >/dev/null
+or exit 1
+
+set -g MEDICATION_SEARCH_SMOKE_APP_ENV \
+    --env RAILS_ENV=production \
+    --env APP_URL=http://localhost \
+    --env ACTIVE_STORAGE_SERVICE=persistent \
+    --env ACTIVE_STORAGE_ROOT=/app/storage \
+    --env DATABASE_URL=postgresql://medtracker:medtracker_password@$MEDICATION_SEARCH_SMOKE_DB:5432/medtracker \
+    --env DATABASE_ROLE= \
+    --env SECRET_KEY_BASE=medication-search-production-image-smoke-secret \
+    --env SOLID_QUEUE_DATABASE_URL=postgresql://medtracker:medtracker_password@$MEDICATION_SEARCH_SMOKE_DB:5432/medtracker_production_queue \
+    --env SOLID_CACHE_DATABASE_URL=postgresql://medtracker:medtracker_password@$MEDICATION_SEARCH_SMOKE_DB:5432/medtracker_production_cache \
+    --env SOLID_CABLE_DATABASE_URL=postgresql://medtracker:medtracker_password@$MEDICATION_SEARCH_SMOKE_DB:5432/medtracker_production_cable \
+    --env NHS_DMD_CLIENT_ID=smoke-client \
+    --env NHS_DMD_CLIENT_SECRET=smoke-secret \
+    --env SSL_CERT_FILE=/tmp/fake-nhs.crt
+
+set -g MEDICATION_SEARCH_SMOKE_CERT_MOUNT \
+    --volume "$MEDICATION_SEARCH_SMOKE_STORAGE:/app/storage" \
+    --volume "$MEDICATION_SEARCH_SMOKE_TMP/fake-nhs.crt:/tmp/fake-nhs.crt:ro"
+
+docker run --rm \
+    --network $MEDICATION_SEARCH_SMOKE_NETWORK \
+    $MEDICATION_SEARCH_SMOKE_APP_ENV \
+    $MEDICATION_SEARCH_SMOKE_CERT_MOUNT \
+    $MEDICATION_SEARCH_SMOKE_IMAGE \
+    bin/rails db:prepare
+or exit 1
+
+set -l setup_code 'result = Admin::BootstrapService.call(email: "smoke@example.test", password: "smoke-password", name: "Smoke Admin", date_of_birth: "1980-01-01"); raise result.error unless result.success?; account = Account.find_by!(email: "smoke@example.test"); household = account.households.sole; household.update!(slug: "smoke-household"); TenantContext.with(account: account, household: household, request_id: "production-image-smoke") { location = household.locations.find_by!(name: "Home"); Medication.create!(household: household, location: location, name: "Ibuprofen", dose_amount: 200, dose_unit: "mg", current_supply: 10, supply_at_last_restock: 10, reorder_threshold: 2) }; AppSettings.instance.update!(medicine_lookup_base_url: "https://fake-nhs/fhir", medicine_lookup_token_url: "https://fake-nhs/token"); raise "dm+d import data must be empty" if NhsDmdImport.exists? || NhsDmdBarcode.exists?'
+
+docker run --rm \
+    --network $MEDICATION_SEARCH_SMOKE_NETWORK \
+    $MEDICATION_SEARCH_SMOKE_APP_ENV \
+    $MEDICATION_SEARCH_SMOKE_CERT_MOUNT \
+    $MEDICATION_SEARCH_SMOKE_IMAGE \
+    bin/rails runner $setup_code
+or exit 1
+
+function run_medication_search_scenario
+    set -l container_name $argv[1]
+    set -l expected_guidance $argv[2]
+    set -e argv[1..2]
+
+    docker run --detach \
+        --name $container_name \
+        --network $MEDICATION_SEARCH_SMOKE_NETWORK \
+        --publish 127.0.0.1::80 \
+        $MEDICATION_SEARCH_SMOKE_APP_ENV \
+        $MEDICATION_SEARCH_SMOKE_CERT_MOUNT \
+        $argv \
+        $MEDICATION_SEARCH_SMOKE_IMAGE >/dev/null
+    or exit 1
+
+    set -l app_port (docker port $container_name 80/tcp | string replace -r '^.*:' '')
+    set -l app_url "http://localhost:$app_port"
+
+    for attempt in (seq 1 60)
+        if curl --silent --fail "$app_url/up" >/dev/null 2>&1
+            break
+        end
+        if test $attempt -eq 60
+            docker logs $container_name
+            echo "Application did not become ready: $container_name" >&2
+            exit 1
+        end
+        sleep 1
+    end
+
+    if docker inspect --format '{{range .Mounts}}{{println .Type .Destination}}{{end}}' $container_name |
+            awk '$1 == "bind" && $2 ~ "^/app" { found = 1 } END { exit found }'
+        true
+    else
+        echo "Application container has a repository bind mount" >&2
+        exit 1
+    end
+
+    set -l cookie_jar "$MEDICATION_SEARCH_SMOKE_TMP/$container_name.cookies"
+    set -l login_page "$MEDICATION_SEARCH_SMOKE_TMP/$container_name-login.html"
+    curl --silent --show-error \
+        --cookie-jar $cookie_jar \
+        "$app_url/login" \
+        --output $login_page
+    or exit 1
+
+    set -l authenticity_token (
+        string match -r 'name="authenticity_token" value="[^"]+"' < $login_page |
+            string replace 'name="authenticity_token" value="' '' |
+            string replace '"' ''
+    )
+    if test -z "$authenticity_token"
+        echo "Login authenticity token was not rendered" >&2
+        exit 1
+    end
+
+    set -l login_status (
+        curl --silent --show-error \
+            --cookie $cookie_jar \
+            --cookie-jar $cookie_jar \
+            --data-urlencode "authenticity_token=$authenticity_token" \
+            --data-urlencode "email=smoke@example.test" \
+            --data-urlencode "password=smoke-password" \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            "$app_url/login"
+    )
+    if not contains $login_status 302 303
+        echo "Public login failed with HTTP $login_status" >&2
+        exit 1
+    end
+
+    set -l response_file "$MEDICATION_SEARCH_SMOKE_TMP/$container_name-search.json"
+    set -l search_status (
+        curl --silent --show-error \
+            --cookie $cookie_jar \
+            --header 'Accept: application/json' \
+            --get \
+            --data-urlencode 'q=paracetamol' \
+            --output $response_file \
+            --write-out '%{http_code}' \
+            "$app_url/households/smoke-household/medication-finder/search.json"
+    )
+
+    if test "$search_status" != 200
+        jq . $response_file
+        docker logs $container_name
+        echo "Medication search returned HTTP $search_status" >&2
+        exit 1
+    end
+
+    jq --exit-status \
+        --arg expected_guidance $expected_guidance \
+        '.results | length == 1 and
+         .[0].display == "Paracetamol 500mg tablets" and
+         .[0].review_prompts == [] and
+         .[0].review_prompt_filter.hidden_count == 0' \
+        $response_file >/dev/null
+    or exit 1
+    jq --exit-status \
+        --arg expected_guidance $expected_guidance \
+        '.review_guidance.status == $expected_guidance and
+         (has("error") | not)' \
+        $response_file >/dev/null
+    or exit 1
+
+    docker rm -f $container_name >/dev/null
+end
+
+run_medication_search_scenario $MEDICATION_SEARCH_SMOKE_NORMAL available
+run_medication_search_scenario \
+    $MEDICATION_SEARCH_SMOKE_UNAVAILABLE \
+    unavailable \
+    --tmpfs /app/data/medication_reviews:ro
+
+echo "Production image medication search smoke test passed"

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -239,6 +239,7 @@ RSpec.describe ApplicationHarnessDependencies do
       'COPY --chown=ruby:ruby --from=assets /app/bin /app/bin',
       'COPY --chown=ruby:ruby --from=assets /app/config /app/config',
       'COPY --chown=ruby:ruby --from=assets /app/db /app/db',
+      'COPY --chown=ruby:ruby --from=assets /app/data /app/data',
       'COPY --chown=ruby:ruby --from=assets /app/lib /app/lib',
       'COPY --chown=ruby:ruby --from=assets /app/public /app/public',
       'COPY --chown=ruby:ruby --from=assets /app/config.ru /app/Rakefile /app/',

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe ApplicationHarnessDependencies do
     end
 
     expect(app_stage).not_to include('COPY --chown=ruby:ruby . .')
+    expect(app_stage).not_to include('COPY --chown=ruby:ruby --from=assets /app/data /app/data')
     expect(app_stage).not_to include('RUN chmod 0755 bin/*')
   end
 
@@ -239,7 +240,8 @@ RSpec.describe ApplicationHarnessDependencies do
       'COPY --chown=ruby:ruby --from=assets /app/bin /app/bin',
       'COPY --chown=ruby:ruby --from=assets /app/config /app/config',
       'COPY --chown=ruby:ruby --from=assets /app/db /app/db',
-      'COPY --chown=ruby:ruby --from=assets /app/data /app/data',
+      'COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/openfda_labels.json /app/data/medication_reviews/openfda_labels.json',
+      'COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/rxclass_terminology.json /app/data/medication_reviews/rxclass_terminology.json',
       'COPY --chown=ruby:ruby --from=assets /app/lib /app/lib',
       'COPY --chown=ruby:ruby --from=assets /app/public /app/public',
       'COPY --chown=ruby:ruby --from=assets /app/config.ru /app/Rakefile /app/',

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe ApplicationHarnessDependencies do
     end
 
     expect(app_stage).not_to include('COPY --chown=ruby:ruby . .')
-    expect(app_stage).not_to include('COPY --chown=ruby:ruby --from=assets /app/data /app/data')
     expect(app_stage).not_to include('RUN chmod 0755 bin/*')
   end
 
@@ -240,8 +239,6 @@ RSpec.describe ApplicationHarnessDependencies do
       'COPY --chown=ruby:ruby --from=assets /app/bin /app/bin',
       'COPY --chown=ruby:ruby --from=assets /app/config /app/config',
       'COPY --chown=ruby:ruby --from=assets /app/db /app/db',
-      'COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/openfda_labels.json /app/data/medication_reviews/openfda_labels.json',
-      'COPY --chown=ruby:ruby --from=assets /app/data/medication_reviews/rxclass_terminology.json /app/data/medication_reviews/rxclass_terminology.json',
       'COPY --chown=ruby:ruby --from=assets /app/lib /app/lib',
       'COPY --chown=ruby:ruby --from=assets /app/public /app/public',
       'COPY --chown=ruby:ruby --from=assets /app/config.ru /app/Rakefile /app/',

--- a/spec/features/medication_lookup_spec.rb
+++ b/spec/features/medication_lookup_spec.rb
@@ -129,37 +129,41 @@ RSpec.describe 'Medication Lookup', :browser, type: :system do
 
   it 'keeps search results visible when medication review guidance is unavailable' do
     stub_nhs_dmd_search(
-      query: 'Paracetamol',
+      query: 'Novelmed',
       results: [
         {
           code: '32223611000001104',
-          display: 'Paracetamol 500mg tablets',
+          display: 'Novelmed 500mg tablets',
           system: 'https://dmd.nhs.uk',
           concept_class: 'VMP'
         }
       ]
     )
-    interaction_lookup = instance_double(MedicationInteractionLookup)
-    allow(interaction_lookup).to receive(:call).and_raise(
-      Errno::ENOENT,
-      'No such file or directory @ rb_sysopen - /app/data/medication_reviews/rxclass_terminology.json'
+    stub_const(
+      'MedicationReviewTerminology::DEFAULT_PATH',
+      Rails.root.join('tmp/missing-rxclass-terminology.json')
     )
-    allow(MedicationInteractionLookup).to receive(:new).and_return(interaction_lookup)
 
     expect(NhsDmdBarcode).not_to exist
 
     sign_in(admin)
     visit medication_finder_path
 
-    fill_in 'medication-search-input', with: 'Paracetamol'
+    fill_in 'medication-search-input', with: 'Novelmed'
     click_button 'Search'
 
-    expect(page).to have_text('Paracetamol 500mg tablets')
+    expect(page).to have_text('Novelmed 500mg tablets')
     expect(page).to have_css(
       '[role="status"]',
-      text: 'Medication review guidance is temporarily unavailable. Search results are still available.'
+      text: 'Medication review information is temporarily unavailable. ' \
+            'Search results may not include interaction guidance.',
+      count: 1
     )
     expect(page).to have_no_text('Search unavailable')
+    within('[data-testid="result-card"]', match: :first) do
+      click_link 'Add Medication'
+    end
+    expect(page).to have_current_path(%r{/medications/new})
   end
 
   it 'allows selecting a search result and prefill a new inventory item' do

--- a/spec/features/medication_lookup_spec.rb
+++ b/spec/features/medication_lookup_spec.rb
@@ -127,6 +127,41 @@ RSpec.describe 'Medication Lookup', :browser, type: :system do
     expect(page).to have_text('Search unavailable')
   end
 
+  it 'keeps search results visible when medication review guidance is unavailable' do
+    stub_nhs_dmd_search(
+      query: 'Paracetamol',
+      results: [
+        {
+          code: '32223611000001104',
+          display: 'Paracetamol 500mg tablets',
+          system: 'https://dmd.nhs.uk',
+          concept_class: 'VMP'
+        }
+      ]
+    )
+    interaction_lookup = instance_double(MedicationInteractionLookup)
+    allow(interaction_lookup).to receive(:call).and_raise(
+      Errno::ENOENT,
+      'No such file or directory @ rb_sysopen - /app/data/medication_reviews/rxclass_terminology.json'
+    )
+    allow(MedicationInteractionLookup).to receive(:new).and_return(interaction_lookup)
+
+    expect(NhsDmdBarcode).not_to exist
+
+    sign_in(admin)
+    visit medication_finder_path
+
+    fill_in 'medication-search-input', with: 'Paracetamol'
+    click_button 'Search'
+
+    expect(page).to have_text('Paracetamol 500mg tablets')
+    expect(page).to have_css(
+      '[role="status"]',
+      text: 'Medication review guidance is temporarily unavailable. Search results are still available.'
+    )
+    expect(page).to have_no_text('Search unavailable')
+  end
+
   it 'allows selecting a search result and prefill a new inventory item' do
     stub_nhs_dmd_search(query: '5016298210989', results: barcode_results)
 

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'GET /medication-finder/search' do
         expect(json['results'].first['code']).to eq('39720311000001101')
         expect(json['results'].first['concept_class']).to eq('VMP')
         expect(json['results'].first['pil_url']).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
+        expect(json['results'].first['review_prompt_status']).to eq('available')
       end
 
       it 'includes existing medication metadata when the result matches accessible stock' do
@@ -140,6 +141,69 @@ RSpec.describe 'GET /medication-finder/search' do
         )
         expect(response.parsed_body.dig('results', 0, 'review_prompt_filter')).to eq('hidden_count' => 0)
         expect(response.parsed_body.dig('results', 0)).not_to have_key('interactions')
+      end
+    end
+
+    context 'when medication-review enrichment is unavailable' do
+      before do
+        login_as_admin
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('NHS_DMD_CLIENT_ID', nil).and_return('test-id')
+        allow(ENV).to receive(:fetch).with('NHS_DMD_CLIENT_SECRET', nil).and_return('test-secret')
+        stub_nhs_dmd_token
+        stub_nhs_dmd_search(
+          query: 'paracetamol',
+          results: [
+            {
+              code: '32223611000001104',
+              display: 'Paracetamol 500mg tablets',
+              system: 'https://dmd.nhs.uk',
+              concept_class: 'VMP'
+            },
+            {
+              code: '32223711000001108',
+              display: 'Paracetamol 250mg tablets',
+              system: 'https://dmd.nhs.uk',
+              concept_class: 'VMP'
+            }
+          ]
+        )
+        interaction_lookup = instance_double(MedicationInteractionLookup)
+        allow(interaction_lookup).to receive(:call).and_raise(
+          Errno::ENOENT,
+          'No such file or directory @ rb_sysopen - /app/data/medication_reviews/rxclass_terminology.json'
+        )
+        allow(MedicationInteractionLookup).to receive(:new).and_return(interaction_lookup)
+        allow(Rails.logger).to receive(:error)
+        Rails.cache.clear
+      end
+
+      it 'preserves NHS results and marks review guidance unavailable' do
+        expect(NhsDmdBarcode).not_to exist
+
+        get medication_finder_search_path(format: :json), params: { q: 'paracetamol' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).not_to have_key('error')
+        expect(response.parsed_body['results']).to contain_exactly(
+          a_hash_including(
+            'code' => '32223611000001104',
+            'display' => 'Paracetamol 500mg tablets',
+            'review_prompts' => [],
+            'review_prompt_filter' => { 'hidden_count' => 0 },
+            'review_prompt_status' => 'unavailable'
+          ),
+          a_hash_including(
+            'code' => '32223711000001108',
+            'display' => 'Paracetamol 250mg tablets',
+            'review_prompts' => [],
+            'review_prompt_filter' => { 'hidden_count' => 0 },
+            'review_prompt_status' => 'unavailable'
+          )
+        )
+        expect(Rails.logger).to have_received(:error)
+          .with('Medication review enrichment failed: Errno::ENOENT')
+          .once
       end
     end
 

--- a/spec/requests/medications_search_spec.rb
+++ b/spec/requests/medications_search_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'GET /medication-finder/search' do
         expect(json['results'].first['code']).to eq('39720311000001101')
         expect(json['results'].first['concept_class']).to eq('VMP')
         expect(json['results'].first['pil_url']).to eq('https://www.medicines.org.uk/emc/product/13866/pil')
-        expect(json['results'].first['review_prompt_status']).to eq('available')
+        expect(json['review_guidance']).to eq('status' => 'available')
       end
 
       it 'includes existing medication metadata when the result matches accessible stock' do
@@ -144,6 +144,48 @@ RSpec.describe 'GET /medication-finder/search' do
       end
     end
 
+    context 'without a local dm+d import or barcode catalogue' do
+      before do
+        login_as_admin
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('NHS_DMD_CLIENT_ID', nil).and_return('test-id')
+        allow(ENV).to receive(:fetch).with('NHS_DMD_CLIENT_SECRET', nil).and_return('test-secret')
+        stub_nhs_dmd_token
+        stub_nhs_dmd_search(
+          query: 'paracetamol',
+          results: [
+            {
+              code: '32223611000001104',
+              display: 'Paracetamol 500mg tablets',
+              system: 'https://dmd.nhs.uk',
+              concept_class: 'VMP'
+            }
+          ]
+        )
+        Rails.cache.clear
+      end
+
+      it 'returns mapped NHS results with review guidance available' do
+        expect(NhsDmdBarcode).not_to exist
+        expect(NhsDmdImport).not_to exist
+
+        get medication_finder_search_path(format: :json), params: { q: 'paracetamol' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['results']).to contain_exactly(
+          a_hash_including(
+            'code' => '32223611000001104',
+            'display' => 'Paracetamol 500mg tablets',
+            'system' => 'https://dmd.nhs.uk',
+            'concept_class' => 'VMP',
+            'review_prompts' => [],
+            'review_prompt_filter' => { 'hidden_count' => 0 }
+          )
+        )
+        expect(response.parsed_body['review_guidance']).to eq('status' => 'available')
+      end
+    end
+
     context 'when medication-review enrichment is unavailable' do
       before do
         login_as_admin
@@ -168,18 +210,19 @@ RSpec.describe 'GET /medication-finder/search' do
             }
           ]
         )
-        interaction_lookup = instance_double(MedicationInteractionLookup)
-        allow(interaction_lookup).to receive(:call).and_raise(
-          Errno::ENOENT,
-          'No such file or directory @ rb_sysopen - /app/data/medication_reviews/rxclass_terminology.json'
+        stub_const(
+          'MedicationReviewTerminology::DEFAULT_PATH',
+          Rails.root.join('tmp/missing-rxclass-terminology.json')
         )
-        allow(MedicationInteractionLookup).to receive(:new).and_return(interaction_lookup)
-        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:error) { |message| logged_errors << message }
         Rails.cache.clear
       end
 
+      let(:logged_errors) { [] }
+
       it 'preserves NHS results and marks review guidance unavailable' do
         expect(NhsDmdBarcode).not_to exist
+        expect(NhsDmdImport).not_to exist
 
         get medication_finder_search_path(format: :json), params: { q: 'paracetamol' }
 
@@ -190,20 +233,21 @@ RSpec.describe 'GET /medication-finder/search' do
             'code' => '32223611000001104',
             'display' => 'Paracetamol 500mg tablets',
             'review_prompts' => [],
-            'review_prompt_filter' => { 'hidden_count' => 0 },
-            'review_prompt_status' => 'unavailable'
+            'review_prompt_filter' => { 'hidden_count' => 0 }
           ),
           a_hash_including(
             'code' => '32223711000001108',
             'display' => 'Paracetamol 250mg tablets',
             'review_prompts' => [],
-            'review_prompt_filter' => { 'hidden_count' => 0 },
-            'review_prompt_status' => 'unavailable'
+            'review_prompt_filter' => { 'hidden_count' => 0 }
           )
         )
-        expect(Rails.logger).to have_received(:error)
-          .with('Medication review enrichment failed: Errno::ENOENT')
-          .once
+        expect(response.parsed_body['review_guidance']).to eq('status' => 'unavailable')
+        expect(response.body).not_to include('Medication search is temporarily unavailable')
+        expect(logged_errors).to eq(['Medication review enrichment failed: Errno::ENOENT'])
+        expect(logged_errors.join).not_to match(
+          /paracetamol|legacy-household|admin|household|user/i
+        )
       end
     end
 

--- a/spec/services/medication_finder_search_responder_spec.rb
+++ b/spec/services/medication_finder_search_responder_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe MedicationFinderSearchResponder do
     context 'when search succeeds with results' do
       let(:search_result_item) { make_search_result }
       let(:nhs_result) { successful_nhs_result(results: [search_result_item], resolved_query: nil, barcode: nil) }
+      let(:mixed_responder) do
+        calls = 0
+        lookup = instance_double(MedicationInteractionLookup)
+        allow(lookup).to receive(:call) do
+          calls += 1
+          raise Errno::ENOENT, 'missing terminology' if calls == 1
+
+          MedicationInteractionLookup::Result.new(
+            visible_prompts: [{ risk_level: 'high' }],
+            hidden_count: 1
+          )
+        end
+        described_class.new(search: search, medication_scope: Medication.none, interaction_lookup: lookup)
+      end
+      let(:mixed_result_matchers) do
+        [
+          a_hash_including(code: 'DMD123', review_prompts: [], review_prompt_filter: { hidden_count: 0 }),
+          a_hash_including(
+            code: 'DMD456',
+            review_prompts: [{ risk_level: 'high' }],
+            review_prompt_filter: { hidden_count: 1 }
+          )
+        ]
+      end
 
       before { allow(search).to receive(:call).and_return(nhs_result) }
 
@@ -110,6 +134,25 @@ RSpec.describe MedicationFinderSearchResponder do
 
         expect(payload[:review_prompts]).to eq([{ risk_level: 'high' }])
         expect(payload[:review_prompt_filter]).to eq(hidden_count: 3)
+        expect(result.body[:review_guidance]).to eq(status: 'available')
+      end
+
+      it 'preserves successful enrichment after another result fails' do
+        search_results = [
+          make_search_result(code: 'DMD123', display: 'First result'),
+          make_search_result(code: 'DMD456', display: 'Second result')
+        ]
+        allow(search).to receive(:call).and_return(successful_nhs_result(results: search_results))
+        allow(Rails.logger).to receive(:error)
+
+        result = mixed_responder.call(query: 'medicine')
+
+        expect(result.status).to eq(:ok)
+        expect(result.body[:results]).to match_array(mixed_result_matchers)
+        expect(result.body[:review_guidance]).to eq(status: 'unavailable')
+        expect(Rails.logger).to have_received(:error)
+          .with('Medication review enrichment failed: Errno::ENOENT')
+          .once
       end
 
       it 'uses resolved_query from the search result when present' do


### PR DESCRIPTION
## Summary

- Keep successful NHS dm+d results visible when optional medication-review enrichment fails.
- Report review guidance once at the response level so clients can distinguish unavailable guidance from a genuine no-prompts result.
- Show one accessible warning while preserving add and restock actions.
- Package only the two medication-review snapshots needed at runtime.
- Exercise the final production image in CI through public login and search endpoints, with PostgreSQL 18, a fake NHS service, an empty import and barcode catalogue, and no application source mount.