### PR TITLE
fix(reminders): guard due notification occurrences

### DIFF
--- a/app/jobs/medication_reminder_job.rb
+++ b/app/jobs/medication_reminder_job.rb
@@ -10,33 +10,80 @@ class MedicationReminderJob < ApplicationJob
     night: 'Night'
   }.freeze
 
-  def perform(household_id, person_id, period, scheduled_time = nil)
+  def perform(household_id, person_id, period, scheduled_time = nil, intended_at = nil)
     household = Household.operational.find_by(id: household_id)
     return record_outcome(:household_unavailable) unless household
 
-    TenantContext.with(account: nil, household: household) do
-      deliver_reminder(household, person_id, period, scheduled_time)
+    event = TenantContext.with(account: nil, household: household) do
+      prepare_reminder(household, person_id, period, scheduled_time, intended_at)
     end
+    return unless event
+
+    TenantContext.with(account: nil, household: household) { deliver_recorded_reminder(event) }
   end
 
   private
 
-  def deliver_reminder(household, person_id, period, scheduled_time)
+  def prepare_reminder(household, person_id, period, scheduled_time, intended_at)
+    return unless reminder_context_available?(household, person_id, period, scheduled_time, intended_at)
+
+    med_names = eligible_medication_names(scheduled_time)
+    return unless med_names
+
+    reserve_reminder(med_names)
+  end
+
+  def reminder_context_available?(household, person_id, period, scheduled_time, intended_at)
     @person = Person.find_by(id: person_id, household: household)
-    return record_outcome(:person_unavailable) unless @person&.account
+    return record_unavailable(:person_unavailable) unless @person&.account
 
     @household = household
     @pref = @person.notification_preference
-    return record_outcome(:preference_disabled) unless @pref&.enabled && @pref.dose_due_enabled
+    return record_unavailable(:preference_disabled) unless @pref&.enabled && @pref.dose_due_enabled
 
     @scheduled_time = scheduled_time
     @period = period
+    @intended_at = intended_occurrence_at(intended_at)
+    return record_unavailable(:invalid_occurrence) unless @intended_at
 
+    true
+  end
+
+  def eligible_medication_names(scheduled_time)
     med_names = MedicationReminderEligibilityQuery.new(person: @person, scheduled_time: scheduled_time).medication_names
-    return record_outcome(:no_medications) if med_names.empty?
+    return record_unavailable(:no_medications) if med_names.empty?
 
     record_outcome(:eligible)
-    send_push_notification(med_names)
+    med_names
+  end
+
+  def reserve_reminder(med_names)
+    event = record_due_event
+    return record_unavailable(:duplicate) unless event
+
+    @med_names = med_names
+    event
+  end
+
+  def record_unavailable(reason)
+    record_outcome(reason)
+    nil
+  end
+
+  def deliver_recorded_reminder(event)
+    send_push_notification(@med_names)
+    event.update!(sent_at: Time.current)
+  end
+
+  def record_due_event
+    timestamp = canonical_occurrence_timestamp
+    NotificationEvent.record_once!(
+      household: @household,
+      person: @person,
+      event_type: 'dose_due',
+      event_key: "dose-due:#{@person.id}:#{timestamp}",
+      metadata: { intended_at: timestamp, delivery_status: 'delivery_unknown' }
+    )
   end
 
   def send_push_notification(med_names)
@@ -71,5 +118,44 @@ class MedicationReminderJob < ApplicationJob
 
     period_label = @scheduled_time.presence || PERIOD_LABELS[@period.to_sym] || @period.to_s.humanize
     "#{period_label} medications: #{med_names.join(', ')}"
+  end
+
+  def intended_occurrence_at(explicit_intended_at)
+    occurrence = explicit_intended_at.presence || scheduled_at || legacy_occurrence_at
+    normalize_occurrence(occurrence)
+  end
+
+  def legacy_occurrence_at
+    hour, min = time_components(@scheduled_time.presence || @pref.time_for_period(@period))
+    return unless hour && min
+
+    today = Time.zone.today
+    Time.zone.local(today.year, today.month, today.day, hour, min)
+  end
+
+  def time_components(value)
+    return [value.hour, value.min] if value.respond_to?(:hour) && value.respond_to?(:min)
+
+    match = value.to_s.match(/\A(\d{1,2}):(\d{1,2})(?::.*)?\z/)
+    return unless match
+
+    hour = match[1].to_i
+    min = match[2].to_i
+    return unless hour.between?(0, 23) && min.between?(0, 59)
+
+    [hour, min]
+  end
+
+  def normalize_occurrence(occurrence)
+    return unless occurrence
+
+    time = occurrence.respond_to?(:in_time_zone) ? occurrence.in_time_zone : Time.zone.parse(occurrence.to_s)
+    time.change(sec: 0)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def canonical_occurrence_timestamp
+    @intended_at.utc.iso8601
   end
 end

--- a/app/jobs/medication_reminder_job.rb
+++ b/app/jobs/medication_reminder_job.rb
@@ -46,6 +46,8 @@ class MedicationReminderJob < ApplicationJob
     @intended_at = intended_occurrence_at(intended_at)
     return record_unavailable(:invalid_occurrence) unless @intended_at
 
+    preserve_legacy_occurrence_for_retry
+
     true
   end
 
@@ -123,6 +125,10 @@ class MedicationReminderJob < ApplicationJob
   def intended_occurrence_at(explicit_intended_at)
     occurrence = explicit_intended_at.presence || scheduled_at || legacy_occurrence_at
     normalize_occurrence(occurrence)
+  end
+
+  def preserve_legacy_occurrence_for_retry
+    arguments[4] = @intended_at if arguments.length < 5
   end
 
   def legacy_occurrence_at

--- a/app/jobs/schedule_daily_reminders_job.rb
+++ b/app/jobs/schedule_daily_reminders_job.rb
@@ -65,7 +65,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
 
   def enqueue_period_reminder(pref, period, send_at)
     enqueue_notification_job(
-      MedicationReminderJob.new(pref.household_id, pref.person_id, period),
+      MedicationReminderJob.new(pref.household_id, pref.person_id, period, nil, send_at),
       send_at:,
       kind: :dose_due
     )
@@ -92,7 +92,7 @@ class ScheduleDailyRemindersJob < ApplicationJob
 
   def enqueue_scheduled_dose_due(pref, send_at, time)
     enqueue_notification_job(
-      MedicationReminderJob.new(pref.household_id, pref.person_id, :scheduled, time),
+      MedicationReminderJob.new(pref.household_id, pref.person_id, :scheduled, time, send_at),
       send_at:,
       kind: :dose_due
     )

--- a/app/models/notification_event.rb
+++ b/app/models/notification_event.rb
@@ -8,13 +8,15 @@ class NotificationEvent < ApplicationRecord
   validates :event_key, presence: true, uniqueness: { scope: :event_type }
 
   def self.record_once!(household:, person:, event_type:, event_key:, metadata: {})
-    create!(
-      household: household,
-      person: person,
-      event_type: event_type,
-      event_key: event_key,
-      metadata: metadata
-    )
+    transaction(requires_new: true) do
+      create!(
+        household: household,
+        person: person,
+        event_type: event_type,
+        event_key: event_key,
+        metadata: metadata
+      )
+    end
   rescue ActiveRecord::RecordNotUnique
     nil
   rescue ActiveRecord::RecordInvalid => e

--- a/spec/architecture/tenant_safety_spec.rb
+++ b/spec/architecture/tenant_safety_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe 'tenant safety architecture' do
     reminder_source = Rails.root.join('app/jobs/medication_reminder_job.rb').read
     scheduler_source = Rails.root.join('app/jobs/schedule_daily_reminders_job.rb').read
 
-    expect(reminder_source).to include('def perform(household_id, person_id, period, scheduled_time = nil)')
+    expect(reminder_source).to include(
+      'def perform(household_id, person_id, period, scheduled_time = nil, intended_at = nil)'
+    )
     expect(scheduler_source).to include('MedicationReminderJob.new(pref.household_id, pref.person_id')
     expect(scheduler_source).not_to include('MedicationReminderJob.new(pref.person_id')
   end

--- a/spec/jobs/medication_reminder_job_concurrency_spec.rb
+++ b/spec/jobs/medication_reminder_job_concurrency_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'timeout'
+
+RSpec.describe MedicationReminderJob do
+  self.use_transactional_tests = false
+
+  fixtures :medications, :dosages
+
+  let(:household) { medications(:vitamin_d).household }
+  let(:account) do
+    Account.create!(email: "reminder-concurrency-#{SecureRandom.hex(4)}@example.test", status: :verified)
+  end
+  let(:person) do
+    Person.create!(
+      household: household,
+      account: account,
+      name: 'Reminder Concurrency Person',
+      date_of_birth: 30.years.ago,
+      person_type: :adult,
+      has_capacity: true
+    )
+  end
+  let(:deliveries) { Queue.new }
+  let!(:sync_record_ids_before) do
+    { change_events: ApiChangeEvent.ids, tombstones: ApiTombstone.ids }
+  end
+
+  before do
+    create_concurrency_records
+    allow(PushNotificationService).to receive(:send_to_account) { deliveries << true }
+  end
+
+  after { cleanup_concurrency_records }
+
+  it 'sends one due notification when the same occurrence executes concurrently' do
+    perform_concurrently
+
+    expect(deliveries.size).to eq(1)
+    expect(NotificationEvent.where(event_type: 'dose_due', person: person).count).to eq(1)
+  end
+
+  def create_concurrency_records
+    TenantContext.with(account: nil, household: household) do
+      person.create_notification_preference!(enabled: true, dose_due_enabled: true)
+      create(:schedule, **concurrency_schedule_attributes)
+    end
+  end
+
+  def concurrency_schedule_attributes
+    {
+      person: person,
+      medication: medications(:vitamin_d),
+      dosage: dosages(:vitamin_d_daily),
+      frequency: 'Once daily',
+      schedule_type: :daily,
+      schedule_config: { 'times' => ['07:15'] },
+      start_date: Date.current - 1.day,
+      end_date: Date.current + 1.month
+    }
+  end
+
+  def perform_concurrently
+    ready = Queue.new
+    start = Queue.new
+    threads = 2.times.map { reminder_thread(ready, start) }
+    2.times { Timeout.timeout(10) { ready.pop } }
+    2.times { start << true }
+    threads.each { join_thread(it) }
+  ensure
+    Array(threads).each(&:kill)
+  end
+
+  def reminder_thread(ready, start)
+    Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        Time.use_zone('Europe/London') do
+          ready << true
+          Timeout.timeout(10) { start.pop }
+          described_class.perform_now(household.id, person.id, :scheduled, '07:15')
+        end
+      end
+    end
+  end
+
+  def join_thread(thread)
+    return thread.value if thread.join(10)
+
+    raise Timeout::Error, 'timed out waiting for reminder worker'
+  end
+
+  def cleanup_concurrency_records
+    TenantContext.with(account: nil, household: household) do
+      NotificationEvent.where(person: person).delete_all
+      person.destroy!
+    end
+    account.destroy!
+    cleanup_sync_records
+  end
+
+  def cleanup_sync_records
+    ApiChangeEvent.where.not(id: sync_record_ids_before.fetch(:change_events)).delete_all
+    ApiTombstone.where.not(id: sync_record_ids_before.fetch(:tombstones)).delete_all
+  end
+end

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -68,6 +68,34 @@ RSpec.describe MedicationReminderJob do
     expect(event.metadata).to include('delivery_status' => 'delivery_unknown')
   end
 
+  context 'when a delivered serialized legacy job deadlocks' do
+    around do |example|
+      original_queue_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+    ensure
+      clear_enqueued_jobs
+      ActiveJob::Base.queue_adapter = original_queue_adapter
+    end
+
+    it 'preserves the occurrence when the queued retry runs' do
+      create_vitamin_schedule(
+        time: '07:15', start_date: Date.new(2026, 5, 11), end_date: Date.new(2026, 6, 12)
+      )
+      deadlock_next_update
+      perform_deadlocked_legacy_retry
+
+      event = NotificationEvent.find_by!(event_type: 'dose_due')
+      expect(PushNotificationService).to have_received(:send_to_account).once
+      expect(NotificationEvent.where(event_type: 'dose_due').count).to eq(1)
+      expect(event).to have_attributes(
+        event_key: "dose-due:#{person.id}:2026-05-12T06:15:00Z",
+        sent_at: nil
+      )
+      expect(event.metadata).to include('delivery_status' => 'delivery_unknown')
+    end
+  end
+
   it 'normalizes explicit London occurrences across summer and winter offsets' do
     create_vitamin_schedule(
       time: '07:15', start_date: Date.new(2026, 1, 1), end_date: Date.new(2026, 12, 31)
@@ -326,6 +354,29 @@ RSpec.describe MedicationReminderJob do
 
   def perform_explicit_occurrence(intended_at)
     described_class.perform_now(household.id, person.id, :scheduled, '07:15', intended_at)
+  end
+
+  def deadlock_next_update
+    deadlock_pending = true
+    allow(NotificationEvent).to receive(:record_once!).and_wrap_original do |original, **attributes|
+      event = original.call(**attributes)
+      if event && deadlock_pending
+        deadlock_pending = false
+        allow(event).to receive(:update!).and_raise(ActiveRecord::Deadlocked)
+      end
+      event
+    end
+  end
+
+  def perform_deadlocked_legacy_retry
+    Time.use_zone('Europe/London') do
+      intended_at = Time.zone.local(2026, 5, 12, 7, 15)
+      executed_at = intended_at + 45.minutes
+      travel_to executed_at do
+        perform_serialized(legacy_scheduled_job, intended_at)
+        perform_enqueued_jobs(only: described_class, at: executed_at + 10.seconds)
+      end
+    end
   end
 
   def create_routine_vitamin

--- a/spec/jobs/medication_reminder_job_spec.rb
+++ b/spec/jobs/medication_reminder_job_spec.rb
@@ -36,6 +36,75 @@ RSpec.describe MedicationReminderJob do
     )
   end
 
+  it 'sends one due notification when the same occurrence is replayed sequentially' do
+    create_vitamin_schedule(
+      time: '07:15', start_date: Date.new(2026, 5, 11), end_date: Date.new(2026, 6, 12)
+    )
+
+    Time.use_zone('Europe/London') do
+      travel_to Time.zone.local(2026, 5, 12, 7, 15) do
+        2.times { described_class.perform_now(household.id, person.id, :scheduled, '07:15') }
+      end
+    end
+
+    expect(PushNotificationService).to have_received(:send_to_account).once
+    expect(NotificationEvent.where(event_type: 'dose_due').count).to eq(1)
+  end
+
+  it 'canonicalizes equivalent serialized three- and four-argument jobs' do
+    person.notification_preference.update!(morning_time: '07:15:00')
+    create_vitamin_schedule(
+      time: '07:15', start_date: Date.new(2026, 5, 11), end_date: Date.new(2026, 6, 12)
+    )
+
+    Time.use_zone('Europe/London') do
+      intended_at = Time.zone.local(2026, 5, 12, 7, 15)
+      travel_to(intended_at) { perform_serialized_legacy_jobs(intended_at) }
+    end
+
+    event = NotificationEvent.find_by!(event_type: 'dose_due')
+    expect(PushNotificationService).to have_received(:send_to_account).once
+    expect(event.event_key).to eq("dose-due:#{person.id}:2026-05-12T06:15:00Z")
+    expect(event.metadata).to include('delivery_status' => 'delivery_unknown')
+  end
+
+  it 'normalizes explicit London occurrences across summer and winter offsets' do
+    create_vitamin_schedule(
+      time: '07:15', start_date: Date.new(2026, 1, 1), end_date: Date.new(2026, 12, 31)
+    )
+
+    Time.use_zone('Europe/London') do
+      [Time.zone.local(2026, 5, 12, 7, 15), Time.zone.local(2026, 12, 12, 7, 15)].each do |intended_at|
+        travel_to intended_at do
+          described_class.perform_now(household.id, person.id, :scheduled, '07:15', intended_at)
+        end
+      end
+    end
+
+    expect(NotificationEvent.where(event_type: 'dose_due').order(:event_key).pluck(:event_key)).to contain_exactly(
+      "dose-due:#{person.id}:2026-05-12T06:15:00Z",
+      "dose-due:#{person.id}:2026-12-12T07:15:00Z"
+    )
+    expect(PushNotificationService).to have_received(:send_to_account).twice
+  end
+
+  it 'keeps an unknown delivery reserved when the application delivery raises' do
+    create_vitamin_schedule(
+      time: '07:15', start_date: Date.new(2026, 5, 11), end_date: Date.new(2026, 6, 12)
+    )
+    allow(PushNotificationService).to receive(:send_to_account).and_raise(IOError, 'provider result unknown')
+
+    Time.use_zone('Europe/London') do
+      intended_at = Time.zone.local(2026, 5, 12, 7, 15)
+      travel_to(intended_at) { perform_unknown_delivery_replay(intended_at) }
+    end
+
+    event = NotificationEvent.find_by!(event_type: 'dose_due')
+    expect(PushNotificationService).to have_received(:send_to_account).once
+    expect(event).to have_attributes(sent_at: nil)
+    expect(event.metadata).to include('delivery_status' => 'delivery_unknown')
+  end
+
   it 'does not send scheduled-time reminders for doses already taken today' do
     schedule = create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
                                  frequency: 'Once daily', schedule_type: :daily,
@@ -227,10 +296,36 @@ RSpec.describe MedicationReminderJob do
     end
   end
 
-  def create_vitamin_schedule(time:)
+  def create_vitamin_schedule(time:, start_date: Time.zone.today, end_date: 1.year.from_now.to_date)
     create(:schedule, person: person, medication: medications(:vitamin_d), dosage: dosages(:vitamin_d_daily),
                       frequency: 'Once daily', schedule_type: :daily,
-                      schedule_config: { 'times' => [time] })
+                      schedule_config: { 'times' => [time] }, start_date:, end_date:)
+  end
+
+  def perform_serialized_legacy_jobs(intended_at)
+    [legacy_period_job, legacy_scheduled_job].each { |job| perform_serialized(job, intended_at) }
+  end
+
+  def legacy_period_job
+    described_class.new(household.id, person.id, :morning)
+  end
+
+  def legacy_scheduled_job
+    described_class.new(household.id, person.id, :scheduled, '07:15')
+  end
+
+  def perform_serialized(job, intended_at)
+    job.scheduled_at = intended_at
+    ActiveJob::Base.deserialize(job.serialize).perform_now
+  end
+
+  def perform_unknown_delivery_replay(intended_at)
+    expect { perform_explicit_occurrence(intended_at) }.to raise_error(IOError, 'provider result unknown')
+    expect { perform_explicit_occurrence(intended_at) }.not_to raise_error
+  end
+
+  def perform_explicit_occurrence(intended_at)
+    described_class.perform_now(household.id, person.id, :scheduled, '07:15', intended_at)
   end
 
   def create_routine_vitamin

--- a/spec/jobs/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/schedule_daily_reminders_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ScheduleDailyRemindersJob do
     expect do
       described_class.perform_now
     end.to have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :morning)
+      .with(household.id, person.id, :morning, nil, Time.zone.local(2026, 5, 12, 8, 0))
       .at(Time.zone.local(2026, 5, 12, 8, 0))
   end
 
@@ -88,7 +88,7 @@ RSpec.describe ScheduleDailyRemindersJob do
     expect do
       described_class.perform_now
     end.to have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :scheduled, '07:15')
+      .with(household.id, person.id, :scheduled, '07:15', Time.zone.local(2026, 5, 12, 7, 15))
       .at(Time.zone.local(2026, 5, 12, 7, 15))
   end
 
@@ -160,7 +160,7 @@ RSpec.describe ScheduleDailyRemindersJob do
     expect do
       described_class.perform_now
     end.not_to have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :scheduled, '07:15')
+      .with(household.id, person.id, :scheduled, '07:15', Time.zone.local(2026, 5, 12, 7, 15))
   end
 
   it 'does not enqueue exact reminders for schedules that do not apply today' do
@@ -173,7 +173,7 @@ RSpec.describe ScheduleDailyRemindersJob do
     expect do
       described_class.perform_now
     end.not_to have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :scheduled, '07:15')
+      .with(household.id, person.id, :scheduled, '07:15', Time.zone.local(2026, 5, 12, 7, 15))
   end
 
   it 'does not enqueue exact reminders for paused schedules' do
@@ -186,7 +186,7 @@ RSpec.describe ScheduleDailyRemindersJob do
     expect do
       described_class.perform_now
     end.not_to have_enqueued_job(MedicationReminderJob)
-      .with(household.id, person.id, :scheduled, '07:15')
+      .with(household.id, person.id, :scheduled, '07:15', Time.zone.local(2026, 5, 12, 7, 15))
   end
 
   it 'loads schedule times once for enabled notification preferences' do
@@ -241,15 +241,21 @@ RSpec.describe ScheduleDailyRemindersJob do
   end
 
   def expect_morning_due_job
-    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :morning], 7, 15)
+    expect_enqueued_at(
+      MedicationReminderJob, [household.id, person.id, :morning, nil, london_time(7, 15)], 7, 15
+    )
   end
 
   def expect_afternoon_due_job
-    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :afternoon], 14)
+    expect_enqueued_at(
+      MedicationReminderJob, [household.id, person.id, :afternoon, nil, london_time(14)], 14
+    )
   end
 
   def expect_scheduled_due_job
-    expect_enqueued_at(MedicationReminderJob, [household.id, person.id, :scheduled, '19:45'], 19, 45)
+    expect_enqueued_at(
+      MedicationReminderJob, [household.id, person.id, :scheduled, '19:45', london_time(19, 45)], 19, 45
+    )
   end
 
   def expect_missed_collision_jobs


### PR DESCRIPTION
## Summary

This adds a database-backed occurrence guard for due reminders so replay, retries, and concurrent workers make at most one application-level send attempt for a person and intended timestamp.

It reuses NotificationEvent with a distinct dose_due type and the existing unique index. New jobs carry the intended occurrence explicitly. Existing queued three- and four-argument jobs remain compatible, including Rails retries that receive a new queue scheduled time.

The event records delivery_unknown until the application send returns. This is intentionally an at-most-once application contract; it does not claim exactly-once provider or device delivery.

## Stack

This is PR 2 of 2 and targets #1808. Merge #1808 first, then this PR.

Build and deploy only the cumulative image from this upper branch after both PRs merge. Avoid a mixed old/new worker window while due jobs are being consumed; no queue purge is required once only the cumulative workers are active.

This PR contains no home-ops or deployment changes.