### PR TITLE
fix(ci): repair test and security checks

### DIFF
--- a/scripts/compare_ruby_ui.rb
+++ b/scripts/compare_ruby_ui.rb
@@ -89,9 +89,9 @@ class RubyUiComparison
   end
 
   def external_temp_parent
-    %w[/private/tmp /tmp].filter_map do |candidate|
+    %w[/tmp /private/tmp].filter_map do |candidate|
       path = Pathname.new(candidate)
-      path.realpath if path.directory? && !within?(path.realpath, @root.realpath)
+      path.realpath if path.directory? && path.writable? && !within?(path.realpath, @root.realpath)
     rescue Errno::ENOENT, Errno::EACCES
       nil
     end.first || raise('No external temporary directory is available')


### PR DESCRIPTION
Two CI tools were failing before they could provide useful results.

The RubyUI comparison command chose `/private/tmp` whenever that directory existed. In the Linux test image it exists but is not writable. The command now selects a writable external temporary directory while keeping generator work outside the MedTracker checkout.

The security job was also locked to Brakeman 8.0.5, which exits when it detects the newer 8.0.6 release. This change upgrades the locked scanner to 8.0.6. The local scan completes with no security warnings.

This is a tooling prerequisite for the API contract stack. It does not change application behaviour.
