### PR TITLE
chore(docs): configure Vale AI-tells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 
 # Ignore mkdocs build output
 /site/
+/.vale/styles/
 __pycache__/
 *.sqlite3
 db/*.sqlite3-*

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.29.0/ai-tells.zip
+
+[*.md]
+BasedOnStyles = ai-tells


### PR DESCRIPTION
## Summary

MedTracker now has one shared Vale configuration for Markdown files.

The configuration pins AI-tells 1.29.0. Vale downloads the package into an ignored local cache, so generated style files do not enter the repository.

Run `vale sync` after checkout. Then run `vale path/to/file.md` to check prose before review.
