### PR TITLE
docs(api): type web push subscription operations

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -13,6 +13,7 @@ module Api
       class InvalidFilterValue < StandardError; end
 
       rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+      rescue_from ActionController::ParameterMissing, with: :render_bad_request
       rescue_from InvalidFilterValue, with: :render_invalid_filter
       rescue_from Pundit::NotAuthorizedError, with: :render_forbidden
 
@@ -204,6 +205,10 @@ module Api
 
       def render_not_found
         render_api_error(code: 'not_found', message: 'Record not found', status: :not_found)
+      end
+
+      def render_bad_request(exception)
+        render_api_error(code: 'bad_request', message: exception.message, status: :bad_request)
       end
 
       def render_forbidden

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1001,9 +1001,23 @@ paths:
       summary: Register a web push subscription.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushSubscriptionCreateRequest'
       responses:
         '201':
           description: Push subscription registered.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     delete:
       operationId: deletePushSubscription
       tags:
@@ -1012,9 +1026,16 @@ paths:
       summary: Revoke a web push subscription.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/push_subscription_endpoint'
       responses:
         '204':
           description: Push subscription revoked.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/push_subscription/test:
     post:
       operationId: testPushSubscription
@@ -1027,6 +1048,18 @@ paths:
       responses:
         '204':
           description: Test notification queued.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '503':
+          description: The test notification could not be sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushTestFailedErrorEnvelope'
   /households/{household_id}/medication_lookup:
     get:
       operationId: searchMedicationLookup
@@ -1396,6 +1429,14 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/DeviceTokenIdentifier'
+    push_subscription_endpoint:
+      name: endpoint
+      in: query
+      required: true
+      schema:
+        type: string
+        format: uri
+        pattern: '^https://'
     page:
       name: page
       in: query
@@ -2052,6 +2093,65 @@ components:
       properties:
         native_device_token:
           $ref: '#/components/schemas/NativeDeviceTokenAttributes'
+    PushSubscriptionKeys:
+      type: object
+      additionalProperties: false
+      required:
+        - p256dh
+        - auth
+      properties:
+        p256dh:
+          type: string
+          minLength: 1
+        auth:
+          type: string
+          minLength: 1
+    PushSubscriptionAttributes:
+      type: object
+      additionalProperties: false
+      required:
+        - endpoint
+        - keys
+      properties:
+        endpoint:
+          type: string
+          format: uri
+          pattern: '^https://'
+        keys:
+          $ref: '#/components/schemas/PushSubscriptionKeys'
+    PushSubscriptionCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - push_subscription
+      properties:
+        push_subscription:
+          $ref: '#/components/schemas/PushSubscriptionAttributes'
+    PushTestFailedError:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+        - request_id
+      properties:
+        code:
+          type: string
+          const: push_test_failed
+        message:
+          type: string
+          const: Unable to send test notification.
+        request_id:
+          type: string
+          minLength: 1
+    PushTestFailedErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/PushTestFailedError'
     ValidationErrors:
       type: object
       additionalProperties:

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1030,6 +1030,8 @@ paths:
       responses:
         '204':
           description: Push subscription revoked.
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1479,6 +1481,12 @@ components:
         type: integer
         minimum: 1
   responses:
+    BadRequest:
+      description: A required request parameter is missing or invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
     Unauthorized:
       description: The bearer credential is absent, invalid, expired, revoked, or no longer active.
       content:

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -605,6 +605,42 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       )
     end
 
+    it 'types web push subscription registration, revocation, and testing' do
+      path = '/households/{household_id}/push_subscription'
+      create_operation = described_class.operation(path, 'post')
+      delete_operation = described_class.operation(path, 'delete')
+      test_operation = described_class.operation("#{path}/test", 'post')
+
+      expect(create_operation.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/PushSubscriptionCreateRequest'
+      )
+      expect(delete_operation.fetch('parameters')).to include(
+        { '$ref' => '#/components/parameters/push_subscription_endpoint' }
+      )
+      expect(test_operation.dig('responses', '503', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/PushTestFailedErrorEnvelope'
+      )
+    end
+
+    it 'requires the web push endpoint and keys without allowing secret response fields' do
+      valid_request = {
+        push_subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/subscription',
+          keys: { p256dh: 'public-key', auth: 'auth-secret' }
+        }
+      }
+      invalid_request = valid_request.deep_merge(push_subscription: { keys: { unexpected: 'secret' } })
+      failed_response = {
+        error: { code: 'push_test_failed', message: 'Unable to send test notification.', request_id: 'request-id' }
+      }
+
+      expect(described_class.schema_errors('PushSubscriptionCreateRequest', valid_request)).to be_empty
+      expect(described_class.schema_errors('PushSubscriptionCreateRequest', invalid_request)).to include(
+        '/push_subscription/keys/unexpected'
+      )
+      expect(described_class.schema_errors('PushTestFailedErrorEnvelope', failed_response)).to be_empty
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -617,6 +617,7 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(delete_operation.fetch('parameters')).to include(
         { '$ref' => '#/components/parameters/push_subscription_endpoint' }
       )
+      expect(delete_operation.dig('responses', '400', '$ref')).to eq('#/components/responses/BadRequest')
       expect(test_operation.dig('responses', '503', 'content', 'application/json', 'schema', '$ref')).to eq(
         '#/components/schemas/PushTestFailedErrorEnvelope'
       )

--- a/spec/requests/api/v1/domain_parity_spec.rb
+++ b/spec/requests/api/v1/domain_parity_spec.rb
@@ -372,6 +372,15 @@ RSpec.describe 'API v1 domain parity' do
     expect(response.parsed_body.dig('error', 'code')).to eq('push_test_failed')
   end
 
+  it 'returns an API error when the push subscription endpoint is missing' do
+    delete api_v1_household_push_subscription_path(household_id),
+           headers: headers,
+           as: :json
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body.dig('error', 'code')).to eq('bad_request')
+  end
+
   it 'uses household-scoped medication lookup from the API' do
     responder = instance_double(
       MedicationFinderSearchResponder,


### PR DESCRIPTION
Web Push registration, revocation, and test notifications already work, but their OpenAPI operations did not describe the browser subscription keys, required endpoint, or test failure response.

This change adds strict request-only key schemas, requires the HTTPS endpoint on deletion, keeps successful responses bodyless, and types the safe `push_test_failed` error envelope without exposing subscription secrets.

Depends on #1848.

Closes #1834.
