### PR TITLE
fix(observability): keep canary telemetry collectible

### DIFF
--- a/app/jobs/observability_canary_job.rb
+++ b/app/jobs/observability_canary_job.rb
@@ -4,6 +4,7 @@ class ObservabilityCanaryJob < ApplicationJob
   queue_as :default
 
   def perform
+    Observability::DeployedCanary.emit(kind: :application_event)
     Observability::DeployedCanary.emit(kind: :job)
   end
 end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -14,6 +14,9 @@ OpenTelemetry.logger = Observability::DatasetLogger.new(
   dataset: 'medtracker.opentelemetry',
   level: Rails.env.test? ? Logger::WARN : Logger::ERROR
 )
+OpenTelemetry.error_handler = lambda do |exception: nil, message: nil|
+  OpenTelemetry.logger.error(exception || message)
+end
 
 module OpenTelemetryConfig
   DEFAULT_PRODUCTION_TRACE_SAMPLE_RATE = 0.1

--- a/docs/operations/application-observability.md
+++ b/docs/operations/application-observability.md
@@ -116,6 +116,9 @@ original exception is re-raised.
 Repeated database-pool collection failures emit at most one warning per minute.
 The first successful collection after degradation emits one recovery event.
 
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` enables trace export only. Set the generic
+`OTEL_EXPORTER_OTLP_ENDPOINT` separately when metrics must also be exported.
+
 ## Ownership
 
 | Area | Owner |
@@ -197,11 +200,12 @@ kubectl -n home exec deploy/med-tracker -c app -- \
   bin/rails observability:canary
 ```
 
-The task creates a new opaque workflow, emits an `application_event` canary
-inside an always-retained `observability.canary` span, increments the bounded
-canary metric, and enqueues one no-argument job. The job inherits the workflow
-and emits its own canary; normal job completion supplies its job identifier.
-It reads and changes no account or medication data.
+The task creates a new opaque workflow, enqueues one no-argument job, and
+flushes the remaining enqueue trace before the short-lived command exits. The
+job inherits the workflow and emits both `application_event` and `job` canaries
+inside always-retained `observability.canary` spans, with distinct attempts.
+The application-event and job canaries increment the bounded metric. It reads
+and changes no account or medication data.
 
 Use the catalogue queries with the emitted event, workflow, request, job, and
 trace identifiers. Poll only until all expected signals appear or fifteen

--- a/lib/observability/deployed_canary.rb
+++ b/lib/observability/deployed_canary.rb
@@ -6,14 +6,16 @@ module Observability
 
     def run
       previous_context = Current.observability_context
-      Current.observability_context = CorrelationContext.start.next_attempt
-      emit(kind: :application_event)
-      ObservabilityCanaryJob.perform_later
+      Current.observability_context = CorrelationContext.start
+      tracer.in_span('observability.canary') { ObservabilityCanaryJob.perform_later }
     ensure
+      flush_trace_provider
       Current.observability_context = previous_context
     end
 
     def emit(kind:)
+      previous_context = Current.observability_context
+      Current.observability_context = (previous_context || CorrelationContext.start).next_attempt
       tracer.in_span('observability.canary') do
         event = Publisher.emit(
           name: :observability_canary,
@@ -25,6 +27,8 @@ module Observability
         record_metric(kind)
         event
       end
+    ensure
+      Current.observability_context = previous_context
     end
 
     def tracer
@@ -51,6 +55,12 @@ module Observability
         error: e
       )
     end
-    private_class_method :record_metric
+
+    def flush_trace_provider
+      OpenTelemetry.tracer_provider.force_flush
+    rescue StandardError
+      nil
+    end
+    private_class_method :record_metric, :flush_trace_provider
   end
 end

--- a/lib/observability/process_log_formatter.rb
+++ b/lib/observability/process_log_formatter.rb
@@ -12,16 +12,47 @@ module Observability
     def call(message, dataset:, severity: nil, time: Time.zone.now)
       raise ArgumentError, 'invalid process dataset' unless DATASETS.include?(dataset)
 
+      begin
+        format(message, dataset:, severity:, time:)
+      rescue StandardError
+        minimal_format(dataset:, severity:)
+      end
+    end
+
+    def format(message, dataset:, severity:, time:)
+      log_level = normalized_severity(message, severity)
       {
         '@timestamp' => time.utc.iso8601(3),
-        'log.level' => normalized_severity(message, severity),
+        'log.level' => log_level,
         'service.name' => 'medtracker',
         'service.component' => dataset.delete_prefix('medtracker.'),
         'event.name' => 'process.message',
         'event.dataset' => dataset,
         'process.pid' => Process.pid
-      }.to_json
+      }.merge(opentelemetry_diagnostic(dataset:, log_level:)).to_json
     end
+    private_class_method :format
+
+    def minimal_format(dataset:, severity:)
+      log_level = severity.to_s.downcase.presence || 'error'
+      {
+        '@timestamp' => Time.now.utc.iso8601(3),
+        'log.level' => log_level,
+        'service.name' => 'medtracker',
+        'service.component' => dataset.delete_prefix('medtracker.'),
+        'event.name' => 'process.message',
+        'event.dataset' => dataset,
+        'process.pid' => Process.pid
+      }.merge(opentelemetry_diagnostic(dataset:, log_level:)).to_json
+    end
+    private_class_method :minimal_format
+
+    def opentelemetry_diagnostic(dataset:, log_level:)
+      return {} unless dataset == 'medtracker.opentelemetry' && log_level == 'error'
+
+      { 'event.reason' => 'export_failed' }
+    end
+    private_class_method :opentelemetry_diagnostic
 
     def normalized_severity(message, severity)
       return severity.to_s.downcase if severity

--- a/lib/observability/process_log_formatter.rb
+++ b/lib/observability/process_log_formatter.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'openssl'
 require 'time'
 
 module Observability
   module ProcessLogFormatter
     DATASETS = %w[medtracker.puma medtracker.solid_queue medtracker.opentelemetry].freeze
+    ERROR_TYPES = {
+      OpenSSL::SSL::SSLError => 'OpenSSL::SSL::SSLError'
+    }.freeze
 
     module_function
 
@@ -29,7 +33,7 @@ module Observability
         'event.name' => 'process.message',
         'event.dataset' => dataset,
         'process.pid' => Process.pid
-      }.merge(opentelemetry_diagnostic(dataset:, log_level:)).to_json
+      }.merge(opentelemetry_diagnostic(message:, dataset:, log_level:)).to_json
     end
     private_class_method :format
 
@@ -43,14 +47,16 @@ module Observability
         'event.name' => 'process.message',
         'event.dataset' => dataset,
         'process.pid' => Process.pid
-      }.merge(opentelemetry_diagnostic(dataset:, log_level:)).to_json
+      }.merge(opentelemetry_diagnostic(message: nil, dataset:, log_level:)).to_json
     end
     private_class_method :minimal_format
 
-    def opentelemetry_diagnostic(dataset:, log_level:)
+    def opentelemetry_diagnostic(message:, dataset:, log_level:)
       return {} unless dataset == 'medtracker.opentelemetry' && log_level == 'error'
 
-      { 'event.reason' => 'export_failed' }
+      { 'event.reason' => 'export_failed' }.tap do |diagnostic|
+        diagnostic['error.type'] = ERROR_TYPES[message.class] if ERROR_TYPES.key?(message.class)
+      end
     end
     private_class_method :opentelemetry_diagnostic
 

--- a/scripts/production_observability_characterization.fish
+++ b/scripts/production_observability_characterization.fish
@@ -208,15 +208,16 @@ for attempt in (seq 1 30)
     sleep 1
 end
 
-set -l canary_trace_count_before (
+set -l canary_trace_body_paths_before (
     docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER 2>&1 |
-        awk '$1 == "POST" && $2 == "/v1/traces" { count += 1 } END { print count + 0 }'
+        awk '$1 == "POST" && $2 == "/canary/v1/traces" && $3 != "-" { sub("^/var/cache/nginx/client_temp", "/otlp", $3); print $3 }'
 )
 
 docker run --rm \
     --network $OBSERVABILITY_CHARACTERIZATION_NETWORK \
     $OBSERVABILITY_CHARACTERIZATION_ENV \
     $OBSERVABILITY_CHARACTERIZATION_MOUNTS \
+    --env OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-receiver:4318/canary \
     $OBSERVABILITY_CHARACTERIZATION_IMAGE \
     bin/rails observability:canary >$OBSERVABILITY_CHARACTERIZATION_TMP/canary.log 2>&1
 or begin
@@ -224,15 +225,37 @@ or begin
     exit 1
 end
 
-set -l canary_trace_count_after (
+set -l canary_trace_body_paths_after (
     docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER 2>&1 |
-        awk '$1 == "POST" && $2 == "/v1/traces" { count += 1 } END { print count + 0 }'
+        awk '$1 == "POST" && $2 == "/canary/v1/traces" && $3 != "-" { sub("^/var/cache/nginx/client_temp", "/otlp", $3); print $3 }'
 )
 
-if test $canary_trace_count_after -le $canary_trace_count_before
-    cat $OBSERVABILITY_CHARACTERIZATION_TMP/canary.log
-    docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER
-    echo 'Canary command did not export a new OpenTelemetry trace request' >&2
+set -l canary_trace_body_paths
+for path in $canary_trace_body_paths_after
+    if not contains -- $path $canary_trace_body_paths_before
+        set --append canary_trace_body_paths $path
+    end
+end
+
+if test (count $canary_trace_body_paths) -eq 0
+    echo 'Canary command did not export an enqueue-side observability trace' >&2
+    exit 1
+end
+
+set -l canary_trace_body_paths_env (string join : $canary_trace_body_paths)
+
+docker exec $OBSERVABILITY_CHARACTERIZATION_RECEIVER chmod -R a+rX /var/cache/nginx/client_temp
+or exit 1
+
+docker run --rm \
+    --entrypoint ruby \
+    --volume "$OBSERVABILITY_CHARACTERIZATION_TMP/otlp:/otlp:ro" \
+    --env "OTLP_TRACE_FILES=$canary_trace_body_paths_env" \
+    --env OTLP_REQUIRED_SPAN_NAME=observability.canary \
+    $OBSERVABILITY_CHARACTERIZATION_IMAGE \
+    scripts/verify_otlp_trace_resources.rb
+or begin
+    echo 'Canary command did not export an enqueue-side observability trace' >&2
     exit 1
 end
 

--- a/scripts/production_observability_characterization.fish
+++ b/scripts/production_observability_characterization.fish
@@ -208,6 +208,34 @@ for attempt in (seq 1 30)
     sleep 1
 end
 
+set -l canary_trace_count_before (
+    docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER 2>&1 |
+        awk '$1 == "POST" && $2 == "/v1/traces" { count += 1 } END { print count + 0 }'
+)
+
+docker run --rm \
+    --network $OBSERVABILITY_CHARACTERIZATION_NETWORK \
+    $OBSERVABILITY_CHARACTERIZATION_ENV \
+    $OBSERVABILITY_CHARACTERIZATION_MOUNTS \
+    $OBSERVABILITY_CHARACTERIZATION_IMAGE \
+    bin/rails observability:canary >$OBSERVABILITY_CHARACTERIZATION_TMP/canary.log 2>&1
+or begin
+    cat $OBSERVABILITY_CHARACTERIZATION_TMP/canary.log
+    exit 1
+end
+
+set -l canary_trace_count_after (
+    docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER 2>&1 |
+        awk '$1 == "POST" && $2 == "/v1/traces" { count += 1 } END { print count + 0 }'
+)
+
+if test $canary_trace_count_after -le $canary_trace_count_before
+    cat $OBSERVABILITY_CHARACTERIZATION_TMP/canary.log
+    docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER
+    echo 'Canary command did not export a new OpenTelemetry trace request' >&2
+    exit 1
+end
+
 docker logs $OBSERVABILITY_CHARACTERIZATION_APP \
     >$OBSERVABILITY_CHARACTERIZATION_TMP/app.log 2>&1
 docker logs $OBSERVABILITY_CHARACTERIZATION_WORKER \

--- a/scripts/production_observability_characterization.fish
+++ b/scripts/production_observability_characterization.fish
@@ -225,6 +225,24 @@ or begin
     exit 1
 end
 
+for attempt in (seq 1 30)
+    if docker logs $OBSERVABILITY_CHARACTERIZATION_WORKER 2>&1 |
+            jq --raw-input --slurp --exit-status '
+                [split("\n")[] | fromjson?] as $records |
+                any($records[]; .["event.name"] == "job.completed" and
+                                   .["medtracker.job.class"] == "ObservabilityCanaryJob") and
+                ([$records[] | select(.["event.name"] == "observability.canary")] | length) == 2
+            ' >/dev/null
+        break
+    end
+    if test $attempt -eq 30
+        docker logs $OBSERVABILITY_CHARACTERIZATION_WORKER
+        echo 'Canary worker did not emit both correlated observability records' >&2
+        exit 1
+    end
+    sleep 1
+end
+
 set -l canary_trace_body_paths_after (
     docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER 2>&1 |
         awk '$1 == "POST" && $2 == "/canary/v1/traces" && $3 != "-" { sub("^/var/cache/nginx/client_temp", "/otlp", $3); print $3 }'
@@ -380,6 +398,29 @@ jq --raw-input --slurp --exit-status \
 or begin
     cat $OBSERVABILITY_CHARACTERIZATION_TMP/worker.log
     echo 'Canonical job count or deployment identity is invalid' >&2
+    exit 1
+end
+
+jq --raw-input --slurp --exit-status \
+    --arg image $OBSERVABILITY_CHARACTERIZATION_IMAGE '
+    [split("\n")[] | fromjson? |
+      select(.["event.name"] == "observability.canary")] as $canaries |
+    ($canaries | length) == 2 and
+    ([$canaries[]["medtracker.canary.kind"]] | sort) == ["application_event", "job"] and
+    ([$canaries[]["medtracker.workflow.id"]] | unique | length) == 1 and
+    ([$canaries[]["medtracker.attempt.id"]] | unique | length) == 2 and
+    all($canaries[];
+        .["event.dataset"] == "medtracker.application" and
+        .["event.outcome"] == "success" and
+        .["medtracker.reason"] == "canary_emitted" and
+        .["service.environment"] == "production" and
+        .["service.version"] == $image and
+        (.["medtracker.workflow.id"] | type) == "string" and
+        (.["medtracker.attempt.id"] | type) == "string")
+' $OBSERVABILITY_CHARACTERIZATION_TMP/worker.log >/dev/null
+or begin
+    cat $OBSERVABILITY_CHARACTERIZATION_TMP/worker.log
+    echo 'Canary worker did not emit both correlated observability records' >&2
     exit 1
 end
 

--- a/scripts/verify_otlp_trace_resources.rb
+++ b/scripts/verify_otlp_trace_resources.rb
@@ -4,6 +4,8 @@ require 'opentelemetry/proto/collector/trace/v1/trace_service_pb'
 require 'zlib'
 
 trace_files = ENV.fetch('OTLP_TRACE_FILES').split(':')
+required_span_name = ENV['OTLP_REQUIRED_SPAN_NAME']
+required_span_found = false
 offenders = trace_files.flat_map do |path|
   payload = File.binread(path)
   payload = Zlib.gunzip(payload) if payload.start_with?("\x1F\x8B".b)
@@ -13,6 +15,10 @@ offenders = trace_files.flat_map do |path|
     [[path, []]]
   else
     request.resource_spans.filter_map do |resource_span|
+      required_span_found ||= resource_span.scope_spans.any? do |scope_span|
+        scope_span.spans.any? { |span| span.name == required_span_name }
+      end if required_span_name
+
       attributes = resource_span.resource&.attributes || []
       host_name = attributes.find { |attribute| attribute.key == 'host.name' }&.value&.string_value
       [path, attributes.map(&:key).sort] unless host_name.is_a?(String) && !host_name.empty?
@@ -25,3 +31,5 @@ end
 unless offenders.empty?
   abort "OTLP trace resource contract failed: #{offenders.map { |path, keys| "#{path} (resource keys: #{keys.join(', ')})" }.join('; ')}"
 end
+
+abort 'OTLP trace required span contract failed' if required_span_name && !required_span_found

--- a/spec/config/observability/open_telemetry_config_exporter_spec.rb
+++ b/spec/config/observability/open_telemetry_config_exporter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'openssl'
 
 RSpec.describe OpenTelemetryConfig do
   context 'when configuring the OpenTelemetry SDK' do
@@ -129,6 +130,36 @@ RSpec.describe OpenTelemetryConfig do
 
       result = described_class.parse_otlp_headers(headers_string)
       expect(result).to eq(expected)
+    end
+  end
+
+  context 'when handling exporter errors' do
+    let(:error_output) { StringIO.new }
+
+    around do |example|
+      original_logger = OpenTelemetry.logger
+      OpenTelemetry.logger = Observability::DatasetLogger.new(
+        error_output,
+        dataset: 'medtracker.opentelemetry',
+        level: Logger::ERROR
+      )
+
+      example.run
+    ensure
+      OpenTelemetry.logger = original_logger
+    end
+
+    it 'preserves only the fixed type of an allowlisted exporter exception' do
+      error = OpenSSL::SSL::SSLError.new('private exporter endpoint')
+
+      OpenTelemetry.handle_error(exception: error, message: 'private exporter payload')
+
+      record = JSON.parse(error_output.string)
+      expect(record).to include(
+        'event.reason' => 'export_failed',
+        'error.type' => 'OpenSSL::SSL::SSLError'
+      )
+      expect(record.to_json).not_to include('private', 'endpoint', 'payload')
     end
   end
 

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -292,7 +292,12 @@ RSpec.describe 'Taskfiles' do
       'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-receiver:4318/canary',
       '$2 == "/canary/v1/traces"',
       'OTLP_REQUIRED_SPAN_NAME=observability.canary',
-      'Canary command did not export an enqueue-side observability trace'
+      'Canary command did not export an enqueue-side observability trace',
+      'ObservabilityCanaryJob',
+      'medtracker.canary.kind',
+      'medtracker.workflow.id',
+      'medtracker.attempt.id',
+      'Canary worker did not emit both correlated observability records'
     ]
   end
 

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -267,6 +267,13 @@ RSpec.describe 'Taskfiles' do
       'docker logs $OBSERVABILITY_CHARACTERIZATION_APP',
       'docker logs $OBSERVABILITY_CHARACTERIZATION_WORKER',
       'docker logs $OBSERVABILITY_CHARACTERIZATION_RECEIVER',
+      *canary_observability_characterization_contract,
+      *observability_characterization_validation_contract
+    ]
+  end
+
+  def observability_characterization_validation_contract
+    [
       'Application container has a repository bind mount',
       'docker exec $OBSERVABILITY_CHARACTERIZATION_RECEIVER chmod -R a+rX /var/cache/nginx/client_temp',
       'scripts/verify_otlp_trace_resources.rb',
@@ -276,6 +283,13 @@ RSpec.describe 'Taskfiles' do
       'Production Puma output is not producer-scoped',
       'Canonical job count or deployment identity is invalid',
       'Canonical records contain nested JSON messages'
+    ]
+  end
+
+  def canary_observability_characterization_contract
+    [
+      'bin/rails observability:canary',
+      'Canary command did not export a new OpenTelemetry trace request'
     ]
   end
 

--- a/spec/config/taskfiles_spec.rb
+++ b/spec/config/taskfiles_spec.rb
@@ -289,7 +289,10 @@ RSpec.describe 'Taskfiles' do
   def canary_observability_characterization_contract
     [
       'bin/rails observability:canary',
-      'Canary command did not export a new OpenTelemetry trace request'
+      'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-receiver:4318/canary',
+      '$2 == "/canary/v1/traces"',
+      'OTLP_REQUIRED_SPAN_NAME=observability.canary',
+      'Canary command did not export an enqueue-side observability trace'
     ]
   end
 

--- a/spec/jobs/observability_canary_job_spec.rb
+++ b/spec/jobs/observability_canary_job_spec.rb
@@ -3,11 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe ObservabilityCanaryJob do
-  it 'emits a job-stage canary without domain arguments' do
-    allow(Observability::DeployedCanary).to receive(:emit)
+  let(:tracer) { instance_double(OpenTelemetry::Trace::Tracer) }
+  let(:counter) { double(add: nil) }
+  let(:emitted_kinds) { [] }
+  let(:emitted_contexts) { [] }
 
+  before do
+    allow(tracer).to receive(:in_span).with('observability.canary').and_yield
+    allow(Observability::DeployedCanary).to receive_messages(tracer:, counter:)
+    allow(Observability::Publisher).to receive(:emit) do |**options|
+      emitted_kinds << options.fetch(:attributes).fetch(:canary_kind)
+      emitted_contexts << Current.observability_context.to_event_fields
+      :event
+    end
+  end
+
+  it 'emits the application and job canaries in the collected worker process' do
     described_class.perform_now
 
-    expect(Observability::DeployedCanary).to have_received(:emit).with(kind: :job)
+    expect(emitted_kinds).to eq(%i[application_event job])
+    expect_workflow_and_attempts
+  end
+
+  def expect_workflow_and_attempts
+    expect_shared_workflow
+    expect_distinct_attempts
+  end
+
+  def expect_shared_workflow
+    expect(workflow_ids).to all(eq(workflow_ids.first))
+    expect(workflow_ids.first).to be_present
+  end
+
+  def expect_distinct_attempts
+    expect(attempt_ids).to eq(attempt_ids.uniq)
+  end
+
+  def workflow_ids
+    emitted_contexts.map { |fields| fields.fetch('medtracker.workflow.id') }
+  end
+
+  def attempt_ids
+    emitted_contexts.map { |fields| fields.fetch('medtracker.attempt.id') }
   end
 end

--- a/spec/lib/observability/deployed_canary_spec.rb
+++ b/spec/lib/observability/deployed_canary_spec.rb
@@ -39,14 +39,60 @@ RSpec.describe Observability::DeployedCanary do
     expect(counter).to have_received(:add).with(1, attributes: { 'canary.kind' => 'application_event' })
   end
 
-  it 'starts an opaque workflow and enqueues a no-argument canary job' do
+  it 'starts an opaque workflow, enqueues a no-argument canary job, and flushes its enqueue trace' do
+    trace_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider, force_flush: :success)
     allow(ObservabilityCanaryJob).to receive(:perform_later)
+    allow(OpenTelemetry).to receive(:tracer_provider).and_return(trace_provider)
 
     described_class.run
 
     expect(ObservabilityCanaryJob).to have_received(:perform_later).with(no_args)
-    expect(Observability::Publisher).to have_received(:emit)
+    expect(tracer).to have_received(:in_span).with('observability.canary')
+    expect(trace_provider).to have_received(:force_flush)
     expect(Current.observability_context).to be_nil
+  end
+
+  it 'does not let a trace flush failure prevent the canary job from being enqueued' do
+    trace_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider)
+    allow(trace_provider).to receive(:force_flush).and_raise(RuntimeError, 'private exporter failure')
+    allow(ObservabilityCanaryJob).to receive(:perform_later)
+
+    allow(OpenTelemetry).to receive(:tracer_provider).and_return(trace_provider)
+
+    expect { described_class.run }.not_to raise_error
+
+    expect(ObservabilityCanaryJob).to have_received(:perform_later).with(no_args)
+    expect(Current.observability_context).to be_nil
+  end
+
+  it 'does not let a failed trace flush result prevent the canary job from being enqueued' do
+    trace_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider, force_flush: :failure)
+    allow(ObservabilityCanaryJob).to receive(:perform_later)
+    allow(OpenTelemetry).to receive(:tracer_provider).and_return(trace_provider)
+
+    expect { described_class.run }.not_to raise_error
+
+    expect(trace_provider).to have_received(:force_flush)
+    expect(ObservabilityCanaryJob).to have_received(:perform_later).with(no_args)
+  end
+
+  it 'uses a distinct attempt for each canary event while preserving the workflow' do
+    context = Observability::CorrelationContext.start.next_attempt
+    contexts = []
+    Current.observability_context = context
+    allow(Observability::Publisher).to receive(:emit) do
+      contexts << Current.observability_context.to_event_fields
+      :event
+    end
+
+    described_class.emit(kind: :application_event)
+    described_class.emit(kind: :job)
+
+    expect(contexts.map { |fields| fields.fetch('medtracker.workflow.id') }).to all(eq(context.workflow_id))
+    attempts = contexts.map { |fields| fields.fetch('medtracker.attempt.id') }
+    expect(attempts).to all(be_present)
+    expect(attempts).to eq(attempts.uniq)
+    expect(Current.observability_context).to eq(context)
   end
 
   it 'does not let a metric failure suppress the canonical canary' do

--- a/spec/lib/observability/process_log_formatter_spec.rb
+++ b/spec/lib/observability/process_log_formatter_spec.rb
@@ -39,6 +39,39 @@ RSpec.describe Observability::ProcessLogFormatter do
     expect(record.to_json).not_to include('example.test', 'secret')
   end
 
+  it 'emits a fixed error type for an allowlisted exporter transport error' do
+    error = OpenSSL::SSL::SSLError.new('private exporter response https://example.test/secret')
+    record = JSON.parse(described_class.call(error, dataset: 'medtracker.opentelemetry', severity: 'ERROR'))
+
+    expect(record).to include(
+      'event.reason' => 'export_failed',
+      'error.type' => 'OpenSSL::SSL::SSLError'
+    )
+    expect(record.to_json).not_to include('example.test', 'secret')
+  end
+
+  it 'limits allowlisted error types to OpenTelemetry error records' do
+    error = OpenSSL::SSL::SSLError.new('private endpoint')
+    puma_record = JSON.parse(described_class.call(error, dataset: 'medtracker.puma', severity: 'ERROR'))
+    info_record = JSON.parse(described_class.call(error, dataset: 'medtracker.opentelemetry', severity: 'INFO'))
+
+    expect(puma_record).not_to have_key('error.type')
+    expect(info_record).not_to have_key('error.type')
+    expect([puma_record, info_record].to_json).not_to include('private endpoint')
+  end
+
+  it 'does not expose an unknown exception class as an error type' do
+    unknown_error_class = stub_const('UnknownExporterError', Class.new(StandardError))
+    record = JSON.parse(
+      described_class.call(unknown_error_class.new('private endpoint'),
+                           dataset: 'medtracker.opentelemetry', severity: 'ERROR')
+    )
+
+    expect(record).to include('event.reason' => 'export_failed')
+    expect(record).not_to have_key('error.type')
+    expect(record.to_json).not_to include('private endpoint', unknown_error_class.name.to_s)
+  end
+
   it 'falls back to the minimal process envelope when formatting fails' do
     record = JSON.parse(
       described_class.call('ERROR: private failure text', dataset: 'medtracker.opentelemetry', time: nil)
@@ -49,6 +82,7 @@ RSpec.describe Observability::ProcessLogFormatter do
       'event.dataset' => 'medtracker.opentelemetry',
       'event.reason' => 'export_failed'
     )
+    expect(record).not_to have_key('error.type')
     expect(record.to_json).not_to include('private failure text')
   end
 end

--- a/spec/lib/observability/process_log_formatter_spec.rb
+++ b/spec/lib/observability/process_log_formatter_spec.rb
@@ -23,7 +23,31 @@ RSpec.describe Observability::ProcessLogFormatter do
 
     expect(record).to include(
       'log.level' => 'error',
-      'event.dataset' => 'medtracker.opentelemetry'
+      'event.dataset' => 'medtracker.opentelemetry',
+      'event.reason' => 'export_failed'
+    )
+    expect(record.to_json).not_to include('private failure text')
+    expect(record).not_to have_key('error.type')
+  end
+
+  it 'does not derive diagnostic fields from an unknown OpenTelemetry error object' do
+    error = RuntimeError.new('private exporter response https://example.test/secret')
+    record = JSON.parse(described_class.call(error, dataset: 'medtracker.opentelemetry', severity: 'ERROR'))
+
+    expect(record).to include('event.reason' => 'export_failed')
+    expect(record).not_to have_key('error.type')
+    expect(record.to_json).not_to include('example.test', 'secret')
+  end
+
+  it 'falls back to the minimal process envelope when formatting fails' do
+    record = JSON.parse(
+      described_class.call('ERROR: private failure text', dataset: 'medtracker.opentelemetry', time: nil)
+    )
+
+    expect(record).to include(
+      'event.name' => 'process.message',
+      'event.dataset' => 'medtracker.opentelemetry',
+      'event.reason' => 'export_failed'
     )
     expect(record.to_json).not_to include('private failure text')
   end

--- a/spec/scripts/verify_otlp_trace_resources_spec.rb
+++ b/spec/scripts/verify_otlp_trace_resources_spec.rb
@@ -44,17 +44,42 @@ RSpec.describe 'OTLP trace resource verification' do # rubocop:disable RSpec/Des
     end
   end
 
-  def verify_trace_bodies(*paths)
+  it 'rejects a trace body without the required safe span name' do
+    Dir.mktmpdir do |directory|
+      trace_path = File.join(directory, 'unrelated.otlp')
+      write_trace_body(trace_path, resources: [resource_with_host_name], span_names: ['unrelated.operation'])
+
+      _output, error, status = verify_trace_bodies(trace_path, required_span_name: 'observability.canary')
+
+      expect(status).not_to be_success
+      expect(error).to include('required span contract')
+      expect(error).not_to include('unrelated.operation')
+    end
+  end
+
+  def verify_trace_bodies(*paths, required_span_name: nil)
+    environment = { 'OTLP_TRACE_FILES' => paths.join(':') }
+    environment['OTLP_REQUIRED_SPAN_NAME'] = required_span_name if required_span_name
+
     Open3.capture3(
-      { 'OTLP_TRACE_FILES' => paths.join(':') },
+      environment,
       'ruby',
       Rails.root.join('scripts/verify_otlp_trace_resources.rb').to_s
     )
   end
 
-  def write_trace_body(path, resources:, gzip: false)
+  def write_trace_body(path, resources:, span_names: [], gzip: false)
     body = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
-      resource_spans: resources.map { |resource| Opentelemetry::Proto::Trace::V1::ResourceSpans.new(resource:) }
+      resource_spans: resources.map do |resource|
+        Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
+          resource:,
+          scope_spans: [
+            Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
+              spans: span_names.map { |name| Opentelemetry::Proto::Trace::V1::Span.new(name:) }
+            )
+          ]
+        )
+      end
     ).to_proto
     body = Zlib.gzip(body) if gzip
     File.binwrite(path, body)


### PR DESCRIPTION
## Summary

The deployed observability canary used to emit one record from the short-lived command process, where production log collection could not see it, and it could exit before its enqueue trace was exported.

This change keeps the public command small and reliable: it creates an opaque workflow, queues the existing worker job, flushes its own canary trace without failing application work, and restores the caller context. The collected worker emits both safe canary records with one workflow and distinct attempts.

Exporter failures remain privacy-safe. Operators receive the fixed `export_failed` reason, plus the fixed `OpenSSL::SSL::SSLError` type only when the logger receives that exact allowlisted exception object. Unknown errors, messages, endpoints, and payloads are never copied into logs.

The production-image check now isolates the command's OTLP path and decodes the captured body to require the exact `observability.canary` span, so unrelated worker traffic cannot create a false pass.

Closes #1773.
Closes #1767.

## Stack position

This is the first PR in stack #1823 and targets `main` directly. PR #1821 depends on it.

Publishing this PR authorizes review only. Do not merge or deploy it, reconcile Flux, mutate canary, enable production tracing, or close #1707 without separate approval.

## Unusual verification

The final production-image observability characterization passed against the real `observability:canary` command and decoded command-specific OTLP trace body.
