### PR TITLE
fix(observability): resolve live database pools

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -45,7 +45,7 @@ module OpenTelemetryConfig
 
   def install_database_pool_metrics
     meter = OpenTelemetry.meter_provider.meter('medtracker.database_pool')
-    pool_resolver = -> { ActiveRecord::Base.connection_handler.connection_pool_list }
+    pool_resolver = -> { ActiveRecord::Base.connection_handler.connection_pool_list(:all) }
     Otel::DatabaseConnectionPoolMetrics.new(pool_resolver:, meter:).install
     pool_class = ActiveRecord::ConnectionAdapters::ConnectionPool
     pool_class.prepend(Otel::ConnectionPoolTimeoutInstrumentation) unless pool_class < Otel::ConnectionPoolTimeoutInstrumentation

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -45,7 +45,8 @@ module OpenTelemetryConfig
 
   def install_database_pool_metrics
     meter = OpenTelemetry.meter_provider.meter('medtracker.database_pool')
-    Otel::DatabaseConnectionPoolMetrics.new(pool: ActiveRecord::Base.connection_pool, meter:).install
+    pool_resolver = -> { ActiveRecord::Base.connection_handler.connection_pool_list }
+    Otel::DatabaseConnectionPoolMetrics.new(pool_resolver:, meter:).install
     pool_class = ActiveRecord::ConnectionAdapters::ConnectionPool
     pool_class.prepend(Otel::ConnectionPoolTimeoutInstrumentation) unless pool_class < Otel::ConnectionPoolTimeoutInstrumentation
   end

--- a/config/observability/database_pool_alerts.yml
+++ b/config/observability/database_pool_alerts.yml
@@ -2,21 +2,21 @@ groups:
   - name: medtracker-database-pool
     rules:
       - alert: MedTrackerDatabasePoolContention
-        expr: max_over_time(medtracker_db_connection_pool_waiting[5m]) > 0
+        expr: max by (db_pool_name, db_namespace) (max_over_time(medtracker_db_connection_pool_waiting[5m])) > 0
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: Database work is waiting for a connection
       - alert: MedTrackerDatabasePoolExhaustion
-        expr: medtracker_db_connection_pool_in_use / medtracker_db_connection_pool_size > 0.9
+        expr: sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_in_use) / sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_size) > 0.9
         for: 10m
         labels:
           severity: critical
         annotations:
           summary: Database connection pool utilization is above 90 percent
       - alert: MedTrackerDatabasePoolCheckoutTimeouts
-        expr: increase(medtracker_db_connection_pool_timeouts_total[5m]) > 0
+        expr: sum by (db_pool_name, db_namespace) (increase(medtracker_db_connection_pool_timeouts_total[5m])) > 0
         for: 1m
         labels:
           severity: critical

--- a/config/observability/database_pool_dashboard.json
+++ b/config/observability/database_pool_dashboard.json
@@ -10,7 +10,7 @@
       "title": "Pool utilization",
       "type": "timeseries",
       "targets": [
-        { "expr": "100 * sum(medtracker_db_connection_pool_in_use) / sum(medtracker_db_connection_pool_size)", "legendFormat": "utilization %" }
+        { "expr": "100 * sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_in_use) / sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_size)", "legendFormat": "{{db_pool_name}} / {{db_namespace}} utilization %" }
       ],
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } }
     },
@@ -19,9 +19,9 @@
       "title": "Connections by state",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum(medtracker_db_connection_pool_size)", "legendFormat": "size" },
-        { "expr": "sum(medtracker_db_connection_pool_in_use)", "legendFormat": "in use" },
-        { "expr": "sum(medtracker_db_connection_pool_idle)", "legendFormat": "idle" }
+        { "expr": "sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_size)", "legendFormat": "{{db_pool_name}} / {{db_namespace}} size" },
+        { "expr": "sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_in_use)", "legendFormat": "{{db_pool_name}} / {{db_namespace}} in use" },
+        { "expr": "sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_idle)", "legendFormat": "{{db_pool_name}} / {{db_namespace}} idle" }
       ]
     },
     {
@@ -29,7 +29,7 @@
       "title": "Waiting threads",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum(medtracker_db_connection_pool_waiting)", "legendFormat": "waiting" }
+        { "expr": "sum by (db_pool_name, db_namespace) (medtracker_db_connection_pool_waiting)", "legendFormat": "{{db_pool_name}} / {{db_namespace}} waiting" }
       ]
     },
     {
@@ -37,7 +37,7 @@
       "title": "Checkout timeouts",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum(rate(medtracker_db_connection_pool_timeouts_total[5m]))", "legendFormat": "timeouts / second" }
+        { "expr": "sum by (db_pool_name, db_namespace) (rate(medtracker_db_connection_pool_timeouts_total[5m]))", "legendFormat": "{{db_pool_name}} / {{db_namespace}} timeouts / second" }
       ]
     }
   ]

--- a/lib/otel/database_connection_pool_metrics.rb
+++ b/lib/otel/database_connection_pool_metrics.rb
@@ -18,9 +18,10 @@ module Otel
       end
     end
 
-    def initialize(pool:, meter:)
-      @pool = pool
+    def initialize(pool_resolver:, meter:)
+      @pool_resolver = pool_resolver
       @meter = meter
+      @error_log_mutex = Mutex.new
     end
 
     def install
@@ -34,30 +35,62 @@ module Otel
       self
     end
 
-    def record_timeout(timed_out_pool = pool)
+    def record_timeout(timed_out_pool)
       timeout_counter&.add(1, attributes: pool_attributes(timed_out_pool))
     end
 
     private
 
-    attr_reader :meter, :pool, :timeout_counter
+    attr_reader :meter, :pool_resolver, :timeout_counter
 
     def install_gauges
       GAUGES.each do |stat_key, (name, description)|
         meter.create_observable_gauge(
           name,
-          callback: -> { pool_stat(stat_key) },
+          callback: -> { pool_observations(stat_key) },
           unit: '1',
           description:
         )
       end
     end
 
-    def pool_stat(stat_key)
-      pool.stat.fetch(stat_key)
+    def pool_observations(stat_key)
+      connection_pools.filter_map do |connection_pool|
+        next if discarded?(connection_pool)
+
+        pool_stat(connection_pool, stat_key)
+      end
     rescue StandardError => e
-      Rails.logger.warn("OpenTelemetry database pool metrics unavailable: #{e.class}: #{e.message}")
-      0
+      log_collection_failure(e)
+      []
+    end
+
+    def connection_pools
+      pool_resolver.call || []
+    end
+
+    def discarded?(connection_pool)
+      connection_pool.respond_to?(:discarded?) && connection_pool.discarded?
+    end
+
+    def pool_stat(connection_pool, stat_key)
+      [connection_pool.stat.fetch(stat_key), pool_attributes(connection_pool)]
+    rescue StandardError => e
+      log_collection_failure(e)
+      nil
+    end
+
+    def log_collection_failure(error)
+      @error_log_mutex.synchronize do
+        return if @last_error_logged_at && monotonic_time - @last_error_logged_at < 60
+
+        @last_error_logged_at = monotonic_time
+        Rails.logger.warn("OpenTelemetry database pool metrics unavailable: #{error.class}: #{error.message}")
+      end
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def pool_attributes(connection_pool)

--- a/lib/otel/database_connection_pool_metrics.rb
+++ b/lib/otel/database_connection_pool_metrics.rb
@@ -65,14 +65,15 @@ module Otel
     end
 
     def collect_pool_metrics
-      connection_pools.each do |connection_pool|
-        next if discarded?(connection_pool)
+      connection_pools.count do |connection_pool|
+        next false if discarded?(connection_pool)
 
         record_pool_metrics(connection_pool)
+        true
       end
     rescue StandardError => e
       log_collection_failure(e)
-      nil
+      0
     end
 
     def connection_pools

--- a/lib/otel/database_connection_pool_metrics.rb
+++ b/lib/otel/database_connection_pool_metrics.rb
@@ -8,6 +8,7 @@ module Otel
       idle: ['medtracker.db.connection_pool.idle', 'Database connections currently idle'],
       waiting: ['medtracker.db.connection_pool.waiting', 'Threads waiting for a database connection']
     }.freeze
+    COLLECTOR_METRIC = 'medtracker.db.connection_pool.collector'
     TIMEOUT_METRIC = 'medtracker.db.connection_pool.timeouts'
 
     class << self
@@ -25,6 +26,7 @@ module Otel
     end
 
     def install
+      install_collector
       install_gauges
       @timeout_counter = meter.create_counter(
         TIMEOUT_METRIC,
@@ -41,28 +43,36 @@ module Otel
 
     private
 
-    attr_reader :meter, :pool_resolver, :timeout_counter
+    attr_reader :gauges, :meter, :pool_resolver, :timeout_counter
+
+    def install_collector
+      meter.create_observable_gauge(
+        COLLECTOR_METRIC,
+        callback: -> { collect_pool_metrics },
+        unit: '1',
+        description: 'Collects database connection pool metrics'
+      )
+    end
 
     def install_gauges
-      GAUGES.each do |stat_key, (name, description)|
-        meter.create_observable_gauge(
+      @gauges = GAUGES.transform_values do |name, description|
+        meter.create_gauge(
           name,
-          callback: -> { pool_observations(stat_key) },
           unit: '1',
           description:
         )
       end
     end
 
-    def pool_observations(stat_key)
-      connection_pools.filter_map do |connection_pool|
+    def collect_pool_metrics
+      connection_pools.each do |connection_pool|
         next if discarded?(connection_pool)
 
-        pool_stat(connection_pool, stat_key)
+        record_pool_metrics(connection_pool)
       end
     rescue StandardError => e
       log_collection_failure(e)
-      []
+      nil
     end
 
     def connection_pools
@@ -73,8 +83,20 @@ module Otel
       connection_pool.respond_to?(:discarded?) && connection_pool.discarded?
     end
 
+    def record_pool_metrics(connection_pool)
+      attributes = pool_attributes(connection_pool)
+
+      GAUGES.each_key do |stat_key|
+        value = pool_stat(connection_pool, stat_key)
+        gauges.fetch(stat_key).record(value, attributes:) unless value.nil?
+      end
+    rescue StandardError => e
+      log_collection_failure(e)
+      nil
+    end
+
     def pool_stat(connection_pool, stat_key)
-      [connection_pool.stat.fetch(stat_key), pool_attributes(connection_pool)]
+      connection_pool.stat.fetch(stat_key)
     rescue StandardError => e
       log_collection_failure(e)
       nil

--- a/spec/config/observability/database_pool_operations_spec.rb
+++ b/spec/config/observability/database_pool_operations_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe DatabasePoolOperations do
     expect(expressions).to include('medtracker_db_connection_pool_idle')
     expect(expressions).to include('medtracker_db_connection_pool_waiting')
     expect(expressions).to include('medtracker_db_connection_pool_timeouts_total')
+    expect(expressions).to include('by (db_pool_name, db_namespace)')
   end
 
   it 'alerts only after sustained contention or a checkout timeout' do
@@ -30,5 +31,6 @@ RSpec.describe DatabasePoolOperations do
     expect(alerts.fetch('MedTrackerDatabasePoolContention')).to include('for' => '5m')
     expect(alerts.fetch('MedTrackerDatabasePoolExhaustion')).to include('for' => '10m')
     expect(alerts.fetch('MedTrackerDatabasePoolCheckoutTimeouts')).to include('for' => '1m')
+    expect(alerts.values.pluck('expr')).to all(include('by (db_pool_name, db_namespace)'))
   end
 end

--- a/spec/config/observability/database_pool_operations_spec.rb
+++ b/spec/config/observability/database_pool_operations_spec.rb
@@ -17,12 +17,14 @@ RSpec.describe DatabasePoolOperations do
   it 'provides dashboard panels for capacity, utilization, waiting, and timeouts' do
     expressions = dashboard.fetch('panels').flat_map { |panel| panel.fetch('targets') }.pluck('expr').join(' ')
 
-    expect(expressions).to include('medtracker_db_connection_pool_size')
-    expect(expressions).to include('medtracker_db_connection_pool_in_use')
-    expect(expressions).to include('medtracker_db_connection_pool_idle')
-    expect(expressions).to include('medtracker_db_connection_pool_waiting')
-    expect(expressions).to include('medtracker_db_connection_pool_timeouts_total')
-    expect(expressions).to include('by (db_pool_name, db_namespace)')
+    expect(expressions).to include(
+      'medtracker_db_connection_pool_size',
+      'medtracker_db_connection_pool_in_use',
+      'medtracker_db_connection_pool_idle',
+      'medtracker_db_connection_pool_waiting',
+      'medtracker_db_connection_pool_timeouts_total',
+      'by (db_pool_name, db_namespace)'
+    )
   end
 
   it 'alerts only after sustained contention or a checkout timeout' do

--- a/spec/config/observability/open_telemetry_config_exporter_spec.rb
+++ b/spec/config/observability/open_telemetry_config_exporter_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe OpenTelemetryConfig do
       expect(Otel::DatabaseConnectionPoolMetrics.current).to be_present
       expect(Otel::DatabaseConnectionPoolMetrics.current.send(:connection_pools)).to include(ActiveRecord::Base.connection_pool)
     end
+
+    it 'resolves connection pools across every Active Record role' do
+      handler = instance_spy(ActiveRecord::ConnectionAdapters::ConnectionHandler, connection_pool_list: [])
+      allow(ActiveRecord::Base).to receive(:connection_handler).and_return(handler)
+
+      Otel::DatabaseConnectionPoolMetrics.current.send(:connection_pools)
+
+      expect(handler).to have_received(:connection_pool_list).with(:all)
+    end
   end
 
   context 'when parsing OTLP headers' do

--- a/spec/config/observability/open_telemetry_config_exporter_spec.rb
+++ b/spec/config/observability/open_telemetry_config_exporter_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe OpenTelemetryConfig do
     it 'installs database pool timeout instrumentation' do
       expect(ActiveRecord::ConnectionAdapters::ConnectionPool).to be < Otel::ConnectionPoolTimeoutInstrumentation
       expect(Otel::DatabaseConnectionPoolMetrics.current).to be_present
+      expect(Otel::DatabaseConnectionPoolMetrics.current.send(:connection_pools)).to include(ActiveRecord::Base.connection_pool)
     end
   end
 

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -22,60 +22,72 @@ RSpec.describe 'Database pool metrics export pipeline' do
     meter.collect
 
     observations = meter.gauges.transform_values(&:recordings)
-    expect(observations).to include(
-      'medtracker.db.connection_pool.size' => [[pool.stat.fetch(:size), a_hash_including('db.pool.name', 'db.namespace')]],
-      'medtracker.db.connection_pool.in_use' => [[pool.stat.fetch(:busy), a_hash_including('db.pool.name', 'db.namespace')]],
-      'medtracker.db.connection_pool.idle' => [[pool.stat.fetch(:idle), a_hash_including('db.pool.name', 'db.namespace')]],
-      'medtracker.db.connection_pool.waiting' => [[pool.stat.fetch(:waiting), a_hash_including('db.pool.name', 'db.namespace')]]
-    )
+    expect(observations).to include(pool_observations(pool))
   end
 
   it 'exports one labelled datapoint for each live pool through the metrics SDK' do
-    primary_config = instance_double(
-      ActiveRecord::DatabaseConfigurations::HashConfig,
-      name: 'primary',
-      database: 'medtracker_test'
+    metric_reader, pools = configured_sdk_metrics
+    metric_reader.pull
+
+    expect(size_data_points(metric_reader)).to contain_exactly(
+      [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }],
+      [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
     )
-    replica_config = instance_double(
-      ActiveRecord::DatabaseConfigurations::HashConfig,
-      name: 'replica',
-      database: 'medtracker_replica'
+  end
+
+  it 'removes a pool that is no longer live from the next export' do
+    metric_reader, pools = configured_sdk_metrics
+    metric_reader.pull
+
+    pools.replace([pools.last])
+    metric_reader.reset
+    metric_reader.pull
+
+    expect(size_data_points(metric_reader)).to eq(
+      [[5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]]
     )
-    primary_pool = instance_double(
-      ActiveRecord::ConnectionAdapters::ConnectionPool,
-      stat: { size: 10, busy: 4, idle: 6, waiting: 0 },
-      db_config: primary_config,
-      discarded?: false
-    )
-    replica_pool = instance_double(
-      ActiveRecord::ConnectionAdapters::ConnectionPool,
-      stat: { size: 5, busy: 2, idle: 3, waiting: 0 },
-      db_config: replica_config,
-      discarded?: false
-    )
+  end
+
+  def pool_observations(pool)
+    attributes = a_hash_including('db.pool.name', 'db.namespace')
+
+    {
+      'medtracker.db.connection_pool.size' => [[pool.stat.fetch(:size), attributes]],
+      'medtracker.db.connection_pool.in_use' => [[pool.stat.fetch(:busy), attributes]],
+      'medtracker.db.connection_pool.idle' => [[pool.stat.fetch(:idle), attributes]],
+      'medtracker.db.connection_pool.waiting' => [[pool.stat.fetch(:waiting), attributes]]
+    }
+  end
+
+  def configured_sdk_metrics
+    pools = [
+      build_pool('primary', 'medtracker_test', 10, 4, 6),
+      build_pool('replica', 'medtracker_replica', 5, 2, 3)
+    ]
     metric_reader = OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new
     meter_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
     meter_provider.add_metric_reader(metric_reader)
     meter = meter_provider.meter('medtracker.database_pool.sdk-export-spec')
 
-    pools = [primary_pool, replica_pool]
     Otel::DatabaseConnectionPoolMetrics.new(pool_resolver: -> { pools }, meter:).install
+    [metric_reader, pools]
+  end
 
-    metric_reader.pull
+  def build_pool(name, database, size, busy, idle)
+    db_config = instance_double(ActiveRecord::DatabaseConfigurations::HashConfig, name:, database:)
 
-    size_metric = metric_reader.metric_snapshots.find { |metric| metric.name == 'medtracker.db.connection_pool.size' }
-    expect(size_metric.data_points.map { |point| [point.value, point.attributes] }).to contain_exactly(
-      [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }],
-      [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
+    instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size:, busy:, idle:, waiting: 0 },
+      db_config:,
+      discarded?: false
     )
+  end
 
-    pools = [replica_pool]
-    metric_reader.reset
-    metric_reader.pull
-
-    size_metric = metric_reader.metric_snapshots.find { |metric| metric.name == 'medtracker.db.connection_pool.size' }
-    expect(size_metric.data_points.map { |point| [point.value, point.attributes] }).to eq(
-      [[5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]]
-    )
+  def size_data_points(metric_reader)
+    metric = metric_reader.metric_snapshots.find do |snapshot|
+      snapshot.name == 'medtracker.db.connection_pool.size'
+    end
+    metric.data_points.map { |point| [point.value, point.attributes] }
   end
 end

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -35,12 +35,25 @@ RSpec.describe 'Database pool metrics export pipeline' do
     )
   end
 
+  it 'exports a numeric collector datapoint that the OTLP exporter can encode' do
+    metric_reader, _pools = configured_sdk_metrics
+    metric_reader.pull
+
+    collector = latest_metric(metric_reader, 'medtracker.db.connection_pool.collector')
+    encoded_metrics = OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter.allocate.send(
+      :encode,
+      metric_reader.metric_snapshots
+    )
+
+    expect(collector.data_points.map(&:value)).to eq([2])
+    expect(encoded_metrics).to be_present
+  end
+
   it 'removes a pool that is no longer live from the next export' do
     metric_reader, pools = configured_sdk_metrics
     metric_reader.pull
 
     pools.replace([pools.last])
-    metric_reader.reset
     metric_reader.pull
 
     expect(size_data_points(metric_reader)).to eq(
@@ -85,9 +98,11 @@ RSpec.describe 'Database pool metrics export pipeline' do
   end
 
   def size_data_points(metric_reader)
-    metric = metric_reader.metric_snapshots.find do |snapshot|
-      snapshot.name == 'medtracker.db.connection_pool.size'
-    end
+    metric = latest_metric(metric_reader, 'medtracker.db.connection_pool.size')
     metric.data_points.map { |point| [point.value, point.attributes] }
+  end
+
+  def latest_metric(metric_reader, name)
+    metric_reader.metric_snapshots.rfind { |snapshot| snapshot.name == name }
   end
 end

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe 'Database pool metrics export pipeline' do
     expect(OpenTelemetry.meter_provider).to be_a(OpenTelemetry::SDK::Metrics::MeterProvider)
   end
 
-  it 'installs metrics against the runtime Active Record pool' do
+  it 'installs metrics against the live Active Record pools' do
     pool = ActiveRecord::Base.connection_pool
     meter = DatabasePoolMetricsTestSupport::Meter.new
 
-    metrics = Otel::DatabaseConnectionPoolMetrics.new(pool:, meter:)
+    metrics = Otel::DatabaseConnectionPoolMetrics.new(pool_resolver: -> { [pool] }, meter:)
     metrics.install
 
     observations = meter.gauges.transform_values(&:observe)
     expect(observations).to include(
-      'medtracker.db.connection_pool.size' => pool.stat.fetch(:size),
-      'medtracker.db.connection_pool.in_use' => pool.stat.fetch(:busy),
-      'medtracker.db.connection_pool.idle' => pool.stat.fetch(:idle),
-      'medtracker.db.connection_pool.waiting' => pool.stat.fetch(:waiting)
+      'medtracker.db.connection_pool.size' => [[pool.stat.fetch(:size), a_hash_including('db.pool.name', 'db.namespace')]],
+      'medtracker.db.connection_pool.in_use' => [[pool.stat.fetch(:busy), a_hash_including('db.pool.name', 'db.namespace')]],
+      'medtracker.db.connection_pool.idle' => [[pool.stat.fetch(:idle), a_hash_including('db.pool.name', 'db.namespace')]],
+      'medtracker.db.connection_pool.waiting' => [[pool.stat.fetch(:waiting), a_hash_including('db.pool.name', 'db.namespace')]]
     )
   end
 end

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Database pool metrics export pipeline' do
   end
 
   it 'exports one labelled datapoint for each live pool through the metrics SDK' do
-    metric_reader, pools = configured_sdk_metrics
+    metric_reader, _pools = configured_sdk_metrics
     metric_reader.pull
 
     expect(size_data_points(metric_reader)).to contain_exactly(

--- a/spec/features/observability/database_pool_metrics_spec.rb
+++ b/spec/features/observability/database_pool_metrics_spec.rb
@@ -19,13 +19,63 @@ RSpec.describe 'Database pool metrics export pipeline' do
 
     metrics = Otel::DatabaseConnectionPoolMetrics.new(pool_resolver: -> { [pool] }, meter:)
     metrics.install
+    meter.collect
 
-    observations = meter.gauges.transform_values(&:observe)
+    observations = meter.gauges.transform_values(&:recordings)
     expect(observations).to include(
       'medtracker.db.connection_pool.size' => [[pool.stat.fetch(:size), a_hash_including('db.pool.name', 'db.namespace')]],
       'medtracker.db.connection_pool.in_use' => [[pool.stat.fetch(:busy), a_hash_including('db.pool.name', 'db.namespace')]],
       'medtracker.db.connection_pool.idle' => [[pool.stat.fetch(:idle), a_hash_including('db.pool.name', 'db.namespace')]],
       'medtracker.db.connection_pool.waiting' => [[pool.stat.fetch(:waiting), a_hash_including('db.pool.name', 'db.namespace')]]
+    )
+  end
+
+  it 'exports one labelled datapoint for each live pool through the metrics SDK' do
+    primary_config = instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      name: 'primary',
+      database: 'medtracker_test'
+    )
+    replica_config = instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      name: 'replica',
+      database: 'medtracker_replica'
+    )
+    primary_pool = instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size: 10, busy: 4, idle: 6, waiting: 0 },
+      db_config: primary_config,
+      discarded?: false
+    )
+    replica_pool = instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size: 5, busy: 2, idle: 3, waiting: 0 },
+      db_config: replica_config,
+      discarded?: false
+    )
+    metric_reader = OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new
+    meter_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
+    meter_provider.add_metric_reader(metric_reader)
+    meter = meter_provider.meter('medtracker.database_pool.sdk-export-spec')
+
+    pools = [primary_pool, replica_pool]
+    Otel::DatabaseConnectionPoolMetrics.new(pool_resolver: -> { pools }, meter:).install
+
+    metric_reader.pull
+
+    size_metric = metric_reader.metric_snapshots.find { |metric| metric.name == 'medtracker.db.connection_pool.size' }
+    expect(size_metric.data_points.map { |point| [point.value, point.attributes] }).to contain_exactly(
+      [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }],
+      [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
+    )
+
+    pools = [replica_pool]
+    metric_reader.reset
+    metric_reader.pull
+
+    size_metric = metric_reader.metric_snapshots.find { |metric| metric.name == 'medtracker.db.connection_pool.size' }
+    expect(size_metric.data_points.map { |point| [point.value, point.attributes] }).to eq(
+      [[5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]]
     )
   end
 end

--- a/spec/lib/otel/database_connection_pool_metrics_spec.rb
+++ b/spec/lib/otel/database_connection_pool_metrics_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     )
   end
 
+  it 'returns the number of live pools from the collector callback' do
+    metrics.install
+
+    collector = meter.observable_gauges.fetch('medtracker.db.connection_pool.collector')
+
+    expect(collector.observe).to eq(1)
+  end
+
   it 'resolves live pools when each gauge is observed' do
     pools = [pool]
     metrics = described_class.new(pool_resolver: -> { pools }, meter:)

--- a/spec/lib/otel/database_connection_pool_metrics_spec.rb
+++ b/spec/lib/otel/database_connection_pool_metrics_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
       'medtracker.db.connection_pool.idle',
       'medtracker.db.connection_pool.waiting'
     )
+    expect(meter.observable_gauges.keys).to contain_exactly('medtracker.db.connection_pool.collector')
     expect(meter.counters.keys).to contain_exactly('medtracker.db.connection_pool.timeouts')
   end
 
@@ -31,8 +32,9 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     metrics.install
 
     attributes = { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }
+    meter.collect
 
-    expect(meter.gauges.transform_values(&:observe)).to eq(
+    expect(meter.gauges.transform_values(&:recordings)).to eq(
       'medtracker.db.connection_pool.size' => [[10, attributes]],
       'medtracker.db.connection_pool.in_use' => [[4, attributes]],
       'medtracker.db.connection_pool.idle' => [[3, attributes]],
@@ -56,14 +58,16 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     metrics = described_class.new(pool_resolver: -> { pools }, meter:)
 
     metrics.install
+    meter.collect
 
-    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').observe).to contain_exactly(
+    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').recordings).to contain_exactly(
       [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }]
     )
 
     pools = [replica_pool]
+    meter.collect
 
-    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').observe).to contain_exactly(
+    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').recordings.last).to eq(
       [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
     )
   end
@@ -100,15 +104,17 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     allow(pool).to receive(:stat).and_raise(ActiveRecord::ConnectionNotEstablished)
     allow(Rails.logger).to receive(:warn)
     metrics.install
+    meter.collect
 
-    expect(meter.gauges.values.map(&:observe)).to all(eq([]))
+    expect(meter.gauges.values.map(&:recordings)).to all(eq([]))
     expect(Rails.logger).to have_received(:warn).with(/database pool metrics unavailable/).once
   end
 
   it 'skips discarded pools without emitting zero-value observations' do
     allow(pool).to receive(:discarded?).and_return(true)
     metrics.install
+    meter.collect
 
-    expect(meter.gauges.values.map(&:observe)).to all(eq([]))
+    expect(meter.gauges.values.map(&:recordings)).to all(eq([]))
   end
 end

--- a/spec/lib/otel/database_connection_pool_metrics_spec.rb
+++ b/spec/lib/otel/database_connection_pool_metrics_spec.rb
@@ -43,17 +43,6 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
   end
 
   it 'resolves live pools when each gauge is observed' do
-    replica_config = instance_double(
-      ActiveRecord::DatabaseConfigurations::HashConfig,
-      name: 'replica',
-      database: 'medtracker_replica'
-    )
-    replica_pool = instance_double(
-      ActiveRecord::ConnectionAdapters::ConnectionPool,
-      stat: { size: 5, busy: 2, dead: 0, idle: 3, waiting: 0 },
-      db_config: replica_config,
-      discarded?: false
-    )
     pools = [pool]
     metrics = described_class.new(pool_resolver: -> { pools }, meter:)
 
@@ -61,14 +50,14 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     meter.collect
 
     expect(meter.gauges.fetch('medtracker.db.connection_pool.size').recordings).to contain_exactly(
-      [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }]
+      pool_recording(pool)
     )
 
-    pools = [replica_pool]
+    pools.replace([replica_pool])
     meter.collect
 
     expect(meter.gauges.fetch('medtracker.db.connection_pool.size').recordings.last).to eq(
-      [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
+      pool_recording(replica_pool)
     )
   end
 
@@ -116,5 +105,26 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     meter.collect
 
     expect(meter.gauges.values.map(&:recordings)).to all(eq([]))
+  end
+
+  def replica_pool
+    replica_config = instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      name: 'replica',
+      database: 'medtracker_replica'
+    )
+    instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size: 5, busy: 2, dead: 0, idle: 3, waiting: 0 },
+      db_config: replica_config,
+      discarded?: false
+    )
+  end
+
+  def pool_recording(connection_pool)
+    [connection_pool.stat.fetch(:size), {
+      'db.pool.name' => connection_pool.db_config.name,
+      'db.namespace' => connection_pool.db_config.database
+    }]
   end
 end

--- a/spec/lib/otel/database_connection_pool_metrics_spec.rb
+++ b/spec/lib/otel/database_connection_pool_metrics_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Otel::DatabaseConnectionPoolMetrics do
-  subject(:metrics) { described_class.new(pool:, meter:) }
+  subject(:metrics) { described_class.new(pool_resolver: -> { [pool] }, meter:) }
 
   let(:meter) { DatabasePoolMetricsTestSupport::Meter.new }
   let(:db_config) { instance_double(ActiveRecord::DatabaseConfigurations::HashConfig, name: 'primary', database: 'medtracker_test') }
@@ -30,11 +30,41 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
   it 'observes current Rails connection pool statistics' do
     metrics.install
 
+    attributes = { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }
+
     expect(meter.gauges.transform_values(&:observe)).to eq(
-      'medtracker.db.connection_pool.size' => 10,
-      'medtracker.db.connection_pool.in_use' => 4,
-      'medtracker.db.connection_pool.idle' => 3,
-      'medtracker.db.connection_pool.waiting' => 2
+      'medtracker.db.connection_pool.size' => [[10, attributes]],
+      'medtracker.db.connection_pool.in_use' => [[4, attributes]],
+      'medtracker.db.connection_pool.idle' => [[3, attributes]],
+      'medtracker.db.connection_pool.waiting' => [[2, attributes]]
+    )
+  end
+
+  it 'resolves live pools when each gauge is observed' do
+    replica_config = instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      name: 'replica',
+      database: 'medtracker_replica'
+    )
+    replica_pool = instance_double(
+      ActiveRecord::ConnectionAdapters::ConnectionPool,
+      stat: { size: 5, busy: 2, dead: 0, idle: 3, waiting: 0 },
+      db_config: replica_config,
+      discarded?: false
+    )
+    pools = [pool]
+    metrics = described_class.new(pool_resolver: -> { pools }, meter:)
+
+    metrics.install
+
+    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').observe).to contain_exactly(
+      [10, { 'db.pool.name' => 'primary', 'db.namespace' => 'medtracker_test' }]
+    )
+
+    pools = [replica_pool]
+
+    expect(meter.gauges.fetch('medtracker.db.connection_pool.size').observe).to contain_exactly(
+      [5, { 'db.pool.name' => 'replica', 'db.namespace' => 'medtracker_replica' }]
     )
   end
 
@@ -66,12 +96,19 @@ RSpec.describe Otel::DatabaseConnectionPoolMetrics do
     expect(meter.counters.fetch('medtracker.db.connection_pool.timeouts').recordings.size).to eq(1)
   end
 
-  it 'returns zero from gauge callbacks when pool statistics are unavailable' do
+  it 'skips unavailable pools and rate-limits the diagnostic' do
     allow(pool).to receive(:stat).and_raise(ActiveRecord::ConnectionNotEstablished)
     allow(Rails.logger).to receive(:warn)
     metrics.install
 
-    expect(meter.gauges.values.map(&:observe)).to all(eq(0))
-    expect(Rails.logger).to have_received(:warn).with(/database pool metrics unavailable/).at_least(:once)
+    expect(meter.gauges.values.map(&:observe)).to all(eq([]))
+    expect(Rails.logger).to have_received(:warn).with(/database pool metrics unavailable/).once
+  end
+
+  it 'skips discarded pools without emitting zero-value observations' do
+    allow(pool).to receive(:discarded?).and_return(true)
+    metrics.install
+
+    expect(meter.gauges.values.map(&:observe)).to all(eq([]))
   end
 end

--- a/spec/support/database_pool_metrics_test_meter.rb
+++ b/spec/support/database_pool_metrics_test_meter.rb
@@ -16,14 +16,19 @@ module DatabasePoolMetricsTestSupport
     def add(value, attributes: {})
       recordings << [value, attributes]
     end
+
+    def record(value, attributes: {})
+      recordings << [value, attributes]
+    end
   end
 
   class Meter
-    attr_reader :counters, :gauges
+    attr_reader :counters, :gauges, :observable_gauges
 
     def initialize
       @counters = {}
       @gauges = {}
+      @observable_gauges = {}
     end
 
     def create_counter(name, **)
@@ -31,7 +36,15 @@ module DatabasePoolMetricsTestSupport
     end
 
     def create_observable_gauge(name, callback:, **)
-      gauges[name] = Metric.new(callback:)
+      observable_gauges[name] = Metric.new(callback:)
+    end
+
+    def create_gauge(name, **)
+      gauges[name] = Metric.new
+    end
+
+    def collect
+      observable_gauges.each_value(&:observe)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Resolve database pools when metrics are collected, avoiding stale pool references and misleading zero values.
- Export labelled primary, cache, queue, and cable pool metrics; retain those labels in dashboards and alerts.

## Verification

- `task test:preflight`
- `task test TEST_FILE=spec/lib/otel/database_connection_pool_metrics_spec.rb`
- `task test TEST_FILE=spec/features/observability/database_pool_metrics_spec.rb`
- `task test TEST_FILE=spec/config/observability/open_telemetry_config_exporter_spec.rb`
- `task test TEST_FILE=spec/config/observability/database_pool_operations_spec.rb`
- `task test`
- `task rubocop`
- `git diff --check origin/main..HEAD`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->