### PR TITLE
fix(nhs-dmd): restore live import progress

### DIFF
--- a/app/components/admin/nhs_dmd_imports/form_view.rb
+++ b/app/components/admin/nhs_dmd_imports/form_view.rb
@@ -5,6 +5,7 @@ module Components
     module NhsDmdImports
       class FormView < Components::Base
         include Phlex::Rails::Helpers::FormWith
+        include Phlex::Rails::Helpers::TurboStreamFrom
 
         def initialize(import_run: nil)
           @import_run = import_run
@@ -16,7 +17,7 @@ module Components
             render_header
             render_form
             render_import_run
-            render_auto_refresh
+            render_stream_subscription
           end
         end
 
@@ -167,12 +168,10 @@ module Components
           "#{@import_run.progress_percentage}%"
         end
 
-        def render_auto_refresh
+        def render_stream_subscription
           return unless @import_run&.active?
 
-          script do
-            plain 'window.setTimeout(function () { window.location.reload(); }, 5000);'
-          end
+          turbo_stream_from(@import_run)
         end
       end
     end

--- a/app/controllers/admin/nhs_dmd_imports_controller.rb
+++ b/app/controllers/admin/nhs_dmd_imports_controller.rb
@@ -17,14 +17,20 @@ module Admin
         return
       end
 
-      import_run = NhsDmdImport.create!(
-        uploaded_filename: uploaded_file.original_filename.presence || File.basename(uploaded_file.path)
-      )
-      NhsDmd::ArchiveStore.new.persist(import_run:, uploaded_file:)
-      NhsDmdImportJob.perform_later(import_run.id)
+      import_run = ActiveRecord::Base.transaction(requires_new: true) do
+        NhsDmdImport.create!(
+          uploaded_filename: uploaded_file.original_filename.presence || File.basename(uploaded_file.path)
+        )
+      end
+      import_run.persist_archive!(uploaded_file)
+      NhsDmdImportJob.perform_later(import_run)
 
       redirect_to new_admin_nhs_dmd_import_path,
                   notice: t('admin.nhs_dmd_imports.started')
+    rescue ActiveRecord::RecordNotUnique => e
+      raise unless e.message.include?('index_nhs_dmd_imports_one_active')
+
+      redirect_to new_admin_nhs_dmd_import_path, alert: t('admin.nhs_dmd_imports.already_running')
     rescue NhsDmd::ArchiveStore::Error, ArgumentError, ActiveRecord::ActiveRecordError, SystemCallError => e
       import_run&.fail!(e.message) if import_run&.queued?
       redirect_to new_admin_nhs_dmd_import_path, alert: e.message

--- a/app/controllers/admin/nhs_dmd_imports_controller.rb
+++ b/app/controllers/admin/nhs_dmd_imports_controller.rb
@@ -22,8 +22,8 @@ module Admin
           uploaded_filename: uploaded_file.original_filename.presence || File.basename(uploaded_file.path)
         )
       end
-      import_run.persist_archive!(uploaded_file)
-      NhsDmdImportJob.perform_later(import_run)
+      NhsDmd::ArchiveStore.new.persist(import_run:, uploaded_file:)
+      NhsDmdImportJob.perform_later(import_run.id)
 
       redirect_to new_admin_nhs_dmd_import_path,
                   notice: t('admin.nhs_dmd_imports.started')

--- a/app/jobs/nhs_dmd_import_reconciliation_job.rb
+++ b/app/jobs/nhs_dmd_import_reconciliation_job.rb
@@ -1,0 +1,9 @@
+class NhsDmdImportReconciliationJob < ApplicationJob
+  INTERRUPTION_MESSAGE = 'Import interrupted because the worker stopped reporting progress.'
+
+  def perform
+    NhsDmdImport.where(status: NhsDmdImport.statuses.values_at(*NhsDmdImport::ACTIVE_STATUSES))
+      .where(updated_at: ..30.minutes.ago)
+      .find_each { |import_run| import_run.fail!(INTERRUPTION_MESSAGE) }
+  end
+end

--- a/app/jobs/nhs_dmd_import_reconciliation_job.rb
+++ b/app/jobs/nhs_dmd_import_reconciliation_job.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 class NhsDmdImportReconciliationJob < ApplicationJob
   INTERRUPTION_MESSAGE = 'Import interrupted because the worker stopped reporting progress.'
 
   def perform
-    NhsDmdImport.where(status: NhsDmdImport.statuses.values_at(*NhsDmdImport::ACTIVE_STATUSES))
-      .where(updated_at: ..30.minutes.ago)
-      .find_each { |import_run| import_run.fail!(INTERRUPTION_MESSAGE) }
+    active_imports = NhsDmdImport.where(status: NhsDmdImport.statuses.values_at(*NhsDmdImport::ACTIVE_STATUSES))
+
+    active_imports.where(updated_at: ..30.minutes.ago).find_each do |import_run|
+      import_run.fail!(INTERRUPTION_MESSAGE)
+    end
   end
 end

--- a/app/models/nhs_dmd_import.rb
+++ b/app/models/nhs_dmd_import.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class NhsDmdImport < ApplicationRecord
+  ACTIVE_STATUSES = %i[queued extracting counting importing].freeze
+
   PROGRESS_COUNTER_KEYS = %i[
     total_records
     processed_records
@@ -28,6 +30,8 @@ class NhsDmdImport < ApplicationRecord
 
   validates :uploaded_filename, presence: true
   validate :complete_archive_reference
+
+  after_update_commit :broadcast_refresh
 
   def self.latest_first
     order(created_at: :desc)
@@ -111,6 +115,10 @@ class NhsDmdImport < ApplicationRecord
 
   def appended_log(message)
     [log.presence, message].compact.join("\n")
+  end
+
+  def broadcast_refresh
+    broadcast_refresh_to(self)
   end
 
   def progress_attributes(progress)

--- a/app/services/nhs_dmd/release_archive_import.rb
+++ b/app/services/nhs_dmd/release_archive_import.rb
@@ -10,12 +10,14 @@ module NhsDmd
     end
 
     def import(uploaded_file_or_path, progress_callback: nil)
-      archive_path = resolve_archive_path(uploaded_file_or_path)
+      ActiveRecord::Base.uncached do
+        archive_path = resolve_archive_path(uploaded_file_or_path)
 
-      Dir.mktmpdir('nhs-dmd-release') do |release_dir|
-        progress_callback&.call(status: :extracting, message: 'Extracting release archive')
-        @extractor.extract(archive_path, release_dir)
-        @importer.import(release_dir, progress_callback: progress_callback)
+        Dir.mktmpdir('nhs-dmd-release') do |release_dir|
+          progress_callback&.call(status: :extracting, message: 'Extracting release archive')
+          @extractor.extract(archive_path, release_dir)
+          @importer.import(release_dir, progress_callback: progress_callback)
+        end
       end
     rescue ReleaseArchiveExtractor::Error => e
       raise Error, e.message

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -672,6 +672,7 @@ cy:
           actions: Camau
           view: Gweld
     nhs_dmd_imports:
+      already_running: Mae mewnforiad NHS dm+d eisoes yn rhedeg. Arhoswch iddo orffen.
       created: 'Rhyddhad NHS dm+d wedi''i fewnforio: %{imported} cofnod wedi''i fewnforio,
         %{skipped} wedi''u hepgor.'
       form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,7 @@ en:
       subtitle: Upload the latest NHS dm+d ZIP and import AMPP names with GTIN barcode
         mappings.
       missing_file: Select an NHS dm+d release ZIP to import.
+      already_running: An NHS dm+d import is already running. Please wait for it to finish.
       created: 'Imported NHS dm+d release: %{imported} records imported, %{skipped}
         skipped.'
       started: NHS dm+d import started. Progress and logs will appear below.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -678,6 +678,7 @@ es:
           actions: Acciones
           view: Ver
     nhs_dmd_imports:
+      already_running: Ya se está ejecutando una importación de NHS dm+d. Espere a que termine.
       created: 'Publicación NHS dm+d importada: %{imported} registros importados,
         %{skipped} omitidos.'
       form:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -455,6 +455,7 @@ ga:
           actions: Gníomhartha
           view: Féach
     nhs_dmd_imports:
+      already_running: Tá iompórtáil NHS dm+d ar siúl cheana féin. Fan go gcríochnóidh sí.
       created: 'Scaoileadh NHS dm+d iompórtáilte: %{imported} taifead iompórtáilte,
         %{skipped} scipeáilte.'
       form:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -679,6 +679,7 @@ pt:
           actions: Ações
           view: Ver
     nhs_dmd_imports:
+      already_running: Já está em execução uma importação do NHS dm+d. Aguarde até terminar.
       created: 'Versão NHS dm+d importada: %{imported} registos importados, %{skipped}
         ignorados.'
       form:

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -11,6 +11,10 @@ production:
     class: ExpireHouseholdExportsJob
     schedule: every hour
     queue: default
+  reconcile_nhs_dmd_imports:
+    class: NhsDmdImportReconciliationJob
+    schedule: every 5 minutes
+    queue: default
 
 # production:
 #   periodic_cleanup:

--- a/db/migrate/20260803150000_enforce_one_active_nhs_dmd_import.rb
+++ b/db/migrate/20260803150000_enforce_one_active_nhs_dmd_import.rb
@@ -1,7 +1,12 @@
+# frozen_string_literal: true
+
 class EnforceOneActiveNhsDmdImport < ActiveRecord::Migration[8.1]
   INDEX_NAME = 'index_nhs_dmd_imports_one_active'
+  INTERRUPTION_MESSAGE = 'Import interrupted because the worker stopped reporting progress.'
 
   def up
+    reconcile_interrupted_imports
+
     execute <<~SQL
       CREATE UNIQUE INDEX #{INDEX_NAME}
       ON nhs_dmd_imports ((1))
@@ -11,5 +16,30 @@ class EnforceOneActiveNhsDmdImport < ActiveRecord::Migration[8.1]
 
   def down
     remove_index :nhs_dmd_imports, name: INDEX_NAME
+  end
+
+  private
+
+  def reconcile_interrupted_imports
+    execute <<~SQL
+      WITH active_imports AS (
+        SELECT id, updated_at,
+               ROW_NUMBER() OVER (ORDER BY updated_at DESC, id DESC) AS recency
+        FROM nhs_dmd_imports
+        WHERE status IN (0, 1, 2, 3)
+      ), interrupted_imports AS (
+        SELECT id
+        FROM active_imports
+        WHERE updated_at <= CURRENT_TIMESTAMP - INTERVAL '30 minutes'
+           OR recency > 1
+      )
+      UPDATE nhs_dmd_imports
+      SET status = 5,
+          completed_at = CURRENT_TIMESTAMP,
+          updated_at = CURRENT_TIMESTAMP,
+          error_message = #{connection.quote(INTERRUPTION_MESSAGE)},
+          log = CONCAT_WS(E'\n', NULLIF(log, ''), #{connection.quote(INTERRUPTION_MESSAGE)})
+      WHERE id IN (SELECT id FROM interrupted_imports)
+    SQL
   end
 end

--- a/db/migrate/20260803150000_enforce_one_active_nhs_dmd_import.rb
+++ b/db/migrate/20260803150000_enforce_one_active_nhs_dmd_import.rb
@@ -1,0 +1,15 @@
+class EnforceOneActiveNhsDmdImport < ActiveRecord::Migration[8.1]
+  INDEX_NAME = 'index_nhs_dmd_imports_one_active'
+
+  def up
+    execute <<~SQL
+      CREATE UNIQUE INDEX #{INDEX_NAME}
+      ON nhs_dmd_imports ((1))
+      WHERE status IN (0, 1, 2, 3)
+    SQL
+  end
+
+  def down
+    remove_index :nhs_dmd_imports, name: INDEX_NAME
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -825,7 +825,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_150000) do
   end
 
   create_table "nhs_dmd_imports", force: :cascade do |t|
+    t.bigint "archive_byte_size"
+    t.string "archive_checksum"
+    t.string "archive_key"
     t.string "archive_path"
+    t.string "archive_service_name"
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.integer "created_count", default: 0, null: false
@@ -1102,6 +1106,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_150000) do
     t.index ["household_id", "created_at"], name: "index_security_audit_events_on_household_id_and_created_at"
     t.index ["household_id"], name: "index_security_audit_events_on_household_id"
     t.index ["id", "household_id"], name: "index_security_audit_events_on_id_and_household_id", unique: true
+  end
+
+  create_table "storage_migration_runs", force: :cascade do |t|
+    t.datetime "acceptance_verified_at"
+    t.datetime "created_at", null: false
+    t.string "destination_service_name", null: false
+    t.bigint "failed_count", default: 0, null: false
+    t.datetime "final_reconciled_at"
+    t.datetime "finalized_at"
+    t.datetime "mirror_queue_drained_at"
+    t.string "phase", default: "backfill", null: false
+    t.bigint "processed_count", default: 0, null: false
+    t.datetime "reconciled_at"
+    t.datetime "recovery_verified_at"
+    t.datetime "rollback_deadline"
+    t.uuid "run_id", default: -> { "gen_random_uuid()" }, null: false
+    t.string "source_service_name", null: false
+    t.bigint "stable_blob_count"
+    t.datetime "updated_at", null: false
+    t.bigint "verified_count", default: 0, null: false
+    t.index ["run_id"], name: "index_storage_migration_runs_on_run_id", unique: true
   end
 
   create_table "support_access_sessions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -844,6 +844,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_120000) do
     t.datetime "updated_at", null: false
     t.integer "updated_count", default: 0, null: false
     t.string "uploaded_filename", null: false
+    t.index "(1)", name: "index_nhs_dmd_imports_one_active", unique: true, where: "(status = ANY (ARRAY[0, 1, 2, 3]))"
   end
 
   create_table "nhs_dmd_supplementary_releases", force: :cascade do |t|

--- a/spec/jobs/nhs_dmd_import_reconciliation_job_spec.rb
+++ b/spec/jobs/nhs_dmd_import_reconciliation_job_spec.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe NhsDmdImportReconciliationJob do
   it 'fails active imports unchanged for at least thirty minutes' do
-    import = NhsDmdImport.create!(uploaded_filename: 'stalled.zip', status: :importing)
-    import.update_column(:updated_at, 30.minutes.ago)
+    import = travel_to(30.minutes.ago) do
+      NhsDmdImport.create!(uploaded_filename: 'stalled.zip', status: :importing)
+    end
 
     described_class.perform_now
 

--- a/spec/jobs/nhs_dmd_import_reconciliation_job_spec.rb
+++ b/spec/jobs/nhs_dmd_import_reconciliation_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe NhsDmdImportReconciliationJob do
+  it 'fails active imports unchanged for at least thirty minutes' do
+    import = NhsDmdImport.create!(uploaded_filename: 'stalled.zip', status: :importing)
+    import.update_column(:updated_at, 30.minutes.ago)
+
+    described_class.perform_now
+
+    expect(import.reload).to have_attributes(
+      status: 'failed',
+      error_message: 'Import interrupted because the worker stopped reporting progress.'
+    )
+    expect(import.log).to include('Import interrupted because the worker stopped reporting progress.')
+  end
+
+  it 'preserves recently updated active imports' do
+    import = NhsDmdImport.create!(uploaded_filename: 'recent.zip', status: :counting)
+
+    described_class.perform_now
+
+    expect(import.reload).to be_counting
+  end
+
+  it 'runs every five minutes in production' do
+    schedule = YAML.safe_load_file(Rails.root.join('config/recurring.yml')).dig(
+      'production', 'reconcile_nhs_dmd_imports'
+    )
+
+    expect(schedule).to include(
+      'class' => described_class.name, 'schedule' => 'every 5 minutes', 'queue' => 'default'
+    )
+  end
+end

--- a/spec/migrations/enforce_one_active_nhs_dmd_import_spec.rb
+++ b/spec/migrations/enforce_one_active_nhs_dmd_import_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260803150000_enforce_one_active_nhs_dmd_import')
+
+RSpec.describe EnforceOneActiveNhsDmdImport do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:migration) { described_class.new }
+
+  it 'reconciles existing interrupted and duplicate active imports before adding the index' do
+    with_index_rebuilt do |imports|
+      expect(imports.transform_values { it.reload.status }).to eq(
+        stale: 'failed', older_recent: 'failed', latest_recent: 'importing'
+      )
+      expect(imports.values_at(:stale, :older_recent).map(&:error_message)).to all(eq(interruption_message))
+      expect(imports.values_at(:stale, :older_recent).map(&:log)).to all(include(interruption_message))
+      expect(connection.index_exists?(:nhs_dmd_imports, name: described_class::INDEX_NAME)).to be(true)
+    end
+  end
+
+  def with_index_rebuilt
+    connection.transaction(requires_new: true) do
+      ActiveRecord::Migration.suppress_messages { migration.down }
+      imports = create_duplicate_active_imports
+      ActiveRecord::Migration.suppress_messages { migration.up }
+      yield imports
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def create_duplicate_active_imports
+    {
+      stale: create_import_at(31.minutes.ago, 'stale.zip'),
+      older_recent: create_import_at(2.minutes.ago, 'older-recent.zip'),
+      latest_recent: create_import_at(1.minute.ago, 'latest-recent.zip')
+    }
+  end
+
+  def create_import_at(time, filename)
+    travel_to(time) { NhsDmdImport.create!(uploaded_filename: filename, status: :importing) }
+  end
+
+  def interruption_message
+    described_class::INTERRUPTION_MESSAGE
+  end
+end

--- a/spec/models/nhs_dmd_import_spec.rb
+++ b/spec/models/nhs_dmd_import_spec.rb
@@ -78,6 +78,53 @@ RSpec.describe NhsDmdImport do
     end
   end
 
+  describe 'active import invariant' do
+    it 'permits only one queued, extracting, counting, or importing record' do
+      described_class.create!(uploaded_filename: 'queued.zip', status: :queued)
+
+      expect do
+        described_class.create!(uploaded_filename: 'importing.zip', status: :importing)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'allows a new active import after the previous import has completed' do
+      import = described_class.create!(uploaded_filename: 'queued.zip', status: :queued)
+      import.update!(status: :completed, completed_at: Time.current)
+
+      expect do
+        described_class.create!(uploaded_filename: 'next.zip', status: :queued)
+      end.not_to raise_error
+    end
+  end
+
+  describe 'Turbo refresh broadcasts' do
+    it 'broadcasts after committed progress updates' do
+      import = described_class.create!(uploaded_filename: 'release.zip')
+      allow(import).to receive(:broadcast_refresh_to)
+
+      import.apply_progress!(status: :importing, message: 'Importing records')
+
+      expect(import).to have_received(:broadcast_refresh_to).with(import)
+    end
+
+    it 'broadcasts after committed terminal updates' do
+      import = described_class.create!(uploaded_filename: 'release.zip')
+      allow(import).to receive(:broadcast_refresh_to)
+      result = NhsDmd::ReleaseImport::Result.new(
+        created_count: 1,
+        updated_count: 0,
+        unchanged_count: 0,
+        skipped_expired_count: 0,
+        skipped_missing_name_count: 0,
+        skipped_invalid_count: 0
+      )
+
+      import.complete!(result)
+
+      expect(import).to have_received(:broadcast_refresh_to).with(import)
+    end
+  end
+
   describe '#progress_percentage' do
     subject(:import) { described_class.new }
 

--- a/spec/requests/admin/nhs_dmd_imports_spec.rb
+++ b/spec/requests/admin/nhs_dmd_imports_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe 'Admin::NhsDmdImports' do
         expect(response.body).to include('500 / 900')
       end
 
+      it 'subscribes to the signed stream for an active latest import without inline polling' do
+        import = NhsDmdImport.create!(uploaded_filename: 'nhsbsa_dmd_release.zip', status: :importing)
+
+        get new_admin_nhs_dmd_import_path
+
+        expect(response.body).to include(
+          '<turbo-cable-stream-source',
+          Turbo::StreamsChannel.signed_stream_name(import)
+        )
+        expect(response.body).not_to include('window.setTimeout')
+      end
+
       it 'renders the full log in a scrollable fixed-height panel pinned to bottom' do
         log_lines = (1..15).map { |index| format('Entry %<index>02d', index: index) }.join("\n")
 
@@ -140,6 +152,15 @@ RSpec.describe 'Admin::NhsDmdImports' do
 
       expect(response).to redirect_to(new_admin_nhs_dmd_import_path)
       expect(flash[:alert]).to eq('Select an NHS dm+d release ZIP to import.')
+    end
+
+    it 'redirects with a friendly alert when another import is active' do
+      NhsDmdImport.create!(uploaded_filename: 'already_running.zip', status: :importing)
+
+      post admin_nhs_dmd_import_path, params: { nhs_dmd_import: { release_zip: uploaded_zip('next_release.zip') } }
+
+      expect(response).to redirect_to(new_admin_nhs_dmd_import_path)
+      expect(flash[:alert]).to eq('An NHS dm+d import is already running. Please wait for it to finish.')
     end
 
     it 'marks the import as failed when the archive cannot be persisted' do

--- a/spec/services/nhs_dmd/archive_migration_spec.rb
+++ b/spec/services/nhs_dmd/archive_migration_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe NhsDmd::ArchiveMigration do
   let(:imports) do
     [
       NhsDmdImport.create!(uploaded_filename: 'first.zip', archive_path: '/legacy/first.zip'),
-      NhsDmdImport.create!(uploaded_filename: 'second.zip', archive_path: '/legacy/second.zip'),
       NhsDmdImport.create!(uploaded_filename: 'complete.zip', archive_path: '/legacy/complete.zip', status: :completed)
     ]
   end
@@ -20,7 +19,7 @@ RSpec.describe NhsDmd::ArchiveMigration do
     result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { true },
                                  service_name: :persistent).call
 
-    expect(result.to_h).to include(processed_count: 2, converted_count: 0, failed_count: 0, applied: false)
+    expect(result.to_h).to include(processed_count: 1, converted_count: 0, failed_count: 0, applied: false)
     expect(store).not_to have_received(:convert_legacy)
   end
 
@@ -30,17 +29,17 @@ RSpec.describe NhsDmd::ArchiveMigration do
     result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { true },
                                  service_name: :s3, apply: true).call
 
-    expect(result.to_h).to include(processed_count: 2, converted_count: 2, failed_count: 0, applied: true)
+    expect(result.to_h).to include(processed_count: 1, converted_count: 1, failed_count: 0, applied: true)
     expect(scope).to have_received(:find_in_batches).with(batch_size: 100)
-    expect(store).to have_received(:convert_legacy).twice
+    expect(store).to have_received(:convert_legacy).once
   end
 
   it 'reports missing legacy files only as aggregate failures' do
     result = described_class.new(scope:, store:, owner_role:, path_exists: ->(_) { false },
                                  service_name: :persistent).call
 
-    expect(result.to_h).to include(processed_count: 2, converted_count: 0, failed_count: 2)
-    expect(result.to_h.to_json).not_to include('/legacy/', 'first.zip', 'second.zip')
+    expect(result.to_h).to include(processed_count: 1, converted_count: 0, failed_count: 1)
+    expect(result.to_h.to_json).not_to include('/legacy/', 'first.zip')
   end
 
   it 'requires the owner-capable database role' do

--- a/spec/services/nhs_dmd/archive_store_spec.rb
+++ b/spec/services/nhs_dmd/archive_store_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe NhsDmd::ArchiveStore do
       checksum: Digest::MD5.base64digest(payload),
       byte_size: payload.bytesize
     )
-    expect(reference.key).not_to include(import_run.uploaded_filename, import_run.id.to_s)
+    expect_opaque_reference(reference)
     expect(import_run.reload).to have_attributes(
       archive_service_name: 'persistent',
       archive_key: reference.key,
@@ -46,7 +46,7 @@ RSpec.describe NhsDmd::ArchiveStore do
 
   it 'resolves retry-safe reads through either declared backend' do
     %i[persistent s3].each do |service_name|
-      run = NhsDmdImport.create!(uploaded_filename: 'release.zip')
+      run = NhsDmdImport.create!(uploaded_filename: 'release.zip', status: :completed)
       store.persist(import_run: run, uploaded_file: upload, service_name:)
 
       first = store.open(run) { |path| File.binread(path) }
@@ -134,6 +134,11 @@ RSpec.describe NhsDmd::ArchiveStore do
 
   def persistent_root
     @persistent_root ||= Dir.mktmpdir('nhs-dmd-persistent')
+  end
+
+  def expect_opaque_reference(reference)
+    expect(reference.key).not_to include(import_run.uploaded_filename)
+    expect(reference.key).to match(%r{\Anhs-dmd/imports/[0-9a-f-]{36}\z})
   end
 
   def s3_root

--- a/spec/services/nhs_dmd/release_archive_import_spec.rb
+++ b/spec/services/nhs_dmd/release_archive_import_spec.rb
@@ -48,37 +48,39 @@ RSpec.describe NhsDmd::ReleaseArchiveImport do
   it 'runs the archive import with the query cache disabled' do
     allow(extractor).to receive(:extract)
     allow(importer).to receive(:import).and_return(result)
-
-    expect(ActiveRecord::Base).to receive(:uncached).and_yield
+    allow(ActiveRecord::Base).to receive(:uncached).and_yield
 
     service.import(uploaded_file, progress_callback: ->(_payload) {})
+
+    expect(ActiveRecord::Base).to have_received(:uncached)
   end
 
   describe 'with a real release archive' do
     let(:importer) { NhsDmd::ReleaseImport.new }
     let(:extractor) { NhsDmd::ReleaseArchiveExtractor.new }
     let(:release_root) { Pathname.new(Dir.mktmpdir('release-archive-import-spec', Rails.root.join('tmp'))) }
-    let(:archive_path) { release_root.join('release.zip') }
     let(:uploaded_file) { Struct.new(:path).new(archive_path.to_s) }
-    let(:archive_entries) do
+
+    def archive_path
+      release_root.join('release.zip')
+    end
+
+    def archive_entries
       {
         'f_ampp2_3000000.xml' => '<ACTUAL_MEDICINAL_PROD_PACKS><AMPPS>' \
-          '<AMPP><APPID>777</APPID><NM>Updated Name</NM></AMPP>' \
-          '</AMPPS></ACTUAL_MEDICINAL_PROD_PACKS>',
+                                 '<AMPP><APPID>777</APPID><NM>Updated Name</NM></AMPP>' \
+                                 '</AMPPS></ACTUAL_MEDICINAL_PROD_PACKS>',
         'f_gtin2_0000000.xml' => '<GTIN_DETAILS><AMPPS>' \
-          '<AMPP><AMPPID>777</AMPPID><GTINDATA><GTIN>5016298210989</GTIN>' \
-          '<STARTDT>2020-01-01</STARTDT></GTINDATA></AMPP>' \
-          '</AMPPS></GTIN_DETAILS>'
+                                 '<AMPP><AMPPID>777</AMPPID><GTINDATA><GTIN>5016298210989</GTIN>' \
+                                 '<STARTDT>2020-01-01</STARTDT></GTINDATA></AMPP>' \
+                                 '</AMPPS></GTIN_DETAILS>'
       }
     end
 
     after { FileUtils.rm_rf(release_root) }
 
     it 'does not serve barcode lookup selects from the query cache' do
-      NhsDmdBarcode.create!(
-        gtin: '5016298210989', code: 'old', display: 'Old Name',
-        system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
-      )
+      create_existing_barcode
       write_release_archive
       barcode_selects = []
       subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
@@ -94,6 +96,13 @@ RSpec.describe NhsDmd::ReleaseArchiveImport do
 
       expect(barcode_selects).not_to be_empty
       expect(barcode_selects).not_to include(include(cached: true))
+    end
+
+    def create_existing_barcode
+      NhsDmdBarcode.create!(
+        gtin: '5016298210989', code: 'old', display: 'Old Name',
+        system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
+      )
     end
 
     def write_release_archive

--- a/spec/services/nhs_dmd/release_archive_import_spec.rb
+++ b/spec/services/nhs_dmd/release_archive_import_spec.rb
@@ -41,4 +41,13 @@ RSpec.describe NhsDmd::ReleaseArchiveImport do
 
     expect(returned_result).to eq(result)
   end
+
+  it 'runs the archive import with the query cache disabled' do
+    allow(extractor).to receive(:extract)
+    allow(importer).to receive(:import).and_return(result)
+
+    expect(ActiveRecord::Base).to receive(:uncached).and_yield
+
+    service.import(uploaded_file, progress_callback: ->(_payload) {})
+  end
 end

--- a/spec/services/nhs_dmd/release_archive_import_spec.rb
+++ b/spec/services/nhs_dmd/release_archive_import_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'zip'
 
 RSpec.describe NhsDmd::ReleaseArchiveImport do
   subject(:service) { described_class.new(importer: importer, extractor: extractor) }
@@ -49,5 +52,56 @@ RSpec.describe NhsDmd::ReleaseArchiveImport do
     expect(ActiveRecord::Base).to receive(:uncached).and_yield
 
     service.import(uploaded_file, progress_callback: ->(_payload) {})
+  end
+
+  describe 'with a real release archive' do
+    let(:importer) { NhsDmd::ReleaseImport.new }
+    let(:extractor) { NhsDmd::ReleaseArchiveExtractor.new }
+    let(:release_root) { Pathname.new(Dir.mktmpdir('release-archive-import-spec', Rails.root.join('tmp'))) }
+    let(:archive_path) { release_root.join('release.zip') }
+    let(:uploaded_file) { Struct.new(:path).new(archive_path.to_s) }
+    let(:archive_entries) do
+      {
+        'f_ampp2_3000000.xml' => '<ACTUAL_MEDICINAL_PROD_PACKS><AMPPS>' \
+          '<AMPP><APPID>777</APPID><NM>Updated Name</NM></AMPP>' \
+          '</AMPPS></ACTUAL_MEDICINAL_PROD_PACKS>',
+        'f_gtin2_0000000.xml' => '<GTIN_DETAILS><AMPPS>' \
+          '<AMPP><AMPPID>777</AMPPID><GTINDATA><GTIN>5016298210989</GTIN>' \
+          '<STARTDT>2020-01-01</STARTDT></GTINDATA></AMPP>' \
+          '</AMPPS></GTIN_DETAILS>'
+      }
+    end
+
+    after { FileUtils.rm_rf(release_root) }
+
+    it 'does not serve barcode lookup selects from the query cache' do
+      NhsDmdBarcode.create!(
+        gtin: '5016298210989', code: 'old', display: 'Old Name',
+        system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
+      )
+      write_release_archive
+      barcode_selects = []
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        next unless payload[:sql].include?('FROM "nhs_dmd_barcodes"') && payload[:sql].start_with?('SELECT')
+
+        barcode_selects << payload
+      end
+
+      ActiveRecord::Base.cache do
+        NhsDmdBarcode.find_by(gtin: '5016298210989')
+        ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { service.import(uploaded_file) }
+      end
+
+      expect(barcode_selects).not_to be_empty
+      expect(barcode_selects).not_to include(include(cached: true))
+    end
+
+    def write_release_archive
+      Zip::File.open(archive_path.to_s, create: true) do |archive|
+        archive_entries.each do |name, content|
+          archive.get_output_stream(name) { |stream| stream.write(content) }
+        end
+      end
+    end
   end
 end

--- a/spec/services/nhs_dmd/release_import_spec.rb
+++ b/spec/services/nhs_dmd/release_import_spec.rb
@@ -463,6 +463,29 @@ RSpec.describe NhsDmd::ReleaseImport do
     )
   end
 
+  it 'does not serve barcode lookup selects from the query cache during an archive import' do
+    NhsDmdBarcode.create!(
+      gtin: '5016298210989', code: 'old', display: 'Old Name',
+      system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
+    )
+    write_ampp_xml([{ appid: '777', nm: 'Updated Name' }])
+    write_single_gtin_xml(amppid: '777', gtin: '5016298210989', startdt: '2020-01-01')
+    barcode_selects = []
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      next unless payload[:sql].include?('FROM "nhs_dmd_barcodes"') && payload[:sql].start_with?('SELECT')
+
+      barcode_selects << payload
+    end
+
+    ActiveRecord::Base.cache do
+      NhsDmdBarcode.find_by(gtin: '5016298210989')
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { importer.import(release_dir) }
+    end
+
+    expect(barcode_selects).not_to be_empty
+    expect(barcode_selects).not_to include(include(cached: true))
+  end
+
   it 'reports unchanged records when re-importing the same release' do
     write_ampp_xml([{ appid: '888', nm: 'Stable Product' }])
     write_single_gtin_xml(amppid: '888', gtin: '4444444444444', startdt: '2020-01-01')

--- a/spec/services/nhs_dmd/release_import_spec.rb
+++ b/spec/services/nhs_dmd/release_import_spec.rb
@@ -463,29 +463,6 @@ RSpec.describe NhsDmd::ReleaseImport do
     )
   end
 
-  it 'does not serve barcode lookup selects from the query cache during an archive import' do
-    NhsDmdBarcode.create!(
-      gtin: '5016298210989', code: 'old', display: 'Old Name',
-      system: 'https://dmd.nhs.uk', concept_class: 'AMPP'
-    )
-    write_ampp_xml([{ appid: '777', nm: 'Updated Name' }])
-    write_single_gtin_xml(amppid: '777', gtin: '5016298210989', startdt: '2020-01-01')
-    barcode_selects = []
-    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
-      next unless payload[:sql].include?('FROM "nhs_dmd_barcodes"') && payload[:sql].start_with?('SELECT')
-
-      barcode_selects << payload
-    end
-
-    ActiveRecord::Base.cache do
-      NhsDmdBarcode.find_by(gtin: '5016298210989')
-      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { importer.import(release_dir) }
-    end
-
-    expect(barcode_selects).not_to be_empty
-    expect(barcode_selects).not_to include(include(cached: true))
-  end
-
   it 'reports unchanged records when re-importing the same release' do
     write_ampp_xml([{ appid: '888', nm: 'Stable Product' }])
     write_single_gtin_xml(amppid: '888', gtin: '4444444444444', startdt: '2020-01-01')


### PR DESCRIPTION
## Summary

- replaces the CSP-blocked inline reload with a signed Turbo Stream subscription and commit-time refresh broadcasts
- bounds long-running import memory by disabling the Active Record query cache around archive imports
- enforces one active import at the database boundary with friendly concurrent-upload handling
- reconciles stale and pre-existing duplicate active runs before index creation, then every five minutes at runtime
- preserves the durable archive-storage and record-ID job contract introduced on current main

## Risks / follow-ups

The matching worker-sidecar topology change is prepared separately in home-ops. Canary validation of a full public DM+D release remains gated on merging an application image and the topology change.