### PR TITLE
docs(api): type household audit logs

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1670,6 +1670,18 @@ paths:
       responses:
         '200':
           description: Audit event collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAuditEventCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
 components:
   securitySchemes:
     bearerAuth:
@@ -2281,6 +2293,48 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/ApiAppTokenCreated'
+    SecurityAuditEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - event_type
+        - actor_account_id
+        - actor_membership_id
+        - request_id
+        - metadata
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        event_type:
+          type: string
+          minLength: 1
+        actor_account_id:
+          $ref: '#/components/schemas/NullableNumericId'
+        actor_membership_id:
+          $ref: '#/components/schemas/NullableNumericId'
+        request_id:
+          type:
+            - string
+            - 'null'
+          minLength: 1
+        metadata:
+          type: object
+          additionalProperties: true
+        created_at:
+          $ref: '#/components/schemas/Timestamp'
+    SecurityAuditEventCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          maxItems: 100
+          items:
+            $ref: '#/components/schemas/SecurityAuditEvent'
     Person:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -147,7 +147,10 @@ end
 module OpenapiStructure
   HTTP_METHODS = %w[delete get head options patch post put trace].freeze
   AUDIENCE_TAGS = ['Public', 'Account', 'Household', 'Household administration'].freeze
-  ALLOWED_FREE_FORM_PATHS = ['#/components/schemas/SyncBatchOperation/properties/attributes'].freeze
+  ALLOWED_FREE_FORM_PATHS = [
+    '#/components/schemas/SecurityAuditEvent/properties/metadata',
+    '#/components/schemas/SyncBatchOperation/properties/attributes'
+  ].freeze
   LOCATOR_PATHS = %w[
     /households/{household_id}/locations/{id}
     /households/{household_id}/medications/{id}
@@ -739,6 +742,36 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       )
     end
 
+    it 'types the bounded household security audit event feed' do
+      operation = described_class.operation('/households/{household_id}/admin/audit_logs', 'get')
+
+      expect(operation.fetch('responses').keys).to include('200', '401', '403', '404', '429')
+      expect(operation.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/SecurityAuditEventCollectionResponse'
+      )
+      expect(described_class.schema('SecurityAuditEvent').fetch('additionalProperties')).to be(false)
+      expect(described_class.schema('SecurityAuditEvent').dig('properties', 'metadata')).to eq(
+        'type' => 'object', 'additionalProperties' => true
+      )
+      collection_schema = described_class.schema('SecurityAuditEventCollectionResponse')
+      expect(collection_schema.dig('properties', 'data', 'maxItems')).to eq(100)
+    end
+
+    it 'matches the bounded descending Rails security audit event feed without leaking diagnostics' do
+      household_id, headers = manager_api_context
+      rows = 101.times.map { |index| contract_security_audit_event(household_id, index) }
+      rows.each { |row| SecurityAuditEvent.create!(row) }
+
+      get api_v1_household_admin_audit_logs_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      payload = response.parsed_body
+      expect(described_class.schema_errors('SecurityAuditEventCollectionResponse', payload)).to be_empty
+      expect(payload.fetch('data').size).to eq(100)
+      expect(payload.fetch('data').pluck('created_at')).to eq(payload.fetch('data').pluck('created_at').sort.reverse)
+      expect_private_audit_diagnostics(payload)
+    end
+
     it 'types notification preference reads and updates' do
       path = '/households/{household_id}/notification_preference'
       get_operation = described_class.operation(path, 'get')
@@ -912,6 +945,27 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
         access_level: 'manage',
         relationship_type: 'carer'
       }
+    end
+
+    def contract_security_audit_event(household_id, index)
+      timestamp = 2.hours.from_now + index.seconds
+      {
+        household_id:,
+        event_type: "contract.audit.#{index}",
+        metadata: { 'sequence' => index },
+        audit_context: {},
+        request_id: "contract-request-#{index}",
+        created_at: timestamp,
+        updated_at: timestamp
+      }
+    end
+
+    def expect_private_audit_diagnostics(payload)
+      invalid_payload = payload.deep_dup
+      invalid_payload.dig('data', 0)['id'] = 'private-audit-payload-value'
+      diagnostics = described_class.schema_errors('SecurityAuditEventCollectionResponse', invalid_payload).join(' ')
+      expect(diagnostics).to include('/data/0/id')
+      expect(diagnostics).not_to include('private-audit-payload-value')
     end
   end
 end


### PR DESCRIPTION
## Summary

- Define strict household security event and collection schemas.
- Keep arbitrary data confined to the documented `metadata` field.
- Document authentication, authorization, missing-household, and rate-limit responses.
- Verify the live Rails response stays household-scoped, newest-first, and limited to 100 events.

## Stack

This is the first pull request in the new API documentation stack. Issue #1835 follows with the medication lookup contract.

## Verification

- The focused OpenAPI contract passed 55 examples.
- The documentation build passed.
- RuboCop inspected 1,781 files successfully.

Closes #1842.
