### PR TITLE
feat(jobs): use fiber workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,10 +56,11 @@ gem 'opentelemetry-metrics-api'
 gem 'opentelemetry-metrics-sdk'
 gem 'opentelemetry-sdk'
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[windows jruby]
+gem 'async', '>= 2.24'
 # Solid Queue is a database-based queuing backend for Active Job [https://github.com/rails/solid_queue]
 gem 'solid_queue'
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: %i[windows jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 # Use Phlex for views [https://github.com/phlex-rb/phlex-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
     aes_key_wrap (1.1.0)
     android_key_attestation (0.3.0)
     ast (2.4.3)
+    async (2.44.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1274.0)
@@ -138,6 +142,10 @@ GEM
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
+    console (1.37.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     cose (1.3.1)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
@@ -213,6 +221,10 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     flay (2.14.4)
       erubi (~> 1.10)
       path_expander (~> 2.0)
@@ -263,6 +275,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
+    io-event (1.19.4)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -853,6 +866,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  async (>= 2.24)
   aws-sdk-s3
   bcrypt
   bootsnap

--- a/app/jobs/low_stock_notification_job.rb
+++ b/app/jobs/low_stock_notification_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LowStockNotificationJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   def perform(household_id, medication_id, take_id)
     household = Household.operational.find_by(id: household_id)

--- a/app/jobs/medication_reminder_job.rb
+++ b/app/jobs/medication_reminder_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MedicationReminderJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   PERIOD_LABELS = {
     morning: 'Morning',

--- a/app/jobs/missed_dose_notification_job.rb
+++ b/app/jobs/missed_dose_notification_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MissedDoseNotificationJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   GRACE_PERIOD = 30.minutes
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module MedTracker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
+    config.active_support.isolation_level = :fiber
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,14 @@
 # Database configuration for MedTracker
 # All environments use DATABASE_URL environment variable
 <% primary_database_role = ENV["DATABASE_ROLE"].to_s.strip %>
+<% primary_database_pool = ENV.fetch("PRIMARY_DB_POOL", 8) %>
+<% queue_database_pool = ENV.fetch("QUEUE_DB_POOL", 8) %>
 
 development:
   primary:
     adapter: postgresql
     url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= primary_database_pool %>
 <% if primary_database_role != "" %>
     variables:
       role: <%= primary_database_role %>
@@ -14,6 +17,7 @@ development:
   queue:
     adapter: postgresql
     url: <%= ENV.fetch('SOLID_QUEUE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_queue') } %>
+    pool: <%= queue_database_pool %>
     migrations_paths: db/queue_migrate
 
 test:
@@ -29,6 +33,7 @@ production:
   primary:
     adapter: postgresql
     url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= primary_database_pool %>
 <% if primary_database_role != "" %>
     variables:
       role: <%= primary_database_role %>
@@ -40,6 +45,7 @@ production:
   queue:
     adapter: postgresql
     url: <%= ENV.fetch('SOLID_QUEUE_DATABASE_URL') { ENV['DATABASE_URL']&.gsub(/\/[^\/]+$/, '/medtracker_production_queue') } %>
+    pool: <%= queue_database_pool %>
     migrations_paths: db/queue_migrate
   cable:
     adapter: postgresql

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -42,6 +42,7 @@ env:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
+    SOLID_QUEUE_SUPERVISOR_MODE: async
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,9 +3,11 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
-      threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+    - queues: notifications
+      fibers: <%= ENV.fetch("JOB_FIBERS", 2) %>
+      polling_interval: 0.1
+    - queues: default
+      threads: 1
       polling_interval: 0.1
 
 development:

--- a/spec/config/solid_queue_runtime_spec.rb
+++ b/spec/config/solid_queue_runtime_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'erb'
+
+module SolidQueueRuntime
+end
+
+RSpec.describe SolidQueueRuntime do
+  it 'uses fiber-scoped Rails execution state' do
+    expect(Rails.application.config.active_support.isolation_level).to eq(:fiber)
+  end
+
+  it 'runs notification jobs on a bounded fiber worker' do
+    notification_worker = workers.find { |worker| worker.fetch('queues') == 'notifications' }
+
+    expect(notification_worker).to include('fibers' => 2, 'polling_interval' => 0.1)
+    expect(notification_worker).not_to have_key('threads')
+  end
+
+  it 'keeps blocking jobs on one thread' do
+    default_worker = workers.find { |worker| worker.fetch('queues') == 'default' }
+
+    expect(default_worker).to include('threads' => 1, 'polling_interval' => 0.1)
+    expect(default_worker).not_to have_key('fibers')
+  end
+
+  it 'runs the Puma-hosted supervisor asynchronously' do
+    expect(puma_config).to include("solid_queue_mode ENV.fetch('SOLID_QUEUE_SUPERVISOR_MODE', 'fork')")
+    expect(deploy_config.dig('env', 'clear', 'SOLID_QUEUE_SUPERVISOR_MODE')).to eq('async')
+  end
+
+  it 'includes the Async runtime dependency' do
+    expect(gemfile).to include("gem 'async', '>= 2.24'")
+  end
+
+  it 'routes notification delivery jobs to the fiber worker' do
+    expect(notification_jobs.map(&:queue_name)).to all(eq('notifications'))
+  end
+
+  it 'sizes the shared primary and queue connection pools explicitly' do
+    expect(database_config.dig('development', 'primary', 'pool')).to eq(8)
+    expect(database_config.dig('development', 'queue', 'pool')).to eq(8)
+    expect(database_config.dig('production', 'primary', 'pool')).to eq(8)
+    expect(database_config.dig('production', 'queue', 'pool')).to eq(8)
+  end
+
+  it 'passes Solid Queue runtime validation in async mode' do
+    configuration = SolidQueue::Configuration.new(mode: :async, skip_recurring: true)
+
+    expect(configuration).to be_valid
+  end
+
+  def workers
+    queue_config.fetch('production').fetch('workers')
+  end
+
+  def queue_config
+    YAML.safe_load(ERB.new(Rails.root.join('config/queue.yml').read).result, aliases: true)
+  end
+
+  def database_config
+    YAML.safe_load(ERB.new(Rails.root.join('config/database.yml').read).result, aliases: true)
+  end
+
+  def puma_config
+    Rails.root.join('config/puma.rb').read
+  end
+
+  def deploy_config
+    YAML.safe_load(Rails.root.join('config/deploy.yml').read, aliases: true)
+  end
+
+  def gemfile
+    Rails.root.join('Gemfile').read
+  end
+
+  def notification_jobs
+    [MedicationReminderJob, MissedDoseNotificationJob, LowStockNotificationJob]
+  end
+end


### PR DESCRIPTION
## Summary

- Run the in-Puma Solid Queue supervisor in async mode so the single container does not fork another copy of the Rails application.
- Move notification delivery jobs onto a bounded two-fiber worker while keeping default, potentially blocking jobs on one thread.
- Use fiber-scoped Rails execution state, add the Async runtime required by Solid Queue 1.6, and size the primary and queue database pools explicitly.

## Rollout

JOB_FIBERS defaults to 2 and can be tuned without an image rebuild. The default worker remains thread-based, and the supervisor mode stays environment-controlled so the later dedicated job-container split can replace this topology cleanly.