### PR TITLE
fix(dev): decouple Serena from application bundle

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,11 +1,9 @@
 project_name: "med-tracker"
-languages: [ruby]
 encoding: "utf-8"
 line_ending: native
 language_backend: LSP
 ignore_all_files_in_gitignore: true
 ls_specific_settings: {}
-additional_workspace_folders: []
 ignored_paths: []
 read_only: false
 excluded_tools: []
@@ -17,3 +15,10 @@ initial_prompt: ""
 symbol_info_budget:
 read_only_memory_patterns: []
 ignored_memory_patterns: []
+ls_additional_workspace_folders: []
+language_servers:
+- ruby
+ls_workspace_folders:
+- .
+activation_command:
+activation_command_timeout: 180.0

--- a/Gemfile
+++ b/Gemfile
@@ -146,8 +146,4 @@ group :development do
   gem 'web-console'
 end
 
-gem 'ruby-lsp', '~> 0.26.9', group: :development
-
-gem 'ruby-lsp-rails', '~> 0.4.8', group: :development
-
 gem 'rubyzip', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -694,12 +694,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
-    ruby-lsp (0.26.10)
-      language_server-protocol (~> 3.17.0)
-      prism (>= 1.2, < 2.0)
-      rbs (>= 3, < 5)
-    ruby-lsp-rails (0.4.8)
-      ruby-lsp (>= 0.26.0, < 0.27.0)
     ruby-progressbar (1.13.0)
     ruby_llm (1.16.0)
       base64
@@ -920,8 +914,6 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   rubocop-rspec_rails
-  ruby-lsp (~> 0.26.9)
-  ruby-lsp-rails (~> 0.4.8)
   ruby_llm
   ruby_ui
   rubycritic

--- a/spec/config/application_harness_dependencies_spec.rb
+++ b/spec/config/application_harness_dependencies_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe ApplicationHarnessDependencies do
     expect(gemfile).not_to include("gem 'rails-controller-testing'")
   end
 
+  it 'keeps editor language server tooling outside the application bundle' do
+    expect(gemfile_dependencies).not_to include('ruby-lsp')
+    expect(gemfile_dependencies).not_to include('ruby-lsp-rails')
+  end
+
   it 'keeps code quality tooling available in local bundles' do
     expect(gemfile).to include("gem 'simplecov', require: false")
     expect(gemfile).to include("gem 'rubycritic', require: false")


### PR DESCRIPTION
## Summary

- Stop treating editor language servers as Rails application dependencies, so branch lockfile drift cannot force Serena through an incomplete host bundle.
- Keep Rails-aware analysis through the supported Ruby LSP composed bundle.
- Update the tracked Serena project config for the 1.7 schema and protect the dependency boundary with a contract spec.

## Verification

- Serena 1.7.0 project health-check passed from a brand-new detached worktree, including symbol overview, symbol lookup, and reference lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->