### PR TITLE
docs(openspec): reconcile DM+D release ledger

### DIFF
--- a/openspec/changes/restore-dmd-import-reliability/design.md
+++ b/openspec/changes/restore-dmd-import-reliability/design.md
@@ -2,7 +2,9 @@
 
 See [proposal.md](proposal.md) for the incident and motivation and [the capability specification](specs/dmd-import-reliability/spec.md) for observable behavior.
 
-The application repair in `damacus/med-tracker#1784` is merged. It replaced the production-CSP-blocked reload, bounded importer caching, added the active-import invariant, and scheduled stale-run reconciliation. Portable storage is also merged as `damacus/med-tracker#1782`; its original branch commit was squash-merged, so the current `main` merge commit is the only valid prerequisite identity. The remaining deployment work in `damacus/home-ops#3999` overlaps `damacus/home-ops#3995`, while the related application-side canary reset correction is under review in `damacus/med-tracker#1785`.
+The application repair in `damacus/med-tracker#1784` is merged. It replaced the production-CSP-blocked reload, bounded importer caching, added the active-import invariant, and scheduled stale-run reconciliation. Portable storage is also merged as `damacus/med-tracker#1782`; its original branch commit was squash-merged, so the current `main` merge commit is the only valid prerequisite identity. The related application-side canary reset correction is merged as `damacus/med-tracker#1785`, and its OpenSpec integration is merged as `damacus/med-tracker#1786`. The deployment boundaries `damacus/home-ops#3995` and `damacus/home-ops#3999` are also merged, with green checks.
+
+The release candidate is resolved but not yet accepted operationally: `ghcr.io/damacus/med-tracker:beta` and `ghcr.io/damacus/med-tracker:sha-2b0c7327e1958f7c828f84951efe45105abadc26` both resolve to OCI index digest `sha256:60f9997464e2bcffc844adcaf4e59c47f94dc52d7c8f64d35ec21cf0d94d2cbc`. The current canary pin predates this landed stack; no canary reconciliation, canary acceptance, or production promotion is recorded here.
 
 The two repositories have different code ownership and cannot form one GitHub branch stack. MedTracker owns import and reset behavior; `damacus/home-ops` contains the process topology and release activation needed to run that behavior in production. This OpenSpec change remains rooted in MedTracker as the single planning authority for the MedTracker production capability, while its explicitly authorized implementation scope crosses the repository boundary. It records deployment requirements without naming or depending on home-ops filesystem or manifest paths.
 
@@ -49,11 +51,11 @@ No MedTracker artifact or implementation shall name home-ops directories, manife
 
 ### 3. Integrate the canary reset before restacking worker topology
 
-PR #1785 changes the reset operation to clean the canary-only S3 target directly and removes its impossible application-health dependency while web is stopped. The corresponding lower deployment boundary, PR #3995, must be updated to consume that application contract and remove obsolete shared-filesystem assumptions before PR #3999 is rebuilt above it.
+PR #1785 changes the reset operation to clean the configured application-storage backend directly and removes its impossible application-health dependency while web is stopped. The current canary selection is persistent storage. The corresponding lower deployment boundary, PR #3995, consumed that application contract and removed obsolete shared-filesystem assumptions before PR #3999 was rebuilt above it. Both deployment boundaries are merged with green checks; the canary remains unreconciled.
 
 The worker remains independent of the reset controller. The reset quiesces web and queue writers for its destructive window; the worker topology supplies ordinary asynchronous execution outside that window.
 
-**Rejected:** Merge PR #3999 directly into the current PR #3995 diff. Keeping the worker layer separate gives focused ownership for Puma isolation and allows lower canary-reset corrections to propagate upward deliberately.
+**Rejected:** Merge PR #3999 directly into the PR #3995 diff. Keeping the worker layer separate gives focused ownership for Puma isolation and allows lower canary-reset corrections to propagate upward deliberately.
 
 ### 4. Use two repository-local stacks and one release dependency
 
@@ -72,22 +74,23 @@ This MedTracker OpenSpec change is the single planning source for both stacks. T
 | --- | --- | --- | --- | --- | --- | --- |
 | P0 | Portable storage, PR #1782 | `main` | Durable, service-neutral application archive contract | - | Landed application and storage smoke evidence | Landed historical prerequisite |
 | M0 | MedTracker DM+D reliability, PR #1784 | `main` | Live progress, bounded import, exclusivity, stale reconciliation | - | Full MedTracker CI | Landed |
-| M1 | Canary S3 reset, PR #1785 | current MedTracker `main` | Reset safety and S3 cleanup behavior | M0 application baseline | Full MedTracker CI | Review-ready |
-| M2 | DM+D OpenSpec integration | PR #1785 branch | This proposal, capability, design, tasks, and combined acceptance contract | M1 | OpenSpec validation, docs build, diff check | Draft until M1 is accepted |
-| H1 | Canary demo rebuild, PR #3995 | current home-ops `main` | Production-data-free canary aligned with M1, kept suspended | Published M1 image contract | Focused topology checks and full render/policy CI | Review-ready after alignment |
-| H2 | Worker isolation, PR #3999 | target: PR #3995 branch; current: `main` | Production and canary worker sidecars plus topology assertions | H1 configuration contract | Focused topology checks and full render/policy CI | Current: open against `main`; target: dependent draft until H1 is accepted |
+| M1 | Canary configured-storage reset, PR #1785 | `main` | Reset safety and configured application-storage cleanup behavior | M0 application baseline | Full MedTracker CI | Landed with green checks |
+| M2 | DM+D OpenSpec integration, PR #1786 | `main` | This proposal, capability, design, tasks, and combined acceptance contract | M1 | OpenSpec validation, docs build, diff check | Landed with green checks |
+| H1 | Canary demo rebuild, PR #3995 | `main` | Production-data-free canary aligned with M1, kept suspended | Published M1 image contract | Focused topology checks and full render/policy CI | Landed with green checks; canary not reconciled |
+| H2 | Worker isolation, PR #3999 | `main` | Production and canary worker sidecars plus topology assertions | H1 configuration contract | Focused topology checks and full render/policy CI | Landed with green checks; canary not reconciled |
+| R1 | Candidate image mapping | `main` commit `2b0c7327e1958f7c828f84951efe45105abadc26` | Same OCI index for `beta` and the immutable candidate tag | M1, M2, H1, H2 | Verified OCI index digest `sha256:60f9997464e2bcffc844adcaf4e59c47f94dc52d7c8f64d35ec21cf0d94d2cbc` | Resolved; current canary pin predates it |
 | E1 | Portable-storage canary evidence, issue #1775 | cumulative canary state | Storage round trips, restore, archive, and background-job evidence | P0, M1, H1, H2 | PHI-safe canary acceptance evidence | Operational gate |
 | O1 | Medication-administration persistence observation | separate evidence lane | Distinguish persisted administrations from reminder events and delivery | Synthetic canary baseline | PHI-safe persisted-data, event, log, and trace evidence | Non-stack follow-up |
 
-P0 and M0 are already on `main`; do not recreate their historical branches or claim that their pre-squash commits remain active parents. Review and land M1 before M2 in MedTracker, and H1 before H2 in home-ops. E1 converges the two stacks at canary acceptance. O1 is deliberately integrated into the release evidence ledger but not forced into a Git stack because the session established no code patch or hard lineage; its unresolved outcome must remain visible and PHI-safe. Changes to a lower boundary are made there and propagated upward; upper branches do not carry workarounds for lower defects. Application images are published before a deployment boundary consumes them. The live cluster remains unchanged until the cumulative branches are green and activation is separately authorized.
+P0 and M0 are already on `main`; do not recreate their historical branches or claim that their pre-squash commits remain active parents. M1 landed before M2 in MedTracker, and H1 landed before H2 in home-ops. E1 converges the landed stacks at canary acceptance. O1 is deliberately integrated into the release evidence ledger but not forced into a Git stack because the session established no code patch or hard lineage; its unresolved outcome must remain visible and PHI-safe. The resolved candidate mapping proves image identity only: the live canary remains unchanged until reconciliation is separately authorized, and production remains unchanged until all acceptance invariants pass.
 
 ### 5. Preserve all active-session evidence without inventing branch lineage
 
 The three active sessions are one release ledger:
 
 - **Portable storage and missed-dose investigation (`019fafbe-9a8f-7291-81e7-4f29d7603dc9`)** established the durable, service-neutral application archive contract now landed as PR #1782 and identified issue #1775 for separately deployed canary evidence. Its historical dependency on PR #1766 is closed because #1766 is merged. The session also found that reminder events matched persisted data but could not prove the upstream administration-persistence path.
-- **Canary reset design and purge runbook (`019fb872-27db-7121-828c-8108c2dbb966`)** established M1/H1 as the lower boundaries, confirmed that no destructive purge or replacement deployment ran in that session, and requires the canary to remain suspended until the production-derived recovery and backup configuration is replaced. It distinguishes backup-free CNPG recovery from application blob storage.
-- **DM+D integration (`019fc792-51a7-73a3-897d-b997229e24a1`)** established M0 as merged and H2 as the upper worker-isolation boundary, then requires all three session outcomes to converge at canary acceptance.
+- **Canary reset design and purge runbook (`019fb872-27db-7121-828c-8108c2dbb966`)** established M1/H1 as the lower boundaries, confirmed that no destructive purge or replacement deployment ran in that session, and distinguished backup-free CNPG recovery from application blob storage. M1 and H1 have since landed; canary reconciliation and acceptance remain outstanding.
+- **DM+D integration (`019fc792-51a7-73a3-897d-b997229e24a1`)** established M0 as merged and H2 as the upper worker-isolation boundary. M2 and H2 have since landed, leaving all three session outcomes to converge at canary acceptance.
 
 The ledger does not assert a technical dependency merely because sessions are active together. It records each owner and gate, preserves an unresolved observation, and uses a stacked branch only where M1→M2 or H1→H2 has real lineage.
 
@@ -130,14 +133,13 @@ Every implementer receives only its objective, owned files, relevant interfaces,
 ## Migration Plan
 
 1. Treat merged PRs #1782 and #1784 as immutable baselines; record their merge identities and do not recreate the historical storage branch or rewrite the merged DM+D branch.
-2. Finish review of MedTracker PR #1785 and publish its exact application image.
-3. Create the MedTracker OpenSpec integration branch from PR #1785, move only this change's artifacts onto it, validate, and open it as the upper dependent PR.
-4. Update home-ops PR #3995 to the S3-reset application contract, preserve the distinction between database recovery removal and application blob storage, rerun its focused and full checks, and keep canary suspended.
-5. Rebuild home-ops PR #3999 on the verified PR #3995 tip, resolve overlap in favor of the combined demo-reset and worker contracts, retarget it to the lower branch, and rerun cumulative checks.
-6. Merge each repository stack lower first. After each lower merge, rebase or replay only the upper boundary onto current `main`, verify its focused diff, and retarget it before merge.
-7. Reconcile canary only after the candidate image and cumulative deployment configuration are available. Run the full DM+D acceptance import and issue #1775 storage/restore evidence.
-8. Capture synthetic medication-administration persistence, reminder-event, delivery, log, and trace evidence as O1; retain a separately owned follow-up if the original persistence question remains unresolved.
-9. Promote the identical image and worker contract to production only after required canary acceptance passes, then verify a production import and automatic reconciliation of old interrupted runs.
+2. Merged MedTracker PR #1785, then replayed, reverified, retargeted, and merged the OpenSpec integration as PR #1786.
+3. Merged home-ops PR #3995 with the configured application-storage reset contract while preserving the distinction between database recovery removal and persistent application blob storage.
+4. Merged home-ops PR #3999 above PR #3995 after resolving the demo-reset and worker-contract overlap and rerunning cumulative checks.
+5. Resolve the exact cumulative MedTracker image mapping: `beta` and `sha-2b0c7327e1958f7c828f84951efe45105abadc26` both identify OCI index digest `sha256:60f9997464e2bcffc844adcaf4e59c47f94dc52d7c8f64d35ec21cf0d94d2cbc`.
+6. Obtain separate authorization and reconcile canary only after the candidate image and cumulative deployment configuration are available. Run the full DM+D acceptance import and issue #1775 storage/restore evidence.
+7. Capture synthetic medication-administration persistence, reminder-event, delivery, log, and trace evidence as O1; retain a separately owned follow-up if the original persistence question remains unresolved.
+8. Promote the identical image and worker contract to production only after required canary acceptance passes, then verify a production import and automatic reconciliation of old interrupted runs.
 
 For every implementation task, the coordinating agent creates the brief and report, dispatches the selected model, obtains independent task review, records the reviewed result in the progress ledger, and only then dispatches the next task. A final Sol whole-branch review precedes any merge request update or production activation.
 

--- a/openspec/changes/restore-dmd-import-reliability/proposal.md
+++ b/openspec/changes/restore-dmd-import-reliability/proposal.md
@@ -14,7 +14,7 @@ No dedicated incident issue was filed; the production evidence and implemented a
 - Keep the boundary between backup-free canary database recovery and optional application blob storage explicit: removing database backup/archive resources MUST NOT be interpreted as disabling durable application archives or S3-compatible application storage.
 - Keep this OpenSpec change rooted in MedTracker because it defines delivery of a MedTracker production capability. Its authorized implementation scope crosses into `damacus/home-ops`, whose deployment configuration is production code required to ship and operate the application.
 - Keep code ownership explicit inside that single MedTracker-owned plan: MedTracker owns application behavior and tests; `damacus/home-ops` owns deployment topology and release activation. MedTracker artifacts may reference the deployment repository, PRs, and behavioral contract but MUST NOT encode home-ops filesystem or manifest paths.
-- Deliver the overlap as repository-local stacked work: the merged MedTracker DM+D contract precedes the canary reset integration, while [damacus/home-ops#3995](https://github.com/damacus/home-ops/pull/3995) is the planned lower deployment boundary and [damacus/home-ops#3999](https://github.com/damacus/home-ops/pull/3999) is planned to be rebuilt above it from its current `main` base.
+- Deliver the overlap as repository-local stacked work: MedTracker PRs [#1785](https://github.com/damacus/med-tracker/pull/1785) and [#1786](https://github.com/damacus/med-tracker/pull/1786), plus [damacus/home-ops#3995](https://github.com/damacus/home-ops/pull/3995) and [#3999](https://github.com/damacus/home-ops/pull/3999), are merged with green checks. The current canary pin predates that landed stack and has not been reconciled.
 - Execute the remaining plan through agent-orchestrated development: this coordinating agent owns architecture, stack lineage, integration, and final verification; fresh bounded subagents implement and independently review each task under adaptive model routing.
 
 Non-goals:
@@ -38,7 +38,7 @@ None.
 ## Impact
 
 - MedTracker DM+D import presentation, persistence lifecycle, archive importer, background jobs, recurring schedule, database invariant, and automated coverage.
-- The `damacus/home-ops` production code for the canary and production worker topology represented by PR #3999, planned to be restacked above the demo-reset deployment contract in PR #3995.
+- The `damacus/home-ops` production code for the canary and production worker topology landed through PR #3995 followed by PR #3999; its operational canary acceptance remains outstanding.
 - Release sequencing: the application image is available before deployment activation; canary proves progress, completion, counts, logs, memory bounds, and web stability before production promotion.
 - Release evidence: portable storage, DM+D reliability, canary reset, worker isolation, and the unresolved reminder-persistence observation each retain an explicit owner, current state, and acceptance disposition even when they do not belong in the same Git branch stack.
 - Delivery process: a durable progress ledger, task-specific agent briefs, independent task review, and final whole-branch review prevent stack or concurrency decisions from being delegated without parent judgment.

--- a/openspec/changes/restore-dmd-import-reliability/tasks.md
+++ b/openspec/changes/restore-dmd-import-reliability/tasks.md
@@ -17,33 +17,33 @@
 
 ## 2. Build the MedTracker stack above the merged baseline
 
-- [x] 2.1 Re-review MedTracker PR #1785 against current `main`, verify its S3 reset safety and removal of the stopped-web health dependency, and keep its full CI green.
+- [x] 2.1 Re-review MedTracker PR #1785 against current `main`, verify its configured-storage reset safety and removal of the stopped-web health dependency, and keep its full CI green.
 - [x] 2.2 Create the M2 integration branch from the verified PR #1785 tip and move only this OpenSpec change's artifacts onto it; confirm the focused diff contains no duplicate application implementation and no home-ops filesystem or manifest paths.
 - [x] 2.3 Run `task openspec:validate`, `task docs:build`, and `git diff --check`, then open M2 as a dependent draft PR whose base is the PR #1785 branch and whose description records the full MedTracker and home-ops stack order.
-- [ ] 2.4 After PR #1785 lands, replay only M2 onto current MedTracker `main`, rerun its checks, verify the focused diff, retarget it to `main`, and merge it only with explicit authorization.
+- [x] 2.4 After PR #1785 landed, replayed M2 onto current MedTracker `main`, reran its checks, verified the focused diff, retargeted it to `main`, and merged it as PR #1786 with explicit authorization.
 
 ## 3. Align the lower home-ops boundary with the application reset contract
 
-- [ ] 3.1 Update home-ops PR #3995 from current upstream `main` and record its focused scope: production-data-free canary rebuild, S3-backed application reset contract, removal of obsolete shared-filesystem assumptions, and no worker-topology changes.
-- [ ] 3.2 Add or update failing deployment assertions for exact application image identity, canary-only S3 targets, reset-controller isolation, production-data exclusion, and continued suspension before changing deployment configuration.
-- [ ] 3.3 Update PR #3995 to consume the verified PR #1785 image and behavior, make its focused assertions green, and preserve the suspended, non-reconciled release state.
-- [ ] 3.4 Run the home-ops focused topology checks, YAML validation, full render/policy checks, and whitespace checks; review the diff against `main` and keep PR #3995 green and review-ready.
-- [ ] 3.5 Prove in the lower deployment boundary that removing canary database recovery, WAL, and backup state does not remove or misidentify the selected application blob-storage mode or durable DM+D archive contract; keep canary suspended until this evidence is green.
+- [x] 3.1 Updated and merged home-ops PR #3995 from current upstream `main` with its focused scope: production-data-free canary rebuild, configured application-storage reset contract, removal of obsolete shared-filesystem assumptions, and no worker-topology changes.
+- [x] 3.2 Added or updated deployment assertions for exact application image identity, configured application-storage reset behavior, reset-controller isolation, production-data exclusion, and continued suspension before changing deployment configuration.
+- [x] 3.3 Updated PR #3995 to consume the verified PR #1785 image and behavior, made its focused assertions green, preserved the suspended, non-reconciled release state, and retained persistent storage as the current canary selection.
+- [x] 3.4 Ran the home-ops focused topology checks, YAML validation, full render/policy checks, and whitespace checks; reviewed the diff against `main`, kept PR #3995 green, and merged it.
+- [x] 3.5 Proved in the lower deployment boundary that removing canary database recovery, WAL, and backup state does not remove or misidentify persistent application blob storage or the durable DM+D archive contract; canary remains suspended pending operational acceptance.
 
 ## 4. Restack worker isolation above the canary rebuild
 
 - [x] 4.1 Rebuild home-ops PR #3999 from the verified PR #3995 tip, retarget its base to the PR #3995 branch, and resolve overlapping canary configuration in favor of both the demo-reset and worker contracts.
 - [x] 4.2 Add or update failing assertions proving production and canary web processes do not run Solid Queue, workers use `bin/jobs`, worker and web share the exact release configuration and durable storage contract, and each worker has an independent one GiB memory limit.
 - [x] 4.3 Make the H2 topology assertions green without adding demo-reset behavior to the worker boundary or changing the lower canary database and reset contract.
-- [x] 4.4 Run focused topology checks, YAML validation, full render/policy checks, and whitespace checks on the cumulative branch; review H2 against H1, document stack order and deferred activation, and keep PR #3999 draft until PR #3995 is accepted.
+- [x] 4.4 Ran focused topology checks, YAML validation, full render/policy checks, and whitespace checks on the cumulative branch; reviewed H2 against H1, documented stack order and deferred activation, kept PR #3999 green, and merged it after PR #3995.
 
 ## 5. Land lower first and validate canary
 
-- [ ] 5.1 With explicit merge authorization, merge MedTracker M1 before M2 and home-ops H1 before H2; after every lower merge, replay and reverify only the remaining upper boundary against current `main`.
-- [ ] 5.2 Publish or resolve the exact cumulative MedTracker image, confirm both canary deployment boundaries are green, and obtain separate authorization before reconciling the suspended canary.
+- [x] 5.1 With explicit merge authorization, merged MedTracker M1 before M2 and home-ops H1 before H2; after every lower merge, replayed and reverified only the remaining upper boundary against current `main`.
+- [ ] 5.2 Use the resolved candidate image mapping, confirm the landed deployment boundaries remain green, and obtain separate authorization before reconciling the suspended canary.
 - [ ] 5.3 Import a full public DM+D release in canary and capture PHI-safe evidence that progress updates without reload, the worker stays within one GiB, the web process remains healthy without restarts, the import completes, and final counts and log match persisted data.
 - [ ] 5.4 Complete issue #1775's applicable canary storage/restore, archive, and background-job evidence using the cumulative image and deployment contract; record only PHI-safe results.
-- [ ] 5.5 Exercise the weekly canary reset around ordinary web and worker execution, verify the S3 cleanup and synthetic baseline remain correct, and correct any failure in its owning lower boundary before restacking upward.
+- [ ] 5.5 Exercise the weekly canary reset around ordinary web and worker execution, verify configured application-storage cleanup and the synthetic baseline remain correct, and correct any failure in its owning lower boundary before restacking upward.
 - [ ] 5.6 Collect synthetic medication-administration persistence, reminder-event, and delivery evidence with PHI-safe logs and traces; retain this as a separately owned follow-up if the upstream persistence question remains unresolved rather than attributing it to DM+D import behavior.
 
 ## 6. Promote and close the incident


### PR DESCRIPTION
## Summary

- Brings the DM+D release ledger in line with the landed MedTracker and deployment-repository stack.
- Records the verified beta and immutable image mapping, while distinguishing configured persistent application storage from database backup and recovery state.

## Operational status

The current canary pin predates the landed stack. Canary reconciliation, operational acceptance, and production promotion remain deliberately open.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->