### PR TITLE
docs(openspec): reconcile Tempo deployment ledger

### DIFF
--- a/openspec/changes/deploy-tempo-trace-backend/design.md
+++ b/openspec/changes/deploy-tempo-trace-backend/design.md
@@ -1,8 +1,8 @@
 ## Context
 
-See [proposal.md](proposal.md) for motivation. The live cluster currently provides Grafana, Loki, Vector, VictoriaMetrics, and Alertmanager, but no general OTLP receiver, trace backend, or Grafana trace data source. The existing OpenEBS-scoped Alloy daemon exposes only its own HTTP endpoint and is not an application trace gateway. Both MedTracker production and canary explicitly set `OTEL_TRACES_EXPORTER=none`.
+See [proposal.md](proposal.md) for motivation. The private Tempo backend, least-privilege RustFS storage, retention, network policy, alerts, Grafana correlation, canary exporter wiring, and focused validation planned here landed in `damacus/home-ops` PR #3974 at merge commit `517a51f668425115f89be9be98961005b4a99011`. This merged implementation boundary does not establish current operational acceptance: the final cumulative canary configuration after the current pause/migration-mount stack still requires the value-aware privacy gate, outage rollback, 24-hour evidence, and production promotion.
 
-`home-ops` is the deployment source of truth. It already owns the monitoring namespace, Grafana data-source provisioning, RustFS bucket identities, and the MedTracker HelmRelease configuration. This OpenSpec change is stored beside the originating application change for review, but implementation must be performed in a writable `home-ops` worktree.
+This MedTracker OpenSpec change is the single planning authority. The `damacus/home-ops` deployment repository owns runtime implementation and reconciliation under its own instructions; these planning artifacts remain here and are not copied into the deployment repository.
 
 Grafana documents a monolithic Kubernetes deployment as a supported Helm path and notes that Tempo has no built-in authentication layer. Grafana also supports provisioning Tempo as a built-in data source at the backend query URL and configuring trace-to-log correlation. The design therefore keeps ingestion and query services cluster-internal and enforces access at the network boundary.
 
@@ -21,12 +21,13 @@ Grafana documents a monolithic Kubernetes deployment as a supported Helm path an
 - Add span-derived metrics, service graphs, tail sampling, or multi-tenancy.
 - Make a single-binary deployment highly available.
 - Change application instrumentation or use traces as an audit record.
+- Expand this change into broader TLS or encryption hardening, which remains separately owned follow-up.
 
 ## Decisions
 
-### 1. Implement and apply the change in `home-ops`
+### 1. Keep planning in MedTracker and runtime implementation in `home-ops`
 
-The manifests, secret references, bucket provisioning, Grafana configuration, and rollout controls belong to `home-ops`. The application repository supplies the emitter and acceptance canary but does not own the backend.
+This MedTracker change remains the sole planning authority. Runtime manifests, secret references, bucket provisioning, Grafana configuration, and rollout controls belong to `damacus/home-ops` and must be changed under that repository's instructions without copying this OpenSpec ledger there. The application repository supplies the emitter and acceptance canary but does not own the backend runtime.
 
 Alternative considered: implement Tempo in MedTracker Compose. Rejected because it would not prove the production transport and would add local services the cluster can already host centrally.
 
@@ -44,7 +45,7 @@ Alternatives considered:
 
 ### 3. Send OTLP/HTTP directly from MedTracker to Tempo
 
-Expose the OTLP/HTTP receiver on cluster port `4318` and the Tempo query API on cluster port `3200`. MedTracker uses its existing `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_TRACES_EXPORTER` contract. No collector is introduced in this slice.
+Expose the OTLP/HTTP receiver on cluster port `4318` and the Tempo query API on cluster port `3200`. MedTracker uses its existing `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_TRACES_EXPORTER` contract. No collector is introduced in this slice.
 
 A NetworkPolicy permits ingestion from the explicitly selected MedTracker canary and, only after promotion, production workload. Query access is limited to Grafana and bounded operator diagnostics. Neither service receives an HTTPRoute, Ingress, LoadBalancer, or external tunnel.
 
@@ -85,7 +86,7 @@ Canary uses:
 
 - `OTEL_TRACES_EXPORTER=otlp`
 - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
-- The cluster-internal OTLP endpoint through the existing secret-backed endpoint contract
+- The cluster-internal OTLP endpoint through the secret-backed `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` contract
 - The exact application image containing the approved tracing implementation
 
 Run the application's safe observability canary and retain only identifiers, image digests, timestamps, queries, counts, and pass/fail results as evidence. Do not record trace payloads containing health data.
@@ -117,5 +118,7 @@ Add a focused repository task that renders and asserts the Tempo, RustFS, Grafan
 5. Configure only MedTracker canary for OTLP/HTTP and deploy the exact approved application digest.
 6. Run the synthetic canary checks for at most 15 minutes, then collect the bounded naturally occurring evidence required by the application observability change.
 7. Promote the same exporter contract to production only after all gates pass and record the exact digest and configuration revision.
+
+Steps 1 through 5 of this implementation sequence landed through task 3.4 in `damacus/home-ops` PR #3974 at merge commit `517a51f668425115f89be9be98961005b4a99011`. The initial demonstrations are not final acceptance evidence because later canary/reset changes superseded them. After the current pause/migration-mount stack, the final cumulative canary configuration must be re-proven before production promotion.
 
 Rollback begins by restoring `OTEL_TRACES_EXPORTER=none` for the affected MedTracker lane. Backend and Grafana resources may remain available while export is disabled. If the Tempo release itself must be removed, stop exporters first and retain the bucket and credentials until the rollback decision and evidence-retention window are complete.

--- a/openspec/changes/deploy-tempo-trace-backend/proposal.md
+++ b/openspec/changes/deploy-tempo-trace-backend/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-MedTracker now emits correlated OpenTelemetry spans, but production and canary both disable trace export because the cluster has no OTLP receiver or trace backend. This blocks production acceptance of the tracing work prompted by the missed-dose investigation and [issue #1707](https://github.com/damacus/med-tracker/issues/1707).
+MedTracker emits correlated OpenTelemetry spans, and the private trace-backend implementation planned here merged in `damacus/home-ops` PR #3974 at merge commit `517a51f668425115f89be9be98961005b4a99011`. Production acceptance remains blocked because the final cumulative canary configuration after the current pause/migration-mount stack has not yet been re-proven through the operational acceptance matrix prompted by the missed-dose investigation and [issue #1707](https://github.com/damacus/med-tracker/issues/1707).
 
 ## What Changes
 
@@ -10,6 +10,7 @@ MedTracker now emits correlated OpenTelemetry spans, but production and canary b
 - Provision Tempo as a Grafana data source and configure trace-to-log navigation to the existing Loki data source.
 - Enable OTLP export for MedTracker canary first, prove an exact deployed revision end to end, and promote the same configuration contract to production only after the canary acceptance matrix passes.
 - Add focused repository and live-cluster verification for rendering, credentials wiring, health, ingestion, querying, privacy, retention, and rollback.
+- Keep this MedTracker change as the single planning authority while runtime implementation and reconciliation remain in the deployment repository under that repository's instructions.
 
 Explicit non-goals:
 
@@ -19,6 +20,7 @@ Explicit non-goals:
 - Changing MedTracker instrumentation, sampling policy, application event schemas, or domain behavior.
 - Enabling trace export for other applications.
 - Treating traces as an audit record or clinically reliable medication history.
+- Expanding this change into broader TLS or encryption hardening; that work remains separately owned follow-up.
 - Keeping the change open for broader observability-platform improvements discovered during implementation; those require separate changes.
 
 ## Capabilities
@@ -33,7 +35,8 @@ None.
 
 ## Impact
 
-- Implementation belongs in the `home-ops` repository, principally under `kubernetes/apps/monitoring/tempo/`, the RustFS bucket and secret provisioning, Grafana data-source provisioning, MedTracker canary and production HelmRelease configuration, and focused Taskfile validation.
+- MedTracker owns the planning artifacts for this change. Runtime implementation belongs in the `damacus/home-ops` deployment repository and follows that repository's instructions; the planning artifacts are not copied there.
+- Implementation tasks 1.1 through 3.4 landed in `damacus/home-ops` PR #3974 at merge commit `517a51f668425115f89be9be98961005b4a99011`; operational acceptance and production promotion remain incomplete.
 - Adds the official monolithic Tempo Helm chart and a single low-volume trace-backend workload to the monitoring namespace.
 - Adds a dedicated RustFS bucket and credentials; no health data, trace payloads, or credentials may be committed to Git.
 - Changes MedTracker canary, and later production, from `OTEL_TRACES_EXPORTER=none` to OTLP/HTTP export through a cluster-internal endpoint.

--- a/openspec/changes/deploy-tempo-trace-backend/tasks.md
+++ b/openspec/changes/deploy-tempo-trace-backend/tasks.md
@@ -1,27 +1,33 @@
 ## 1. Freeze the `home-ops` Contract
 
-- [ ] 1.1 Start from a fresh writable `home-ops` worktree, copy this OpenSpec change into its planning home without changing the accepted scope, and record the current manifest revision plus live absence of Tempo, OTLP services, and a Grafana trace data source.
-- [ ] 1.2 Add a failing focused repository task that asserts the pinned Tempo source, private ports, dedicated secret and bucket, 14-day retention, NetworkPolicy peers, Grafana data-source UIDs and correlations, canary OTLP settings, and production's disabled exporter.
-- [ ] 1.3 Confirm the current official monolithic Tempo chart and major-version values schema, then pin the compatible chart and image through the repository's dependency-management conventions.
+Implementation tasks 1.1 through 3.4 landed in `damacus/home-ops` PR #3974 at merge commit `517a51f668425115f89be9be98961005b4a99011`. This MedTracker change remains the single planning authority; runtime work stays in the deployment repository under that repository's instructions.
+
+- [x] 1.1 Start from a fresh writable deployment-repository worktree while retaining the planning ledger here, and record the deployment revision plus a PHI-safe baseline of Tempo, OTLP services, and the Grafana trace data source before implementation.
+- [x] 1.2 Add a failing focused repository task that asserts the pinned Tempo source, private ports, dedicated secret and bucket, 14-day retention, NetworkPolicy peers, Grafana data-source UIDs and correlations, canary OTLP settings, and production's disabled exporter.
+- [x] 1.3 Confirm the current official monolithic Tempo chart and major-version values schema, then pin the compatible chart and image through the repository's dependency-management conventions.
 
 ## 2. Deploy the Private Trace Backend
 
-- [ ] 2.1 Extend the RustFS provisioning and ExternalSecret contracts with a dedicated `tempo-traces` bucket and least-privilege Tempo identity, keeping every credential out of Git and rendered verification output.
-- [ ] 2.2 Add the monitoring Tempo Flux resources with one monolithic replica, OTLP/HTTP on cluster port 4318, query API on cluster port 3200, explicit health probes and resources, RustFS trace storage, and 14-day retention.
-- [ ] 2.3 Add NetworkPolicy that permits ingestion only from the selected MedTracker lane and queries only from Grafana and bounded operator diagnostics, and prove that no Ingress, HTTPRoute, LoadBalancer, or external tunnel exposes Tempo.
-- [ ] 2.4 Add Tempo metric discovery and only the bounded workload, durable-storage, sustained-rejection, restart, and resource-pressure alerts supported by the deployed version; make the focused backend contract green.
+- [x] 2.1 Extend the RustFS provisioning and ExternalSecret contracts with a dedicated `tempo-traces` bucket and least-privilege Tempo identity, keeping every credential out of Git and rendered verification output.
+- [x] 2.2 Add the monitoring Tempo Flux resources with one monolithic replica, OTLP/HTTP on cluster port 4318, query API on cluster port 3200, explicit health probes and resources, RustFS trace storage, and 14-day retention.
+- [x] 2.3 Add NetworkPolicy that permits ingestion only from the selected MedTracker lane and queries only from Grafana and bounded operator diagnostics, and prove that no Ingress, HTTPRoute, LoadBalancer, or external tunnel exposes Tempo.
+- [x] 2.4 Add Tempo metric discovery and only the bounded workload, durable-storage, sustained-rejection, restart, and resource-pressure alerts supported by the deployed version; make the focused backend contract green.
 
 ## 3. Connect Grafana and MedTracker Canary
 
-- [ ] 3.1 Add a failing Grafana provisioning check for stable Tempo UID `tempo`, the internal query URL, TraceQL search, trace-to-Loki correlation, and Loki `trace.id` derived links.
-- [ ] 3.2 Provision the Tempo data source and bidirectional Loki correlation without changing Prometheus as Grafana's default or enabling service graphs and span-derived metrics.
-- [ ] 3.3 Configure only MedTracker canary with secret-backed `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_EXPORTER=otlp`, and `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`; assert production remains `OTEL_TRACES_EXPORTER=none`.
-- [ ] 3.4 Run the focused observability task, secret and policy checks, repository YAML/schema validation, Flux rendering and diff, and the normal `home-ops` quality gates until they pass.
+- [x] 3.1 Add a failing Grafana provisioning check for stable Tempo UID `tempo`, the internal query URL, TraceQL search, trace-to-Loki correlation, and Loki `trace.id` derived links.
+- [x] 3.2 Provision the Tempo data source and bidirectional Loki correlation without changing Prometheus as Grafana's default or enabling service graphs and span-derived metrics.
+- [x] 3.3 Configure only MedTracker canary with secret-backed `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_TRACES_EXPORTER=otlp`, and `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`; assert production remains `OTEL_TRACES_EXPORTER=none`.
+- [x] 3.4 Run the focused observability task, secret and policy checks, repository YAML/schema validation, Flux rendering and diff, and the normal `home-ops` quality gates until they pass.
 
 ## 4. Prove, Promote, and Stop
 
-- [ ] 4.1 Reconcile RustFS provisioning, Tempo, monitoring, and Grafana in dependency order; verify pinned workload versions, healthy storage, healthy Grafana data source, scrape targets, alert state, and cluster-only endpoints before enabling canary.
-- [ ] 4.2 Deploy the exact approved MedTracker canary digest and prove within 15 minutes that its safe observability trace is searchable by trace ID and bounded TraceQL, displays the expected parent-child spans, links bidirectionally with Loki, and contains no prohibited data.
-- [ ] 4.3 Exercise a controlled canary-only exporter outage, prove application requests and the safe operation remain available, restore the tested endpoint, and record the successful rollback without exporting sensitive evidence.
-- [ ] 4.4 Collect the bounded 24-hour naturally occurring evidence required by `standardize-app-tracing-and-logging`; treat absent unsafe workflows as not applicable with final-image contract references rather than generating health-data actions.
-- [ ] 4.5 Promote the same endpoint, protocol, privacy, and fail-open contract to the exact production digest, rerun the finite production checks, record immutable revisions and safe query evidence, and stop this change; file any broader collector, HA, service-graph, multi-application, or capacity work as separate changes.
+- [ ] 4.1 After the current pause/migration-mount stack, reconcile the final cumulative RustFS, Tempo, monitoring, Grafana, and canary configuration in dependency order; verify pinned workload versions, healthy storage, a healthy Grafana data source, scrape targets, alert state, and cluster-only endpoints before acceptance.
+- [ ] 4.2 Deploy the exact approved MedTracker canary digest and re-prove within 15 minutes that its safe observability trace is searchable by trace ID and bounded TraceQL, displays the expected parent-child spans, links bidirectionally with Loki, and passes the value-aware gate for prohibited data.
+- [ ] 4.3 Exercise a controlled canary-only exporter outage against the final cumulative configuration, prove application requests and the safe operation remain available, restore the tested endpoint, and record the successful rollback without exporting sensitive evidence.
+- [ ] 4.4 Collect the bounded 24-hour naturally occurring evidence required by `standardize-app-tracing-and-logging` from the final cumulative configuration; treat absent unsafe workflows as not applicable with final-image contract references rather than generating health-data actions.
+- [ ] 4.5 Promote the same endpoint, protocol, privacy, and fail-open contract to the exact production digest only after tasks 4.1 through 4.4 pass, rerun the finite production checks, record immutable revisions and safe query evidence, and stop implementation; file any broader collector, HA, service-graph, multi-application, capacity, TLS, or encryption work as separate changes.
+
+## 5. Sync and Archive
+
+- [ ] 5.1 After production acceptance is complete, use the final PR for this OpenSpec change to sync the delta into the main `cluster-trace-backend` spec and archive the change.


### PR DESCRIPTION
This reconciles the Tempo OpenSpec ledger with the implementation that already merged in damacus/home-ops#3974, while keeping operational acceptance and production promotion explicitly open.

MedTracker remains the single planning authority. The deployment repository remains responsible for runtime implementation and reconciliation; no deployment filesystem paths or copied planning artifacts are introduced here.

This is the second PR in the MedTracker documentation stack:

1. #1790 — sync and archive only changes that are already complete
2. This PR — reconcile the still-active Tempo change without syncing or archiving it

The final PR for the Tempo OpenSpec change will come only after production acceptance. That final PR must both sync the delta spec and archive the change.