### PR TITLE
docs(api): type native device token operations

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -956,9 +956,23 @@ paths:
       summary: Register a native device token.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NativeDeviceTokenCreateRequest'
       responses:
         '201':
           description: Device token registered.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/native_device_tokens/{id}:
     delete:
       operationId: deleteNativeDeviceToken
@@ -972,6 +986,12 @@ paths:
       responses:
         '204':
           description: Device token revoked.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/push_subscription:
     post:
       operationId: createPushSubscription
@@ -2009,6 +2029,29 @@ components:
       properties:
         notification_preference:
           $ref: '#/components/schemas/NotificationPreferenceAttributes'
+    NativeDeviceTokenAttributes:
+      type: object
+      additionalProperties: false
+      required:
+        - device_token
+        - platform
+      properties:
+        device_token:
+          type: string
+          minLength: 1
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+    NativeDeviceTokenCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - native_device_token
+      properties:
+        native_device_token:
+          $ref: '#/components/schemas/NativeDeviceTokenAttributes'
     ValidationErrors:
       type: object
       additionalProperties:

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -580,6 +580,31 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       ).to include('/notification_preference')
     end
 
+    it 'types native device token registration and revocation' do
+      create_operation = described_class.operation('/households/{household_id}/native_device_tokens', 'post')
+      delete_operation = described_class.operation('/households/{household_id}/native_device_tokens/{id}', 'delete')
+
+      expect(create_operation.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/NativeDeviceTokenCreateRequest'
+      )
+      expect(create_operation.fetch('responses').keys).to include('201', '401', '403', '422')
+      expect(delete_operation.fetch('responses').keys).to include('204', '401', '403')
+    end
+
+    it 'accepts only the native device token fields supported by Rails' do
+      valid_request = {
+        native_device_token: { device_token: 'opaque-device-token', platform: 'ios' }
+      }
+      invalid_request = {
+        native_device_token: { device_token: 'opaque-device-token', platform: 'windows', secret: 'private' }
+      }
+
+      expect(described_class.schema_errors('NativeDeviceTokenCreateRequest', valid_request)).to be_empty
+      expect(described_class.schema_errors('NativeDeviceTokenCreateRequest', invalid_request)).to contain_exactly(
+        '/native_device_token/platform', '/native_device_token/secret'
+      )
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')


### PR DESCRIPTION
Native device token registration and revocation already work for mobile clients, but OpenAPI did not describe the request body or failure responses.

This change types the registration envelope, limits platforms to iOS and Android as Rails does, keeps successful responses bodyless, and documents authentication, validation, and rate-limit failures.

Depends on #1847.

Closes #1833.
