### PR TITLE
fix(seeds): keep test audit evidence consistent

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,46 @@
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
 # Seed reference medicine data in all environments
-Rails.logger.debug 'Seeding default locations...'
-load Rails.root.join('db/seeds/seed_locations.rb')
+if Rails.env.local?
+  PaperTrail.request(enabled: false) do
+    Rails.logger.debug 'Seeding default locations...'
+    load Rails.root.join('db/seeds/seed_locations.rb')
 
-Rails.logger.debug 'Seeding medicines...'
-load Rails.root.join('db/seeds/seed_medications.rb')
+    Rails.logger.debug 'Seeding medicines...'
+    load Rails.root.join('db/seeds/seed_medications.rb')
+
+    Rails.logger.debug 'Loading fixtures...'
+
+    # Load fixtures in order to respect foreign key constraints
+    SpecFixtureLoader.load(
+      :accounts,
+      :account_otp_keys,
+      :people,
+      :users,
+      :locations,
+      :location_memberships,
+      :medications,
+      :dosages,
+      :schedules,
+      :person_medications,
+      :carer_relationships,
+      :medication_takes
+    )
+    FixtureHouseholdSetup.apply!
+
+    Rails.logger.debug 'Fixtures loaded successfully!'
+    Rails.logger.debug "\nYou can now login with:"
+    Rails.logger.debug '  Email: jane.doe@example.com (no 2FA)'
+    Rails.logger.debug '  Password: password'
+    Rails.logger.debug '  Note: damacus@example.com has TOTP enabled'
+  end
+else
+  Rails.logger.debug 'Seeding default locations...'
+  load Rails.root.join('db/seeds/seed_locations.rb')
+
+  Rails.logger.debug 'Seeding medicines...'
+  load Rails.root.join('db/seeds/seed_medications.rb')
+end
 
 if Rails.env.production?
   # In production, invite initial users from db/seeds/users.yml.
@@ -17,32 +52,4 @@ if Rails.env.production?
   # custom users.yml via a k8s ConfigMap volume at /app/db/seeds/users.yml.
   Rails.logger.debug 'Seeding initial users via invitations...'
   load Rails.root.join('db/seeds/seed_users.rb')
-end
-
-# Load fixtures from spec/fixtures for development/test environments
-if Rails.env.local?
-  Rails.logger.debug 'Loading fixtures...'
-
-  # Load fixtures in order to respect foreign key constraints
-  SpecFixtureLoader.load(
-    :accounts,
-    :account_otp_keys,
-    :people,
-    :users,
-    :locations,
-    :location_memberships,
-    :medications,
-    :dosages,
-    :schedules,
-    :person_medications,
-    :carer_relationships,
-    :medication_takes
-  )
-  FixtureHouseholdSetup.apply!
-
-  Rails.logger.debug 'Fixtures loaded successfully!'
-  Rails.logger.debug "\nYou can now login with:"
-  Rails.logger.debug '  Email: jane.doe@example.com (no 2FA)'
-  Rails.logger.debug '  Password: password'
-  Rails.logger.debug '  Note: damacus@example.com has TOTP enabled'
 end

--- a/spec/seeds/audit_evidence_spec.rb
+++ b/spec/seeds/audit_evidence_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Seeds' do
+  self.use_transactional_tests = false
+
+  before { truncate_runtime_tables }
+
+  around do |example|
+    example.run
+  ensure
+    restore_fixture_baseline
+  end
+
+  it 'does not leave unmatched audit versions after seeding synthetic fixtures', :aggregate_failures do
+    load Rails.root.join('db/seeds.rb')
+
+    expect(PaperTrail::Version.count).to be_zero
+    expect(verify_seeded_evidence).to be_valid
+    expect(User.find_by!(email_address: 'damacus@example.com').authenticate('password')).to be_truthy
+  end
+
+  it 'keeps PaperTrail enabled for non-local seed paths' do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('staging'))
+
+    load Rails.root.join('db/seeds.rb')
+
+    expect(PaperTrail::Version.where(item_type: 'Location')).to exist
+  end
+
+  def verify_seeded_evidence
+    connection = ActiveRecord::Base.connection
+    connection.execute('SET ROLE med_tracker_audit_verifier')
+    Audit::Verification::DatabaseVerifier.new.call
+  ensure
+    connection.execute('RESET ROLE')
+  end
+
+  def truncate_runtime_tables
+    connection = ActiveRecord::Base.connection
+    tables = connection.tables - %w[ar_internal_metadata schema_migrations]
+    quoted_tables = tables.map { |table| connection.quote_table_name(table) }.join(', ')
+    connection.execute("TRUNCATE TABLE #{quoted_tables} RESTART IDENTITY CASCADE")
+  end
+
+  def restore_fixture_baseline
+    truncate_runtime_tables
+
+    PaperTrail.request(enabled: false) do
+      fixture_names = Rails.root.glob('spec/fixtures/*.yml').map { |path| path.basename('.yml').to_s }
+      SpecFixtureLoader.load(fixture_names)
+      FixtureHouseholdSetup.apply!
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Running the normal local/test seed workflow created audited reference rows and then replaced those rows with fixtures. That left PaperTrail versions pointing at records that no longer existed, causing the real database audit verifier to report broken evidence.

This change treats the complete local/test seed lifecycle as synthetic baseline creation. PaperTrail is disabled only around local reference seeds, fixture loading, and fixture household setup. Staging and production seed paths remain audited, including production invitations.

The integration coverage runs the real seed entry point, checks the real database verifier, preserves fixture login, proves the non-local path still creates audit evidence, and restores the shared fixture baseline for later tests.

Closes #1745.

## Stack position

This is the second PR in stack #1823. It is stacked on #1820, and #1822 is stacked on this PR. Review and merge #1820 first.

Publishing this PR authorizes review only. Do not merge or deploy the stack without separate approval.
