### PR TITLE
fix(reminders): prevent overlapping due jobs

### DIFF
--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -56,15 +56,19 @@ class ScheduleDailyRemindersJob < ApplicationJob
         next
       end
 
-      enqueue_notification_job(
-        MedicationReminderJob.new(pref.household_id, pref.person_id, period),
-        send_at:,
-        kind: :dose_due
-      )
+      enqueue_period_reminder(pref, period, send_at)
       scheduled_times << send_at
     end
 
     scheduled_times
+  end
+
+  def enqueue_period_reminder(pref, period, send_at)
+    enqueue_notification_job(
+      MedicationReminderJob.new(pref.household_id, pref.person_id, period),
+      send_at:,
+      kind: :dose_due
+    )
   end
 
   def enqueue_schedule_time_reminders_for(pref, period_reminder_times)
@@ -78,7 +82,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
     return record_invalid_schedule(:unknown) if send_at.blank?
     return record_past_occurrence(schedule_kind(pref)) if send_at < Time.current
 
-    enqueue_scheduled_dose_due(pref, send_at, time) if pref.dose_due_enabled && !period_reminder_times.include?(send_at)
+    enqueue_scheduled_dose_due(pref, send_at, time) if pref.dose_due_enabled && period_reminder_times.exclude?(send_at)
     enqueue_missed_dose_check_for(pref.person, send_at, time) if pref.missed_dose_enabled
   end
 

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -39,11 +39,13 @@ class ScheduleDailyRemindersJob < ApplicationJob
   end
 
   def enqueue_reminders_for(pref)
-    enqueue_period_reminders_for(pref) if pref.dose_due_enabled
-    enqueue_schedule_time_reminders_for(pref)
+    period_reminder_times = pref.dose_due_enabled ? enqueue_period_reminders_for(pref) : []
+    enqueue_schedule_time_reminders_for(pref, period_reminder_times)
   end
 
   def enqueue_period_reminders_for(pref)
+    scheduled_times = []
+
     PERIODS.each do |period|
       time = pref.time_for_period(period)
       next unless time
@@ -59,21 +61,24 @@ class ScheduleDailyRemindersJob < ApplicationJob
         send_at:,
         kind: :dose_due
       )
+      scheduled_times << send_at
     end
+
+    scheduled_times
   end
 
-  def enqueue_schedule_time_reminders_for(pref)
+  def enqueue_schedule_time_reminders_for(pref, period_reminder_times)
     configured_times_for(pref.person).each do |time|
-      enqueue_configured_time_for(pref, time)
+      enqueue_configured_time_for(pref, time, period_reminder_times)
     end
   end
 
-  def enqueue_configured_time_for(pref, time)
+  def enqueue_configured_time_for(pref, time, period_reminder_times)
     send_at = build_send_time_from_configured_time(time)
     return record_invalid_schedule(:unknown) if send_at.blank?
     return record_past_occurrence(schedule_kind(pref)) if send_at < Time.current
 
-    enqueue_scheduled_dose_due(pref, send_at, time) if pref.dose_due_enabled
+    enqueue_scheduled_dose_due(pref, send_at, time) if pref.dose_due_enabled && !period_reminder_times.include?(send_at)
     enqueue_missed_dose_check_for(pref.person, send_at, time) if pref.missed_dose_enabled
   end
 

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -53,50 +53,10 @@ RSpec.describe ScheduleDailyRemindersJob do
   it 'keeps the London period reminder at a configured-time collision while preserving other reminders' do
     Time.use_zone('Europe/London') do
       travel_to Time.zone.local(2026, 5, 12, 6, 0) do
-        create(:notification_preference, person: person, morning_time: '07:15:00', afternoon_time: '14:00:00',
-                                         evening_time: nil, night_time: nil, dose_due_enabled: true,
-                                         missed_dose_enabled: true)
-        create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
-                          frequency: 'Twice daily', schedule_type: :multiple_daily,
-                          schedule_config: { 'times' => %w[07:15 19:45] })
-        create(:person_medication, :routine, person: person, medication: medications(:paracetamol),
-                                             dosage: dosages(:paracetamol_adult))
-        allow(PushNotificationService).to receive(:send_to_account)
-
-        expect do
-          described_class.perform_now
-        end.to have_enqueued_job(MedicationReminderJob)
-          .with(household.id, person.id, :morning)
-          .at(Time.zone.local(2026, 5, 12, 7, 15))
-          .and(
-            have_enqueued_job(MedicationReminderJob)
-              .with(household.id, person.id, :afternoon)
-              .at(Time.zone.local(2026, 5, 12, 14, 0))
-          )
-          .and(
-            have_enqueued_job(MedicationReminderJob)
-              .with(household.id, person.id, :scheduled, '19:45')
-              .at(Time.zone.local(2026, 5, 12, 19, 45))
-          )
-          .and(
-            have_enqueued_job(MissedDoseNotificationJob)
-              .with(household.id, person.id, '2026-05-12', '07:15')
-              .at(Time.zone.local(2026, 5, 12, 7, 45))
-          )
-          .and(
-            have_enqueued_job(MissedDoseNotificationJob)
-              .with(household.id, person.id, '2026-05-12', '19:45')
-              .at(Time.zone.local(2026, 5, 12, 20, 15))
-          )
-
-        expect(enqueued_jobs.count { |entry| entry.fetch(:job) == MedicationReminderJob }).to eq(3)
-
-        MedicationReminderJob.perform_now(household.id, person.id, :morning)
-
-        expect(PushNotificationService).to have_received(:send_to_account).with(
-          person.account,
-          hash_including(body: 'Morning medications: Vitamin D, Paracetamol')
-        )
+        prepare_london_collision
+        described_class.perform_now
+        expect_london_collision_jobs
+        expect_collision_delivery
       end
     end
   end
@@ -254,6 +214,63 @@ RSpec.describe ScheduleDailyRemindersJob do
 
   def enable_missed_dose_notifications(target)
     create(:notification_preference, person: target, dose_due_enabled: false, missed_dose_enabled: true)
+  end
+
+  def prepare_london_collision
+    create(:notification_preference, person: person, morning_time: '07:15:00', afternoon_time: '14:00:00',
+                                     evening_time: nil, night_time: nil, dose_due_enabled: true,
+                                     missed_dose_enabled: true)
+    create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                      frequency: 'Twice daily', schedule_type: :multiple_daily,
+                      schedule_config: { 'times' => %w[07:15 19:45] })
+    create(:person_medication, :routine, person: person, medication: medications(:paracetamol),
+                                         dosage: dosages(:paracetamol_adult))
+    allow(PushNotificationService).to receive(:send_to_account)
+  end
+
+  def expect_london_collision_jobs
+    expect_due_collision_jobs
+    expect_missed_collision_jobs
+    expect(enqueued_jobs.count { |entry| entry.fetch(:job) == MedicationReminderJob }).to eq(3)
+  end
+
+  def expect_due_collision_jobs
+    expect_morning_due_job
+    expect_afternoon_due_job
+    expect_scheduled_due_job
+  end
+
+  def expect_morning_due_job
+    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :morning], 7, 15)
+  end
+
+  def expect_afternoon_due_job
+    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :afternoon], 14)
+  end
+
+  def expect_scheduled_due_job
+    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :scheduled, '19:45'], 19, 45)
+  end
+
+  def expect_missed_collision_jobs
+    expect_enqueued_at(MissedDoseNotificationJob, [household.id, person.id, '2026-05-12', '07:15'], 7, 45)
+    expect_enqueued_at(MissedDoseNotificationJob, [household.id, person.id, '2026-05-12', '19:45'], 20, 15)
+  end
+
+  def expect_enqueued_at(job_class, arguments, hour, min = 0)
+    expect(job_class).to have_been_enqueued.with(*arguments).at(london_time(hour, min))
+  end
+
+  def london_time(hour, min = 0)
+    Time.zone.local(2026, 5, 12, hour, min)
+  end
+
+  def expect_collision_delivery
+    MedicationReminderJob.perform_now(household.id, person.id, :morning)
+    expect(PushNotificationService).to have_received(:send_to_account).with(
+      person.account,
+      hash_including(body: 'Morning medications: Vitamin D, Paracetamol')
+    )
   end
 
   def reminder_enqueue_event(events)

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -50,6 +50,57 @@ RSpec.describe ScheduleDailyRemindersJob do
       .at(Time.zone.local(2026, 5, 12, 8, 0))
   end
 
+  it 'keeps the London period reminder at a configured-time collision while preserving other reminders' do
+    Time.use_zone('Europe/London') do
+      travel_to Time.zone.local(2026, 5, 12, 6, 0) do
+        create(:notification_preference, person: person, morning_time: '07:15:00', afternoon_time: '14:00:00',
+                                         evening_time: nil, night_time: nil, dose_due_enabled: true,
+                                         missed_dose_enabled: true)
+        create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
+                          frequency: 'Twice daily', schedule_type: :multiple_daily,
+                          schedule_config: { 'times' => %w[07:15 19:45] })
+        create(:person_medication, :routine, person: person, medication: medications(:paracetamol),
+                                             dosage: dosages(:paracetamol_adult))
+        allow(PushNotificationService).to receive(:send_to_account)
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(MedicationReminderJob)
+          .with(household.id, person.id, :morning)
+          .at(Time.zone.local(2026, 5, 12, 7, 15))
+          .and(
+            have_enqueued_job(MedicationReminderJob)
+              .with(household.id, person.id, :afternoon)
+              .at(Time.zone.local(2026, 5, 12, 14, 0))
+          )
+          .and(
+            have_enqueued_job(MedicationReminderJob)
+              .with(household.id, person.id, :scheduled, '19:45')
+              .at(Time.zone.local(2026, 5, 12, 19, 45))
+          )
+          .and(
+            have_enqueued_job(MissedDoseNotificationJob)
+              .with(household.id, person.id, '2026-05-12', '07:15')
+              .at(Time.zone.local(2026, 5, 12, 7, 45))
+          )
+          .and(
+            have_enqueued_job(MissedDoseNotificationJob)
+              .with(household.id, person.id, '2026-05-12', '19:45')
+              .at(Time.zone.local(2026, 5, 12, 20, 15))
+          )
+
+        expect(enqueued_jobs.count { |entry| entry.fetch(:job) == MedicationReminderJob }).to eq(3)
+
+        MedicationReminderJob.perform_now(household.id, person.id, :morning)
+
+        expect(PushNotificationService).to have_received(:send_to_account).with(
+          person.account,
+          hash_including(body: 'Morning medications: Vitamin D, Paracetamol')
+        )
+      end
+    end
+  end
+
   it 'records a past occurrence instead of enqueuing it' do
     events = []
     allow(Observability::CanonicalLogger).to receive(:write) { |event| events << event.to_h }


### PR DESCRIPTION
## Summary

A reminder period and a medication configured time could schedule two due-reminder jobs for the same person and timestamp. Both jobs independently considered the medication due.

This change keeps the period reminder on an exact collision and suppresses only the configured-time due reminder. That preserves the combined reminder for scheduled and direct routine medications. The configured missed-dose check still runs, and non-colliding reminders are unchanged.

## Stack

This is PR 1 of 2 and targets main. Merge this before #1809.

This PR changes application scheduling only. It contains no home-ops or deployment changes.