### PR TITLE
chore(deps): automerge green updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,59 +3,14 @@
   "extends": [
     "local>damacus/renovate-config"
   ],
-  "automerge": false,
+  "automerge": true,
+  "automergeType": "pr",
+  "ignoreTests": false,
+  "platformAutomerge": false,
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": false,
+    "automerge": true,
     "automergeType": "pr",
     "ignoreTests": false
-  },
-  "packageRules": [
-    {
-      "description": "Require review for GitHub Actions non-major updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "automerge": false,
-      "automergeType": "pr",
-      "ignoreTests": false
-    },
-    {
-      "description": "Require review for npm development dependency non-major updates",
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": false,
-      "automergeType": "pr",
-      "ignoreTests": false
-    },
-    {
-      "description": "Require review for Bundler patch updates",
-      "matchManagers": ["bundler"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": false,
-      "automergeType": "pr",
-      "ignoreTests": false
-    },
-    {
-      "description": "Require review for Cargo dependency updates",
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": false,
-      "automergeType": "pr",
-      "ignoreTests": false
-    },
-    {
-      "description": "Require review for Docker patch and digest updates",
-      "matchManagers": ["dockerfile", "docker-compose"],
-      "matchUpdateTypes": ["patch", "digest"],
-      "automerge": false,
-      "automergeType": "pr",
-      "ignoreTests": false
-    },
-    {
-      "description": "Keep major updates manual",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    }
-  ]
+  }
 }

--- a/spec/config/json_spec.rb
+++ b/spec/config/json_spec.rb
@@ -5,62 +5,22 @@ require 'rails_helper'
 
 RSpec.describe JSON do
   let(:config) { described_class.parse(Rails.root.join('renovate.json').read) }
-  let(:package_rules) { config.fetch('packageRules') }
 
-  def rule_for(description)
-    package_rules.find { |rule| rule.fetch('description') == description }
+  it 'automerge dependency updates only after the complete branch is green' do
+    expect(config).to include(
+      'automerge' => true,
+      'automergeType' => 'pr',
+      'ignoreTests' => false,
+      'platformAutomerge' => false
+    )
   end
 
-  it 'does not automerge every dependency update from the shared preset' do
-    expect(config.fetch('automerge')).to be(false)
-  end
-
-  it 'requires review for GitHub Actions non-major updates' do
-    rule = rule_for('Require review for GitHub Actions non-major updates')
-
-    expect(rule.fetch('matchManagers')).to eq(['github-actions'])
-    expect(rule.fetch('matchUpdateTypes')).to contain_exactly('minor', 'patch', 'digest')
-    expect(rule.fetch('automerge')).to be(false)
-    expect(rule.fetch('ignoreTests')).to be(false)
-  end
-
-  it 'requires review for npm development dependency non-major updates' do
-    rule = rule_for('Require review for npm development dependency non-major updates')
-
-    expect(rule.fetch('matchManagers')).to eq(['npm'])
-    expect(rule.fetch('matchDepTypes')).to eq(['devDependencies'])
-    expect(rule.fetch('matchUpdateTypes')).to contain_exactly('minor', 'patch')
-    expect(rule.fetch('automerge')).to be(false)
-  end
-
-  it 'requires review for Bundler patch updates' do
-    rule = rule_for('Require review for Bundler patch updates')
-
-    expect(rule.fetch('matchManagers')).to eq(['bundler'])
-    expect(rule.fetch('matchUpdateTypes')).to eq(['patch'])
-    expect(rule.fetch('automerge')).to be(false)
-  end
-
-  it 'requires review for Docker patch and digest updates' do
-    rule = rule_for('Require review for Docker patch and digest updates')
-
-    expect(rule.fetch('matchManagers')).to contain_exactly('dockerfile', 'docker-compose')
-    expect(rule.fetch('matchUpdateTypes')).to contain_exactly('patch', 'digest')
-    expect(rule.fetch('automerge')).to be(false)
-  end
-
-  it 'requires review for lockfile maintenance' do
-    lockfile_maintenance = config.fetch('lockFileMaintenance')
-
-    expect(lockfile_maintenance.fetch('enabled')).to be(true)
-    expect(lockfile_maintenance.fetch('automerge')).to be(false)
-    expect(lockfile_maintenance.fetch('ignoreTests')).to be(false)
-  end
-
-  it 'keeps major updates manual' do
-    rule = rule_for('Keep major updates manual')
-
-    expect(rule.fetch('matchUpdateTypes')).to eq(['major'])
-    expect(rule.fetch('automerge')).to be(false)
+  it 'automerge lockfile maintenance only after the complete branch is green' do
+    expect(config.fetch('lockFileMaintenance')).to include(
+      'enabled' => true,
+      'automerge' => true,
+      'automergeType' => 'pr',
+      'ignoreTests' => false
+    )
   end
 end


### PR DESCRIPTION
## Summary

Renovate currently opens routine dependency updates but leaves every one waiting for a manual merge. This change lets the dependency queue drain automatically once the complete branch is green, including major updates and lockfile maintenance.

Renovate performs the merge itself instead of delegating to GitHub auto-merge. That matters because the current GitHub ruleset does not require every CI job; Renovate will wait for all reported branch checks, including Rust checks, before merging.

## Risks / follow-ups

The `comfy-table` v8 PR currently fails the Rust build because v8 removed an API used by the CLI. It will remain open under this policy until its compatibility change is implemented and CI passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->