### PR TITLE
fix(stock): correct threshold forecast boundaries

### DIFF
--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -55,9 +55,7 @@ class SupplyLevel
     return 0 if low_stock?
 
     surplus = current - reorder_threshold
-    return 0 if surplus <= 0
-
-    (surplus.to_f / daily_consumption).ceil
+    (surplus / daily_consumption).ceil
   end
 
   def days_until_out_of_stock(daily_consumption:)

--- a/app/models/supply_level.rb
+++ b/app/models/supply_level.rb
@@ -10,7 +10,9 @@ class SupplyLevel
   end
 
   def current
-    raw_current || BigDecimal('0')
+    return BigDecimal('0') unless tracked?
+
+    BigDecimal(raw_current.to_s)
   end
 
   def tracked?
@@ -62,7 +64,7 @@ class SupplyLevel
     return nil unless forecast_available?(daily_consumption:)
     return 0 if out_of_stock?
 
-    (current.to_f / daily_consumption).ceil
+    (current / daily_consumption).ceil
   end
 
   def forecast_available?(daily_consumption:)

--- a/spec/models/supply_level_spec.rb
+++ b/spec/models/supply_level_spec.rb
@@ -39,6 +39,44 @@ RSpec.describe SupplyLevel do
     end
   end
 
+  describe '#crossed_low_stock_threshold_from?' do
+    it 'returns true when supply crosses from above to the reorder threshold' do
+      supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 10.000000000000002)).to be true
+    end
+
+    it 'returns true when supply crosses from above to below the reorder threshold' do
+      supply_level = described_class.new(current: 9, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 11)).to be true
+    end
+
+    it 'returns false when supply remains above the reorder threshold' do
+      supply_level = described_class.new(current: 11, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 12)).to be false
+    end
+
+    it 'returns false when supply was already at the reorder threshold' do
+      supply_level = described_class.new(current: 9, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 10)).to be false
+    end
+
+    it 'returns false when supply is not tracked' do
+      supply_level = described_class.new(current: nil, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 11)).to be false
+    end
+
+    it 'returns false when the previous supply is unavailable' do
+      supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: nil)).to be false
+    end
+  end
+
   describe '#out_of_stock?' do
     it 'returns false when current supply is nil' do
       supply_level = described_class.new(current: nil, reorder_threshold: 10, last_restock: nil)
@@ -74,8 +112,30 @@ RSpec.describe SupplyLevel do
       expect(supply_level.days_until_low_stock(daily_consumption: 0)).to be_nil
     end
 
+    it 'subtracts the reorder reserve and rounds partial days up' do
+      supply_level = described_class.new(current: 15, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.days_until_low_stock(daily_consumption: 2)).to eq(3)
+    end
+
+    it 'does not add a day when decimal consumption divides the reserve exactly' do
+      supply_level = described_class.new(
+        current: BigDecimal('0.07'),
+        reorder_threshold: 0,
+        last_restock: 1
+      )
+
+      expect(supply_level.days_until_low_stock(daily_consumption: 0.01)).to eq(7)
+    end
+
     it 'returns zero when already low stock' do
       supply_level = described_class.new(current: 10, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.days_until_low_stock(daily_consumption: 2)).to eq(0)
+    end
+
+    it 'returns zero when supply is below the reorder threshold' do
+      supply_level = described_class.new(current: 5, reorder_threshold: 10, last_restock: 50)
 
       expect(supply_level.days_until_low_stock(daily_consumption: 2)).to eq(0)
     end

--- a/spec/models/supply_level_spec.rb
+++ b/spec/models/supply_level_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe SupplyLevel do
 
       expect(supply_level.current).to eq(0)
     end
+
+    it 'normalizes a string current supply' do
+      supply_level = described_class.new(current: '9.0', reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.current).to eq(BigDecimal('9.0'))
+    end
+
+    it 'normalizes a float current supply without losing its decimal value' do
+      supply_level = described_class.new(current: 10.000000000000002, reorder_threshold: 10, last_restock: nil)
+
+      expect(supply_level.current).to eq(BigDecimal('10.000000000000002'))
+    end
   end
 
   describe '#percentage' do
@@ -50,6 +62,12 @@ RSpec.describe SupplyLevel do
       supply_level = described_class.new(current: 9, reorder_threshold: 10, last_restock: 50)
 
       expect(supply_level.crossed_low_stock_threshold_from?(previous_current: 11)).to be true
+    end
+
+    it 'normalizes supply values returned by the stock query' do
+      supply_level = described_class.new(current: '9.0', reorder_threshold: '10.0', last_restock: 50)
+
+      expect(supply_level.crossed_low_stock_threshold_from?(previous_current: '11.0')).to be true
     end
 
     it 'returns false when supply remains above the reorder threshold' do
@@ -152,6 +170,22 @@ RSpec.describe SupplyLevel do
       supply_level = described_class.new(current: 5, reorder_threshold: 1, last_restock: 10)
 
       expect(supply_level.days_until_out_of_stock(daily_consumption: 2)).to eq(3)
+    end
+
+    it 'returns zero when supply is below zero' do
+      supply_level = described_class.new(current: -3, reorder_threshold: 10, last_restock: 50)
+
+      expect(supply_level.days_until_out_of_stock(daily_consumption: 2)).to eq(0)
+    end
+
+    it 'does not add a day when decimal consumption divides the supply exactly' do
+      supply_level = described_class.new(
+        current: BigDecimal('0.07'),
+        reorder_threshold: 0,
+        last_restock: 1
+      )
+
+      expect(supply_level.days_until_out_of_stock(daily_consumption: 0.01)).to eq(7)
     end
   end
 end


### PR DESCRIPTION
## Summary

`SupplyLevel` decides when stock crosses the reorder threshold and how many days remain before that threshold is reached. Important boundaries were not directly characterized, allowing mutation testing to remove guards, weaken the crossing comparison, or corrupt forecast arithmetic without failing tests.

This change makes those boundaries explicit: crossing exactly to or below the threshold, remaining above it, already-low and untracked stock, and missing history. Forecasts now retain exact BigDecimal arithmetic instead of converting the reserve to Float, which could turn an exact seven-day result into eight days.

The redundant second low-stock guard is removed, leaving `low_stock?` as the single owner of the non-positive reserve boundary. Both focused mutation subjects now kill every mutation with clean control workers.

Closes #1819.

## Stack position

This is the third and final PR in stack #1823. It is stacked on #1821; review and merge #1820, then #1821, before this PR.

The delegated authorization work from #1673 is deliberately deferred and is not present in this stack. Publishing this PR authorizes review only; do not merge or deploy the stack without separate approval.

## Unusual verification

Focused mutation testing completed at 100% for both `SupplyLevel#crossed_low_stock_threshold_from?` and `SupplyLevel#days_until_low_stock`, with no surviving mutations or neutral worker failures.
