### PR TITLE
feat(storage): support portable production backends

### DIFF
--- a/Taskfiles/prod.yml
+++ b/Taskfiles/prod.yml
@@ -49,6 +49,98 @@ tasks:
           APP_IMAGE_REF: '{{ .IMAGE_REF }}'
       - ./scripts/production_observability_characterization.fish '{{ .IMAGE_REF }}'
 
+  storage-disk-smoke:
+    desc: Verify Disk storage from the final production image
+    vars:
+      IMAGE_REF: '{{ .APP_IMAGE_REF | default "med-tracker:storage-disk-smoke" }}'
+    cmds:
+      - task: build
+        vars:
+          APP_IMAGE_REF: '{{ .IMAGE_REF }}'
+      - ./scripts/production_storage_smoke.fish '{{ .IMAGE_REF }}' disk
+
+  storage-s3-smoke:
+    desc: Verify S3 storage from the final production image
+    vars:
+      IMAGE_REF: '{{ .APP_IMAGE_REF | default "med-tracker:storage-s3-smoke" }}'
+    cmds:
+      - task: build
+        vars:
+          APP_IMAGE_REF: '{{ .IMAGE_REF }}'
+      - ./scripts/production_storage_smoke.fish '{{ .IMAGE_REF }}' s3
+
+  storage-migration-start:
+    desc: Start or dry-run a portable storage migration
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=start STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" rails storage:migration'
+
+  storage-migration-resume:
+    desc: Resume or dry-run a portable storage migration
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=resume STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" rails storage:migration'
+
+  storage-migration-reconcile:
+    desc: Reconcile or dry-run a stable portable storage set
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=reconcile STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" STORAGE_MIGRATION_MUTATIONS_QUIESCED="{{ .MUTATIONS_QUIESCED }}" STORAGE_MIGRATION_MIRROR_QUEUE_DRAINED="{{ .MIRROR_QUEUE_DRAINED }}" rails storage:migration'
+
+  storage-migration-cutover-eligibility:
+    desc: Report portable storage cutover eligibility
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=cutover_eligibility STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" rails storage:migration'
+
+  storage-migration-cutover:
+    desc: Cut over or dry-run portable storage
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=cutover STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" rails storage:migration'
+
+  storage-migration-rollback:
+    desc: Roll back or dry-run portable storage inside the rollback window
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=rollback STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" STORAGE_MIGRATION_SOURCE_VERIFIED="{{ .SOURCE_VERIFIED }}" STORAGE_MIGRATION_MIRROR_QUEUE_DRAINED="{{ .MIRROR_QUEUE_DRAINED }}" rails storage:migration'
+
+  storage-migration-finalize:
+    desc: Finalize or dry-run portable storage after its rollback window
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=finalize STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_APPLY="{{ .APPLY }}" STORAGE_MIGRATION_CONFIRM="{{ .CONFIRM }}" STORAGE_MIGRATION_ACCEPTANCE_VERIFIED="{{ .ACCEPTANCE_VERIFIED }}" STORAGE_MIGRATION_RECOVERY_VERIFIED="{{ .RECOVERY_VERIFIED }}" STORAGE_MIGRATION_FINAL_RECONCILED="{{ .FINAL_RECONCILED }}" rails storage:migration'
+
+  storage-migration-retirement-eligibility:
+    desc: Report whether the inactive source can be retired
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner STORAGE_MIGRATION_ACTION=retirement_eligibility STORAGE_MIGRATION_RUN_ID="{{ .RUN_ID }}" STORAGE_MIGRATION_SOURCE="{{ .SOURCE }}" STORAGE_MIGRATION_DESTINATION="{{ .DESTINATION }}" STORAGE_MIGRATION_PHASE="{{ .PHASE }}" STORAGE_MIGRATION_LIVE_SOURCE_DEPENDENCY="{{ .LIVE_SOURCE_DEPENDENCY }}" rails storage:migration'
+
+  storage-convert-nhs-dmd-archives:
+    desc: Convert or report every live path-backed NHS dm+d archive
+    cmds:
+      - task: :internal:run
+        vars:
+          ENVIRONMENT: prod
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner NHS_DMD_ARCHIVE_SERVICE="{{ .SERVICE }}" NHS_DMD_ARCHIVE_APPLY="{{ .APPLY }}" rails storage:convert_nhs_dmd_archives'
+
   up:
     desc: Start production server (local validation)
     summary: |
@@ -137,7 +229,7 @@ tasks:
       - task: :internal:run
         vars:
           ENVIRONMENT: prod
-          COMMAND: 'env DATABASE_ROLE=med_tracker_owner ATTACHMENT_ID="{{ .attachment_id }}" rails med_tracker:storage:verify_restore'
+          COMMAND: 'env DATABASE_ROLE=med_tracker_owner ATTACHMENT_ID="{{ .attachment_id }}" DATABASE_RECOVERY_REFERENCE="{{ .DATABASE_RECOVERY_REFERENCE }}" DISK_RECOVERY_REFERENCE="{{ .DISK_RECOVERY_REFERENCE }}" S3_RECOVERY_REFERENCE="{{ .S3_RECOVERY_REFERENCE }}" STORAGE_MIGRATION_RUN_ID="{{ .STORAGE_MIGRATION_RUN_ID }}" AUTHORIZED_RETRIEVAL_VERIFIED="{{ .AUTHORIZED_RETRIEVAL_VERIFIED }}" CROSS_HOUSEHOLD_DENIAL_VERIFIED="{{ .CROSS_HOUSEHOLD_DENIAL_VERIFIED }}" rails med_tracker:storage:verify_restore'
 
   import-dmd-barcodes:
     desc: Import NHS dm+d GTIN barcode mappings from CSV

--- a/app/controllers/admin/nhs_dmd_imports_controller.rb
+++ b/app/controllers/admin/nhs_dmd_imports_controller.rb
@@ -20,12 +20,12 @@ module Admin
       import_run = NhsDmdImport.create!(
         uploaded_filename: uploaded_file.original_filename.presence || File.basename(uploaded_file.path)
       )
-      import_run.persist_archive!(uploaded_file)
-      NhsDmdImportJob.perform_later(import_run)
+      NhsDmd::ArchiveStore.new.persist(import_run:, uploaded_file:)
+      NhsDmdImportJob.perform_later(import_run.id)
 
       redirect_to new_admin_nhs_dmd_import_path,
                   notice: t('admin.nhs_dmd_imports.started')
-    rescue ArgumentError, ActiveRecord::ActiveRecordError, SystemCallError => e
+    rescue NhsDmd::ArchiveStore::Error, ArgumentError, ActiveRecord::ActiveRecordError, SystemCallError => e
       import_run&.fail!(e.message) if import_run&.queued?
       redirect_to new_admin_nhs_dmd_import_path, alert: e.message
     end

--- a/app/jobs/nhs_dmd_import_job.rb
+++ b/app/jobs/nhs_dmd_import_job.rb
@@ -22,8 +22,11 @@ class NhsDmdImportJob < ApplicationJob
 
   def perform_import(import_run)
     import_run.start!
-    result = archive_importer.import(import_run.archive_path, progress_callback: progress_callback_for(import_run))
+    result = archive_store.open(import_run) do |archive_path|
+      archive_importer.import(archive_path, progress_callback: progress_callback_for(import_run))
+    end
     import_run.reload.complete!(result)
+    archive_store.cleanup(import_run)
   end
 
   def resolve_import_run(import_run_or_id)
@@ -36,6 +39,10 @@ class NhsDmdImportJob < ApplicationJob
     @archive_importer ||= NhsDmd::ReleaseArchiveImport.new
   end
 
+  def archive_store
+    @archive_store ||= NhsDmd::ArchiveStore.new
+  end
+
   def progress_callback_for(import_run)
     lambda do |progress|
       import_run.reload.apply_progress!(progress)
@@ -44,5 +51,13 @@ class NhsDmdImportJob < ApplicationJob
 
   def fail_import(import_run, error)
     import_run&.reload&.fail!(error.message)
+    archive_store.cleanup(import_run) if import_run
+  rescue NhsDmd::ArchiveStore::Error => e
+    Observability::DiagnosticEvent.emit(
+      component: :nhs_dmd_import,
+      reason: :operation_failed,
+      severity: :error,
+      error: e
+    )
   end
 end

--- a/app/jobs/nhs_dmd_import_job.rb
+++ b/app/jobs/nhs_dmd_import_job.rb
@@ -26,7 +26,7 @@ class NhsDmdImportJob < ApplicationJob
       archive_importer.import(archive_path, progress_callback: progress_callback_for(import_run))
     end
     import_run.reload.complete!(result)
-    archive_store.cleanup(import_run)
+    cleanup_archive(import_run)
   end
 
   def resolve_import_run(import_run_or_id)
@@ -51,7 +51,11 @@ class NhsDmdImportJob < ApplicationJob
 
   def fail_import(import_run, error)
     import_run&.reload&.fail!(error.message)
-    archive_store.cleanup(import_run) if import_run
+    cleanup_archive(import_run) if import_run
+  end
+
+  def cleanup_archive(import_run)
+    archive_store.cleanup(import_run)
   rescue NhsDmd::ArchiveStore::Error => e
     Observability::DiagnosticEvent.emit(
       component: :nhs_dmd_import,

--- a/app/models/nhs_dmd_import.rb
+++ b/app/models/nhs_dmd_import.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'fileutils'
-
 class NhsDmdImport < ApplicationRecord
   PROGRESS_COUNTER_KEYS = %i[
     total_records
@@ -15,6 +13,9 @@ class NhsDmdImport < ApplicationRecord
     skipped_missing_name_count
     skipped_invalid_count
   ].freeze
+  ARCHIVE_REFERENCE_FIELDS = %i[
+    archive_service_name archive_key archive_checksum archive_byte_size
+  ].freeze
 
   enum :status, {
     queued: 0,
@@ -26,18 +27,24 @@ class NhsDmdImport < ApplicationRecord
   }, default: :queued, validate: true
 
   validates :uploaded_filename, presence: true
+  validate :complete_archive_reference
 
   def self.latest_first
     order(created_at: :desc)
   end
 
-  def persist_archive!(uploaded_file)
-    source_path = uploaded_file.respond_to?(:path) ? uploaded_file.path : uploaded_file.to_s
-    raise ArgumentError, 'Import archive is missing.' if source_path.blank?
+  def persist_archive!(uploaded_file, store: NhsDmd::ArchiveStore.new, service_name: nil)
+    options = { import_run: self, uploaded_file: }
+    options[:service_name] = service_name if service_name
+    store.persist(**options)
+  end
 
-    FileUtils.mkdir_p(archive_directory)
-    FileUtils.cp(source_path, archive_destination_path)
-    update!(archive_path: archive_destination_path.to_s)
+  def archive_reference?
+    archive_reference_values.all?(&:present?)
+  end
+
+  def legacy_archive?
+    archive_path.present? && !archive_reference?
   end
 
   def start!
@@ -92,16 +99,14 @@ class NhsDmdImport < ApplicationRecord
     result.imported_count + result.skipped_count + result.unchanged_count
   end
 
-  def archive_directory
-    Rails.root.join('storage', 'nhs_dmd', 'imports', id.to_s)
+  def complete_archive_reference
+    return if archive_reference_values.none?(&:present?) || archive_reference?
+
+    ARCHIVE_REFERENCE_FIELDS.select { public_send(it).blank? }.each { errors.add(it, :blank) }
   end
 
-  def archive_destination_path
-    archive_directory.join(sanitized_filename)
-  end
-
-  def sanitized_filename
-    File.basename(uploaded_filename.to_s).gsub(/[^A-Za-z0-9.\-_]/, '_').presence || 'release.zip'
+  def archive_reference_values
+    ARCHIVE_REFERENCE_FIELDS.map { public_send(it) }
   end
 
   def appended_log(message)

--- a/app/models/storage_migration_run.rb
+++ b/app/models/storage_migration_run.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class StorageMigrationRun < ApplicationRecord
+  SERVICES = %w[persistent s3].freeze
+
+  before_validation { self.run_id ||= SecureRandom.uuid }
+
+  enum :phase, {
+    backfill: 'backfill',
+    reconciled: 'reconciled',
+    rollback_window: 'rollback_window',
+    finalized: 'finalized'
+  }, validate: true
+
+  validates :run_id, presence: true, uniqueness: true
+  validates :source_service_name, :destination_service_name, inclusion: { in: SERVICES }
+  validates :processed_count, :verified_count, :failed_count,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :services_differ
+
+  def finalization_attributes(timestamp)
+    {
+      phase: :finalized,
+      acceptance_verified_at: timestamp,
+      recovery_verified_at: timestamp,
+      final_reconciled_at: timestamp,
+      finalized_at: timestamp
+    }
+  end
+
+  private
+
+  def services_differ
+    return if source_service_name.blank? || destination_service_name.blank?
+    return unless source_service_name == destination_service_name
+
+    errors.add(:destination_service_name, 'must differ from source service')
+  end
+end

--- a/app/services/nhs_dmd/archive_migration.rb
+++ b/app/services/nhs_dmd/archive_migration.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module NhsDmd
+  class ArchiveMigration
+    Result = Data.define(:processed_count, :converted_count, :failed_count, :applied)
+    DEFAULT_BATCH_SIZE = 100
+
+    def initialize(scope: NhsDmdImport.all, store: ArchiveStore.new, **options)
+      @scope = scope
+      @store = store
+      @owner_role = options.fetch(:owner_role) do
+        -> { ActiveRecord::Base.connection.select_value('SELECT current_user') == 'med_tracker_owner' }
+      end
+      @path_exists = options.fetch(:path_exists, ->(path) { File.file?(path) })
+      @service_name = options.fetch(:service_name, Rails.configuration.active_storage.service).to_sym
+      @batch_size = options.fetch(:batch_size, DEFAULT_BATCH_SIZE)
+      @apply = options.fetch(:apply, false)
+    end
+
+    def call
+      raise SecurityError, 'archive migration requires the owner database role' unless owner_role.call
+      raise ArgumentError, 'unsupported archive service' unless ProductionStorage::SERVICES.include?(service_name.to_s)
+
+      counts = { processed_count: 0, converted_count: 0, failed_count: 0 }
+      legacy_scope.find_in_batches(batch_size:) do |imports|
+        imports.each { process(it, counts) }
+      end
+      Result.new(**counts, applied: apply)
+    end
+
+    private
+
+    attr_reader :scope, :store, :owner_role, :path_exists, :service_name, :batch_size, :apply
+
+    def legacy_scope
+      scope.where.not(status: NhsDmdImport.statuses.values_at('completed', 'failed'))
+           .where(archive_key: nil)
+           .where.not(archive_path: [nil, ''])
+    end
+
+    def process(import_run, counts)
+      return unless import_run.active?
+
+      counts[:processed_count] += 1
+      unless path_exists.call(import_run.archive_path)
+        counts[:failed_count] += 1
+        return
+      end
+      return unless apply
+
+      store.convert_legacy(import_run:, service_name:)
+      counts[:converted_count] += 1
+    rescue StandardError
+      counts[:failed_count] += 1
+    end
+  end
+end

--- a/app/services/nhs_dmd/archive_store.rb
+++ b/app/services/nhs_dmd/archive_store.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module NhsDmd
+  class ArchiveStore
+    class Error < StandardError; end
+
+    Reference = Data.define(:service_name, :key, :checksum, :byte_size)
+
+    def initialize(service_registry: ActiveStorage::Blob.services)
+      @service_registry = service_registry
+    end
+
+    def persist(import_run:, uploaded_file:, service_name: Rails.configuration.active_storage.service)
+      path = upload_path(uploaded_file)
+      reference = build_reference(path, service_name)
+      service = fetch_service(service_name)
+      upload_and_verify(service, path, reference)
+      attach_reference(import_run, reference)
+      reference
+    rescue StandardError
+      service&.delete(reference.key) if service && reference
+      raise Error, 'archive_persistence_failed'
+    end
+
+    def open(import_run)
+      if import_run.archive_reference?
+        service = fetch_service(import_run.archive_service_name)
+        service.open(import_run.archive_key, checksum: import_run.archive_checksum, verify: true) do |file|
+          return yield(file.path)
+        end
+      end
+      return yield(import_run.archive_path) if import_run.legacy_archive?
+
+      raise Error, 'archive_reference_missing'
+    rescue Error
+      raise
+    rescue StandardError
+      raise Error, 'archive_read_failed'
+    end
+
+    def cleanup(import_run)
+      raise Error, 'archive_not_terminal' if import_run.active?
+
+      fetch_service(import_run.archive_service_name).delete(import_run.archive_key) if import_run.archive_reference?
+      FileUtils.rm_f(import_run.archive_path) if import_run.legacy_archive?
+      import_run.update!(
+        archive_service_name: nil,
+        archive_key: nil,
+        archive_checksum: nil,
+        archive_byte_size: nil,
+        archive_path: nil
+      )
+    rescue Error
+      raise
+    rescue StandardError
+      raise Error, 'archive_cleanup_failed'
+    end
+
+    def convert_legacy(import_run:, service_name: Rails.configuration.active_storage.service)
+      raise Error, 'legacy_archive_missing' unless import_run.active? && import_run.legacy_archive?
+
+      legacy_path = import_run.archive_path
+      reference = persist(import_run:, uploaded_file: legacy_path, service_name:)
+      FileUtils.rm_f(legacy_path)
+      reference
+    end
+
+    private
+
+    attr_reader :service_registry
+
+    def fetch_service(service_name)
+      service_registry.fetch(service_name.to_sym)
+    rescue KeyError
+      raise Error, 'archive_service_unavailable'
+    end
+
+    def upload_path(uploaded_file)
+      path = uploaded_file.respond_to?(:path) ? uploaded_file.path : uploaded_file.to_s
+      raise Error, 'archive_missing' if path.blank? || !File.file?(path)
+
+      path
+    end
+
+    def build_reference(path, service_name)
+      Reference.new(
+        service_name: service_name.to_s,
+        key: "nhs-dmd/imports/#{SecureRandom.uuid}",
+        checksum: Digest::MD5.file(path).base64digest,
+        byte_size: File.size(path)
+      )
+    end
+
+    def upload_and_verify(service, path, reference)
+      File.open(path, 'rb') { service.upload(reference.key, it, checksum: reference.checksum) }
+      service.open(reference.key, checksum: reference.checksum, verify: true) { it.read(1) }
+    end
+
+    def attach_reference(import_run, reference)
+      import_run.update!(
+        archive_service_name: reference.service_name,
+        archive_key: reference.key,
+        archive_checksum: reference.checksum,
+        archive_byte_size: reference.byte_size,
+        archive_path: nil
+      )
+    end
+  end
+end

--- a/app/services/nhs_dmd/archive_store.rb
+++ b/app/services/nhs_dmd/archive_store.rb
@@ -23,19 +23,16 @@ module NhsDmd
     end
 
     def open(import_run)
-      if import_run.archive_reference?
-        service = fetch_service(import_run.archive_service_name)
-        service.open(import_run.archive_key, checksum: import_run.archive_checksum, verify: true) do |file|
-          return yield(file.path)
-        end
+      value = nil
+      consumer_error = nil
+      read_archive(import_run) do |archive_path|
+        value = yield(archive_path)
+      rescue StandardError => e
+        consumer_error = e
       end
-      return yield(import_run.archive_path) if import_run.legacy_archive?
+      raise consumer_error if consumer_error
 
-      raise Error, 'archive_reference_missing'
-    rescue Error
-      raise
-    rescue StandardError
-      raise Error, 'archive_read_failed'
+      value
     end
 
     def cleanup(import_run)
@@ -69,9 +66,25 @@ module NhsDmd
 
     attr_reader :service_registry
 
+    def read_archive(import_run)
+      if import_run.archive_reference?
+        service = fetch_service(import_run.archive_service_name)
+        service.open(import_run.archive_key, checksum: import_run.archive_checksum, verify: true) do |file|
+          return yield(file.path)
+        end
+      end
+      return yield(import_run.archive_path) if import_run.legacy_archive?
+
+      raise Error, 'archive_reference_missing'
+    rescue Error
+      raise
+    rescue StandardError
+      raise Error, 'archive_read_failed'
+    end
+
     def fetch_service(service_name)
       service_registry.fetch(service_name.to_sym)
-    rescue KeyError
+    rescue KeyError, RuntimeError
       raise Error, 'archive_service_unavailable'
     end
 

--- a/app/services/storage/recovery_set.rb
+++ b/app/services/storage/recovery_set.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Storage
+  class RecoverySet
+    class Error < StandardError; end
+
+    Result = Data.define(:database_reference, :storage_references, :migration_phase)
+    BACKENDS = {
+      'test' => %i[disk],
+      'local' => %i[disk],
+      'persistent' => %i[disk],
+      'persistent_with_s3_mirror' => %i[disk s3],
+      's3_with_persistent_mirror' => %i[disk s3],
+      's3' => %i[s3]
+    }.freeze
+
+    def initialize(blob_scope: ActiveStorage::Blob.all, migration_run: nil, backends: nil)
+      @blob_scope = blob_scope
+      @migration_run = migration_run
+      @backends = backends
+    end
+
+    def required_backends
+      required = backends || service_names.flat_map { BACKENDS.fetch(it) }.uniq
+      required |= %i[disk s3] if migration_run && !migration_run.finalized?
+      required.sort_by { %i[disk s3].index(it) }
+    rescue KeyError
+      raise Error, 'unsupported_blob_service'
+    end
+
+    def record(database_reference:, disk_reference: nil, s3_reference: nil)
+      raise Error, 'database_recovery_reference_required' if database_reference.blank?
+
+      references = {}
+      required_backends.each do |backend|
+        reference = backend == :disk ? disk_reference : s3_reference
+        raise Error, "#{backend}_recovery_reference_required" if reference.blank?
+
+        references[backend] = reference
+      end
+      Result.new(
+        database_reference:,
+        storage_references: references,
+        migration_phase: migration_run&.phase
+      )
+    end
+
+    private
+
+    attr_reader :blob_scope, :migration_run, :backends
+
+    def service_names
+      blob_scope.distinct.pluck(:service_name)
+    end
+  end
+end

--- a/app/services/storage/restore_verifier.rb
+++ b/app/services/storage/restore_verifier.rb
@@ -37,7 +37,7 @@ module Storage
         attachment_id: attachment.id,
         blob_id: blob.id,
         byte_size: blob.byte_size,
-        required_backends: RecoverySet.new(blob_scope: ActiveStorage::Blob.where(id: blob.id)).required_backends,
+        required_backends: RecoverySet.new.required_backends,
         **access
       )
     rescue ActiveStorage::IntegrityError, ActiveStorage::FileNotFoundError
@@ -60,13 +60,17 @@ module Storage
     end
 
     def verify_stored_object!(blob)
-      service = service_registry.fetch(blob.service_name.to_sym)
+      service = fetch_service(blob.service_name)
       unless service.exist?(blob.key)
         raise VerificationError, 'The restored attachment record exists but its stored object is missing'
       end
 
       service.open(blob.key, checksum: blob.checksum, verify: true) { it.read(1) }
-    rescue KeyError
+    end
+
+    def fetch_service(service_name)
+      service_registry.fetch(service_name.to_sym)
+    rescue KeyError, RuntimeError
       raise VerificationError, 'The restored blob service is unavailable'
     end
 

--- a/app/services/storage/restore_verifier.rb
+++ b/app/services/storage/restore_verifier.rb
@@ -4,33 +4,49 @@ module Storage
   class RestoreVerifier
     class VerificationError < StandardError; end
 
-    Result = Data.define(:attachment_id, :blob_id, :byte_size)
+    Result = Data.define(
+      :attachment_id,
+      :blob_id,
+      :byte_size,
+      :required_backends,
+      :authorized_retrieval,
+      :cross_household_denied
+    )
 
-    def self.call(attachment_id: nil)
-      new(attachment_id: attachment_id).call
+    def self.call(attachment_id: nil, **)
+      new(attachment_id:, **).call
     end
 
-    def initialize(attachment_id: nil)
+    def initialize(
+      attachment_id: nil,
+      service_registry: ActiveStorage::Blob.services,
+      access_verifier: nil
+    )
       @attachment_id = attachment_id
+      @service_registry = service_registry
+      @access_verifier = access_verifier
     end
 
     def call
       attachment = restored_attachment
       blob = attachment.blob
       verify_stored_object!(blob)
+      access = verify_access!(attachment)
 
       Result.new(
         attachment_id: attachment.id,
         blob_id: blob.id,
-        byte_size: blob.byte_size
+        byte_size: blob.byte_size,
+        required_backends: RecoverySet.new(blob_scope: ActiveStorage::Blob.where(id: blob.id)).required_backends,
+        **access
       )
-    rescue ActiveStorage::IntegrityError
+    rescue ActiveStorage::IntegrityError, ActiveStorage::FileNotFoundError
       raise VerificationError, 'The restored object checksum does not match its database record'
     end
 
     private
 
-    attr_reader :attachment_id
+    attr_reader :attachment_id, :service_registry, :access_verifier
 
     def restored_attachment
       attachment = if attachment_id.present?
@@ -44,11 +60,24 @@ module Storage
     end
 
     def verify_stored_object!(blob)
-      unless blob.service.exist?(blob.key)
+      service = service_registry.fetch(blob.service_name.to_sym)
+      unless service.exist?(blob.key)
         raise VerificationError, 'The restored attachment record exists but its stored object is missing'
       end
 
-      blob.open { |file| file.read(1) }
+      service.open(blob.key, checksum: blob.checksum, verify: true) { it.read(1) }
+    rescue KeyError
+      raise VerificationError, 'The restored blob service is unavailable'
+    end
+
+    def verify_access!(attachment)
+      return { authorized_retrieval: nil, cross_household_denied: nil } unless access_verifier
+
+      evidence = access_verifier.call(attachment:)
+      raise VerificationError, 'authorized_retrieval_failed' unless evidence[:authorized_retrieval] == true
+      raise VerificationError, 'cross_household_denial_failed' unless evidence[:cross_household_denied] == true
+
+      evidence.slice(:authorized_retrieval, :cross_household_denied)
     end
   end
 end

--- a/app/services/storage_migration/backfill.rb
+++ b/app/services/storage_migration/backfill.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module StorageMigration
+  class Backfill
+    Result = Data.define(
+      :run_id,
+      :source_service_name,
+      :destination_service_name,
+      :phase,
+      :processed_count,
+      :verified_count,
+      :failed_count
+    ) do
+      def successful?
+        failed_count.zero?
+      end
+    end
+
+    DIRECTIONS = {
+      %i[persistent s3] => :persistent_with_s3_mirror,
+      %i[s3 persistent] => :s3_with_persistent_mirror
+    }.freeze
+    DEFAULT_BATCH_SIZE = 100
+
+    def initialize(source_service_name:, destination_service_name:, **options)
+      @source_service_name = source_service_name.to_sym
+      @destination_service_name = destination_service_name.to_sym
+      @blob_scope = options.fetch(:blob_scope, ActiveStorage::Blob.all)
+      @service_registry = options.fetch(:service_registry, ActiveStorage::Blob.services)
+      @batch_size = Integer(options.fetch(:batch_size, DEFAULT_BATCH_SIZE))
+      @run_id = options.fetch(:run_id, SecureRandom.uuid)
+      @copy_missing = options.fetch(:copy_missing, true)
+      validate!
+    end
+
+    def call
+      counts = { processed_count: 0, verified_count: 0, failed_count: 0 }
+      blob_scope.find_in_batches(batch_size:) do |blobs|
+        blobs.each { process(it, counts) }
+      end
+      result = Result.new(
+        run_id:,
+        source_service_name:,
+        destination_service_name:,
+        phase: DIRECTIONS.fetch(direction),
+        **counts
+      )
+      emit(result)
+      result
+    end
+
+    private
+
+    attr_reader :source_service_name, :destination_service_name, :blob_scope, :service_registry,
+                :batch_size, :run_id, :copy_missing
+
+    def validate!
+      raise ArgumentError, 'unsupported storage migration direction' unless DIRECTIONS.key?(direction)
+      raise ArgumentError, 'batch_size must be positive' unless batch_size.positive?
+
+      source_service
+      destination_service
+    end
+
+    def direction
+      [source_service_name, destination_service_name]
+    end
+
+    def source_service
+      service_registry.fetch(source_service_name)
+    end
+
+    def destination_service
+      service_registry.fetch(destination_service_name)
+    end
+
+    def process(blob, counts)
+      counts[:processed_count] += 1
+      if destination_service.exist?(blob.key)
+        verify(blob, destination_service)
+      elsif copy_missing
+        copy(blob)
+        verify(blob, destination_service)
+      else
+        raise ActiveStorage::FileNotFoundError
+      end
+      counts[:verified_count] += 1
+    rescue StandardError
+      counts[:failed_count] += 1
+    end
+
+    def copy(blob)
+      source_service.open(blob.key, checksum: blob.checksum, verify: true) do |source_file|
+        destination_service.upload(blob.key, source_file, checksum: blob.checksum)
+      end
+    end
+
+    def verify(blob, service)
+      service.open(blob.key, checksum: blob.checksum, verify: true) { |file| file.read(1) }
+    end
+
+    def emit(result)
+      Observability::StorageEvent.migration(
+        service: DIRECTIONS.fetch(direction),
+        outcome: result.successful? ? :success : :failure,
+        reason: result.successful? ? :completed : :failed,
+        counts: result.to_h.slice(:processed_count, :verified_count, :failed_count)
+      )
+    end
+  end
+end

--- a/app/services/storage_migration/command.rb
+++ b/app/services/storage_migration/command.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module StorageMigration
+  class Command
+    class InputError < StandardError; end
+
+    ACTIONS = %w[
+      start resume reconcile cutover_eligibility cutover rollback finalize retirement_eligibility
+    ].freeze
+    APPLY_CONFIRMATION = {
+      %w[persistent s3] => 'persistent-to-s3',
+      %w[s3 persistent] => 's3-to-persistent'
+    }.freeze
+    SOURCE_PHASE = {
+      %w[persistent s3] => 'persistent_with_s3_mirror',
+      %w[s3 persistent] => 's3_with_persistent_mirror'
+    }.freeze
+    DESTINATION_PHASE = {
+      %w[persistent s3] => 's3_with_persistent_mirror',
+      %w[s3 persistent] => 'persistent_with_s3_mirror'
+    }.freeze
+
+    def initialize(
+      environment: ENV,
+      output: $stdout,
+      error: $stderr,
+      owner_role: -> { ActiveRecord::Base.connection.select_value('SELECT current_user') == 'med_tracker_owner' }
+    )
+      @environment = environment
+      @output = output
+      @error = error
+      @owner_role = owner_role
+    end
+
+    def call
+      raise SecurityError unless owner_role.call
+
+      action = fetch('STORAGE_MIGRATION_ACTION')
+      raise InputError, 'invalid_action' unless ACTIONS.include?(action)
+
+      payload, status = action == 'start' ? start : continue(action)
+      write(output, payload.merge(outcome: status.zero? ? 'passed' : 'blocked', action:))
+      status
+    rescue SecurityError
+      failure('owner_role_required', 3)
+    rescue InputError, KeyError, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+      failure(input_failure_code(e), 2)
+    end
+
+    private
+
+    attr_reader :environment, :output, :error, :owner_role
+
+    def start
+      source, destination = direction_inputs
+      validate_phase!(SOURCE_PHASE.fetch([source, destination]))
+      ensure_confirmation!(source, destination)
+      run_id = SecureRandom.uuid
+      run = if apply?
+              StorageMigrationRun.create!(source_service_name: source, destination_service_name: destination,
+                                          run_id:)
+            end
+      migration = backfill(source:, destination:, run_id:, copy_missing: apply?)
+      run&.update!(migration_counts(migration))
+      [migration_payload(migration, run_id:), migration.successful? ? 0 : 1]
+    end
+
+    def continue(action)
+      run = StorageMigrationRun.find_by!(run_id: fetch('STORAGE_MIGRATION_RUN_ID'))
+      source, destination = direction_inputs
+      raise InputError, 'migration_direction_mismatch' unless run_direction(run) == [source, destination]
+
+      validate_action_phase!(action, source, destination)
+      ensure_confirmation!(source, destination) if mutating_action?(action)
+      return resume(run) if action == 'resume'
+
+      lifecycle_result(action, run)
+    end
+
+    def resume(run)
+      migration = backfill(
+        source: run.source_service_name,
+        destination: run.destination_service_name,
+        run_id: run.run_id,
+        copy_missing: apply?
+      )
+      run.update!(migration_counts(migration)) if apply?
+      [migration_payload(migration, run_id: run.run_id), migration.successful? ? 0 : 1]
+    end
+
+    def lifecycle_result(action, run)
+      lifecycle = Lifecycle.new(run:, owner_role: -> { true })
+      operation = send("run_#{action}", lifecycle)
+      [lifecycle_payload(operation), operation.eligible ? 0 : 1]
+    end
+
+    def run_reconcile(lifecycle)
+      lifecycle.reconcile(
+        apply: apply?,
+        mutations_quiesced: enabled?('STORAGE_MIGRATION_MUTATIONS_QUIESCED'),
+        mirror_queue_drained: enabled?('STORAGE_MIGRATION_MIRROR_QUEUE_DRAINED')
+      )
+    end
+
+    def run_cutover_eligibility(lifecycle)
+      lifecycle.cutover
+    end
+
+    def run_cutover(lifecycle)
+      lifecycle.cutover(apply: apply?)
+    end
+
+    def run_rollback(lifecycle)
+      lifecycle.rollback(
+        apply: apply?,
+        source_verified: enabled?('STORAGE_MIGRATION_SOURCE_VERIFIED'),
+        mirror_queue_drained: enabled?('STORAGE_MIGRATION_MIRROR_QUEUE_DRAINED')
+      )
+    end
+
+    def run_finalize(lifecycle)
+      lifecycle.finalize(
+        apply: apply?,
+        acceptance_verified: enabled?('STORAGE_MIGRATION_ACCEPTANCE_VERIFIED'),
+        recovery_verified: enabled?('STORAGE_MIGRATION_RECOVERY_VERIFIED'),
+        final_reconciled: enabled?('STORAGE_MIGRATION_FINAL_RECONCILED')
+      )
+    end
+
+    def run_retirement_eligibility(lifecycle)
+      lifecycle.retirement_eligibility(
+        live_source_dependency: enabled?('STORAGE_MIGRATION_LIVE_SOURCE_DEPENDENCY')
+      )
+    end
+
+    def backfill(source:, destination:, run_id:, copy_missing:)
+      Backfill.new(
+        source_service_name: source,
+        destination_service_name: destination,
+        run_id:,
+        copy_missing:
+      ).call
+    end
+
+    def direction_inputs
+      direction = [fetch('STORAGE_MIGRATION_SOURCE'), fetch('STORAGE_MIGRATION_DESTINATION')]
+      raise InputError, 'invalid_storage_direction' unless APPLY_CONFIRMATION.key?(direction)
+
+      direction
+    end
+
+    def validate_action_phase!(action, source, destination)
+      expected = if %w[rollback finalize].include?(action)
+                   DESTINATION_PHASE.fetch([source, destination])
+                 elsif action == 'retirement_eligibility'
+                   destination
+                 else
+                   SOURCE_PHASE.fetch([source, destination])
+                 end
+      validate_phase!(expected)
+    end
+
+    def validate_phase!(expected)
+      raise InputError, 'storage_phase_mismatch' unless fetch('STORAGE_MIGRATION_PHASE') == expected
+    end
+
+    def ensure_confirmation!(source, destination)
+      return unless apply?
+      return if environment['STORAGE_MIGRATION_CONFIRM'] == APPLY_CONFIRMATION.fetch([source, destination])
+
+      raise InputError, 'confirmation_required'
+    end
+
+    def mutating_action?(action)
+      apply? && %w[cutover_eligibility retirement_eligibility].exclude?(action)
+    end
+
+    def apply?
+      enabled?('STORAGE_MIGRATION_APPLY')
+    end
+
+    def enabled?(key)
+      environment[key] == 'true'
+    end
+
+    def fetch(key)
+      environment.fetch(key).presence || raise(KeyError, key)
+    end
+
+    def run_direction(run)
+      [run.source_service_name, run.destination_service_name]
+    end
+
+    def migration_counts(migration)
+      migration.to_h.slice(:processed_count, :verified_count, :failed_count)
+    end
+
+    def migration_payload(migration, run_id:)
+      migration_counts(migration).merge(run_id:, applied: apply?,
+                                        reason: migration.successful? ? 'completed' : 'failed')
+    end
+
+    def lifecycle_payload(operation)
+      operation.to_h.slice(
+        :run_id,
+        :eligible,
+        :applied,
+        :reason,
+        :processed_count,
+        :verified_count,
+        :failed_count
+      )
+    end
+
+    def input_failure_code(error)
+      return error.message if error.is_a?(InputError)
+      return 'migration_run_not_found' if error.is_a?(ActiveRecord::RecordNotFound)
+      return 'invalid_migration_state' if error.is_a?(ActiveRecord::RecordInvalid)
+
+      'required_input_missing'
+    end
+
+    def failure(code, status)
+      write(error, outcome: 'failed', failure_code: code)
+      status
+    end
+
+    def write(io, payload)
+      io.puts(JSON.generate(payload))
+    end
+  end
+end

--- a/app/services/storage_migration/lifecycle.rb
+++ b/app/services/storage_migration/lifecycle.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+module StorageMigration
+  class Lifecycle
+    Result = Data.define(
+      :run_id,
+      :eligible,
+      :applied,
+      :reason,
+      :processed_count,
+      :verified_count,
+      :failed_count
+    )
+
+    Direction = Data.define(
+      :source,
+      :destination,
+      :source_mirror,
+      :destination_mirror
+    )
+
+    DIRECTIONS = {
+      %w[persistent s3] => Direction.new(
+        source: 'persistent',
+        destination: 's3',
+        source_mirror: 'persistent_with_s3_mirror',
+        destination_mirror: 's3_with_persistent_mirror'
+      ),
+      %w[s3 persistent] => Direction.new(
+        source: 's3',
+        destination: 'persistent',
+        source_mirror: 's3_with_persistent_mirror',
+        destination_mirror: 'persistent_with_s3_mirror'
+      )
+    }.freeze
+
+    DEFAULT_ROLLBACK_WINDOW = 24.hours
+
+    def initialize(run:, blob_scope: ActiveStorage::Blob.all, **options)
+      @run = run
+      @blob_scope = blob_scope
+      @service_registry = options.fetch(:service_registry, ActiveStorage::Blob.services)
+      @owner_role = options.fetch(:owner_role, method(:owner_role?))
+      @clock = options.fetch(:clock, -> { Time.current })
+      @after_transition = options.fetch(:after_transition, -> {})
+    end
+
+    def reconcile(mutations_quiesced:, mirror_queue_drained:, apply: false)
+      authorize!
+      gate = reconciliation_gate(mutations_quiesced:, mirror_queue_drained:)
+      return result(reason: gate) if gate
+
+      backfill = reconcile_blobs(apply:)
+      return migration_result(backfill, reason: :destination_unverified) unless backfill.successful?
+      return migration_result(backfill, eligible: true, reason: :reconciliation_ready) unless apply
+
+      record_reconciliation(backfill)
+      migration_result(backfill, eligible: true, applied: true, reason: :reconciled)
+    end
+
+    def cutover(apply: false, rollback_window: DEFAULT_ROLLBACK_WINDOW)
+      authorize!
+      gate = cutover_gate
+      return result(reason: gate) if gate
+
+      return result(eligible: true, reason: :cutover_ready) unless apply
+
+      transition(
+        expected_services: [direction.source, direction.source_mirror],
+        target_service: direction.destination_mirror,
+        attributes: { phase: :rollback_window, rollback_deadline: clock.call + rollback_window },
+        success_reason: :cutover_complete
+      )
+    end
+
+    def rollback(source_verified:, mirror_queue_drained:, apply: false)
+      authorize!
+      return result(reason: :rollback_window_required) unless run.rollback_window?
+      return result(reason: :rollback_window_expired) if rollback_window_expired?
+      return result(reason: :source_unverified) unless source_verified
+      return result(reason: :mirror_queue_pending) unless mirror_queue_drained
+      return result(eligible: true, reason: :rollback_ready) unless apply
+
+      transition(
+        expected_services: [direction.destination_mirror],
+        target_service: direction.source_mirror,
+        attributes: reset_for_backfill,
+        success_reason: :rollback_complete
+      )
+    end
+
+    def finalize(acceptance_verified:, recovery_verified:, final_reconciled:, apply: false)
+      authorize!
+      gate = finalization_gate(acceptance_verified:, recovery_verified:, final_reconciled:)
+      return result(reason: gate) if gate
+      return result(eligible: true, reason: :finalization_ready) unless apply
+
+      timestamp = clock.call
+      transition(
+        expected_services: [direction.destination_mirror],
+        target_service: direction.destination,
+        attributes: run.finalization_attributes(timestamp),
+        success_reason: :finalized
+      )
+    end
+
+    def retirement_eligibility(live_source_dependency:)
+      authorize!
+      return result(reason: :finalization_required) unless run.finalized?
+      return result(reason: :acceptance_required) unless run.acceptance_verified_at
+      return result(reason: :recovery_required) unless run.recovery_verified_at
+      return result(reason: :final_reconciliation_required) unless run.final_reconciled_at
+      return result(reason: :live_source_dependency) if live_source_dependency
+
+      result(eligible: true, reason: :source_retirement_eligible)
+    end
+
+    private
+
+    attr_reader :run, :blob_scope, :service_registry, :owner_role, :clock, :after_transition
+
+    def direction
+      DIRECTIONS.fetch([run.source_service_name, run.destination_service_name])
+    end
+
+    def authorize!
+      raise SecurityError, 'storage migration requires the owner database role' unless owner_role.call
+    end
+
+    def stable_set?
+      run.stable_blob_count == blob_scope.count &&
+        blob_scope.where.not(service_name: [direction.source, direction.source_mirror]).none?
+    end
+
+    def rollback_window_expired?
+      run.rollback_deadline && clock.call >= run.rollback_deadline
+    end
+
+    def reconciliation_gate(mutations_quiesced:, mirror_queue_drained:)
+      return :mutations_not_quiesced unless mutations_quiesced
+
+      :mirror_queue_pending unless mirror_queue_drained
+    end
+
+    def reconcile_blobs(apply:)
+      Backfill.new(
+        source_service_name: direction.source,
+        destination_service_name: direction.destination,
+        blob_scope:,
+        service_registry:,
+        run_id: run.run_id,
+        copy_missing: apply
+      ).call
+    end
+
+    def record_reconciliation(backfill)
+      run.update!(
+        phase: :reconciled,
+        processed_count: backfill.processed_count,
+        verified_count: backfill.verified_count,
+        failed_count: backfill.failed_count,
+        stable_blob_count: blob_scope.count,
+        reconciled_at: clock.call,
+        mirror_queue_drained_at: clock.call
+      )
+    end
+
+    def cutover_gate
+      return :reconciliation_required unless run.reconciled?
+      return :mirror_queue_pending unless run.mirror_queue_drained_at
+
+      :stable_set_changed unless stable_set?
+    end
+
+    def finalization_gate(acceptance_verified:, recovery_verified:, final_reconciled:)
+      return :rollback_window_required unless run.rollback_window?
+      return :rollback_window_open unless rollback_window_expired?
+      return :acceptance_required unless acceptance_verified
+      return :recovery_required unless recovery_verified
+
+      :final_reconciliation_required unless final_reconciled
+    end
+
+    def transition(expected_services:, target_service:, attributes:, success_reason:)
+      applied = false
+      ActiveStorage::Blob.transaction do
+        records = blob_scope.lock.to_a
+        valid_transition = records.all? { expected_services.include?(it.service_name) }
+        raise ActiveRecord::Rollback unless valid_transition
+
+        update_services(records, target_service)
+        run.update!(attributes)
+        after_transition.call
+        applied = true
+      end
+      return result(reason: :transaction_rolled_back) unless applied
+
+      result(eligible: true, applied: true, reason: success_reason)
+    rescue StandardError
+      result(reason: :transaction_rolled_back)
+    end
+
+    def update_services(records, target_service)
+      records.each { it.update!(service_name: target_service) }
+    end
+
+    def reset_for_backfill
+      {
+        phase: :backfill,
+        stable_blob_count: nil,
+        reconciled_at: nil,
+        mirror_queue_drained_at: nil,
+        rollback_deadline: nil
+      }
+    end
+
+    def migration_result(backfill, reason:, eligible: false, applied: false)
+      result(
+        eligible:,
+        applied:,
+        reason:,
+        processed_count: backfill.processed_count,
+        verified_count: backfill.verified_count,
+        failed_count: backfill.failed_count
+      )
+    end
+
+    def result(reason:, **)
+      Result.new(run_id: run.run_id,
+                 eligible: false,
+                 applied: false,
+                 reason:,
+                 processed_count: run.processed_count,
+                 verified_count: run.verified_count,
+                 failed_count: run.failed_count, **)
+    end
+
+    def owner_role?
+      ActiveRecord::Base.connection.select_value('SELECT current_user') == 'med_tracker_owner'
+    end
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   storage = ProductionStorage.resolve
   config.active_storage.service = storage.service
+  config.after_initialize do
+    Observability::StorageEvent.configuration(service: storage.service)
+  end
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,5 +7,5 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   passw passphrase email secret token _key crypt salt certificate otp ssn cvv cvc q query search
-  authorization_code id_token access_token refresh_token device_token bundle payload ciphertext backup
+  authorization_code id_token access_token refresh_token device_token bundle payload ciphertext backup checksum
 ]

--- a/config/observability/signal_registry.yml
+++ b/config/observability/signal_registry.yml
@@ -145,6 +145,13 @@ introduced_signal_paths:
     failure_policy: log_and_trace_emission_are_fail_open_and_metric_failure_emits_a_bounded_diagnostic
     owner: platform_observability
     verification: deployed_canary_unit_final_image_and_production_acceptance_contracts
+  - type: storage_stage_adapter
+    source: lib/observability/storage_event.rb
+    operational_sink: canonical_operational_event_publisher
+    privacy_classification: fixed_storage_modes_phases_and_aggregate_counts_only
+    failure_policy: fail_open_through_the_operational_publisher
+    owner: platform_storage
+    verification: storage_event_and_privacy_contract_specs
   - type: bounded_metric_label_mapper
     source: lib/observability/metric_labels.rb
     operational_sink: opentelemetry_metrics

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,29 +10,21 @@ persistent:
   service: Disk
   root: <%= ENV.fetch("ACTIVE_STORAGE_ROOT", "/app/storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+s3:
+  service: S3
+  endpoint: <%= ENV["ACTIVE_STORAGE_S3_ENDPOINT"] %>
+  bucket: <%= ENV["ACTIVE_STORAGE_S3_BUCKET"] %>
+  region: <%= ENV["ACTIVE_STORAGE_S3_REGION"] %>
+  access_key_id: <%= ENV["ACTIVE_STORAGE_S3_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY"] %>
+  force_path_style: <%= ENV.fetch("ACTIVE_STORAGE_S3_FORCE_PATH_STYLE", "true") == "true" %>
 
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
+persistent_with_s3_mirror:
+  service: Mirror
+  primary: persistent
+  mirrors: [ s3 ]
 
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+s3_with_persistent_mirror:
+  service: Mirror
+  primary: s3
+  mirrors: [ persistent ]

--- a/db/migrate/20260802070000_create_storage_migration_runs.rb
+++ b/db/migrate/20260802070000_create_storage_migration_runs.rb
@@ -1,0 +1,24 @@
+class CreateStorageMigrationRuns < ActiveRecord::Migration[8.1]
+  def change
+    create_table :storage_migration_runs do |t|
+      t.uuid :run_id, null: false, default: -> { 'gen_random_uuid()' }
+      t.string :source_service_name, null: false
+      t.string :destination_service_name, null: false
+      t.string :phase, null: false, default: 'backfill'
+      t.bigint :processed_count, null: false, default: 0
+      t.bigint :verified_count, null: false, default: 0
+      t.bigint :failed_count, null: false, default: 0
+      t.bigint :stable_blob_count
+      t.datetime :reconciled_at
+      t.datetime :mirror_queue_drained_at
+      t.datetime :rollback_deadline
+      t.datetime :acceptance_verified_at
+      t.datetime :recovery_verified_at
+      t.datetime :final_reconciled_at
+      t.datetime :finalized_at
+      t.timestamps
+    end
+
+    add_index :storage_migration_runs, :run_id, unique: true
+  end
+end

--- a/db/migrate/20260802071000_add_durable_archive_reference_to_nhs_dmd_imports.rb
+++ b/db/migrate/20260802071000_add_durable_archive_reference_to_nhs_dmd_imports.rb
@@ -1,0 +1,10 @@
+class AddDurableArchiveReferenceToNhsDmdImports < ActiveRecord::Migration[8.1]
+  def change
+    change_table :nhs_dmd_imports, bulk: true do |t|
+      t.string :archive_service_name
+      t.string :archive_key
+      t.string :archive_checksum
+      t.bigint :archive_byte_size
+    end
+  end
+end

--- a/docs/adrs/0008-production-upload-storage.md
+++ b/docs/adrs/0008-production-upload-storage.md
@@ -2,63 +2,97 @@
 
 - Status: Accepted
 - Date: 2026-07-10
+- Amended: 2026-08-02
 
 ## Context
 
-Active Storage previously selected the development-oriented `local` service in
-production. Docker Compose happened to mount a named volume at `/app/storage`,
-while the hosted Kubernetes deployment used a 5 Gi Longhorn `ReadWriteOnce`
-claim. Rails did not distinguish that durable mount from the writable directory
-inside an application image, so a missing mount could silently accept uploads
-that disappeared with the pod.
+The original decision made production Disk storage fail closed. A real durable
+mount at `/app/storage`, a single web replica, a `ReadWriteOnce` claim, and a
+`Recreate` rollout prevented uploads from silently landing in an ephemeral
+container filesystem. Those constraints remain valid for Disk deployments.
 
-The hosted deployment already has one web replica, uses the `Recreate` strategy,
-and cannot mount its `ReadWriteOnce` claim from multiple nodes. That topology is
-deliberately single-node.
+MedTracker must also support customers that select S3-compatible object storage
+and must not make S3 a requirement for customers that continue to use Disk.
+Operators need a verified migration in either direction without rewriting
+logical blob keys, weakening attachment authorization, or assuming that a
+retired source is still current.
 
 ## Decision
 
-Production uses the `persistent` Active Storage disk service rooted at
-`ACTIVE_STORAGE_ROOT`, which defaults to `/app/storage`.
-`ACTIVE_STORAGE_SERVICE` may select only `persistent`. At runtime the application
-verifies that the root is absolute, exists, is writable, and is listed as a mount
-point by the Linux kernel. Production boot fails when any check fails. Asset
-compilation with `SECRET_KEY_BASE_DUMMY=1` skips only the runtime mount check.
+Production explicitly selects one of four Active Storage services:
 
-The deployment contract is:
+1. `persistent`: Disk-only steady state.
+2. `persistent_with_s3_mirror`: Disk-readable migration state.
+3. `s3_with_persistent_mirror`: S3-readable migration or rollback state.
+4. `s3`: S3-only steady state.
 
-- one web replica;
-- a `ReadWriteOnce` persistent volume;
-- `Recreate` deployment strategy;
-- coordinated backups of PostgreSQL Active Storage records and `/app/storage`;
-- encrypted off-cluster retention and regular isolated restore tests.
+Disk-inclusive modes retain the original fail-closed `ACTIVE_STORAGE_ROOT`
+checks. S3-inclusive modes require endpoint, bucket, region, access key, and
+secret key configuration. `persistent` remains the default, so a customer can
+run or upgrade MedTracker without S3 settings.
 
-Horizontal web scaling is not supported by this storage contract. Scaling web
-replicas requires either an RWX storage service with demonstrated cross-node
-semantics or a migration to object storage before replicas are increased.
+### Topology constraints
 
-## Rejected Alternative: Object Storage
+A Disk-only deployment may use the existing `ReadWriteOnce` and `Recreate`
+single-pod topology. Every process that performs storage work must see the same
+durable root. Horizontal web scaling is not supported by that topology unless
+the operator separately proves suitable shared-filesystem semantics.
 
-Object storage is a strong future choice for portable, horizontally scaled
-deployments, but adopting it now would add an S3 provider dependency, secrets,
-bucket lifecycle policy, and a live blob migration while the deployed topology
-remains single-replica. That operational expansion is not needed to make the
-current Longhorn-backed service durable and fail closed.
+S3-only deployments do not mount `/app/storage`; independently scheduled web
+and worker pods are permitted because the durable object service is shared.
+Selecting S3 does not itself require a web/worker split.
 
-Object storage remains the preferred migration path when horizontal scaling or
-cross-cluster portability becomes a requirement. Rails mirror services can be
-used during that migration, followed by a verified copy and service cutover.
+### Symmetric migration
+
+Disk to S3 uses `persistent` → `persistent_with_s3_mirror` →
+`s3_with_persistent_mirror` → `s3`. S3 to Disk uses the same states in reverse.
+Backfill copies by logical key, verifies recorded checksums, tolerates valid
+existing destinations, and resumes safely. Cutover requires quiesced storage
+mutations, drained mirror work, and a stable fully verified blob set. Blob
+service identities change in one database transaction.
+
+During the rollback window, writes continue to both services. An in-window rollback
+returns to the source-primary mirror state. After finalization,
+returning to the former backend is a new migration with a newly provisioned and
+fully reconciled destination; it is not rollback.
+
+Source retirement is optional and is never performed by the application. It is
+eligible only after the rollback window, acceptance, recovery proof, final
+reconciliation, and explicit operator sign-off.
+
+### Recovery
+
+Every recovery point coordinates PostgreSQL with the backends required by live
+blob service identities and the active migration phase:
+
+- Disk-only: database plus Disk recovery reference.
+- S3-only: database plus S3 recovery reference.
+- Mirror or rollback window: database plus both storage references.
+
+The existing 35-daily and 12-monthly retention objectives continue to apply.
+Every accepted recovery point must pass an isolated restore, integrity check,
+authorized retrieval, and cross-household denial check.
+
+## Rejected alternatives
+
+Making object storage mandatory would add infrastructure and credential
+requirements for customers whose durable Disk topology is sufficient. Keeping
+separate one-way migration implementations would duplicate verification,
+rollback, and privacy behavior. Copying the Disk directory directly would copy
+physical sharding rather than the Active Storage logical service contract.
 
 ## Consequences
 
-Uploads cannot be accepted when the production volume is absent or mounted at
-the wrong path. Compose, Kamal, and hosted Kubernetes must all mount the same
-root. Operators must back up the database and blob volume as one recovery set.
-Deployments remain single-replica until the storage decision changes.
+Operators choose and provision a supported backend explicitly. Disk remains a
+supported steady state. S3 enables storage-independent scheduling but adds
+provider-owned durability, access-policy, lifecycle, and recovery duties.
+Migration phases protect both backends and require maintenance gates. No
+deployment may delete a source merely because application finalization passed.
 
-## Related Documents
+## Related documents
 
 - `docs/operations/upload-storage-backup-and-restore.md`
+- `docs/operations/home-ops-portable-storage-handoff.md`
 - `config/storage.yml`
 - `config/environments/production.rb`
-- GitHub issue #1551
+- GitHub issues #1551 and #1774

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,9 @@ or unredacted logs publicly.
   stable operation IDs, and audience/resource tags when extending the OpenAPI contract.
 - [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
 - [External Integration Architecture](adrs/0010-external-integration-architecture.md): choose `/api/v1`, `/mcp`, or SMART on FHIR by client audience.
-- [Production Upload Storage](adrs/0008-production-upload-storage.md): understand the single-node persistent-volume decision and scaling boundary.
-- [Upload Storage Backup and Restore](operations/upload-storage-backup-and-restore.md): back up and verify database records with stored blobs.
+- [Production Upload Storage](adrs/0008-production-upload-storage.md): understand optional Disk and S3 modes, topology, and migration boundaries.
+- [Upload Storage Backup and Restore](operations/upload-storage-backup-and-restore.md): record and verify backend-aware recovery sets.
+- [Home-Ops Portable Storage Handoff](operations/home-ops-portable-storage-handoff.md): apply the deployment inputs and maintenance gates safely.
 - [Pre-0.5 database upgrade](pre-0-5-database-upgrade.md): bootstrap existing PostgreSQL databases before the household/RLS cutover.
 
 ---

--- a/docs/operations/home-ops-portable-storage-handoff.md
+++ b/docs/operations/home-ops-portable-storage-handoff.md
@@ -1,0 +1,77 @@
+# Home-Ops Portable Storage Handoff
+
+This handoff is bounded to deployment inputs and maintenance gates for the
+portable-storage application contract. It does not authorize a production
+migration, volume removal, web/worker split, or source deletion.
+
+## Supported deployment choices
+
+### Disk-only deployment
+
+Set `ACTIVE_STORAGE_SERVICE=persistent`. Mount a writable durable volume at
+`ACTIVE_STORAGE_ROOT` in every process that performs storage work. The existing
+Longhorn `ReadWriteOnce`, one-pod, `Recreate` topology remains supported. Do not
+add S3 settings.
+
+### S3-only deployment
+
+Set `ACTIVE_STORAGE_SERVICE=s3`. Do not mount `/app/storage` in the application
+or worker. Supply the endpoint, bucket, region, access key id, secret access
+key, and path-style setting through the existing secret-delivery mechanism.
+Grant least privilege for object read, write, delete, list, and multipart
+operations in the isolated MedTracker bucket; do not grant cluster-wide object
+administration.
+
+Canary and production MUST use separate buckets, credentials, Disk volumes,
+backup policies, migration runs, and recovery evidence. A canary round trip is
+not authority to alter production.
+
+## Migration phases
+
+The deployment value must match the operator workflow exactly:
+
+- `persistent`: Disk steady state.
+- `persistent_with_s3_mirror`: Disk primary, S3 mirror.
+- `s3_with_persistent_mirror`: S3 primary, Disk mirror.
+- `s3`: S3 steady state.
+
+Disk to S3 advances through the list; S3 to Disk moves through it in reverse.
+Keep both storage systems available throughout either mirror phase and its
+rollback window.
+
+## Maintenance gates
+
+Before cutover, put the application in a maintenance state that stops attachment
+mutations and storage-dependent job dispatch. Drain mirror, analysis, purge,
+export-expiry, and NHS dm+d work. Then run reconciliation, cutover eligibility,
+and the dry-run cutover command. Apply only with the direction-specific
+confirmation value.
+
+The application tasks are:
+
+```fish
+task prod:storage-migration-start
+task prod:storage-migration-resume
+task prod:storage-migration-reconcile
+task prod:storage-migration-cutover-eligibility
+task prod:storage-migration-cutover
+task prod:storage-migration-rollback
+task prod:storage-migration-finalize
+task prod:storage-migration-retirement-eligibility
+```
+
+The task input includes source, destination, current phase, run id where
+applicable, explicit gate values, `APPLY=true`, and `CONFIRM=persistent-to-s3`
+or `CONFIRM=s3-to-persistent`. Omitting `APPLY=true` is a dry run.
+
+## Rollback and retirement
+
+Before the deadline, verify the source and drain mirror work, then use the
+rollback task and return the deployment to the source-primary mirror phase.
+After finalization, returning to the former backend is a new migration, not
+rollback.
+
+The application reports retirement eligibility only. Home-Ops automation MUST NOT delete
+a bucket, credential, PersistentVolumeClaim, snapshot, backup, or
+recovery history automatically. Source retirement requires a separate approved
+deployment change and explicit operator sign-off.

--- a/docs/operations/upload-storage-backup-and-restore.md
+++ b/docs/operations/upload-storage-backup-and-restore.md
@@ -1,71 +1,82 @@
 # Upload Storage Backup and Restore
 
-Production uploads use a deliberately single-node persistent disk mounted at
-`/app/storage`. Rails refuses to boot when this path is not a real mount point.
-The hosted Kubernetes contract is a Longhorn `ReadWriteOnce` claim with a
-`Recreate` deployment. Do not increase web replicas under this contract.
+Production supports durable Disk and S3-compatible storage. The selected
+backend and any active migration determine the recovery set; S3 is optional.
 
-## Recovery Set
+## Recovery set
 
-Every recoverable backup must contain both parts from the same recovery point:
+Every recovery point includes PostgreSQL, including
+`active_storage_attachments`, `active_storage_blobs`,
+`active_storage_variant_records`, and `storage_migration_runs`.
+Add storage references as follows:
 
-1. PostgreSQL, including `active_storage_attachments`,
-   `active_storage_blobs`, and `active_storage_variant_records`.
-2. Every object below `/app/storage`.
+- **Disk-only**: a coordinated snapshot or backup of `/app/storage`.
+- **S3-only**: a protected bucket recovery point; no blob-volume snapshot is
+  required.
+- **Mirror or rollback-window**: coordinated Disk and S3 recovery points.
 
-The self-service MedTracker ZIP export is not an upload backup and does not
-replace this recovery set.
+The database and required storage references must describe the same recovery
+point. A self-service MedTracker ZIP export does not replace this set.
 
-Pause writes or use storage and database snapshots whose recovery timestamps
-are coordinated. Encrypt backups in transit and at rest, keep a copy outside the
-application cluster, and restrict access to the same operators who can restore
-production health data.
+Encrypt backups in transit and at rest, retain an off-cluster copy, and restrict
+access to recovery operators. Keep at least 35 daily backups and 12 monthly backups
+for every required part. Shorter retention requires a documented risk
+and data-retention decision.
 
-The minimum retention contract is 35 daily backups and 12 monthly backups for
-both parts of the recovery set. Provider snapshot retention may exceed this,
-but shorter retention requires a documented risk decision and data-retention
-review.
+## Backup checklist
 
-## Backup Checklist
+1. Quiesce storage mutations or use coordinated point-in-time mechanisms.
+2. Record the app image, schema version, timestamp, operator, database recovery
+   reference, selected storage service, and active migration run and phase.
+3. Record `DISK_RECOVERY_REFERENCE` only when Disk is required.
+4. Record `S3_RECOVERY_REFERENCE` only when S3 is required.
+5. Confirm every required artifact is readable and has the same retention
+   label.
+6. Schedule an isolated restore. A backup is not accepted until that restore
+   passes.
 
-1. Record the app image tag, schema migration version, database recovery point,
-   persistent-volume snapshot identifier, timestamp, and operator.
-2. Create the PostgreSQL backup and Longhorn volume snapshot at a coordinated
-   recovery point.
-3. Copy or replicate both encrypted backups off cluster.
-4. Confirm both artifacts are readable and covered by the same retention label.
-5. Schedule the isolated restore test; a snapshot is not verified until it has
-   been restored and checked.
+## Isolated restore
 
-## Isolated Restore
-
-1. Create an isolated database and persistent volume with no production routes.
-2. Restore PostgreSQL and `/app/storage` from the same recorded recovery set.
-3. Mount the restored volume at `/app/storage`.
-4. Run migrations with the owner-capable database role.
-5. Start the app with `ACTIVE_STORAGE_SERVICE=persistent` and
-   `ACTIVE_STORAGE_ROOT=/app/storage`.
-6. Choose a restored attachment id and run:
+1. Create an isolated database and storage destination with no production
+   routes.
+2. Restore PostgreSQL and the required Disk, S3, or dual storage set.
+3. Configure the restored service identity exactly as recorded. Mount
+   `/app/storage` only for a Disk-inclusive phase.
+4. Run migrations with `DATABASE_ROLE=med_tracker_owner`.
+5. Start the application and choose a restored attachment id.
+6. Verify authorized retrieval through the application and denial from a user
+   in another household.
+7. Run the backend-aware verifier. This Disk example intentionally omits an S3
+   reference:
 
 ```fish
-task prod:verify-storage-restore ATTACHMENT_ID=123
+task prod:verify-storage-restore \
+  ATTACHMENT_ID=123 \
+  DATABASE_RECOVERY_REFERENCE=db-snapshot-opaque \
+  DISK_RECOVERY_REFERENCE=disk-snapshot-opaque \
+  AUTHORIZED_RETRIEVAL_VERIFIED=true \
+  CROSS_HOUSEHOLD_DENIAL_VERIFIED=true
 ```
 
-The check fails if the database attachment is missing, its object key does not
-exist on the restored volume, or Active Storage detects a checksum mismatch.
-The command prints only attachment id, blob id, and byte size; it does not print
-filenames or upload contents.
+For S3-only recovery, provide `S3_RECOVERY_REFERENCE` instead. During a mirror
+or rollback phase, provide both and include `STORAGE_MIGRATION_RUN_ID`.
 
-7. Verify the attachment through its authorized household route and confirm a
-   user outside that household cannot retrieve it.
-8. Record the recovery point, attachment id, image tag, duration, tester, and
-   result. Destroy the isolated environment after evidence is retained.
+The command fails for an absent record, unavailable service, missing object,
+checksum mismatch, incomplete access evidence, wrong database role, or missing
+required recovery reference. Its JSON evidence excludes filenames, contents,
+checksums, household ids, person ids, and medication data.
 
-## Migration and Scaling
+8. Record duration, tester, command result, and deployment-level recovery
+   evidence. Destroy the isolated environment after evidence is retained.
 
-Before horizontal scaling, choose an RWX volume with tested multi-node behavior
-or migrate blobs to object storage. For object storage, configure provider
-credentials outside Git, apply bucket encryption, versioning, lifecycle, and
-access policies, copy every existing key, verify database checksums against the
-destination, and only then change the selected service. Keep the source volume
-read-only until the rollback window expires.
+## Migration recovery and source retention
+
+Protect both storage backends from the first mirror phase until finalization.
+An in-window rollback uses the recorded migration run and returns to the
+source-primary mirror service. After finalization, moving back is a future
+reverse migration with full backfill and verification.
+
+Keeping the inactive source is valid. The application never removes it.
+Retirement requires an expired rollback window, acceptance evidence, an
+isolated recovery proof, final reconciliation, no live dependency, and explicit
+deployment approval.

--- a/lib/observability/operational_event.rb
+++ b/lib/observability/operational_event.rb
@@ -23,7 +23,8 @@ module Observability
       diagnostic: 'diagnostic.occurred',
       observability_canary: 'observability.canary',
       http_request_completed: 'http.request.completed',
-      job_completed: 'job.completed'
+      job_completed: 'job.completed',
+      storage_stage: 'storage.stage'
     }.freeze
     SEVERITIES = %i[debug info warn error fatal].freeze
     OUTCOMES = %i[success failure unknown].freeze
@@ -58,7 +59,13 @@ module Observability
       notification_provider: 'medtracker.notification.provider',
       recipient_count: 'medtracker.notification.recipient_count',
       canary_kind: 'medtracker.canary.kind',
-      diagnostic_component: 'medtracker.diagnostic.component'
+      diagnostic_component: 'medtracker.diagnostic.component',
+      storage_operation: 'medtracker.storage.operation',
+      storage_backend: 'medtracker.storage.backend',
+      storage_phase: 'medtracker.storage.phase',
+      processed_count: 'medtracker.storage.processed_count',
+      verified_count: 'medtracker.storage.verified_count',
+      failed_count: 'medtracker.storage.failed_count'
     }.freeze
     EVENT_ATTRIBUTE_KEYS = {
       medication_take_attempted: %i[source_category actor_role],
@@ -77,7 +84,10 @@ module Observability
       diagnostic: %i[diagnostic_component],
       observability_canary: %i[canary_kind],
       http_request_completed: %i[http_method route status_code duration],
-      job_completed: %i[job_class job_queue duration]
+      job_completed: %i[job_class job_queue duration],
+      storage_stage: %i[
+        storage_operation storage_backend storage_phase processed_count verified_count failed_count
+      ]
     }.freeze
     CATEGORICAL_VALUES = {
       source_category: %w[schedule person_medication unknown],
@@ -95,6 +105,11 @@ module Observability
       notification_channel: %w[web_push native_push mixed none unknown],
       notification_provider: %w[web_push apns fcm unknown],
       canary_kind: %w[application_event job],
+      storage_operation: %w[configuration migration],
+      storage_backend: %w[disk s3 dual],
+      storage_phase: %w[
+        persistent persistent_with_s3_mirror s3_with_persistent_mirror s3
+      ],
       diagnostic_component: %w[
         audit_log medication_guard test_push nhs_dmd_import mcp_audit passkey_security
         opentelemetry ai_audit ai_suggestion auth_token_audit barcode_catalog external_lookup

--- a/lib/observability/operational_event_sanitizer.rb
+++ b/lib/observability/operational_event_sanitizer.rb
@@ -13,7 +13,10 @@ module Observability
       status_code: ->(value) { value.is_a?(Integer) && value.between?(100, 599) },
       duration: ->(value) { value.is_a?(Integer) && value >= 0 },
       job_class: ->(value) { value.to_s.match?(/\A[A-Z][A-Za-z0-9_:]{0,127}\z/) },
-      job_queue: ->(value) { value.to_s.match?(/\A[a-z0-9_-]{1,64}\z/) }
+      job_queue: ->(value) { value.to_s.match?(/\A[a-z0-9_-]{1,64}\z/) },
+      processed_count: ->(value) { value.is_a?(Integer) && value >= 0 },
+      verified_count: ->(value) { value.is_a?(Integer) && value >= 0 },
+      failed_count: ->(value) { value.is_a?(Integer) && value >= 0 }
     }.freeze
 
     private

--- a/lib/observability/publisher.rb
+++ b/lib/observability/publisher.rb
@@ -23,13 +23,15 @@ module Observability
       return if ActiveSupport::IsolatedExecutionState[EXECUTION_STATE_KEY]
 
       ActiveSupport::IsolatedExecutionState[EXECUTION_STATE_KEY] = true
-      CanonicalLogger.write(event)
-      event
-    rescue StandardError => e
-      emergency(error: e, event_name: event.to_h['event.name'])
-      nil
-    ensure
-      ActiveSupport::IsolatedExecutionState.delete(EXECUTION_STATE_KEY)
+      begin
+        CanonicalLogger.write(event)
+        event
+      rescue StandardError => e
+        emergency(error: e, event_name: event.to_h['event.name'])
+        nil
+      ensure
+        ActiveSupport::IsolatedExecutionState.delete(EXECUTION_STATE_KEY)
+      end
     end
 
     def emergency(error:, event_name:)

--- a/lib/observability/storage_event.rb
+++ b/lib/observability/storage_event.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Observability
+  module StorageEvent
+    BACKENDS = {
+      persistent: :disk,
+      persistent_with_s3_mirror: :dual,
+      s3_with_persistent_mirror: :dual,
+      s3: :s3
+    }.freeze
+
+    module_function
+
+    def configuration(service:)
+      emit(
+        service:,
+        event: {
+          operation: :configuration,
+          outcome: :success,
+          reason: :configured,
+          counts: { processed_count: 0, verified_count: 0, failed_count: 0 }
+        }
+      )
+    end
+
+    def migration(service:, outcome:, reason:, counts:, error: nil)
+      emit(
+        service:,
+        event: { operation: :migration, outcome:, reason:, counts:, error: }
+      )
+    end
+
+    def emit(service:, event:)
+      phase = service.to_sym
+      Publisher.emit(
+        name: :storage_stage,
+        outcome: event.fetch(:outcome),
+        severity: event.fetch(:outcome).to_sym == :failure ? :error : :info,
+        reason: event.fetch(:reason),
+        attributes: {
+          storage_operation: event.fetch(:operation),
+          storage_backend: BACKENDS.fetch(phase),
+          storage_phase: phase,
+          **event.fetch(:counts)
+        },
+        error_type: event[:error]&.class
+      )
+    end
+    private_class_method :emit
+  end
+end

--- a/lib/production_storage.rb
+++ b/lib/production_storage.rb
@@ -5,14 +5,30 @@ module ProductionStorage
 
   Configuration = Data.define(:service, :root)
 
-  SERVICE = 'persistent'
+  SERVICES = %w[
+    persistent
+    persistent_with_s3_mirror
+    s3_with_persistent_mirror
+    s3
+  ].freeze
+  DISK_SERVICES = %w[persistent persistent_with_s3_mirror s3_with_persistent_mirror].freeze
+  S3_SERVICES = %w[persistent_with_s3_mirror s3_with_persistent_mirror s3].freeze
+  S3_SETTINGS = %w[
+    ACTIVE_STORAGE_S3_ENDPOINT
+    ACTIVE_STORAGE_S3_BUCKET
+    ACTIVE_STORAGE_S3_REGION
+    ACTIVE_STORAGE_S3_ACCESS_KEY_ID
+    ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY
+  ].freeze
+  DEFAULT_SERVICE = 'persistent'
   DEFAULT_ROOT = '/app/storage'
   DEFAULT_MOUNTINFO_PATH = '/proc/self/mountinfo'
 
   def self.resolve(environment: ENV, mountinfo_path: Pathname(DEFAULT_MOUNTINFO_PATH))
     service = service_name(environment)
-    root = storage_root(environment)
-    validate_mount!(root, mountinfo_path) unless asset_compilation?(environment)
+    root = storage_root(environment) if DISK_SERVICES.include?(service)
+    validate_mount!(root, mountinfo_path) if root && !asset_compilation?(environment)
+    validate_s3!(environment) if S3_SERVICES.include?(service)
 
     Configuration.new(service: service.to_sym, root: root)
   rescue Errno::ENOENT, Errno::EACCES => e
@@ -20,14 +36,18 @@ module ProductionStorage
   end
 
   def self.service_name(environment)
-    service = environment.fetch('ACTIVE_STORAGE_SERVICE', SERVICE)
-    unless service == SERVICE
-      raise ConfigurationError, "ACTIVE_STORAGE_SERVICE must be #{SERVICE.inspect} in production"
-    end
+    service = environment.fetch('ACTIVE_STORAGE_SERVICE', DEFAULT_SERVICE)
+    return service if SERVICES.include?(service)
 
-    service
+    raise ConfigurationError, "ACTIVE_STORAGE_SERVICE must be one of #{SERVICES.join(', ')} in production"
   end
   private_class_method :service_name
+
+  def self.validate_s3!(environment)
+    missing_setting = S3_SETTINGS.find { |name| environment[name].to_s.strip.empty? }
+    raise ConfigurationError, "#{missing_setting} is required" if missing_setting
+  end
+  private_class_method :validate_s3!
 
   def self.storage_root(environment)
     root = Pathname(environment.fetch('ACTIVE_STORAGE_ROOT', DEFAULT_ROOT)).cleanpath

--- a/lib/schema_inventory.rb
+++ b/lib/schema_inventory.rb
@@ -74,6 +74,7 @@ class SchemaInventory
     oauth_grants
     platform_admins
     push_subscriptions
+    storage_migration_runs
     support_access_sessions
     users
     versions

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,14 +1,54 @@
 # frozen_string_literal: true
 
+require 'json'
+
 namespace :med_tracker do
   namespace :storage do
     desc 'Verify an attachment restored from the database and persistent storage backup'
     task verify_restore: :environment do
-      result = Storage::RestoreVerifier.call(attachment_id: ENV['ATTACHMENT_ID'].presence)
-      puts "Storage restore verified: attachment_id=#{result.attachment_id} " \
-           "blob_id=#{result.blob_id} byte_size=#{result.byte_size}"
-    rescue Storage::RestoreVerifier::VerificationError => e
-      abort "Storage restore verification failed: #{e.message}"
+      role = ActiveRecord::Base.connection.select_value('SELECT current_user')
+      raise SecurityError unless role == 'med_tracker_owner'
+
+      access_verifier = lambda do |**|
+        {
+          authorized_retrieval: ENV['AUTHORIZED_RETRIEVAL_VERIFIED'] == 'true',
+          cross_household_denied: ENV['CROSS_HOUSEHOLD_DENIAL_VERIFIED'] == 'true'
+        }
+      end
+      result = Storage::RestoreVerifier.call(
+        attachment_id: ENV['ATTACHMENT_ID'].presence,
+        access_verifier:
+      )
+      migration_run = StorageMigrationRun.find_by(run_id: ENV['STORAGE_MIGRATION_RUN_ID'].presence)
+      recovery = Storage::RecoverySet.new(
+        backends: result.required_backends,
+        migration_run:
+      ).record(
+        database_reference: ENV.fetch('DATABASE_RECOVERY_REFERENCE', nil),
+        disk_reference: ENV.fetch('DISK_RECOVERY_REFERENCE', nil),
+        s3_reference: ENV.fetch('S3_RECOVERY_REFERENCE', nil)
+      )
+      puts JSON.generate(
+        outcome: 'passed',
+        attachment_id: result.attachment_id,
+        blob_id: result.blob_id,
+        byte_size: result.byte_size,
+        required_backends: result.required_backends,
+        authorized_retrieval: result.authorized_retrieval,
+        cross_household_denied: result.cross_household_denied,
+        database_reference: recovery.database_reference,
+        storage_references: recovery.storage_references,
+        migration_phase: recovery.migration_phase
+      )
+    rescue SecurityError
+      warn JSON.generate(outcome: 'failed', failure_code: 'owner_role_required')
+      exit(1)
+    rescue Storage::RestoreVerifier::VerificationError
+      warn JSON.generate(outcome: 'failed', failure_code: 'restore_verification_failed')
+      exit(1)
+    rescue Storage::RecoverySet::Error, KeyError
+      warn JSON.generate(outcome: 'failed', failure_code: 'recovery_reference_invalid')
+      exit(1)
     end
   end
 end

--- a/lib/tasks/storage_migration.rake
+++ b/lib/tasks/storage_migration.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'json'
+
+namespace :storage do
+  desc 'Run a bounded portable-storage migration operation'
+  task migration: :environment do
+    status = StorageMigration::Command.new.call
+    exit(status) unless status.zero?
+  end
+
+  desc 'Convert or report live path-backed NHS dm+d archives'
+  task convert_nhs_dmd_archives: :environment do
+    result = NhsDmd::ArchiveMigration.new(
+      service_name: ENV.fetch('NHS_DMD_ARCHIVE_SERVICE'),
+      apply: ENV['NHS_DMD_ARCHIVE_APPLY'] == 'true'
+    ).call
+    puts JSON.generate({ outcome: result.failed_count.zero? ? 'passed' : 'failed' }.merge(result.to_h))
+    exit(1) unless result.failed_count.zero?
+  rescue SecurityError, ArgumentError, KeyError => e
+    failure_code = e.is_a?(SecurityError) ? 'owner_role_required' : 'invalid_input'
+    warn JSON.generate(outcome: 'failed', failure_code:)
+    exit(2)
+  end
+end

--- a/openspec/changes/support-portable-production-storage/.openspec.yaml
+++ b/openspec/changes/support-portable-production-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/support-portable-production-storage/design.md
+++ b/openspec/changes/support-portable-production-storage/design.md
@@ -1,0 +1,138 @@
+## Context
+
+See `proposal.md` for motivation and `specs/portable-production-storage/spec.md` for the behavior contract. ADR 0008 currently permits only the `persistent` Active Storage Disk service at `/app/storage` and couples hosted production to one mounted `ReadWriteOnce` volume. `ProductionStorage` rejects every other service and verifies that the Disk root is a writable kernel mount.
+
+Active Storage records a `service_name` on each blob. Changing only the environment default affects new blobs but neither moves existing bytes nor changes how existing records resolve their service. Rails 8.1 Mirror service writes to its primary synchronously and mirrors new uploads asynchronously; historical blobs still require an explicit backfill and integrity proof.
+
+The NHS dm+d importer also persists a pathname below the application storage directory across its request-to-job boundary. That path is process-local unless all participating processes share the same filesystem. The replacement boundary must use the configured storage service without weakening the household-scoped Active Storage attachment model for this global administrative import.
+
+The cluster provides RustFS, but that deployment detail must remain optional. The application owns backend selection, portable references, migration state, verification, and recovery contracts. Deployment repositories own mounts or buckets, identities, secret delivery, scheduling, and source retirement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat durable Disk and private S3-compatible services as supported production steady states.
+- Provide one symmetric migration mechanism for Disk-to-S3 and S3-to-Disk moves.
+- Preserve reads and writes during bounded online backfill and quiesced cutover phases.
+- Keep storage selection out of medication, attachment authorization, export, and import behavior.
+- Make migration, rollback, recovery, and retirement operator-controlled and PHI-safe.
+- Describe the deployment capability gained or constrained by each backend without imposing one topology on all operators.
+
+**Non-Goals:**
+
+- Requiring an S3-compatible service for production, development, or test.
+- Adding GCS, Azure Blob, NFS, RWX, or another storage adapter in this change.
+- Replacing Solid Queue or requiring separate web and worker deployments.
+- Automatically deleting a source backend or its recovery history.
+- Changing household export contents, NHS dm+d import semantics, or attachment authorization.
+
+## Decisions
+
+### 1. Keep Disk and S3 as explicit first-class steady modes
+
+`ProductionStorage` will accept two steady modes:
+
+- `persistent`, backed by the existing mounted durable root and retaining the current service name; and
+- `s3`, backed by an explicitly configured private S3-compatible endpoint and bucket.
+
+Disk validates its absolute, writable persistent mount and ignores absent S3 configuration. S3 validates its required non-secret inputs and credentials but does not require `/app/storage`. Neither mode detects or falls back to the other automatically. Development and test retain their existing local Disk services.
+
+The hosted deployment may choose RustFS, while another customer may remain on a mounted Disk backend indefinitely or select another compatible S3 provider.
+
+**Rejected alternatives:** making S3 the final mandatory mode would prevent simple single-process installations; silently falling back to Disk could accept uploads into an ephemeral image; automatically selecting a backend from available credentials would make boot behavior and recovery state ambiguous.
+
+### 2. Treat scheduling independence as a backend capability
+
+Disk remains valid when every process performing storage work accesses the same durable root. That can be one Puma process with embedded Solid Queue, multiple containers in one pod sharing the volume, or an operator-provided shared filesystem with separately proven semantics. The application will not claim that an RWO-backed Disk deployment supports independently scheduled pods.
+
+S3 mode removes the shared mount requirement and therefore permits independently scheduled web and worker processes. Splitting those processes remains a separate deployment decision.
+
+**Rejected alternative:** forcing a worker split as part of storage portability would increase baseline memory and make a deployment topology, rather than application behavior, mandatory.
+
+### 3. Use a symmetric four-state migration machine
+
+Define four production service states:
+
+1. `persistent`: Disk is the sole service and existing production baseline.
+2. `persistent_with_s3_mirror`: Disk is readable primary and S3 is mirror.
+3. `s3_with_persistent_mirror`: S3 is readable primary and Disk is mirror.
+4. `s3`: S3 is the sole service.
+
+Disk-to-S3 follows states 1 → 2 → 3 → 4. S3-to-Disk follows 4 → 3 → 2 → 1. An operator can enter a new reverse migration after either source was previously retired by provisioning a fresh destination and starting from the corresponding steady state. Retaining `persistent` avoids rewriting existing blob service identities merely to keep using the already-supported Disk backend.
+
+Each state is selected explicitly. Disk-inclusive states validate the mount; S3-inclusive states validate object-storage inputs. The two mirror states are normal migration states in either direction, not one-way special cases.
+
+**Rejected alternative:** separate migration implementations for each direction would duplicate reconciliation, retry, transaction, and privacy behavior and make reverse migration more likely to drift.
+
+### 4. Backfill and reconcile by logical service key
+
+A direction-neutral migration run records its opaque run id, source service, destination service, phase, and aggregate progress. It iterates live blob records using the owner-capable operational database role in bounded batches. For each blob it checks the logical key on the destination, copies from the source when absent, and opens the destination with the recorded checksum. An existing valid destination object is accepted, which makes retries idempotent.
+
+The mirror state covers new uploads during online backfill, but enqueue success is not replication proof. The cutover gate therefore:
+
+1. stops attachment mutations and storage-dependent job dispatch;
+2. drains pending mirror, analyze, and purge work;
+3. reconciles a stable live blob set;
+4. requires zero missing or corrupt destination blobs; and
+5. atomically changes that stable set to the destination-primary mirror service.
+
+If the database transaction rolls back, every blob retains its prior readable service. Destination copies remain safe and the migration can resume.
+
+**Rejected alternatives:** changing the default service alone strands existing blobs; relying only on Mirror service omits historical backfill; copying the Disk directory directly preserves Disk sharding rather than service logical keys and does not update blob service identities.
+
+### 5. Separate rollback from future migration
+
+During a cutover rollback window, writes continue to both services and rollback atomically returns the verified set to the source-primary mirror state. Finalization changes the set to the destination steady service only after the window, acceptance, recovery proof, and final reconciliation.
+
+After finalization, returning to the former backend is not described as rollback. It is a new migration with a newly validated destination, full backfill, cutover, rollback window, and recovery proof. This distinction prevents operators from assuming that retired source data is still current.
+
+Source retirement is an explicit deployment action, never an application side effect. Keeping both storage systems after finalization remains valid, although the inactive copy is not assumed current unless a new migration reconciles it.
+
+### 6. Persist queued inputs as service-neutral references
+
+The NHS dm+d request persists an opaque service name, logical key, checksum, and byte size before enqueue. A small archive-store boundary resolves that reference through the selected Active Storage service API. It does not create a household-less attachment or weaken household RLS.
+
+Existing queued path-backed imports must finish or be converted before a deployment removes their required filesystem. The same reference works with Disk or S3; only the service resolver changes.
+
+### 7. Keep operator evidence backend-aware and PHI-safe
+
+Provide bounded commands for starting or resuming migration, reconciliation, cutover eligibility, cutover, rollback, finalization, and source-retirement eligibility. Material mutations default to dry-run and require explicit source, destination, phase, and confirmation inputs. Output contains aggregate counts and opaque run ids, never filenames, contents, credentials, checksums, household ids, person ids, or medication data.
+
+Acceptance must prove Disk-only operation without S3 settings, S3-only operation without a mounted blob volume, and a canary round trip from Disk to S3 and back to Disk. This is where bidirectionality becomes deployed evidence rather than an untested configuration promise.
+
+### 8. Build recovery sets from recorded service state
+
+Recovery tooling resolves the set of services required by live blob records and the active migration phase:
+
+- Disk steady state coordinates PostgreSQL with the durable filesystem recovery point.
+- S3 steady state coordinates PostgreSQL with the protected bucket recovery point.
+- Mirror and rollback states protect both services until finalization.
+
+The isolated restore verifier resolves blobs through their recorded service, verifies integrity, and proves authorized and cross-household behavior. Existing daily and monthly retention objectives remain unchanged. Off-cluster protection and provider-specific backup mechanics remain deployment responsibilities.
+
+ADR 0008 will be amended rather than superseded: its fail-closed Disk rules remain the Disk-mode contract, while the follow-up records explicit backend selection, S3 mode, portability, and the limits of each deployment topology.
+
+## Risks / Trade-offs
+
+- **[A mirror job lags or fails before cutover]** → Drain storage queues and require stable full reconciliation rather than treating enqueue success as replication proof.
+- **[Reverse migration is treated as an untested rollback path]** → Exercise a complete Disk-to-S3-to-Disk canary round trip and use the same state machine and commands in both directions.
+- **[Blob service names continue selecting the old primary]** → Make service-name distribution an explicit invariant and change the verified set atomically.
+- **[Concurrent deletion races with backfill]** → Permit online copying but establish the final live set only while mutations and storage jobs are quiesced.
+- **[Disk mode is deployed with an inaccessible worker filesystem]** → Validate the durable root in each storage-dependent process and document that independent scheduling requires demonstrated shared access.
+- **[S3-compatible behavior differs between providers]** → Verify upload, existence, download, integrity, delete, private access, and failure behavior against the operator's actual service before cutover.
+- **[A source is assumed current after finalization]** → Distinguish in-window rollback from a future reverse migration and require a new full reconciliation.
+- **[Migration reads health-related content]** → Restrict execution to the owner-capable operator boundary and emit only aggregate PHI-safe evidence.
+- **[Recovery captures the database and wrong blob generation]** → Record backend-specific recovery references and reject the recovery point until isolated verification passes.
+
+## Migration Plan
+
+1. Add both steady modes, both mirror modes, service-neutral queued inputs, direction-neutral migration commands, and backend-aware recovery while production remains in its current Disk state.
+2. Prove the unchanged Disk-only configuration in a final production image without S3 settings.
+3. In canary, provision an isolated S3-compatible destination, select `persistent_with_s3_mirror`, backfill, reconcile, and cut over to `s3_with_persistent_mirror`.
+4. Exercise in-window rollback to Disk, repeat cutover, prove S3-only behavior without `/app/storage`, and finalize to `s3` without automatically deleting the Disk source.
+5. Provision a fresh durable Disk destination and run the full reverse path: `s3` → `s3_with_persistent_mirror` → `persistent_with_s3_mirror` → `persistent`, including a rollback exercise and isolated restore.
+6. Record the round-trip evidence and update ADR 0008 and deployment documentation. Production remains on its selected backend until an operator separately approves a migration.
+7. For any later customer migration, repeat the proven directional sequence, retain the source throughout its rollback window, and retire it only after explicit sign-off.
+
+Before finalization, rollback selects the source-primary mirror state and atomically restores source-readable service identities. After finalization, moving back uses a new migration rather than an in-place rollback.

--- a/openspec/changes/support-portable-production-storage/proposal.md
+++ b/openspec/changes/support-portable-production-storage/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Production storage is currently coupled to a Longhorn `ReadWriteOnce` volume, while the proposed S3 migration would make object storage a permanent requirement. GitHub issue [#1774](https://github.com/damacus/med-tracker/issues/1774) needs a portable storage boundary instead: operators must be able to run MedTracker with durable Disk storage or S3-compatible storage and migrate safely in either direction without changing application behavior.
+
+## What Changes
+
+- Keep durable Disk storage as a supported production configuration that does not require S3 credentials or an object-storage service.
+- Add an optional private S3-compatible production configuration suitable for independently scheduled web and background processes.
+- Introduce an idempotent, resumable migration boundary that can move live blobs from Disk to S3-compatible storage or from S3-compatible storage to Disk, verifies the destination before cutover, and retains the source through an explicit rollback window.
+- Make queued storage inputs, including NHS dm+d release archives, use service-agnostic durable blob references instead of application-local pathnames.
+- Define backup, isolated restore, privacy-safe diagnostics, and deployed acceptance contracts for either selected production backend.
+- Preserve isolated Disk services for development and test.
+- Amend ADR 0008 to describe Disk as one supported production topology and document the operational capabilities and constraints of each backend.
+
+This change does not require S3 for self-hosted or customer installations, introduce NFS or RWX storage, replace Solid Queue, or require web and background processes to be deployed separately. Independent process scheduling remains available only when the selected durable backend is reachable by both processes.
+
+## Capabilities
+
+### New Capabilities
+
+- `portable-production-storage`: Defines explicit Disk and S3-compatible production modes, bidirectional verified migration, service-agnostic queued inputs, backend-aware recovery, and safe source retirement.
+
+### Modified Capabilities
+
+None. The repository has no existing main OpenSpec capability for production blob storage.
+
+## Impact
+
+- Rails Active Storage configuration and production storage validation.
+- NHS dm+d import persistence and job execution.
+- Bidirectional migration, reconciliation, cutover, rollback, backup, restore, and production acceptance tooling.
+- ADR 0008 and self-hosted deployment documentation.
+- The `home-ops` deployment may provision private S3-compatible buckets and identities when that mode is selected, but S3 infrastructure and credentials remain optional and infrastructure edits remain outside this repo-local change.

--- a/openspec/changes/support-portable-production-storage/specs/portable-production-storage/spec.md
+++ b/openspec/changes/support-portable-production-storage/specs/portable-production-storage/spec.md
@@ -1,0 +1,177 @@
+## Purpose
+
+Defines portable production blob storage so operators can run MedTracker with durable Disk or private S3-compatible storage and migrate safely between them without changing medication or attachment behavior.
+
+## ADDED Requirements
+
+### Requirement: Production storage backend selection is explicit and portable
+The system SHALL support durable Disk and private S3-compatible storage as first-class production backends. The selected backend MUST be explicit, MUST validate its own required configuration, and MUST NOT require configuration for an unselected backend or silently fall back to another backend.
+
+#### Scenario: Customer runs production without S3
+- **GIVEN** production explicitly selects durable Disk storage and provides a valid writable persistent root
+- **WHEN** the application and its storage-dependent jobs boot without S3 endpoint or credential settings
+- **THEN** they use Disk storage successfully without contacting or requiring an S3-compatible service
+
+#### Scenario: Customer runs production without a mounted blob volume
+- **GIVEN** production explicitly selects private S3-compatible storage and provides valid endpoint, bucket, region, and credentials
+- **WHEN** the application and its storage-dependent jobs boot without a persistent blob mount
+- **THEN** they use the selected S3-compatible service successfully
+
+#### Scenario: Selected backend configuration is invalid
+- **GIVEN** the selected production backend is missing a required setting or cannot access its declared durable storage
+- **WHEN** production storage configuration is validated
+- **THEN** startup fails closed without exposing credentials or selecting an undeclared fallback
+
+### Requirement: Supported backends preserve application and privacy behavior
+Medication, attachment, export, and import behavior SHALL be independent of the selected production storage backend. Storage access MUST preserve household authorization and MUST expose private blobs only through authorized application behavior or short-lived private service access. Configuration, migration output, logs, traces, and metrics MUST NOT disclose credentials, object contents, original filenames, medication data, or person data.
+
+#### Scenario: Authorized attachment access is backend-independent
+- **GIVEN** an authenticated account is authorized to access a household attachment stored on either supported backend
+- **WHEN** the account requests the attachment
+- **THEN** the system returns the same authorized content without exposing the underlying storage location publicly
+
+#### Scenario: Cross-household access is denied
+- **GIVEN** an account is not authorized for the household that owns an attachment
+- **WHEN** the account attempts to retrieve that attachment from either supported backend
+- **THEN** access is denied without revealing whether the underlying blob exists
+
+#### Scenario: Storage failure is reported safely
+- **GIVEN** the selected backend cannot complete an upload, download, verification, or deletion
+- **WHEN** the operation fails
+- **THEN** diagnostics identify the operation and backend mode without disclosing protected content, filenames, credentials, checksums, household identifiers, or person identifiers
+
+### Requirement: Queued storage inputs use durable service references
+Every production job input that must survive beyond its originating request SHALL be persisted through the selected durable storage service before enqueue and referenced by opaque service identity and logical key rather than an application-local pathname. Storage-dependent jobs MUST work when every participating process can access the selected backend.
+
+#### Scenario: NHS dm+d import crosses the request-job boundary
+- **GIVEN** an authorized administrator submits a valid NHS dm+d release archive
+- **WHEN** the import job is enqueued
+- **THEN** the verified archive is represented by an opaque durable service reference rather than a process-local pathname
+
+#### Scenario: Disk-backed worker accesses the declared durable root
+- **GIVEN** production selects Disk and every process that performs storage work has access to the same declared durable root
+- **WHEN** a storage-dependent job runs
+- **THEN** it resolves the durable reference and completes without requiring S3
+
+#### Scenario: S3-backed worker has no blob mount
+- **GIVEN** production selects S3-compatible storage and a worker has no persistent blob mount
+- **WHEN** it analyzes or purges an attachment, expires an export, or processes an NHS dm+d archive
+- **THEN** it resolves the durable reference through the selected S3-compatible service
+
+### Requirement: Migration is bidirectional, resumable, and idempotent
+The system SHALL support verified Disk-to-S3 and S3-to-Disk migration using the same migration contract. A migration SHALL mirror new writes from the readable source to the destination, backfill every live source blob under its logical key, verify destination content before cutover, and allow interrupted phases to resume safely without creating duplicate logical blobs.
+
+#### Scenario: Customer starts either migration direction
+- **GIVEN** production is stable on Disk or S3-compatible storage and the other supported backend has been provisioned as a destination
+- **WHEN** an operator starts a migration
+- **THEN** the current backend remains the readable primary and new writes are mirrored to the destination
+
+#### Scenario: Existing blob is backfilled
+- **GIVEN** a live blob exists on the source and is absent from the destination
+- **WHEN** the migration processes that blob
+- **THEN** it writes the same logical key to the destination and verifies the destination content against the recorded blob checksum
+
+#### Scenario: Migration resumes after interruption
+- **GIVEN** a previous migration processed only part of the live blob set
+- **WHEN** the operator resumes the same source-to-destination migration
+- **THEN** already verified destination blobs are accepted without duplication and remaining blobs continue processing
+
+#### Scenario: Concurrent mutation reaches a fixed point
+- **GIVEN** uploads or deletions may occur during online backfill
+- **WHEN** final reconciliation begins
+- **THEN** storage mutations are quiesced, pending mirror work is drained, and reconciliation establishes a stable live set with no missing or corrupt destination blobs
+
+### Requirement: Cutover, rollback, and future reverse migration preserve data
+The system SHALL treat each blob's selected service as migration state, SHALL update the verified cutover set atomically, and SHALL preserve writes to both backends for a defined rollback window. Both migration directions MUST support in-window rollback. Completing one migration MUST NOT prevent an operator from provisioning the other backend later and performing a new reverse migration.
+
+#### Scenario: Verification blocks cutover in either direction
+- **GIVEN** one or more live blobs are absent from the destination or fail integrity verification
+- **WHEN** an operator requests cutover
+- **THEN** no blob service identities change and the source remains the readable primary
+
+#### Scenario: Verified cutover enters rollback mode
+- **GIVEN** every live blob is verified on the destination and pending mirror work is drained
+- **WHEN** the cutover transaction completes
+- **THEN** the destination becomes the readable primary and new writes continue to mirror to the source for the rollback window
+
+#### Scenario: Cutover transaction rolls back
+- **GIVEN** the transaction that changes blob service identities fails
+- **WHEN** the database transaction rolls back
+- **THEN** every blob retains its previous readable service and the cutover can be retried safely
+
+#### Scenario: Operator rolls back during the window
+- **GIVEN** the destination is primary and every post-cutover write has also been mirrored to the source
+- **WHEN** an operator invokes rollback before the window closes
+- **THEN** the source becomes the readable primary again without losing post-cutover blobs
+
+#### Scenario: Customer later migrates from S3 back to Disk
+- **GIVEN** production previously finalized on S3-compatible storage and no longer retains its former Disk source
+- **WHEN** an operator provisions a new durable Disk destination and starts an S3-to-Disk migration
+- **THEN** the system performs the same mirror, backfill, verification, cutover, and rollback contract used for Disk-to-S3 migration
+
+### Requirement: Source retirement is explicit and optional
+The system SHALL NOT require an operator to retire a healthy source backend after migration. Retirement SHALL require completed acceptance evidence, an expired rollback window, a final reconciliation, and explicit operator sign-off. Remaining on Disk indefinitely MUST remain a supported steady state.
+
+#### Scenario: Customer remains on Disk
+- **GIVEN** production uses a valid durable Disk backend and no migration is active
+- **WHEN** the deployment is operated or upgraded
+- **THEN** the application remains supported without an S3-compatible service
+
+#### Scenario: Premature source retirement is rejected
+- **GIVEN** a rollback window is open, final reconciliation has not passed, or a live workflow still depends on the source
+- **WHEN** source retirement eligibility is evaluated
+- **THEN** the source remains required and the unmet gate is reported safely
+
+#### Scenario: Operator retains both backends after migration
+- **GIVEN** migration and acceptance have succeeded
+- **WHEN** the operator chooses not to retire the source
+- **THEN** the application does not delete the source or its recovery history automatically
+
+### Requirement: Backup and restore follow the selected storage state
+The production recovery contract SHALL coordinate PostgreSQL records with every storage service required by live blob service identities. Disk-only recovery SHALL NOT require an object-storage backup, S3-only recovery SHALL NOT require a blob-volume snapshot, and an active migration or rollback window SHALL protect both participating backends. A recovery point MUST pass isolated verification before it is accepted as recoverable.
+
+#### Scenario: Disk-only recovery set is recorded
+- **GIVEN** production is stable on Disk with no migration active
+- **WHEN** a recovery point is recorded
+- **THEN** it identifies the database and durable Disk recovery points without requiring an S3 recovery reference
+
+#### Scenario: S3-only recovery set is recorded
+- **GIVEN** production is stable on S3-compatible storage with no migration active
+- **WHEN** a recovery point is recorded
+- **THEN** it identifies the database and private bucket recovery points without requiring a blob-volume snapshot
+
+#### Scenario: Migration recovery set protects both services
+- **GIVEN** migration or its rollback window is active
+- **WHEN** a recovery point is recorded
+- **THEN** it protects the database plus both participating storage services and records the active migration phase
+
+#### Scenario: Restored attachment is verified
+- **GIVEN** a recorded recovery set is restored into an isolated environment
+- **WHEN** restore verification resolves a representative attachment through its recorded service
+- **THEN** it proves integrity, authorized retrieval, and cross-household denial or rejects the recovery point
+
+### Requirement: Deployment topology matches the selected backend
+The deployment SHALL make the selected backend available to every process that performs storage work. Disk mode MUST NOT claim filesystem-independent scheduling unless those processes share the same durable filesystem. S3-compatible mode MUST support web and worker processes that are scheduled independently and have no shared blob mount.
+
+#### Scenario: Disk topology is declared honestly
+- **GIVEN** production selects Disk
+- **WHEN** deployment compatibility is evaluated
+- **THEN** each storage-dependent process is colocated with or mounted to the same durable root and no independent-scheduling claim is made without demonstrated shared access
+
+#### Scenario: S3 topology supports independent processes
+- **GIVEN** production selects S3-compatible storage
+- **WHEN** web and worker processes are scheduled independently
+- **THEN** both access the same private bucket without sharing a node-mounted blob filesystem
+
+### Requirement: Development and test remain isolated
+Development and test SHALL continue to use environment-local Disk services and MUST NOT require production S3 credentials, production mounted storage, or access to hosted buckets.
+
+#### Scenario: Test execution is isolated
+- **GIVEN** the automated test environment has no production storage credentials or mount
+- **WHEN** tests create or destroy attachments
+- **THEN** all blob operations remain inside the test-specific temporary Disk root
+
+#### Scenario: Development remains self-contained
+- **GIVEN** a developer has not explicitly configured an external storage integration
+- **WHEN** the development application starts
+- **THEN** it uses its local development Disk service without contacting a production backend

--- a/openspec/changes/support-portable-production-storage/tasks.md
+++ b/openspec/changes/support-portable-production-storage/tasks.md
@@ -1,0 +1,40 @@
+This change ends when both production backends, both migration directions, backend-aware recovery, and one canary Disk-to-S3-to-Disk round trip are proven. Migrating production, retiring its volume, or splitting web and worker deployments requires a separately approved deployment change.
+
+## 1. Explicit Production Storage Modes
+
+- [x] 1.1 Add failing `ProductionStorage` specs for `persistent`, `persistent_with_s3_mirror`, `s3_with_persistent_mirror`, and `s3`, covering preservation of the existing Disk service identity, backend-specific validation, no undeclared fallback, secret-safe errors, Disk operation without S3 settings, S3 operation without a mount, and unchanged development/test isolation; verify with `task test TEST_FILE=spec/lib/production_storage_spec.rb`.
+- [x] 1.2 Implement the four explicit Active Storage services and phase-aware production resolver, retaining fail-closed durable-mount checks only for Disk-inclusive modes and requiring external S3 configuration only for S3-inclusive modes.
+- [x] 1.3 Add failing privacy-contract specs and then emit aggregate storage-mode and migration events that exclude credentials, filenames, checksums, contents, household ids, person ids, and medication data.
+- [x] 1.4 Add task-wrapped final-production-image smokes that prove Disk-only boot and storage operations without S3 settings and S3-only boot and storage operations without `/app/storage`.
+
+## 2. Symmetric Migration and Cutover
+
+- [x] 2.1 Add failing service specs for Disk-to-S3 and S3-to-Disk backfill, bounded batching, existing valid destinations, missing or corrupt blobs, interruption resumption, and idempotent retries.
+- [x] 2.2 Implement one direction-neutral migration service that copies live blobs by logical key, verifies the destination, and reports opaque run ids plus aggregate progress without changing blob service identities.
+- [x] 2.3 Add failing specs for both directions covering stable-set reconciliation, mirror-queue drain requirements, cutover blocking, atomic `service_name` transitions, transaction rollback, in-window rollback, finalization, and source-retirement eligibility.
+- [x] 2.4 Implement dry-run-by-default reconciliation, cutover, rollback, finalization, and retirement-eligibility services using the symmetric four-state machine and one transaction for each service-name transition.
+- [x] 2.5 Expose task-wrapped operator commands for migration start/resume, reconciliation, cutover eligibility, cutover, rollback, finalization, and retirement eligibility; cover source/destination validation, owner-role enforcement, confirmations, exit statuses, and JSON output in command specs.
+
+## 3. Service-Neutral Queued Inputs
+
+- [x] 3.1 Add a migration and failing model specs for NHS dm+d archive service name, opaque logical key, checksum, and byte size while retaining bounded compatibility with existing `archive_path` records.
+- [x] 3.2 Add failing archive-store and integration specs for verified persistence before enqueue, resolution through Disk and S3 services, retry-safe reads, terminal cleanup, private access, legacy conversion, and PHI-safe failure behavior.
+- [x] 3.3 Implement the archive-store boundary, update the authorized request and `NhsDmdImportJob` to exchange durable service references, and add a bounded command that converts or reports every non-terminal legacy path before its filesystem can be removed.
+
+## 4. Backend-Aware Recovery and Documentation
+
+- [x] 4.1 Add failing restore-verifier specs for Disk-only, S3-only, and mirror-phase recovery sets, including missing or corrupt blobs, owner-role selection, authorized retrieval, cross-household denial, and PHI-safe evidence.
+- [x] 4.2 Make restore verification service-agnostic and update the task-wrapped recovery command to record the database plus only the storage recovery references required by live blob service identities and the active migration phase.
+- [x] 4.3 Amend ADR 0008 and the backup/restore runbook with both supported steady modes, both migration directions, topology constraints, rollback-versus-future-migration semantics, existing retention objectives, and explicit optional source retirement; validate with `task docs:build`.
+- [x] 4.4 Publish a bounded `home-ops` handoff for optional Disk and S3 deployments, canary/production isolation, least-privilege S3 inputs when selected, mount requirements when Disk is selected, migration phase values, maintenance gates, rollback commands, and the prohibition on automatic source deletion.
+
+## 5. Repository Verification
+
+- [x] 5.1 Run focused specs for production storage, both migration directions, operator commands, Active Storage authorization, household export expiry, NHS dm+d requests/jobs, restore verification, and observability; fix every failure before broad gates.
+- [x] 5.2 Run `task rubocop`, `task test`, both final-production-image storage smokes, `task docs:build`, `task openspec:validate`, and `git diff --check`; do not publish implementation while any gate is red.
+
+## 6. Bounded Deployed Acceptance
+
+- [ ] 6.1 In isolated canary storage, execute and retain PHI-safe evidence for Disk → Disk-primary mirror → S3-primary mirror → S3, including one verified in-window rollback before S3 finalization.
+- [ ] 6.2 From the S3 steady state, provision a fresh canary Disk destination and execute S3 → S3-primary mirror → Disk-primary mirror → Disk, including one verified rollback and final isolated restore.
+- [ ] 6.3 Prove upload, authorized download, cross-household denial, analysis, purge, export expiry, NHS dm+d import, background execution, and Loki/Tempo evidence in both final canary modes; record the round-trip result without migrating production or deleting either production storage backend.

--- a/scripts/production_storage_smoke.fish
+++ b/scripts/production_storage_smoke.fish
@@ -1,0 +1,160 @@
+#!/usr/bin/env fish
+
+if test (count $argv) -ne 2
+    echo 'Usage: production_storage_smoke.fish IMAGE_REF disk|s3' >&2
+    exit 2
+end
+
+for command_name in docker
+    if not command -q $command_name
+        echo "Required command is unavailable: $command_name" >&2
+        exit 2
+    end
+end
+
+set -g STORAGE_SMOKE_IMAGE $argv[1]
+set -g STORAGE_SMOKE_MODE $argv[2]
+set -g STORAGE_SMOKE_ROOT (realpath (dirname (status filename))/..)
+set -g STORAGE_SMOKE_SUFFIX (random)
+set -g STORAGE_SMOKE_PREFIX "storage-smoke-$STORAGE_SMOKE_SUFFIX"
+set -g STORAGE_SMOKE_NETWORK "$STORAGE_SMOKE_PREFIX-network"
+set -g STORAGE_SMOKE_DB "$STORAGE_SMOKE_PREFIX-db"
+set -g STORAGE_SMOKE_DISK_VOLUME "$STORAGE_SMOKE_PREFIX-disk"
+set -g STORAGE_SMOKE_S3_VOLUME "$STORAGE_SMOKE_PREFIX-s3"
+set -g STORAGE_SMOKE_S3_CONTAINER "$STORAGE_SMOKE_PREFIX-rustfs"
+
+function cleanup_storage_smoke --on-event fish_exit
+    docker rm -f $STORAGE_SMOKE_S3_CONTAINER $STORAGE_SMOKE_DB >/dev/null 2>&1
+    docker network rm $STORAGE_SMOKE_NETWORK >/dev/null 2>&1
+    docker volume rm $STORAGE_SMOKE_DISK_VOLUME $STORAGE_SMOKE_S3_VOLUME >/dev/null 2>&1
+end
+
+if not contains $STORAGE_SMOKE_MODE disk s3
+    echo "Unsupported storage smoke mode: $STORAGE_SMOKE_MODE" >&2
+    exit 2
+end
+
+docker network create $STORAGE_SMOKE_NETWORK >/dev/null
+or exit 1
+
+docker run --detach \
+    --name $STORAGE_SMOKE_DB \
+    --network $STORAGE_SMOKE_NETWORK \
+    --env POSTGRES_USER=medtracker \
+    --env POSTGRES_PASSWORD=medtracker_password \
+    --env POSTGRES_DB=medtracker \
+    --env POSTGRES_MULTIPLE_DATABASES=medtracker_production_queue,medtracker_production_cache,medtracker_production_cable \
+    --volume "$STORAGE_SMOKE_ROOT/compose/init-roles.sql:/docker-entrypoint-initdb.d/001-init-roles.sql:ro" \
+    --volume "$STORAGE_SMOKE_ROOT/compose/init-multiple-dbs.sh:/docker-entrypoint-initdb.d/002-init-multiple-dbs.sh:ro" \
+    postgres:18-alpine >/dev/null
+or exit 1
+
+for attempt in (seq 1 60)
+    if docker exec $STORAGE_SMOKE_DB pg_isready -U medtracker -d medtracker >/dev/null 2>&1
+        break
+    end
+    if test $attempt -eq 60
+        docker logs $STORAGE_SMOKE_DB
+        echo 'PostgreSQL did not become ready' >&2
+        exit 1
+    end
+    sleep 1
+end
+
+docker volume create $STORAGE_SMOKE_DISK_VOLUME >/dev/null
+or exit 1
+
+set -g STORAGE_SMOKE_COMMON_ENV \
+    --env RAILS_ENV=production \
+    --env APP_URL=http://localhost \
+    --env APP_VERSION=$STORAGE_SMOKE_IMAGE \
+    --env SECRET_KEY_BASE=production-storage-smoke-secret \
+    --env DATABASE_URL=postgresql://medtracker:medtracker_password@$STORAGE_SMOKE_DB:5432/medtracker \
+    --env DATABASE_ROLE= \
+    --env SOLID_QUEUE_DATABASE_URL=postgresql://medtracker:medtracker_password@$STORAGE_SMOKE_DB:5432/medtracker_production_queue \
+    --env SOLID_CACHE_DATABASE_URL=postgresql://medtracker:medtracker_password@$STORAGE_SMOKE_DB:5432/medtracker_production_cache \
+    --env SOLID_CABLE_DATABASE_URL=postgresql://medtracker:medtracker_password@$STORAGE_SMOKE_DB:5432/medtracker_production_cable
+
+docker run --rm \
+    --network $STORAGE_SMOKE_NETWORK \
+    $STORAGE_SMOKE_COMMON_ENV \
+    --env ACTIVE_STORAGE_SERVICE=persistent \
+    --env ACTIVE_STORAGE_ROOT=/app/storage \
+    --volume "$STORAGE_SMOKE_DISK_VOLUME:/app/storage" \
+    $STORAGE_SMOKE_IMAGE \
+    bin/rails db:prepare
+or exit 1
+
+set -g STORAGE_SMOKE_RUNNER 'require "digest"; require "stringio"; key = "storage-smoke/#{SecureRandom.uuid}"; payload = "portable-storage-smoke"; service = ActiveStorage::Blob.services.fetch(Rails.configuration.active_storage.service); checksum = Digest::MD5.base64digest(payload); begin; service.upload(key, StringIO.new(payload), checksum: checksum); raise "download mismatch" unless service.download(key) == payload; ensure; service.delete(key); end; raise "delete failed" if service.exist?(key); puts "storage smoke passed"'
+
+if test $STORAGE_SMOKE_MODE = disk
+    set -l disk_runner 'mounts = File.readlines("/proc/self/mountinfo"); raise "Disk smoke is missing /app/storage mount" unless mounts.any? { |line| line.split.fetch(4) == "/app/storage" }; '"$STORAGE_SMOKE_RUNNER"
+    docker run --rm \
+        --network $STORAGE_SMOKE_NETWORK \
+        $STORAGE_SMOKE_COMMON_ENV \
+        --env ACTIVE_STORAGE_SERVICE=persistent \
+        --env ACTIVE_STORAGE_ROOT=/app/storage \
+        --volume "$STORAGE_SMOKE_DISK_VOLUME:/app/storage" \
+        $STORAGE_SMOKE_IMAGE \
+        bin/rails runner $disk_runner
+    or exit 1
+
+    echo 'Final production-image Disk storage smoke passed'
+    exit 0
+end
+
+docker volume create $STORAGE_SMOKE_S3_VOLUME >/dev/null
+or exit 1
+
+docker run --detach \
+    --name $STORAGE_SMOKE_S3_CONTAINER \
+    --network $STORAGE_SMOKE_NETWORK \
+    --network-alias rustfs \
+    --env RUSTFS_ACCESS_KEY=storage-smoke-access \
+    --env RUSTFS_SECRET_KEY=storage-smoke-secret \
+    --env RUSTFS_VOLUMES=/data \
+    --volume "$STORAGE_SMOKE_S3_VOLUME:/data" \
+    rustfs/rustfs:1.0.0-alpha.90 /data >/dev/null
+or exit 1
+
+set -g STORAGE_SMOKE_S3_ENV \
+    --env ACTIVE_STORAGE_SERVICE=s3 \
+    --env ACTIVE_STORAGE_S3_ENDPOINT=http://rustfs:9000 \
+    --env ACTIVE_STORAGE_S3_BUCKET=medtracker-storage-smoke \
+    --env ACTIVE_STORAGE_S3_REGION=us-east-1 \
+    --env ACTIVE_STORAGE_S3_ACCESS_KEY_ID=storage-smoke-access \
+    --env ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY=storage-smoke-secret \
+    --env ACTIVE_STORAGE_S3_FORCE_PATH_STYLE=true
+
+set -l bucket_runner 'require "aws-sdk-s3"; client = Aws::S3::Client.new(endpoint: ENV.fetch("ACTIVE_STORAGE_S3_ENDPOINT"), region: ENV.fetch("ACTIVE_STORAGE_S3_REGION"), access_key_id: ENV.fetch("ACTIVE_STORAGE_S3_ACCESS_KEY_ID"), secret_access_key: ENV.fetch("ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY"), force_path_style: true); client.create_bucket(bucket: ENV.fetch("ACTIVE_STORAGE_S3_BUCKET"))'
+set -l rustfs_ready false
+for attempt in (seq 1 60)
+    docker run --rm \
+        --network $STORAGE_SMOKE_NETWORK \
+        $STORAGE_SMOKE_COMMON_ENV \
+        $STORAGE_SMOKE_S3_ENV \
+        $STORAGE_SMOKE_IMAGE \
+        bin/rails runner $bucket_runner >/dev/null 2>&1
+    if test $status -eq 0
+        set rustfs_ready true
+        break
+    end
+    sleep 1
+end
+
+if test $rustfs_ready != true
+    docker logs $STORAGE_SMOKE_S3_CONTAINER
+    echo 'RustFS did not become ready for the S3 smoke' >&2
+    exit 1
+end
+
+set -l s3_runner 'mounts = File.readlines("/proc/self/mountinfo"); raise "S3 smoke unexpectedly mounted /app/storage" if mounts.any? { |line| line.split.fetch(4) == "/app/storage" }; '"$STORAGE_SMOKE_RUNNER"
+docker run --rm \
+    --network $STORAGE_SMOKE_NETWORK \
+    $STORAGE_SMOKE_COMMON_ENV \
+    $STORAGE_SMOKE_S3_ENV \
+    $STORAGE_SMOKE_IMAGE \
+    bin/rails runner $s3_runner
+or exit 1
+
+echo 'Final production-image S3 storage smoke passed'

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -158,6 +158,50 @@ RSpec.describe 'Taskfiles' do
     expect(observability_characterization_script).to include(*observability_characterization_contract)
   end
 
+  it 'defines final production-image smokes for Disk and S3 storage' do
+    disk_task = prod_taskfile.dig('tasks', 'storage-disk-smoke')
+    s3_task = prod_taskfile.dig('tasks', 'storage-s3-smoke')
+
+    expect(disk_task.fetch('cmds')).to include(*storage_smoke_commands(:disk))
+    expect(s3_task.fetch('cmds')).to include(*storage_smoke_commands(:s3))
+    expect(storage_smoke_script).to include(
+      'ACTIVE_STORAGE_SERVICE=persistent',
+      'ACTIVE_STORAGE_SERVICE=s3',
+      'bin/rails db:prepare',
+      'ACTIVE_STORAGE_S3_ENDPOINT=http://rustfs:9000',
+      'service.upload(key, StringIO.new(payload), checksum: checksum)',
+      'raise "download mismatch" unless service.download(key) == payload',
+      'raise "delete failed" if service.exist?(key)',
+      'S3 smoke unexpectedly mounted /app/storage'
+    )
+  end
+
+  it 'exposes every bounded storage migration operator command' do
+    actions = %w[
+      start resume reconcile cutover-eligibility cutover rollback finalize retirement-eligibility
+    ]
+
+    actions.each do |action|
+      task = prod_taskfile.dig('tasks', "storage-migration-#{action}")
+      expect(task.dig('cmds', 0, 'vars', 'COMMAND')).to include(
+        'DATABASE_ROLE=med_tracker_owner',
+        "STORAGE_MIGRATION_ACTION=#{action.tr('-', '_')}",
+        'rails storage:migration'
+      )
+    end
+  end
+
+  it 'exposes the bounded NHS dm+d legacy archive conversion command' do
+    command = prod_taskfile.dig('tasks', 'storage-convert-nhs-dmd-archives', 'cmds', 0, 'vars', 'COMMAND')
+
+    expect(command).to include(
+      'DATABASE_ROLE=med_tracker_owner',
+      'NHS_DMD_ARCHIVE_SERVICE="{{ .SERVICE }}"',
+      'NHS_DMD_ARCHIVE_APPLY="{{ .APPLY }}"',
+      'rails storage:convert_nhs_dmd_archives'
+    )
+  end
+
   def dev_taskfile
     YAML.safe_load(Rails.root.join('Taskfiles/dev.yml').read, aliases: true, permitted_classes: [Symbol])
   end
@@ -202,6 +246,10 @@ RSpec.describe 'Taskfiles' do
     Rails.root.join('scripts/production_observability_characterization.fish').read
   end
 
+  def storage_smoke_script
+    Rails.root.join('scripts/production_storage_smoke.fish').read
+  end
+
   def observability_image_reference
     '{{ .APP_IMAGE_REF | default "med-tracker:observability-characterization" }}'
   end
@@ -227,5 +275,15 @@ RSpec.describe 'Taskfiles' do
       'Canonical job count or deployment identity is invalid',
       'Canonical records contain nested JSON messages'
     ]
+  end
+
+  def storage_smoke_commands(mode)
+    image = "{{ .APP_IMAGE_REF | default \"med-tracker:storage-#{mode}-smoke\" }}"
+    [
+      { 'task' => 'build', 'vars' => { 'APP_IMAGE_REF' => '{{ .IMAGE_REF }}' } },
+      "./scripts/production_storage_smoke.fish '{{ .IMAGE_REF }}' #{mode}"
+    ].tap do
+      expect(prod_taskfile.dig('tasks', "storage-#{mode}-smoke", 'vars', 'IMAGE_REF')).to eq(image)
+    end
   end
 end

--- a/spec/jobs/nhs_dmd_import_job_spec.rb
+++ b/spec/jobs/nhs_dmd_import_job_spec.rb
@@ -6,15 +6,21 @@ RSpec.describe NhsDmdImportJob do
   let(:import_run) do
     NhsDmdImport.create!(
       uploaded_filename: 'nhsbsa_dmd_release.zip',
-      archive_path: Rails.root.join('tmp/import-spec/release.zip').to_s,
+      archive_service_name: 'persistent',
+      archive_key: SecureRandom.uuid,
+      archive_checksum: Digest::MD5.base64digest('archive'),
+      archive_byte_size: 7,
       status: :queued
     )
   end
 
   let(:service) { instance_double(NhsDmd::ReleaseArchiveImport) }
+  let(:archive_store) { instance_double(NhsDmd::ArchiveStore, cleanup: nil) }
 
   before do
     allow(NhsDmd::ReleaseArchiveImport).to receive(:new).and_return(service)
+    allow(NhsDmd::ArchiveStore).to receive(:new).and_return(archive_store)
+    allow(archive_store).to receive(:open).with(import_run).and_yield('/private/tmp/opaque-release')
   end
 
   def progress_update(message, **overrides)
@@ -82,6 +88,8 @@ RSpec.describe NhsDmdImportJob do
     expect(import_run.log).to include('Starting AMPP name import')
       .and include('Starting GTIN import')
       .and include('Processed 880 import records')
+    expect(service).to have_received(:import).with('/private/tmp/opaque-release', progress_callback: anything)
+    expect(archive_store).to have_received(:cleanup).with(import_run)
   end
 
   it 'marks the import as failed when the archive import errors' do
@@ -95,5 +103,6 @@ RSpec.describe NhsDmdImportJob do
     expect(import_run).to be_failed
     expect(import_run.error_message).to eq('bad zip')
     expect(import_run.completed_at).to be_present
+    expect(archive_store).to have_received(:cleanup).with(import_run)
   end
 end

--- a/spec/jobs/nhs_dmd_import_job_spec.rb
+++ b/spec/jobs/nhs_dmd_import_job_spec.rb
@@ -92,6 +92,25 @@ RSpec.describe NhsDmdImportJob do
     expect(archive_store).to have_received(:cleanup).with(import_run)
   end
 
+  it 'keeps a completed import successful when archive cleanup fails' do
+    complete_import_via(service)
+    allow(archive_store).to receive(:cleanup)
+      .and_raise(NhsDmd::ArchiveStore::Error, 'archive_cleanup_failed')
+    allow(Observability::DiagnosticEvent).to receive(:emit)
+
+    expect do
+      described_class.perform_now(import_run.id)
+    end.not_to raise_error
+
+    expect(import_run.reload).to have_attributes(completed_import_attributes)
+    expect(Observability::DiagnosticEvent).to have_received(:emit).with(
+      component: :nhs_dmd_import,
+      reason: :operation_failed,
+      severity: :error,
+      error: an_instance_of(NhsDmd::ArchiveStore::Error)
+    )
+  end
+
   it 'marks the import as failed when the archive import errors' do
     allow(service).to receive(:import).and_raise(NhsDmd::ReleaseArchiveImport::Error, 'bad zip')
 

--- a/spec/lib/observability/operational_event_privacy_contract_spec.rb
+++ b/spec/lib/observability/operational_event_privacy_contract_spec.rb
@@ -73,6 +73,36 @@ RSpec.describe Observability::OperationalEvent do
     expect(labels).to eq('outcome' => 'success', 'source_category' => 'schedule')
   end
 
+  it 'keeps storage events aggregate and excludes protected migration inputs' do
+    serialized = storage_event.to_json
+
+    markers.each_value { |marker| expect(serialized).not_to include(marker) }
+    expect(JSON.parse(serialized)).to include(
+      'event.name' => 'storage.stage',
+      'medtracker.storage.processed_count' => 7,
+      'medtracker.storage.failed_count' => 1,
+      'error.type' => 'RuntimeError'
+    )
+  end
+
+  def storage_event
+    operational_event_class.build(
+      name: :storage_stage,
+      outcome: :failure,
+      severity: :error,
+      reason: :failed,
+      attributes: markers.merge(
+        storage_operation: :migration,
+        storage_backend: :dual,
+        storage_phase: :persistent_with_s3_mirror,
+        processed_count: 7,
+        verified_count: 6,
+        failed_count: 1
+      ),
+      error: RuntimeError.new(markers.fetch(:exception_text))
+    )
+  end
+
   def operational_event_class
     Observability::OperationalEvent
   end

--- a/spec/lib/observability/publisher_spec.rb
+++ b/spec/lib/observability/publisher_spec.rb
@@ -48,4 +48,27 @@ RSpec.describe Observability::Publisher do
     expect(result).to be_nil
     expect(Observability::EmergencyDiagnostic).to have_received(:write).once
   end
+
+  it 'keeps suppressing nested writes until the outer write finishes' do
+    writes = 0
+    allow(Observability::CanonicalLogger).to receive(:write) do
+      writes += 1
+      next unless writes == 1
+
+      2.times { emit_event }
+    end
+
+    emit_event
+
+    expect(Observability::CanonicalLogger).to have_received(:write).once
+  end
+
+  def emit_event
+    described_class.emit(
+      name: :medication_take_attempted,
+      outcome: :unknown,
+      severity: :info,
+      reason: :requested
+    )
+  end
 end

--- a/spec/lib/observability/storage_event_spec.rb
+++ b/spec/lib/observability/storage_event_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Observability::StorageEvent do
+  before do
+    allow(Observability::CanonicalLogger).to receive(:write)
+  end
+
+  it 'emits the selected steady storage mode' do
+    event = described_class.configuration(service: :persistent)
+
+    expect(event.to_h).to include(
+      'event.name' => 'storage.stage',
+      'event.outcome' => 'success',
+      'medtracker.reason' => 'configured',
+      'medtracker.storage.operation' => 'configuration',
+      'medtracker.storage.backend' => 'disk',
+      'medtracker.storage.phase' => 'persistent'
+    )
+  end
+
+  it 'emits aggregate migration progress for either direction' do
+    event = described_class.migration(
+      service: :s3_with_persistent_mirror,
+      outcome: :success,
+      reason: :completed,
+      counts: { processed_count: 12, verified_count: 11, failed_count: 1 }
+    )
+
+    expect(event.to_h).to include(
+      'event.name' => 'storage.stage',
+      'medtracker.storage.operation' => 'migration',
+      'medtracker.storage.backend' => 'dual',
+      'medtracker.storage.phase' => 's3_with_persistent_mirror',
+      'medtracker.storage.processed_count' => 12,
+      'medtracker.storage.verified_count' => 11,
+      'medtracker.storage.failed_count' => 1
+    )
+  end
+end

--- a/spec/lib/production_storage_documentation_spec.rb
+++ b/spec/lib/production_storage_documentation_spec.rb
@@ -5,23 +5,37 @@ require 'rails_helper'
 RSpec.describe ProductionStorage, '.documentation' do
   let(:adr) { Rails.root.join('docs/adrs/0008-production-upload-storage.md').read }
   let(:runbook) { Rails.root.join('docs/operations/upload-storage-backup-and-restore.md').read }
+  let(:home_ops_handoff) { Rails.root.join('docs/operations/home-ops-portable-storage-handoff.md').read }
   let(:compose) { Rails.root.join('compose.yaml').read }
   let(:deploy) { Rails.root.join('config/deploy.yml').read }
 
-  it 'records the accepted single-node persistent-volume decision' do
-    expect(adr).to include('Status: Accepted')
-    expect(adr).to include('ReadWriteOnce')
-    expect(adr).to include('Recreate')
-    expect(adr).to include('Horizontal web scaling is not supported')
-    expect(adr).to include('Object storage')
+  it 'amends the accepted decision with both steady modes and symmetric migration' do
+    expect(adr).to include(
+      'Status: Accepted', 'ReadWriteOnce', 'Recreate', '`persistent`', '`s3`',
+      'Disk to S3', 'S3 to Disk', 'in-window rollback', 'new migration'
+    )
   end
 
   it 'documents coordinated database and blob backups with retention' do
-    expect(runbook).to include('active_storage_attachments')
-    expect(runbook).to include('active_storage_blobs')
-    expect(runbook).to include('/app/storage')
-    expect(runbook).to include('35 daily backups')
-    expect(runbook).to include('12 monthly backups')
+    expect(runbook).to include(
+      'active_storage_attachments', 'active_storage_blobs', '/app/storage',
+      '35 daily backups', '12 monthly backups', 'Disk-only', 'S3-only',
+      'Mirror or rollback-window', 'DISK_RECOVERY_REFERENCE', 'S3_RECOVERY_REFERENCE'
+    )
+  end
+
+  it 'provides a bounded home-ops handoff without making S3 mandatory' do
+    expect(home_ops_handoff).to include(
+      'Disk-only deployment',
+      'S3-only deployment',
+      'canary',
+      'production',
+      'least privilege',
+      'maintenance',
+      'rollback',
+      'MUST NOT delete'
+    )
+    expect(home_ops_handoff).to include(*ProductionStorage::SERVICES.map { "`#{it}`" })
   end
 
   it 'documents and exposes the restored-attachment smoke check' do
@@ -57,8 +71,11 @@ RSpec.describe ProductionStorage, '.documentation' do
     storage = Rails.root.join('config/storage.yml').read
 
     expect(production).to include('ProductionStorage.resolve')
-    expect(storage).to include("persistent:\n  service: Disk")
-    expect(storage).to include("test:\n  service: Disk")
-    expect(storage).to include("local:\n  service: Disk")
+    expect(storage).to include(
+      "persistent:\n  service: Disk", "s3:\n  service: S3",
+      "persistent_with_s3_mirror:\n  service: Mirror",
+      "s3_with_persistent_mirror:\n  service: Mirror",
+      "test:\n  service: Disk", "local:\n  service: Disk"
+    )
   end
 end

--- a/spec/lib/production_storage_spec.rb
+++ b/spec/lib/production_storage_spec.rb
@@ -4,18 +4,26 @@ require 'rails_helper'
 require Rails.root.join('lib/production_storage')
 
 RSpec.describe ProductionStorage do
-  def resolve(root:, service: 'persistent', mounted: true, dummy: false)
+  let(:s3_environment) do
+    {
+      'ACTIVE_STORAGE_S3_ENDPOINT' => 'https://objects.example.test',
+      'ACTIVE_STORAGE_S3_BUCKET' => 'medtracker-production',
+      'ACTIVE_STORAGE_S3_REGION' => 'local',
+      'ACTIVE_STORAGE_S3_ACCESS_KEY_ID' => 'access-key-marker',
+      'ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY' => 'secret-key-marker'
+    }
+  end
+
+  def resolve(service: 'persistent', root: nil, mounted: true, dummy: false, environment: {})
     mountinfo = Tempfile.new('mountinfo')
-    mountinfo.write("36 25 0:32 / #{root} rw,relatime - ext4 /dev/test rw\n") if mounted
+    mountinfo.write("36 25 0:32 / #{root} rw,relatime - ext4 /dev/test rw\n") if mounted && root
     mountinfo.close
 
-    environment = {
-      'ACTIVE_STORAGE_SERVICE' => service,
-      'ACTIVE_STORAGE_ROOT' => root.to_s
-    }
-    environment['SECRET_KEY_BASE_DUMMY'] = '1' if dummy
+    resolved_environment = environment.merge('ACTIVE_STORAGE_SERVICE' => service)
+    resolved_environment['ACTIVE_STORAGE_ROOT'] = root.to_s if root
+    resolved_environment['SECRET_KEY_BASE_DUMMY'] = '1' if dummy
 
-    described_class.resolve(environment: environment, mountinfo_path: Pathname(mountinfo.path))
+    described_class.resolve(environment: resolved_environment, mountinfo_path: Pathname(mountinfo.path))
   ensure
     mountinfo&.unlink
   end
@@ -27,6 +35,69 @@ RSpec.describe ProductionStorage do
       expect(configuration.service).to eq(:persistent)
       expect(configuration.root).to eq(Pathname(directory).realpath)
     end
+  end
+
+  it 'selects the disk-primary mirror with both backend configurations' do
+    Dir.mktmpdir do |directory|
+      configuration = resolve(
+        service: 'persistent_with_s3_mirror',
+        root: Pathname(directory),
+        environment: s3_environment
+      )
+
+      expect(configuration.service).to eq(:persistent_with_s3_mirror)
+      expect(configuration.root).to eq(Pathname(directory).realpath)
+    end
+  end
+
+  it 'selects the S3-primary mirror with both backend configurations' do
+    Dir.mktmpdir do |directory|
+      configuration = resolve(
+        service: 's3_with_persistent_mirror',
+        root: Pathname(directory),
+        environment: s3_environment
+      )
+
+      expect(configuration.service).to eq(:s3_with_persistent_mirror)
+      expect(configuration.root).to eq(Pathname(directory).realpath)
+    end
+  end
+
+  it 'selects S3 without requiring a disk root or mount' do
+    configuration = resolve(service: 's3', mounted: false, environment: s3_environment)
+
+    expect(configuration.service).to eq(:s3)
+    expect(configuration.root).to be_nil
+  end
+
+  it 'does not require S3 settings for persistent disk' do
+    Dir.mktmpdir do |directory|
+      expect { resolve(root: Pathname(directory)) }.not_to raise_error
+    end
+  end
+
+  it 'requires every S3 setting only for S3-inclusive services' do
+    %w[
+      ACTIVE_STORAGE_S3_ENDPOINT
+      ACTIVE_STORAGE_S3_BUCKET
+      ACTIVE_STORAGE_S3_REGION
+      ACTIVE_STORAGE_S3_ACCESS_KEY_ID
+      ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY
+    ].each do |setting|
+      incomplete_environment = s3_environment.except(setting)
+
+      expect { resolve(service: 's3', mounted: false, environment: incomplete_environment) }
+        .to raise_error(described_class::ConfigurationError, /#{setting} is required/)
+    end
+  end
+
+  it 'does not disclose configured credentials when S3 validation fails' do
+    environment = s3_environment.except('ACTIVE_STORAGE_S3_BUCKET')
+
+    expect { resolve(service: 's3', mounted: false, environment: environment) }
+      .to raise_error(described_class::ConfigurationError, /ACTIVE_STORAGE_S3_BUCKET is required/) do |error|
+        expect(error.message).not_to include('access-key-marker', 'secret-key-marker')
+      end
   end
 
   it 'rejects unsupported production services' do

--- a/spec/models/nhs_dmd_import_spec.rb
+++ b/spec/models/nhs_dmd_import_spec.rb
@@ -3,6 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe NhsDmdImport do
+  describe 'durable archive reference' do
+    it 'accepts a complete service-neutral reference' do
+      import = described_class.new(
+        uploaded_filename: 'release.zip',
+        archive_service_name: 'persistent',
+        archive_key: SecureRandom.uuid,
+        archive_checksum: Digest::MD5.base64digest('archive'),
+        archive_byte_size: 7
+      )
+
+      expect(import).to be_valid
+    end
+
+    it 'rejects partial service-neutral references' do
+      import = described_class.new(uploaded_filename: 'release.zip', archive_service_name: 'persistent')
+
+      expect(import).not_to be_valid
+      expect(import.errors[:archive_key]).to be_present
+    end
+
+    it 'retains bounded compatibility with an existing archive path' do
+      import = described_class.new(uploaded_filename: 'release.zip', archive_path: '/legacy/release.zip')
+
+      expect(import).to be_valid
+      expect(import).to be_legacy_archive
+    end
+
+    it 'filters archive keys and checksums from framework parameter logging' do
+      filtered = ActiveSupport::ParameterFilter
+                 .new(Rails.application.config.filter_parameters)
+                 .filter(archive_key: 'opaque-key', archive_checksum: 'private-checksum')
+
+      expect(filtered).to eq(archive_key: '[FILTERED]', archive_checksum: '[FILTERED]')
+    end
+  end
+
   describe '#start!' do
     it 'sets started_at to current time when blank' do
       import = described_class.create!(uploaded_filename: 'release.zip')

--- a/spec/requests/admin/nhs_dmd_imports_spec.rb
+++ b/spec/requests/admin/nhs_dmd_imports_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe 'Admin::NhsDmdImports' do
       upload = uploaded_zip('nhsbsa_dmd_release.zip')
       import_run = nil
 
-      allow(NhsDmdImportJob).to receive(:perform_later) do |record|
-        import_run = record
+      allow(NhsDmdImportJob).to receive(:perform_later) do |record_id|
+        import_run = NhsDmdImport.find(record_id)
       end
 
       post admin_nhs_dmd_import_path, params: { nhs_dmd_import: { release_zip: upload } }
@@ -126,8 +126,13 @@ RSpec.describe 'Admin::NhsDmdImports' do
       expect(import_run).to be_a(NhsDmdImport)
       expect(import_run.uploaded_filename).to eq('nhsbsa_dmd_release.zip')
       expect(import_run).to be_queued
-      expect(import_run.archive_path).to be_present
-      expect(File.exist?(import_run.archive_path)).to be(true)
+      expect(import_run).to have_attributes(
+        archive_service_name: 'test',
+        archive_key: a_string_matching(%r{\Anhs-dmd/imports/[0-9a-f-]+\z}),
+        archive_checksum: be_present,
+        archive_byte_size: be_positive,
+        archive_path: nil
+      )
     end
 
     it 'redirects with an alert when no file is provided' do
@@ -140,11 +145,14 @@ RSpec.describe 'Admin::NhsDmdImports' do
     it 'marks the import as failed when the archive cannot be persisted' do
       upload = uploaded_zip('broken_release.zip')
       failed_import = nil
+      archive_store = instance_double(NhsDmd::ArchiveStore)
+      allow(archive_store).to receive(:persist)
+        .and_raise(NhsDmd::ArchiveStore::Error, 'archive_persistence_failed')
+      allow(NhsDmd::ArchiveStore).to receive(:new).and_return(archive_store)
 
       allow(NhsDmdImport).to receive(:create!).and_wrap_original do |original, *args|
         original.call(*args).tap do |import_run|
           failed_import = import_run
-          allow(import_run).to receive(:persist_archive!).and_raise(SystemCallError.new('disk full'))
         end
       end
 
@@ -153,7 +161,7 @@ RSpec.describe 'Admin::NhsDmdImports' do
       end.to change(NhsDmdImport, :count).by(1)
 
       expect(response).to redirect_to(new_admin_nhs_dmd_import_path)
-      expect(flash[:alert]).to include('disk full')
+      expect(flash[:alert]).to eq('archive_persistence_failed')
       expect(failed_import.reload).to be_failed
       expect(failed_import).not_to be_active
     end

--- a/spec/services/nhs_dmd/archive_migration_spec.rb
+++ b/spec/services/nhs_dmd/archive_migration_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NhsDmd::ArchiveMigration do
+  let(:store) { instance_double(NhsDmd::ArchiveStore) }
+  let(:owner_role) { -> { true } }
+  let(:scope) { NhsDmdImport.where(id: imports) }
+  let(:imports) do
+    [
+      NhsDmdImport.create!(uploaded_filename: 'first.zip', archive_path: '/legacy/first.zip'),
+      NhsDmdImport.create!(uploaded_filename: 'second.zip', archive_path: '/legacy/second.zip'),
+      NhsDmdImport.create!(uploaded_filename: 'complete.zip', archive_path: '/legacy/complete.zip', status: :completed)
+    ]
+  end
+
+  before { allow(store).to receive(:convert_legacy) }
+
+  it 'reports every non-terminal legacy reference without mutating by default' do
+    result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { true },
+                                 service_name: :persistent).call
+
+    expect(result.to_h).to include(processed_count: 2, converted_count: 0, failed_count: 0, applied: false)
+    expect(store).not_to have_received(:convert_legacy)
+  end
+
+  it 'converts each live legacy reference in bounded batches when explicitly applied' do
+    allow(scope).to receive(:find_in_batches).and_call_original
+
+    result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { true },
+                                 service_name: :s3, apply: true).call
+
+    expect(result.to_h).to include(processed_count: 2, converted_count: 2, failed_count: 0, applied: true)
+    expect(scope).to have_received(:find_in_batches).with(batch_size: 100)
+    expect(store).to have_received(:convert_legacy).twice
+  end
+
+  it 'reports missing legacy files only as aggregate failures' do
+    result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { false },
+                                 service_name: :persistent).call
+
+    expect(result.to_h).to include(processed_count: 2, converted_count: 0, failed_count: 2)
+    expect(result.to_h.to_json).not_to include('/legacy/', 'first.zip', 'second.zip')
+  end
+
+  it 'requires the owner-capable database role' do
+    migration = described_class.new(scope:, store:, owner_role: -> { false }, service_name: :persistent)
+
+    expect { migration.call }.to raise_error(SecurityError, 'archive migration requires the owner database role')
+  end
+end

--- a/spec/services/nhs_dmd/archive_store_spec.rb
+++ b/spec/services/nhs_dmd/archive_store_spec.rb
@@ -58,6 +58,29 @@ RSpec.describe NhsDmd::ArchiveStore do
     end
   end
 
+  it 'preserves errors raised by the archive consumer' do
+    store.persist(import_run:, uploaded_file: upload, service_name: :persistent)
+
+    expect do
+      store.open(import_run) { raise NhsDmd::ReleaseArchiveImport::Error, 'bad zip' }
+    end.to raise_error(NhsDmd::ReleaseArchiveImport::Error, 'bad zip')
+  end
+
+  it 'reports a missing configured service through the archive store contract' do
+    registry = ActiveStorage::Service::Registry.new({})
+    unavailable_store = described_class.new(service_registry: registry)
+    import_run.update!(
+      archive_service_name: 'missing',
+      archive_key: 'missing-key',
+      archive_checksum: Digest::MD5.base64digest('missing'),
+      archive_byte_size: 7
+    )
+
+    expect do
+      unavailable_store.open(import_run) { nil }
+    end.to raise_error(NhsDmd::ArchiveStore::Error, 'archive_service_unavailable')
+  end
+
   it 'deletes a durable archive only after the import becomes terminal' do
     store.persist(import_run:, uploaded_file: upload, service_name: :s3)
 

--- a/spec/services/nhs_dmd/archive_store_spec.rb
+++ b/spec/services/nhs_dmd/archive_store_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NhsDmd::ArchiveStore do
+  let(:services) do
+    {
+      persistent: ActiveStorage::Service::DiskService.new(root: persistent_root),
+      s3: ActiveStorage::Service::DiskService.new(root: s3_root)
+    }
+  end
+  let(:store) { described_class.new(service_registry: services) }
+  let(:import_run) { NhsDmdImport.create!(uploaded_filename: 'patient-medications.zip') }
+  let(:upload) do
+    Tempfile.create(['release', '.zip']).tap do |file|
+      file.write(payload)
+      file.rewind
+    end
+  end
+
+  after do
+    upload.close
+    FileUtils.rm_f(upload.path)
+    FileUtils.rm_rf(persistent_root)
+    FileUtils.rm_rf(s3_root)
+  end
+
+  it 'persists and verifies an opaque durable reference before returning' do
+    reference = store.persist(import_run:, uploaded_file: upload, service_name: :persistent)
+
+    expect(reference.to_h).to include(
+      service_name: 'persistent',
+      checksum: Digest::MD5.base64digest(payload),
+      byte_size: payload.bytesize
+    )
+    expect(reference.key).not_to include(import_run.uploaded_filename, import_run.id.to_s)
+    expect(import_run.reload).to have_attributes(
+      archive_service_name: 'persistent',
+      archive_key: reference.key,
+      archive_checksum: reference.checksum,
+      archive_byte_size: payload.bytesize,
+      archive_path: nil
+    )
+    expect(services.fetch(:persistent).download(reference.key)).to eq(payload)
+  end
+
+  it 'resolves retry-safe reads through either declared backend' do
+    %i[persistent s3].each do |service_name|
+      run = NhsDmdImport.create!(uploaded_filename: 'release.zip')
+      store.persist(import_run: run, uploaded_file: upload, service_name:)
+
+      first = store.open(run) { |path| File.binread(path) }
+      second = store.open(run) { |path| File.binread(path) }
+
+      expect(first).to eq(payload)
+      expect(second).to eq(payload)
+      expect(services.fetch(service_name)).to exist(run.archive_key)
+    end
+  end
+
+  it 'deletes a durable archive only after the import becomes terminal' do
+    store.persist(import_run:, uploaded_file: upload, service_name: :s3)
+
+    expect { store.cleanup(import_run) }.to raise_error(NhsDmd::ArchiveStore::Error, 'archive_not_terminal')
+    import_run.update!(status: :completed)
+    key = import_run.archive_key
+
+    store.cleanup(import_run)
+
+    expect(services.fetch(:s3)).not_to exist(key)
+    expect(import_run.reload).to have_attributes(
+      archive_service_name: nil,
+      archive_key: nil,
+      archive_checksum: nil,
+      archive_byte_size: nil
+    )
+  end
+
+  it 'converts a live legacy path and removes it only after verified persistence' do
+    legacy = Tempfile.create(['legacy-release', '.zip']).tap do |file|
+      file.write(payload)
+      file.close
+    end
+    import_run.update!(archive_path: legacy.path)
+
+    store.convert_legacy(import_run:, service_name: :s3)
+
+    expect(import_run.reload.archive_service_name).to eq('s3')
+    expect(import_run.archive_path).to be_nil
+    expect(File).not_to exist(legacy.path)
+  ensure
+    legacy&.close
+    FileUtils.rm_f(legacy.path) if legacy
+  end
+
+  it 'returns a PHI-safe failure and no durable reference when verification fails' do
+    service = services.fetch(:persistent)
+    allow(service).to receive(:open).and_raise(ActiveStorage::IntegrityError)
+
+    expect do
+      store.persist(import_run:, uploaded_file: upload, service_name: :persistent)
+    end.to raise_error(NhsDmd::ArchiveStore::Error, 'archive_persistence_failed')
+
+    expect(import_run.reload.archive_key).to be_nil
+    expect(import_run.error_message).to be_nil
+  end
+
+  it 'does not expose a public archive URL boundary' do
+    expect(store).not_to respond_to(:url)
+  end
+
+  def persistent_root
+    @persistent_root ||= Dir.mktmpdir('nhs-dmd-persistent')
+  end
+
+  def s3_root
+    @s3_root ||= Dir.mktmpdir('nhs-dmd-s3')
+  end
+
+  def payload
+    'verified archive data'
+  end
+end

--- a/spec/services/storage/recovery_set_spec.rb
+++ b/spec/services/storage/recovery_set_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Storage::RecoverySet do
+  it 'requires only database and Disk references for Disk-only live identities' do
+    set = described_class.new(blob_scope: blob_scope('persistent'))
+
+    expect(set.required_backends).to eq(%i[disk])
+    expect(set.record(database_reference: 'db-1', disk_reference: 'disk-1').to_h).to eq(
+      database_reference: 'db-1',
+      storage_references: { disk: 'disk-1' },
+      migration_phase: nil
+    )
+  end
+
+  it 'requires only database and S3 references for S3-only live identities' do
+    set = described_class.new(blob_scope: blob_scope('s3'))
+
+    expect(set.required_backends).to eq(%i[s3])
+    expect(set.record(database_reference: 'db-1', s3_reference: 's3-1').storage_references)
+      .to eq(s3: 's3-1')
+  end
+
+  it 'requires both storage references for mirror identities or an active migration' do
+    mirror_set = described_class.new(blob_scope: blob_scope('persistent_with_s3_mirror'))
+    active_run = instance_double(StorageMigrationRun, finalized?: false, phase: 'rollback_window')
+    migration_set = described_class.new(blob_scope: blob_scope('persistent'), migration_run: active_run)
+
+    expect(mirror_set.required_backends).to eq(%i[disk s3])
+    expect(migration_set.required_backends).to eq(%i[disk s3])
+  end
+
+  it 'rejects missing recovery references with a PHI-safe code' do
+    set = described_class.new(blob_scope: blob_scope('s3'))
+
+    expect { set.record(database_reference: 'db-1') }
+      .to raise_error(described_class::Error, 's3_recovery_reference_required')
+  end
+
+  def blob_scope(*service_names)
+    instance_double(ActiveRecord::Relation, distinct: instance_double(ActiveRecord::Relation, pluck: service_names))
+  end
+end

--- a/spec/services/storage/restore_verifier_spec.rb
+++ b/spec/services/storage/restore_verifier_spec.rb
@@ -55,6 +55,33 @@ RSpec.describe Storage::RestoreVerifier do
     FileUtils.remove_entry(s3_root) if s3_root && File.exist?(s3_root)
   end
 
+  it 'requires recovery references for every live blob service' do
+    test_service = service_registry.fetch('test')
+    registry = { test: test_service, persistent_with_s3_mirror: test_service }.with_indifferent_access
+    allow(ActiveStorage::Blob).to receive(:services).and_return(registry)
+    other_blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new('other restored object'),
+      filename: 'other.txt',
+      service_name: 'persistent_with_s3_mirror'
+    )
+
+    expect(verification.required_backends).to eq(%i[disk s3])
+  ensure
+    other_blob&.purge
+  end
+
+  it 'normalizes a missing Active Storage service as a verification failure' do
+    registry = ActiveStorage::Service::Registry.new({})
+
+    expect do
+      described_class.new(
+        attachment_id: attachment.id,
+        service_registry: registry,
+        access_verifier:
+      ).call
+    end.to raise_error(described_class::VerificationError, 'The restored blob service is unavailable')
+  end
+
   def storage_registry(s3_service)
     test_service = service_registry.fetch('test')
     { s3: s3_service, test: test_service, 's3' => s3_service, 'test' => test_service }

--- a/spec/services/storage/restore_verifier_spec.rb
+++ b/spec/services/storage/restore_verifier_spec.rb
@@ -3,10 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Storage::RestoreVerifier do
-  subject(:verification) { described_class.call(attachment_id: attachment.id) }
+  subject(:verification) do
+    described_class.new(
+      attachment_id: attachment.id,
+      service_registry:,
+      access_verifier:
+    ).call
+  end
 
   let(:person) { create(:person) }
   let(:attachment) { person.avatar.attachment }
+  let(:service_registry) { ActiveStorage::Blob.services }
+  let(:access_verifier) do
+    ->(attachment:) { { authorized_retrieval: attachment.present?, cross_household_denied: true } }
+  end
 
   before do
     person.avatar.attach(io: StringIO.new('restored avatar'), filename: 'avatar.png', content_type: 'image/png')
@@ -19,13 +29,40 @@ RSpec.describe Storage::RestoreVerifier do
   it 'verifies that the restored blob exists and matches its stored checksum' do
     result = verification
 
-    expect(result.attachment_id).to eq(attachment.id)
-    expect(result.blob_id).to eq(attachment.blob_id)
-    expect(result.byte_size).to eq('restored avatar'.bytesize)
+    expect(result.to_h).to include(
+      attachment_id: attachment.id,
+      blob_id: attachment.blob_id,
+      byte_size: 'restored avatar'.bytesize,
+      required_backends: [:disk],
+      authorized_retrieval: true,
+      cross_household_denied: true
+    )
+  end
+
+  it 'verifies an S3-selected blob without using the current default service' do
+    s3_root = Dir.mktmpdir('restore-verifier-s3')
+    s3_service = ActiveStorage::Service::DiskService.new(root: s3_root)
+    blob = attachment.blob
+    s3_service.upload(blob.key, StringIO.new('restored avatar'), checksum: blob.checksum)
+    registry = storage_registry(s3_service)
+    allow(ActiveStorage::Blob).to receive(:services).and_return(registry)
+    blob.update!(service_name: 's3')
+    result = described_class.new(attachment_id: attachment.id, service_registry: registry, access_verifier:).call
+
+    expect(result.required_backends).to eq([:s3])
+  ensure
+    blob&.update!(service_name: 'test')
+    FileUtils.remove_entry(s3_root) if s3_root && File.exist?(s3_root)
+  end
+
+  def storage_registry(s3_service)
+    test_service = service_registry.fetch('test')
+    { s3: s3_service, test: test_service, 's3' => s3_service, 'test' => test_service }
   end
 
   it 'rejects a database attachment whose stored object is missing' do
-    allow(attachment.blob.service).to receive(:exist?).with(attachment.blob.key).and_return(false)
+    allow(service_registry.fetch(attachment.blob.service_name)).to receive(:exist?)
+      .with(attachment.blob.key).and_return(false)
 
     expect { verification }
       .to raise_error(described_class::VerificationError, /stored object is missing/)
@@ -33,14 +70,27 @@ RSpec.describe Storage::RestoreVerifier do
 
   it 'rejects a restored object that fails the Active Storage integrity check' do
     allow(ActiveStorage::Attachment).to receive(:find_by).with(id: attachment.id).and_return(attachment)
-    allow(attachment.blob).to receive(:open).and_raise(ActiveStorage::IntegrityError)
+    service = service_registry.fetch(attachment.blob.service_name)
+    allow(service).to receive(:open).and_raise(ActiveStorage::IntegrityError)
 
     expect { verification }
       .to raise_error(described_class::VerificationError, /checksum/)
   end
 
   it 'requires an attachment from the restored database' do
-    expect { described_class.call(attachment_id: 'missing') }
+    expect { described_class.new(attachment_id: 'missing', service_registry:, access_verifier:).call }
       .to raise_error(described_class::VerificationError, /attachment/)
+  end
+
+  it 'rejects incomplete authorization evidence without exposing household details' do
+    verifier = ->(attachment:) { { authorized_retrieval: attachment.present?, cross_household_denied: false } }
+
+    expect do
+      described_class.new(
+        attachment_id: attachment.id,
+        service_registry:,
+        access_verifier: verifier
+      ).call
+    end.to raise_error(described_class::VerificationError, 'cross_household_denial_failed')
   end
 end

--- a/spec/services/storage_migration/backfill_spec.rb
+++ b/spec/services/storage_migration/backfill_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StorageMigration::Backfill do
+  subject(:backfill) do
+    described_class.new(
+      source_service_name:,
+      destination_service_name:,
+      blob_scope:,
+      service_registry:,
+      batch_size: 2
+    )
+  end
+
+  before do
+    blobs.zip(payloads).each do |blob, payload|
+      source_service.upload(blob.key, StringIO.new(payload), checksum: blob.checksum)
+    end
+  end
+
+  after do
+    FileUtils.rm_rf(source_root)
+    FileUtils.rm_rf(destination_root)
+    ActiveStorage::Blob.where(id: blobs.map(&:id)).delete_all
+  end
+
+  it 'backfills Disk blobs to S3 by logical key in bounded batches' do
+    allow(blob_scope).to receive(:find_in_batches).and_call_original
+
+    result = backfill.call
+
+    expect(blob_scope).to have_received(:find_in_batches).with(batch_size: 2)
+    expect(result.to_h).to include(
+      source_service_name: :persistent,
+      destination_service_name: :s3,
+      phase: :persistent_with_s3_mirror,
+      processed_count: 3,
+      verified_count: 3,
+      failed_count: 0
+    )
+    expect(result.run_id).to match(Observability::CorrelationContext::UUID_PATTERN)
+    expect_downloads(payloads)
+  end
+
+  it 'uses the same contract to backfill S3 blobs to Disk' do
+    result = reverse_backfill
+
+    expect(result.to_h).to include(processed_count: 3, verified_count: 3, failed_count: 0)
+    expect_reverse_downloads
+  ensure
+    ActiveStorage::Blob.where(id: reverse_blobs.map(&:id)).delete_all
+  end
+
+  it 'accepts an existing valid destination without uploading it again' do
+    first_blob = blobs.first
+    destination_service.upload(first_blob.key, StringIO.new(payloads.first), checksum: first_blob.checksum)
+    allow(destination_service).to receive(:upload).and_call_original
+
+    result = backfill.call
+
+    expect(result.failed_count).to be_zero
+    expect(destination_service).not_to have_received(:upload).with(
+      first_blob.key,
+      anything,
+      checksum: first_blob.checksum
+    )
+  end
+
+  it 'reports missing source blobs without disclosing blob details' do
+    source_service.delete(blobs.second.key)
+
+    result = backfill.call
+
+    expect(result.to_h).to include(processed_count: 3, verified_count: 2, failed_count: 1)
+    expect(result.to_h.to_json).not_to include(blobs.second.key, blobs.second.filename.to_s)
+  end
+
+  it 'reports a corrupt existing destination instead of accepting it' do
+    first_blob = blobs.first
+    destination_service.upload(first_blob.key, StringIO.new('corrupt'), checksum: Digest::MD5.base64digest('corrupt'))
+
+    result = backfill.call
+
+    expect(result.to_h).to include(processed_count: 3, verified_count: 2, failed_count: 1)
+  end
+
+  it 'resumes safely after interruption and accepts already verified blobs' do
+    upload_count = 0
+    allow(destination_service).to receive(:upload).and_wrap_original do |method, *args, **keywords|
+      upload_count += 1
+      raise Interrupt if upload_count == 2
+
+      method.call(*args, **keywords)
+    end
+
+    expect { backfill.call }.to raise_error(Interrupt)
+    uploads_before_resume = upload_count
+
+    result = backfill.call
+
+    expect(upload_count - uploads_before_resume).to eq(2)
+    expect(result.to_h).to include(processed_count: 3, verified_count: 3, failed_count: 0)
+    expect_downloads(payloads)
+  end
+
+  it 'is idempotent when the same migration is retried' do
+    first_result = backfill.call
+    allow(destination_service).to receive(:upload).and_call_original
+
+    second_result = backfill.call
+
+    expect(first_result.failed_count).to be_zero
+    expect(second_result.to_h).to include(processed_count: 3, verified_count: 3, failed_count: 0)
+    expect(destination_service).not_to have_received(:upload)
+  end
+
+  def create_blob(payload:, service_name:)
+    blob = ActiveStorage::Blob.new(
+      key: SecureRandom.base58(28),
+      filename: 'opaque.bin',
+      content_type: 'application/octet-stream',
+      byte_size: payload.bytesize,
+      checksum: Digest::MD5.base64digest(payload),
+      service_name:
+    )
+    blob.save!(validate: false)
+    blob
+  end
+
+  def disk_service(root)
+    ActiveStorage::Service::DiskService.new(root:)
+  end
+
+  def source_service_name
+    :persistent
+  end
+
+  def destination_service_name
+    :s3
+  end
+
+  def payloads
+    %w[first second third]
+  end
+
+  def blobs
+    @blobs ||= payloads.map { |payload| create_blob(payload:, service_name: source_service_name) }
+  end
+
+  def blob_scope
+    @blob_scope ||= ActiveStorage::Blob.where(id: blobs)
+  end
+
+  def source_root
+    @source_root ||= Dir.mktmpdir('storage-migration-source')
+  end
+
+  def destination_root
+    @destination_root ||= Dir.mktmpdir('storage-migration-destination')
+  end
+
+  def service_registry
+    @service_registry ||= { persistent: disk_service(source_root), s3: disk_service(destination_root) }
+  end
+
+  def source_service
+    service_registry.fetch(source_service_name)
+  end
+
+  def destination_service
+    service_registry.fetch(destination_service_name)
+  end
+
+  def reverse_backfill
+    populate_reverse_source
+    described_class.new(source_service_name: :s3, destination_service_name: :persistent,
+                        blob_scope: ActiveStorage::Blob.where(id: reverse_blobs),
+                        service_registry:, batch_size: 2).call
+  end
+
+  def reverse_blobs
+    @reverse_blobs ||= payloads.map { |payload| create_blob(payload:, service_name: :s3) }
+  end
+
+  def populate_reverse_source
+    reverse_blobs.zip(payloads).each do |blob, payload|
+      service_registry.fetch(:s3).upload(blob.key, StringIO.new(payload), checksum: blob.checksum)
+    end
+  end
+
+  def expect_reverse_downloads
+    reverse_blobs.zip(payloads).each do |blob, payload|
+      expect(service_registry.fetch(:persistent).download(blob.key)).to eq(payload)
+    end
+  end
+
+  def expect_downloads(expected_payloads)
+    blobs.zip(expected_payloads).each do |blob, payload|
+      expect(destination_service.download(blob.key)).to eq(payload)
+    end
+  end
+end

--- a/spec/services/storage_migration/command_spec.rb
+++ b/spec/services/storage_migration/command_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StorageMigration::Command do
+  let(:output) { StringIO.new }
+  let(:error) { StringIO.new }
+  let(:environment) do
+    {
+      'STORAGE_MIGRATION_ACTION' => 'start',
+      'STORAGE_MIGRATION_SOURCE' => 'persistent',
+      'STORAGE_MIGRATION_DESTINATION' => 's3',
+      'STORAGE_MIGRATION_PHASE' => 'persistent_with_s3_mirror'
+    }
+  end
+  let(:owner_role) { -> { true } }
+  let(:command) { described_class.new(environment:, output:, error:, owner_role:) }
+
+  def backfill_result
+    @backfill_result ||= StorageMigration::Backfill::Result.new(
+      run_id: SecureRandom.uuid,
+      source_service_name: :persistent,
+      destination_service_name: :s3,
+      phase: :persistent_with_s3_mirror,
+      processed_count: 3,
+      verified_count: 3,
+      failed_count: 0
+    )
+  end
+
+  before do
+    allow(StorageMigration::Backfill).to receive(:new)
+      .and_return(instance_double(StorageMigration::Backfill, call: backfill_result))
+  end
+
+  it 'defaults migration start to a read-only JSON dry run' do
+    expect { expect(command.call).to eq(0) }.not_to change(StorageMigrationRun, :count)
+
+    expect(StorageMigration::Backfill).to have_received(:new).with(hash_including(copy_missing: false))
+    expect(JSON.parse(output.string)).to include(
+      'outcome' => 'passed',
+      'action' => 'start',
+      'applied' => false,
+      'processed_count' => 3,
+      'verified_count' => 3,
+      'failed_count' => 0
+    )
+  end
+
+  it 'requires an exact confirmation before applying a mutation' do
+    environment['STORAGE_MIGRATION_APPLY'] = 'true'
+
+    expect { expect(command.call).to eq(2) }.not_to change(StorageMigrationRun, :count)
+    expect(JSON.parse(error.string)).to include(
+      'outcome' => 'failed',
+      'failure_code' => 'confirmation_required'
+    )
+  end
+
+  it 'creates an opaque resumable run only when start is explicitly applied' do
+    environment.merge!(
+      'STORAGE_MIGRATION_APPLY' => 'true',
+      'STORAGE_MIGRATION_CONFIRM' => 'persistent-to-s3'
+    )
+
+    expect { expect(command.call).to eq(0) }.to change(StorageMigrationRun, :count).by(1)
+
+    expect(StorageMigration::Backfill).to have_received(:new).with(hash_including(copy_missing: true))
+    expect(JSON.parse(output.string).fetch('run_id'))
+      .to match(Observability::CorrelationContext::UUID_PATTERN)
+  end
+
+  it 'rejects unsupported directions and phase mismatches without loading storage services' do
+    environment['STORAGE_MIGRATION_DESTINATION'] = 'persistent'
+
+    expect(command.call).to eq(2)
+    expect(StorageMigration::Backfill).not_to have_received(:new)
+    expect(JSON.parse(error.string)).to include('failure_code' => 'invalid_storage_direction')
+  end
+
+  it 'enforces the owner-capable database role before reading migration state' do
+    command = described_class.new(environment:, output:, error:, owner_role: -> { false })
+
+    expect(command.call).to eq(3)
+    expect(JSON.parse(error.string)).to include('failure_code' => 'owner_role_required')
+  end
+
+  it 'dispatches resume and every lifecycle operation with explicit gates' do
+    run = StorageMigrationRun.create!(source_service_name: :persistent, destination_service_name: :s3)
+    lifecycle = stub_lifecycle(run)
+
+    dispatch_actions(run)
+    expect_lifecycle_dispatches(run, lifecycle)
+  end
+
+  def stub_lifecycle(run)
+    result = lifecycle_result(run)
+    lifecycle = instance_double(
+      StorageMigration::Lifecycle,
+      reconcile: result,
+      cutover: result,
+      rollback: result,
+      finalize: result,
+      retirement_eligibility: result
+    )
+    allow(StorageMigration::Lifecycle).to receive(:new).and_return(lifecycle)
+    lifecycle
+  end
+
+  def lifecycle_result(run)
+    StorageMigration::Lifecycle::Result.new(
+      run_id: run.run_id,
+      eligible: true,
+      applied: false,
+      reason: :ready,
+      processed_count: 2,
+      verified_count: 2,
+      failed_count: 0
+    )
+  end
+
+  def dispatch_actions(run)
+    migration_actions.each do |action|
+      reset_output
+      environment.merge!(migration_environment(action, run))
+      expect_successful_dispatch(action)
+    end
+  end
+
+  def expect_successful_dispatch(action)
+    expect(command.call).to eq(0)
+    expect(JSON.parse(output.string)).to include('action' => action)
+  end
+
+  def expect_lifecycle_dispatches(run, lifecycle)
+    expect(StorageMigration::Backfill).to have_received(:new).with(hash_including(run_id: run.run_id))
+    expect(lifecycle).to have_received(:cutover).twice
+    %i[reconcile rollback finalize retirement_eligibility].each do |operation|
+      expect(lifecycle).to have_received(operation)
+    end
+  end
+
+  def migration_actions
+    %w[resume reconcile cutover_eligibility cutover rollback finalize retirement_eligibility]
+  end
+
+  def reset_output
+    output.truncate(0)
+    output.rewind
+  end
+
+  def migration_environment(action, run)
+    {
+      'STORAGE_MIGRATION_ACTION' => action,
+      'STORAGE_MIGRATION_RUN_ID' => run.run_id,
+      'STORAGE_MIGRATION_PHASE' => command_phase(action),
+      'STORAGE_MIGRATION_MUTATIONS_QUIESCED' => 'true',
+      'STORAGE_MIGRATION_MIRROR_QUEUE_DRAINED' => 'true',
+      'STORAGE_MIGRATION_SOURCE_VERIFIED' => 'true',
+      'STORAGE_MIGRATION_ACCEPTANCE_VERIFIED' => 'true',
+      'STORAGE_MIGRATION_RECOVERY_VERIFIED' => 'true',
+      'STORAGE_MIGRATION_FINAL_RECONCILED' => 'true',
+      'STORAGE_MIGRATION_LIVE_SOURCE_DEPENDENCY' => 'false'
+    }
+  end
+
+  it 'never writes configured secrets or blob details to command output' do
+    environment.merge!(
+      'ACTIVE_STORAGE_S3_SECRET_ACCESS_KEY' => 'do-not-print',
+      'ORIGINAL_FILENAME' => 'private-medication-record.zip'
+    )
+
+    command.call
+
+    expect(output.string).not_to include('do-not-print', 'private-medication-record.zip')
+  end
+
+  def command_phase(action)
+    return 's3_with_persistent_mirror' if %w[rollback finalize].include?(action)
+    return 's3' if action == 'retirement_eligibility'
+
+    'persistent_with_s3_mirror'
+  end
+end

--- a/spec/services/storage_migration/lifecycle_spec.rb
+++ b/spec/services/storage_migration/lifecycle_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StorageMigration::Lifecycle do
+  before do
+    allow(ActiveStorage::Blob).to receive(:services).and_return(service_registry)
+    blobs.zip(%w[first second]).each do |blob, payload|
+      service_registry.fetch(source_service_name).upload(blob.key, StringIO.new(payload), checksum: blob.checksum)
+      service_registry.fetch(destination_service_name).upload(blob.key, StringIO.new(payload), checksum: blob.checksum)
+    end
+  end
+
+  after do
+    ActiveStorage::Blob.where(id: blobs.map(&:id)).delete_all
+    FileUtils.rm_rf(source_root)
+    FileUtils.rm_rf(destination_root)
+  end
+
+  it 'reconciles a stable set only after storage mutations stop and mirror work drains' do
+    blocked = lifecycle.reconcile(apply: true, mutations_quiesced: false, mirror_queue_drained: true)
+
+    expect(blocked.to_h).to include(eligible: false, applied: false, reason: :mutations_not_quiesced)
+    expect(run.reload).to be_backfill
+
+    result = lifecycle.reconcile(apply: true, mutations_quiesced: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: true, applied: true, reason: :reconciled)
+    expect(run.reload).to be_reconciled
+    expect(run.stable_blob_count).to eq(2)
+  end
+
+  it 'blocks reconciliation and cutover while mirror work is pending' do
+    result = lifecycle.reconcile(apply: true, mutations_quiesced: true, mirror_queue_drained: false)
+
+    expect(result.to_h).to include(eligible: false, applied: false, reason: :mirror_queue_pending)
+    expect(lifecycle.cutover(apply: true).reason).to eq(:reconciliation_required)
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent'))
+  end
+
+  it 'blocks cutover when a destination blob is corrupt' do
+    service_registry.fetch(destination_service_name).upload(
+      blobs.first.key,
+      StringIO.new('corrupt'),
+      checksum: Digest::MD5.base64digest('corrupt')
+    )
+
+    result = lifecycle.reconcile(apply: true, mutations_quiesced: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: false, applied: false, reason: :destination_unverified)
+    expect(lifecycle.cutover(apply: true).reason).to eq(:reconciliation_required)
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent'))
+  end
+
+  it 'keeps cutover dry-run by default' do
+    reconcile!
+
+    result = lifecycle.cutover
+
+    expect(result.to_h).to include(eligible: true, applied: false, reason: :cutover_ready)
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent'))
+  end
+
+  it 'keeps reconciliation dry-run by default and does not repair missing objects' do
+    destination = service_registry.fetch(destination_service_name)
+    destination.delete(blobs.first.key)
+
+    result = lifecycle.reconcile(mutations_quiesced: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: false, applied: false, reason: :destination_unverified)
+    expect(destination).not_to exist(blobs.first.key)
+    expect(run.reload).to be_backfill
+  end
+
+  it 'atomically enters the destination-primary rollback window' do
+    reconcile!
+
+    result = lifecycle.cutover(apply: true, rollback_window: 2.hours)
+
+    expect(result.to_h).to include(eligible: true, applied: true, reason: :cutover_complete)
+    expect(blobs.map { it.reload.service_name }).to all(eq('s3_with_persistent_mirror'))
+    expect(run.reload).to be_rollback_window
+    expect(run.rollback_deadline).to eq(clock.call + 2.hours)
+  end
+
+  it 'supports the same cutover transition from S3 to Disk' do
+    run.update!(source_service_name: :s3, destination_service_name: :persistent)
+    blobs.each { it.update!(service_name: 's3') }
+    reconcile!
+
+    lifecycle.cutover(apply: true)
+
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent_with_s3_mirror'))
+  end
+
+  it 'rolls every service identity back when the cutover transaction fails' do
+    reconcile!
+    failing_lifecycle = described_class.new(
+      run:,
+      blob_scope:,
+      service_registry:,
+      owner_role: -> { true },
+      clock:,
+      after_transition: -> { raise ActiveRecord::Rollback }
+    )
+
+    result = failing_lifecycle.cutover(apply: true)
+
+    expect(result.to_h).to include(applied: false, reason: :transaction_rolled_back)
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent'))
+    expect(run.reload).to be_reconciled
+  end
+
+  it 'rolls back during the window after the source is verified and mirror work drains' do
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 2.hours)
+
+    result = lifecycle.rollback(apply: true, source_verified: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: true, applied: true, reason: :rollback_complete)
+    expect(blobs.map { it.reload.service_name }).to all(eq('persistent_with_s3_mirror'))
+    expect(run.reload).to be_backfill
+  end
+
+  it 'keeps rollback dry-run by default' do
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 2.hours)
+
+    result = lifecycle.rollback(source_verified: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: true, applied: false, reason: :rollback_ready)
+    expect(blobs.map { it.reload.service_name }).to all(eq('s3_with_persistent_mirror'))
+  end
+
+  it 'rejects rollback after the rollback window' do
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 2.hours)
+    late_lifecycle = described_class.new(
+      run:,
+      blob_scope:,
+      service_registry:,
+      owner_role: -> { true },
+      clock: -> { clock.call + 3.hours }
+    )
+
+    result = late_lifecycle.rollback(apply: true, source_verified: true, mirror_queue_drained: true)
+
+    expect(result.to_h).to include(eligible: false, applied: false, reason: :rollback_window_expired)
+    expect(blobs.map { it.reload.service_name }).to all(eq('s3_with_persistent_mirror'))
+  end
+
+  it 'finalizes only after the window, acceptance, recovery, and final reconciliation' do
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 2.hours)
+    late_lifecycle = lifecycle_at(clock.call + 3.hours)
+
+    blocked = late_lifecycle.finalize(apply: true, acceptance_verified: false,
+                                      recovery_verified: true, final_reconciled: true)
+    result = late_lifecycle.finalize(apply: true, acceptance_verified: true,
+                                     recovery_verified: true, final_reconciled: true)
+
+    expect(blocked.to_h).to include(eligible: false, applied: false, reason: :acceptance_required)
+    expect(result.to_h).to include(eligible: true, applied: true, reason: :finalized)
+    expect(blobs.map { it.reload.service_name }).to all(eq('s3'))
+    expect(run.reload).to be_finalized
+  end
+
+  it 'keeps finalization dry-run by default' do
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 1.second)
+    late_lifecycle = described_class.new(
+      run:,
+      blob_scope:,
+      service_registry:,
+      owner_role: -> { true },
+      clock: -> { clock.call + 2.seconds }
+    )
+
+    result = late_lifecycle.finalize(acceptance_verified: true,
+                                     recovery_verified: true, final_reconciled: true)
+
+    expect(result.to_h).to include(eligible: true, applied: false, reason: :finalization_ready)
+    expect(blobs.map { it.reload.service_name }).to all(eq('s3_with_persistent_mirror'))
+  end
+
+  it 'requires finalization and no live source dependency before source retirement' do
+    expect(lifecycle.retirement_eligibility(live_source_dependency: false).reason).to eq(:finalization_required)
+    reconcile!
+    lifecycle.cutover(apply: true, rollback_window: 1.second)
+    late_lifecycle = lifecycle_at(clock.call + 2.seconds)
+    late_lifecycle.finalize(apply: true, acceptance_verified: true,
+                            recovery_verified: true, final_reconciled: true)
+
+    expect(late_lifecycle.retirement_eligibility(live_source_dependency: true).reason)
+      .to eq(:live_source_dependency)
+    expect(late_lifecycle.retirement_eligibility(live_source_dependency: false).to_h)
+      .to include(eligible: true, applied: false, reason: :source_retirement_eligible)
+  end
+
+  def reconcile!
+    lifecycle.reconcile(apply: true, mutations_quiesced: true, mirror_queue_drained: true)
+  end
+
+  def clock
+    @clock ||= -> { Time.zone.parse('2026-08-02 08:00:00') }
+  end
+
+  def source_service_name
+    :persistent
+  end
+
+  def destination_service_name
+    :s3
+  end
+
+  def source_root
+    @source_root ||= Dir.mktmpdir('storage-lifecycle-source')
+  end
+
+  def destination_root
+    @destination_root ||= Dir.mktmpdir('storage-lifecycle-destination')
+  end
+
+  def service_registry
+    @service_registry ||= begin
+      persistent = ActiveStorage::Service::DiskService.new(root: source_root)
+      s3 = ActiveStorage::Service::DiskService.new(root: destination_root)
+      {
+        persistent:, s3:, 'persistent' => persistent, 's3' => s3,
+        'persistent_with_s3_mirror' => persistent, 's3_with_persistent_mirror' => s3
+      }
+    end
+  end
+
+  def blobs
+    @blobs ||= %w[first second].map { |payload| create_blob(payload:) }
+  end
+
+  def blob_scope
+    @blob_scope ||= ActiveStorage::Blob.where(id: blobs)
+  end
+
+  def run
+    @run ||= StorageMigrationRun.create!(source_service_name:, destination_service_name:)
+  end
+
+  def lifecycle
+    @lifecycle ||= lifecycle_at(clock.call)
+  end
+
+  def lifecycle_at(time)
+    described_class.new(run:, blob_scope:, service_registry:, owner_role: -> { true }, clock: -> { time })
+  end
+
+  def create_blob(payload:)
+    blob = ActiveStorage::Blob.new(
+      key: SecureRandom.base58(28),
+      filename: 'opaque.bin',
+      content_type: 'application/octet-stream',
+      byte_size: payload.bytesize,
+      checksum: Digest::MD5.base64digest(payload),
+      service_name: source_service_name
+    )
+    blob.save!(validate: false)
+    blob
+  end
+end

--- a/spec/tasks/rake/task_storage_verify_restore_spec.rb
+++ b/spec/tasks/rake/task_storage_verify_restore_spec.rb
@@ -13,28 +13,92 @@ RSpec.describe Rake::Task do
   end
 
   around do |example|
-    previous_attachment_id = ENV.fetch('ATTACHMENT_ID', nil)
+    previous = ENV.to_h.slice(
+      'ATTACHMENT_ID',
+      'DATABASE_RECOVERY_REFERENCE',
+      'DISK_RECOVERY_REFERENCE',
+      'S3_RECOVERY_REFERENCE',
+      'AUTHORIZED_RETRIEVAL_VERIFIED',
+      'CROSS_HOUSEHOLD_DENIAL_VERIFIED',
+      'STORAGE_MIGRATION_RUN_ID'
+    )
+    ENV.update(
+      'DATABASE_RECOVERY_REFERENCE' => 'database-snapshot-1',
+      'DISK_RECOVERY_REFERENCE' => 'disk-snapshot-1',
+      'AUTHORIZED_RETRIEVAL_VERIFIED' => 'true',
+      'CROSS_HOUSEHOLD_DENIAL_VERIFIED' => 'true'
+    )
     example.run
   ensure
-    ENV['ATTACHMENT_ID'] = previous_attachment_id
+    %w[
+      ATTACHMENT_ID DATABASE_RECOVERY_REFERENCE DISK_RECOVERY_REFERENCE S3_RECOVERY_REFERENCE
+      AUTHORIZED_RETRIEVAL_VERIFIED CROSS_HOUSEHOLD_DENIAL_VERIFIED STORAGE_MIGRATION_RUN_ID
+    ].each { ENV.delete(it) }
+    ENV.update(previous)
   end
 
-  it 'reports the restored attachment and blob without health data' do
-    ENV['ATTACHMENT_ID'] = '42'
-    result = Storage::RestoreVerifier::Result.new(attachment_id: 42, blob_id: 84, byte_size: 512)
-    allow(Storage::RestoreVerifier).to receive(:call).with(attachment_id: '42').and_return(result)
+  it 'reports only the database and required storage recovery references without health data' do
+    configure_successful_restore
+    output = capture_stdout { task.invoke }
 
-    expect { task.invoke }
-      .to output("Storage restore verified: attachment_id=42 blob_id=84 byte_size=512\n").to_stdout
+    expect(JSON.parse(output)).to include(expected_recovery_payload)
+    expect(output).not_to include('unused-s3-snapshot')
+  end
+
+  def configure_successful_restore
+    ENV['ATTACHMENT_ID'] = '42'
+    ENV['S3_RECOVERY_REFERENCE'] = 'unused-s3-snapshot'
+    result = Storage::RestoreVerifier::Result.new(
+      attachment_id: 42,
+      blob_id: 84,
+      byte_size: 512,
+      required_backends: [:disk],
+      authorized_retrieval: true,
+      cross_household_denied: true
+    )
+    allow(Storage::RestoreVerifier).to receive(:call).and_return(result)
+    allow(ActiveRecord::Base.connection).to receive(:select_value)
+      .with('SELECT current_user').and_return('med_tracker_owner')
+  end
+
+  def expected_recovery_payload
+    {
+      'outcome' => 'passed',
+      'attachment_id' => 42,
+      'required_backends' => ['disk'],
+      'database_reference' => 'database-snapshot-1',
+      'storage_references' => { 'disk' => 'disk-snapshot-1' }
+    }
   end
 
   it 'fails the smoke check when verification fails' do
     ENV['ATTACHMENT_ID'] = nil
+    allow(ActiveRecord::Base.connection).to receive(:select_value)
+      .with('SELECT current_user').and_return('med_tracker_owner')
     allow(Storage::RestoreVerifier).to receive(:call)
-      .with(attachment_id: nil)
       .and_raise(Storage::RestoreVerifier::VerificationError, 'No attachment found')
 
     expect { task.invoke }.to raise_error(SystemExit)
-      .and output(/Storage restore verification failed: No attachment found/).to_stderr
+      .and output(/"outcome":"failed","failure_code":"restore_verification_failed"/).to_stderr
+  end
+
+  it 'rejects a non-owner database role before selecting restored records' do
+    allow(ActiveRecord::Base.connection).to receive(:select_value)
+      .with('SELECT current_user').and_return('med_tracker_app')
+    allow(Storage::RestoreVerifier).to receive(:call)
+
+    expect { task.invoke }.to raise_error(SystemExit)
+      .and output(/"failure_code":"owner_role_required"/).to_stderr
+    expect(Storage::RestoreVerifier).not_to have_received(:call)
+  end
+
+  def capture_stdout
+    original = $stdout
+    stream = StringIO.new
+    $stdout = stream
+    yield
+    stream.string
+  ensure
+    $stdout = original
   end
 end


### PR DESCRIPTION
## Summary

- Supports explicit Disk-only, S3-only, and mirrored production storage modes without making S3 mandatory.
- Adds a dry-run-first, direction-neutral migration lifecycle with reconciliation, transactional cutover, rollback, finalization, owner-role checks, and aggregate operational evidence.
- Makes queued NHS dm+d archives service-neutral and adds backend-aware restore verification.
- Documents backup, recovery, migration, and the bounded home-ops handoff.

## Verification

- `task rubocop` — 1,740 files inspected, no offences.
- `task test` — 5,001 examples, 0 failures, 1 existing OIDC-only pending example.
- `task prod:storage-disk-smoke` — final production image upload/download/delete passed without S3 settings.
- `task prod:storage-s3-smoke` — final production image upload/download/delete passed with S3 selected.
- `task docs:build` — passed.
- `task openspec:validate` — 7 changes passed, 0 failed.
- `git diff --check` — passed.

## Risks / follow-ups

- Depends on #1766 for the operational-event foundation. Until #1766 merges, GitHub will also show its commits in this PR; #1766 is currently clean and green.
- Deployed Disk-to-S3-to-Disk canary acceptance remains tracked in #1775. This change does not migrate production or delete either production storage backend.