### PR TITLE
fix(notifications): trace missed doses

### DIFF
--- a/app/jobs/missed_dose_notification_job.rb
+++ b/app/jobs/missed_dose_notification_job.rb
@@ -7,7 +7,7 @@ class MissedDoseNotificationJob < ApplicationJob
 
   def perform(household_id, person_id, scheduled_on, scheduled_time)
     household = Household.operational.find_by(id: household_id)
-    return unless household
+    return log_skip('household_unavailable') unless household
 
     TenantContext.with(account: nil, household: household) do
       deliver_missed_dose_notification(household, person_id, scheduled_on, scheduled_time)
@@ -18,16 +18,16 @@ class MissedDoseNotificationJob < ApplicationJob
 
   def deliver_missed_dose_notification(household, person_id, scheduled_on, scheduled_time)
     person = Person.find_by(id: person_id, household: household)
-    return unless person
+    return log_skip('person_unavailable') unless person
 
     recipients = MissedDoseNotificationRecipientsQuery.new(person: person).call
-    return if recipients.empty?
+    return log_skip('no_recipients') if recipients.empty?
 
     scheduled_at = parsed_scheduled_at(scheduled_on, scheduled_time)
-    return unless missed_dose_due?(person, scheduled_time, scheduled_at)
+    return log_skip('no_due_dose') unless missed_dose_due?(person, scheduled_time, scheduled_at)
 
     event = record_missed_dose_event(household, person, scheduled_on, scheduled_time)
-    return unless event
+    return log_skip('duplicate') unless event
 
     deliver_or_record_skip(event, household, person, recipients)
   end
@@ -54,7 +54,7 @@ class MissedDoseNotificationJob < ApplicationJob
 
   def deliver_or_record_skip(event, household, person, recipients)
     active_recipients = recipients.select { |recipient| active_push_recipient?(recipient) }
-    return record_skip(event, person, 'no_active_push_subscriptions') if active_recipients.empty?
+    return record_skip(event, 'no_active_push_subscriptions') if active_recipients.empty?
 
     active_recipients.each do |recipient|
       PushNotificationService.send_to_account(
@@ -65,6 +65,9 @@ class MissedDoseNotificationJob < ApplicationJob
       )
     end
     event.update!(sent_at: Time.current)
+    Rails.logger.info(
+      "[MissedDoseNotificationJob] outcome=sent recipient_count=#{active_recipients.size}"
+    )
   end
 
   def active_push_recipient?(recipient)
@@ -87,8 +90,12 @@ class MissedDoseNotificationJob < ApplicationJob
     nil
   end
 
-  def record_skip(event, person, reason)
+  def record_skip(event, reason)
     event.update!(skipped_reason: reason)
-    Rails.logger.info("[MissedDoseNotificationJob] Skipped person_id=#{person.id} reason=#{reason}")
+    log_skip(reason)
+  end
+
+  def log_skip(reason)
+    Rails.logger.info("[MissedDoseNotificationJob] outcome=skipped reason=#{reason}")
   end
 end

--- a/app/services/medication_administration/record_dose.rb
+++ b/app/services/medication_administration/record_dose.rb
@@ -90,18 +90,28 @@ module MedicationAdministration
 
     def rule_blocked_failure(prepared_take, source:, user:, options:)
       publish_rule_blocked_metric(prepared_take, source:, user:, options:)
+      log_outcome('blocked', source:, reason: prepared_take.error)
       failure(prepared_take.error)
     end
 
     def persistence_failure(source:, user:, options:)
       publish_take_metric('take_errors.med_tracker', source:, user:, options:, error: :create_failed)
+      log_outcome('failed', source:, reason: :create_failed)
       failure(:create_failed)
     end
 
     def success(take, source:, user:, options:)
       publish_dose_taken(take)
       publish_take_metric('take_recorded.med_tracker', source:, user:, options:)
+      log_outcome('recorded', source:)
       Result.new(success: true, take: take, error: nil)
+    end
+
+    def log_outcome(outcome, source:, reason: nil)
+      message = "[MedicationAdministration::RecordDose] outcome=#{outcome} " \
+                "source_type=#{source.class.model_name.singular}"
+      message += " reason=#{reason}" if reason
+      Rails.logger.info(message)
     end
 
     def prepare_take(source:, amount_override:, taken_from_medication_id:, user:, options:)

--- a/spec/jobs/missed_dose_notification_job_spec.rb
+++ b/spec/jobs/missed_dose_notification_job_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe MissedDoseNotificationJob do
 
   it 'sends one private notification when a scheduled dose is overdue' do
     create_schedule
+    allow(Rails.logger).to receive(:info)
 
     travel_to Time.zone.local(2026, 5, 12, 7, 46) do
       described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
@@ -40,6 +41,9 @@ RSpec.describe MissedDoseNotificationJob do
       path: "/households/#{household.slug}/dashboard"
     )
     expect(NotificationEvent.where(event_type: 'missed_dose').count).to eq(1)
+    expect(Rails.logger).to have_received(:info).with(
+      '[MissedDoseNotificationJob] outcome=sent recipient_count=1'
+    )
   end
 
   it 'suppresses duplicates for the same scheduled occurrence' do
@@ -55,12 +59,16 @@ RSpec.describe MissedDoseNotificationJob do
   it 'does not send when the dose was taken in the dose window' do
     schedule = create_schedule
     create(:medication_take, :for_schedule, schedule: schedule, taken_at: Time.zone.local(2026, 5, 12, 7, 20))
+    allow(Rails.logger).to receive(:info)
 
     travel_to Time.zone.local(2026, 5, 12, 7, 46) do
       described_class.perform_now(household.id, person.id, scheduled_on, scheduled_time)
     end
 
     expect(PushNotificationService).not_to have_received(:send_to_account)
+    expect(Rails.logger).to have_received(:info).with(
+      '[MissedDoseNotificationJob] outcome=skipped reason=no_due_dose'
+    )
   end
 
   it 'does not send when missed-dose notifications are disabled' do

--- a/spec/services/medication_administration/record_dose_spec.rb
+++ b/spec/services/medication_administration/record_dose_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe MedicationAdministration::RecordDose do
     payloads
   end
 
+  def expect_record_dose_log(details)
+    expect(Rails.logger).to have_received(:info).with(
+      "[MedicationAdministration::RecordDose] #{details}"
+    )
+  end
+
   shared_examples 'a successful dose' do |expected_amount|
     it 'returns success' do
       expect(result.success).to be true
@@ -563,6 +569,7 @@ RSpec.describe MedicationAdministration::RecordDose do
     it 'publishes attempted and recorded metric events for a successful dose' do
       schedule = schedules(:john_paracetamol)
       result = nil
+      allow(Rails.logger).to receive(:info)
 
       travel_to Time.current.end_of_day - 1.minute do
         attempted_payloads = captured_event_payloads('take_attempted.med_tracker') do
@@ -576,12 +583,14 @@ RSpec.describe MedicationAdministration::RecordDose do
         expect(result.success).to be true
         expect_metric_payload(attempted_payloads, source: schedule)
       end
+      expect_record_dose_log('outcome=recorded source_type=schedule')
     end
 
     it 'publishes attempted and blocked metric events when rules prevent a dose' do
       schedule = schedules(:john_paracetamol)
       schedule.medication.update!(current_supply: 0)
       result = nil
+      allow(Rails.logger).to receive(:info)
 
       attempted_payloads = captured_event_payloads('take_attempted.med_tracker') do
         blocked_payloads = captured_event_payloads('take_blocked_by_rules.med_tracker') do
@@ -593,11 +602,13 @@ RSpec.describe MedicationAdministration::RecordDose do
 
       expect(result.error).to eq(:out_of_stock)
       expect_metric_payload(attempted_payloads, source: schedule)
+      expect_record_dose_log('outcome=blocked source_type=schedule reason=out_of_stock')
     end
 
     it 'publishes an error metric when take persistence fails' do
       schedule = schedules(:john_paracetamol)
       allow(schedule).to receive(:effective_dose_unit).and_return(nil)
+      allow(Rails.logger).to receive(:info)
       result = nil
 
       travel_to Time.current.end_of_day - 1.minute do
@@ -608,6 +619,7 @@ RSpec.describe MedicationAdministration::RecordDose do
         expect(result.error).to eq(:create_failed)
         expect_metric_payload(payloads, source: schedule, error: 'create_failed')
       end
+      expect_record_dose_log('outcome=failed source_type=schedule reason=create_failed')
     end
 
     it 'publishes one event for a successful scheduled dose' do


### PR DESCRIPTION
## Summary

Production could show that missed-dose jobs ran, but not why they sent or whether recording a dose succeeded. That made a false-alert report impossible to distinguish from a missing administration record.

This adds privacy-safe outcome logs for both sides of that decision: missed-dose jobs now report sent and skipped outcome categories, while dose recording reports recorded, blocked, or persistence-failed outcomes. The messages intentionally omit person identifiers, medication details, dose values, and timestamps.

## Operational context

The production investigation found six sent 08:00 missed-dose events from 23–28 July with no corresponding administration records. Today’s administration was recorded before the cutoff and correctly produced no missed-dose event. These signals will make the next occurrence traceable without exposing clinical data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->