### PR TITLE
docs(api): type notification preference operations

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1981,6 +1981,7 @@ components:
     NotificationPreferenceAttributes:
       type: object
       additionalProperties: false
+      minProperties: 1
       properties:
         enabled:
           type: boolean

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -868,6 +868,21 @@ paths:
       responses:
         '200':
           description: Notification preference resource.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferenceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     patch:
       operationId: updateNotificationPreference
       tags:
@@ -876,9 +891,30 @@ paths:
       summary: Update the signed-in person's notification preference.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferenceUpdateRequest'
       responses:
         '200':
           description: Notification preference updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferenceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     put:
       operationId: replaceNotificationPreference
       tags:
@@ -887,9 +923,30 @@ paths:
       summary: Replace the signed-in person's notification preference.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferenceUpdateRequest'
       responses:
         '200':
           description: Notification preference updated.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferenceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/native_device_tokens:
     post:
       operationId: createNativeDeviceToken
@@ -1856,6 +1913,101 @@ components:
           items:
             type: string
             minLength: 1
+    NotificationPreferenceTime:
+      oneOf:
+        - type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'
+        - type: 'null'
+    NotificationPreferenceTimeInput:
+      oneOf:
+        - type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$'
+        - type: 'null'
+    NotificationPreference:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - portable_id
+        - person_id
+        - person_portable_id
+        - enabled
+        - dose_due_enabled
+        - missed_dose_enabled
+        - low_stock_enabled
+        - private_text_enabled
+        - morning_time
+        - afternoon_time
+        - evening_time
+        - night_time
+        - updated_at
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        person_id:
+          $ref: '#/components/schemas/NumericId'
+        person_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        enabled:
+          type: boolean
+        dose_due_enabled:
+          type: boolean
+        missed_dose_enabled:
+          type: boolean
+        low_stock_enabled:
+          type: boolean
+        private_text_enabled:
+          type: boolean
+        morning_time:
+          $ref: '#/components/schemas/NotificationPreferenceTime'
+        afternoon_time:
+          $ref: '#/components/schemas/NotificationPreferenceTime'
+        evening_time:
+          $ref: '#/components/schemas/NotificationPreferenceTime'
+        night_time:
+          $ref: '#/components/schemas/NotificationPreferenceTime'
+        updated_at:
+          $ref: '#/components/schemas/Timestamp'
+    NotificationPreferenceResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/NotificationPreference'
+    NotificationPreferenceAttributes:
+      type: object
+      additionalProperties: false
+      properties:
+        enabled:
+          type: boolean
+        dose_due_enabled:
+          type: boolean
+        missed_dose_enabled:
+          type: boolean
+        low_stock_enabled:
+          type: boolean
+        private_text_enabled:
+          type: boolean
+        morning_time:
+          $ref: '#/components/schemas/NotificationPreferenceTimeInput'
+        afternoon_time:
+          $ref: '#/components/schemas/NotificationPreferenceTimeInput'
+        evening_time:
+          $ref: '#/components/schemas/NotificationPreferenceTimeInput'
+        night_time:
+          $ref: '#/components/schemas/NotificationPreferenceTimeInput'
+    NotificationPreferenceUpdateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - notification_preference
+      properties:
+        notification_preference:
+          $ref: '#/components/schemas/NotificationPreferenceAttributes'
     ValidationErrors:
       type: object
       additionalProperties:

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -574,6 +574,12 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       ).to include('/notification_preference/unexpected')
     end
 
+    it 'rejects empty notification preference updates' do
+      expect(
+        described_class.schema_errors('NotificationPreferenceUpdateRequest', notification_preference: {})
+      ).to include('/notification_preference')
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -537,6 +537,43 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       ).to include('/data/unexpected')
     end
 
+    it 'types notification preference reads and updates' do
+      path = '/households/{household_id}/notification_preference'
+      get_operation = described_class.operation(path, 'get')
+      patch_operation = described_class.operation(path, 'patch')
+      put_operation = described_class.operation(path, 'put')
+
+      expect(get_operation.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/NotificationPreferenceResponse'
+      )
+      [patch_operation, put_operation].each do |operation|
+        expect(operation.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
+          '#/components/schemas/NotificationPreferenceUpdateRequest'
+        )
+        expect(operation.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+          '#/components/schemas/NotificationPreferenceResponse'
+        )
+      end
+    end
+
+    it 'matches the notification preference Rails payload and rejects request drift' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+      create(:notification_preference, person: users(:admin).person)
+
+      get api_v1_household_notification_preference_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('NotificationPreferenceResponse', response.parsed_body)).to be_empty
+      expect(
+        described_class.schema_errors(
+          'NotificationPreferenceUpdateRequest',
+          notification_preference: { enabled: true, unexpected: true }
+        )
+      ).to include('/notification_preference/unexpected')
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')


### PR DESCRIPTION
Notification preferences are available through the API, but their read and update operations were still untyped in OpenAPI.

This change documents the exact preference fields, nullable reminder times, update envelope, ETag response header, and real error responses. The contract test validates a real Rails response and rejects unknown update fields.

Depends on #1846.

Closes #1832.
