### PR TITLE
fix(canary): load demo baseline without superuser

### DIFF
--- a/app/services/demo_baseline/loader.rb
+++ b/app/services/demo_baseline/loader.rb
@@ -5,9 +5,7 @@ module DemoBaseline
     class InvalidBaselineError < StandardError; end
 
     class << self
-      def load!
-        new.load!
-      end
+      delegate :load!, to: :new
     end
 
     def initialize(connection: ActiveRecord::Base.connection)

--- a/app/services/demo_baseline/loader.rb
+++ b/app/services/demo_baseline/loader.rb
@@ -6,21 +6,62 @@ module DemoBaseline
 
     class << self
       def load!
-        ActiveRecord::FixtureSet.reset_cache
-        ActiveRecord::FixtureSet.create_fixtures(FIXTURES_PATH, FIXTURE_NAMES)
-        new.verify!
+        new.load!
+      end
+    end
+
+    def initialize(connection: ActiveRecord::Base.connection)
+      @connection = connection
+    end
+
+    def load!
+      with_demo_tenant_context do
+        fixture_sets.each do |fixture_set|
+          fixture_set.table_rows.each do |table_name, rows|
+            connection.insert_fixture(rows, table_name) if rows.any?
+          end
+          connection.reset_pk_sequence!(fixture_set.table_name)
+        end
+
+        verify_without_tenant_context!
       end
     end
 
     def verify!
+      with_demo_tenant_context { verify_without_tenant_context! }
+    end
+
+    private
+
+    attr_reader :connection
+
+    def fixture_sets
+      ActiveRecord::FixtureSet.reset_cache
+      FIXTURE_NAMES.map do |fixture_name|
+        ActiveRecord::FixtureSet.new(nil, fixture_name, nil, FIXTURES_PATH.join(fixture_name))
+      end
+    end
+
+    def with_demo_tenant_context
+      connection.transaction(requires_new: true) do
+        connection.select_value(
+          "SELECT set_config('med_tracker.current_household_id', #{connection.quote(demo_household_id.to_s)}, true)"
+        )
+        yield
+      end
+    end
+
+    def demo_household_id
+      ActiveRecord::FixtureSet.identify(:demo_household)
+    end
+
+    def verify_without_tenant_context!
       summary = baseline_summary
       raise InvalidBaselineError, 'baseline counts do not match the committed contract' unless valid_summary?(summary)
       raise InvalidBaselineError, 'baseline contains delivery registrations or credentials' unless delivery_state_empty?
 
       summary
     end
-
-    private
 
     def baseline_summary
       {

--- a/spec/services/demo_baseline/loader_spec.rb
+++ b/spec/services/demo_baseline/loader_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe DemoBaseline::Loader do
     expect(ActiveStorage::Blob.count).to be_zero
   end
 
+  it 'loads under the non-superuser owner role with forced row-level security', :aggregate_failures do
+    ActiveRecord::Base.connection.execute('SET LOCAL ROLE med_tracker_owner')
+
+    result = described_class.load!
+
+    expect_baseline_summary(result)
+    expect_demo_records
+  end
+
+  it 'verifies the baseline under the non-superuser owner role after loading' do
+    described_class.load!
+    ActiveRecord::Base.connection.execute("SELECT set_config('med_tracker.current_household_id', '', true)")
+    ActiveRecord::Base.connection.execute('SET LOCAL ROLE med_tracker_owner')
+
+    expect_baseline_summary(described_class.new.verify!)
+  end
+
   def expect_baseline_summary(result)
     expect(result).to eq(
       baseline: DemoBaseline::IDENTIFIER,


### PR DESCRIPTION
## Summary

- Load the committed demo baseline without disabling PostgreSQL system triggers.
- Apply the demo household RLS context only within the reset transaction.
- Cover loading and verification under the same non-superuser owner role used by canary.

## Verification

-  passed.
- Docker Desktop was unavailable after a supported restart, so , the focused loader spec, and  could not run locally. CI is the execution gate for this draft.

## Risks / follow-ups

- After CI passes, deploy this exact image through a separate home-ops PR, then run one canary reset and check the fixture counts.