### PR TITLE
docs(api): type medication lookup

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1071,9 +1071,45 @@ paths:
       summary: Search external medication lookup data.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - name: q
+          in: query
+          required: false
+          description: Medicine name, dm+d code, or barcode to search for.
+          schema:
+            type: string
+        - name: form
+          in: query
+          required: false
+          description: Dosage form used to filter search results.
+          schema:
+            type: string
+        - name: strength
+          in: query
+          required: false
+          description: Medicine strength used to filter search results.
+          schema:
+            type: string
       responses:
         '200':
           description: Medication lookup results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MedicationLookupResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '503':
+          description: Medication lookup is temporarily unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MedicationLookupUnavailableResponse'
   /households/{household_id}/ai_medication_suggestions:
     post:
       operationId: generateAiMedicationSuggestions
@@ -2335,6 +2371,388 @@ components:
           maxItems: 100
           items:
             $ref: '#/components/schemas/SecurityAuditEvent'
+    MedicationLookupResponse:
+      oneOf:
+        - $ref: '#/components/schemas/MedicationLookupEmptyResponse'
+        - $ref: '#/components/schemas/MedicationLookupSearchResponse'
+    MedicationLookupEmptyResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - results
+        - permissions
+      properties:
+        results:
+          type: array
+          maxItems: 0
+        permissions:
+          $ref: '#/components/schemas/MedicationLookupPermissions'
+    MedicationLookupSearchResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - results
+        - review_guidance
+        - query
+        - barcode
+        - barcode_resolution
+        - form
+        - strength
+        - permissions
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MedicationLookupResult'
+        review_guidance:
+          $ref: '#/components/schemas/MedicationLookupReviewGuidance'
+        query:
+          type: string
+          minLength: 1
+        barcode:
+          type:
+            - string
+            - 'null'
+        barcode_resolution:
+          oneOf:
+            - $ref: '#/components/schemas/MedicationLookupBarcodeResolution'
+            - type: 'null'
+        form:
+          type:
+            - string
+            - 'null'
+        strength:
+          type:
+            - string
+            - 'null'
+        permissions:
+          $ref: '#/components/schemas/MedicationLookupPermissions'
+    MedicationLookupUnavailableResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - results
+        - error
+      properties:
+        results:
+          type: array
+          maxItems: 0
+        error:
+          type: string
+          const: Medication search is temporarily unavailable.
+    MedicationLookupPermissions:
+      type: object
+      additionalProperties: false
+      required:
+        - can_create
+        - can_update
+      properties:
+        can_create:
+          type: boolean
+        can_update:
+          type: boolean
+    MedicationLookupBarcodeResolution:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - source
+      properties:
+        status:
+          type: string
+          const: resolved
+        source:
+          type:
+            - string
+            - 'null'
+    MedicationLookupReviewGuidance:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - available
+            - unavailable
+    MedicationLookupResult:
+      type: object
+      additionalProperties: false
+      required:
+        - barcode
+        - code
+        - name
+        - description
+        - display
+        - system
+        - concept_class
+        - category
+        - trade_family
+        - trade_family_group
+        - package_size
+        - package_quantity
+        - package_unit
+        - directions
+        - warnings
+        - pil_url
+        - spc_url
+        - concept_class_label
+        - source_label
+        - match_reason
+        - match_reason_label
+        - related_medications
+        - review_prompts
+        - review_prompt_filter
+      properties:
+        barcode:
+          type:
+            - string
+            - 'null'
+        code:
+          type:
+            - string
+            - 'null'
+        name:
+          type:
+            - string
+            - 'null'
+        description:
+          type:
+            - string
+            - 'null'
+        display:
+          type: string
+          minLength: 1
+        system:
+          type:
+            - string
+            - 'null'
+        concept_class:
+          type:
+            - string
+            - 'null'
+        category:
+          type:
+            - string
+            - 'null'
+        trade_family:
+          oneOf:
+            - $ref: '#/components/schemas/MedicationLookupTradeFamily'
+            - type: 'null'
+        trade_family_group:
+          oneOf:
+            - $ref: '#/components/schemas/MedicationLookupTradeFamily'
+            - type: 'null'
+        package_size:
+          type:
+            - string
+            - 'null'
+        package_quantity:
+          type:
+            - number
+            - string
+            - 'null'
+        package_unit:
+          type:
+            - string
+            - 'null'
+        directions:
+          type:
+            - string
+            - 'null'
+        warnings:
+          type:
+            - string
+            - 'null'
+        pil_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+        spc_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+        concept_class_label:
+          type:
+            - string
+            - 'null'
+        source_label:
+          type:
+            - string
+            - 'null'
+        match_reason:
+          type:
+            - string
+            - 'null'
+        match_reason_label:
+          type:
+            - string
+            - 'null'
+        existing_medication:
+          $ref: '#/components/schemas/MedicationLookupExistingMedication'
+        related_medications:
+          type: array
+          items:
+            $ref: '#/components/schemas/MedicationLookupRelatedMedication'
+        review_prompts:
+          type: array
+          items:
+            $ref: '#/components/schemas/MedicationLookupReviewPrompt'
+        review_prompt_filter:
+          $ref: '#/components/schemas/MedicationLookupReviewPromptFilter'
+    MedicationLookupTradeFamily:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - name
+      properties:
+        code:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+    MedicationLookupExistingMedication:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - location
+        - current_supply
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        name:
+          type: string
+          minLength: 1
+        location:
+          type: string
+          minLength: 1
+        path:
+          type: string
+        refill_path:
+          type: string
+        current_supply:
+          type: string
+    MedicationLookupRelatedMedication:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - location
+        - current_supply
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        name:
+          type: string
+          minLength: 1
+        location:
+          type: string
+          minLength: 1
+        path:
+          type: string
+        current_supply:
+          type: string
+    MedicationLookupReviewPrompt:
+      type: object
+      additionalProperties: false
+      required:
+        - evidence_record_id
+        - risk_level
+        - risk_level_label
+        - match_confidence
+        - match_confidence_label
+        - matched_term
+        - match_type
+        - source_instruction
+        - match_reason
+        - interacting_medication_name
+        - description
+        - source_name
+        - source_checked_on
+        - source_version
+        - source_effective_on
+        - source_url
+        - evidence_text
+      properties:
+        evidence_record_id:
+          $ref: '#/components/schemas/NumericId'
+        risk_level:
+          type: string
+          enum:
+            - high
+            - moderate
+            - low
+            - unknown
+        risk_level_label:
+          type: string
+          minLength: 1
+        match_confidence:
+          type: string
+          enum:
+            - high
+            - moderate
+            - low
+            - unknown
+        match_confidence_label:
+          type: string
+          minLength: 1
+        matched_term:
+          type: string
+          minLength: 1
+        match_type:
+          type: string
+          enum:
+            - curated
+            - ingredient
+            - class
+        source_instruction:
+          type: string
+          minLength: 1
+        match_reason:
+          type: string
+          minLength: 1
+        interacting_medication_name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
+        source_name:
+          type: string
+          minLength: 1
+        source_checked_on:
+          $ref: '#/components/schemas/Date'
+        source_version:
+          type:
+            - string
+            - 'null'
+        source_effective_on:
+          oneOf:
+            - $ref: '#/components/schemas/Date'
+            - type: 'null'
+        source_url:
+          type: string
+          format: uri
+        evidence_text:
+          type: string
+          minLength: 1
+    MedicationLookupReviewPromptFilter:
+      type: object
+      additionalProperties: false
+      required:
+        - hidden_count
+      properties:
+        hidden_count:
+          type: integer
+          minimum: 0
     Person:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -877,6 +877,55 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('PushTestFailedErrorEnvelope', failed_response)).to be_empty
     end
 
+    it 'types medication lookup filters and outcomes' do
+      operation = described_class.operation('/households/{household_id}/medication_lookup', 'get')
+      query_parameters = operation.fetch('parameters').filter_map do |parameter|
+        parameter['name'] if parameter['in'] == 'query'
+      end
+
+      expect(query_parameters).to contain_exactly('q', 'form', 'strength')
+      expect(operation.fetch('responses').keys).to include('200', '401', '403', '404', '429', '503')
+      expect(operation.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/MedicationLookupResponse'
+      )
+      expect(operation.dig('responses', '503', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/MedicationLookupUnavailableResponse'
+      )
+    end
+
+    it 'matches empty and successful medication lookup Rails responses' do
+      household_id, headers = manager_api_context
+
+      get api_v1_household_medication_lookup_path(household_id), headers:, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('MedicationLookupResponse', response.parsed_body)).to be_empty
+
+      allow(NhsDmd::Search).to receive(:new).and_return(contract_medication_search)
+      get api_v1_household_medication_lookup_path(household_id), params: { q: 'aspirin' }, headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('MedicationLookupResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'matches the medication lookup Rails unavailable response' do
+      household_id, headers = manager_api_context
+      search_result = NhsDmd::Search::Result.new(results: [], error: 'unavailable')
+      allow(NhsDmd::Search).to receive(:new).and_return(instance_double(NhsDmd::Search, call: search_result))
+
+      get api_v1_household_medication_lookup_path(household_id), params: { q: 'aspirin' }, headers:, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(described_class.schema_errors('MedicationLookupUnavailableResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'keeps web navigation fields optional in medication lookup matches' do
+      existing_medication = described_class.schema('MedicationLookupExistingMedication')
+      related_medication = described_class.schema('MedicationLookupRelatedMedication')
+
+      expect(existing_medication.fetch('required')).not_to include('path', 'refill_path')
+      expect(related_medication.fetch('required')).not_to include('path')
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')
@@ -958,6 +1007,22 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
         created_at: timestamp,
         updated_at: timestamp
       }
+    end
+
+    def contract_medication_search
+      search_result = NhsDmd::SearchResult.new(
+        code: '39720311000001101',
+        display: 'Aspirin 300mg tablets',
+        system: 'https://dmd.nhs.uk',
+        concept_class: 'VMP',
+        package_quantity: 28,
+        package_unit: 'tablet',
+        directions: 'Take with water',
+        warnings: 'Follow the medicine label.'
+      )
+      outcome = NhsDmd::Search::Result.new(results: [search_result], error: nil, resolved_query: 'aspirin')
+
+      instance_double(NhsDmd::Search, call: outcome)
     end
 
     def expect_private_audit_diagnostics(payload)


### PR DESCRIPTION
## Why

Mobile clients need a stable medication search contract. The API previously listed the endpoint but did not describe its filters or response data.

## What changed

- Document the name, dosage form, and strength filters.
- Define strict schemas for empty results, successful searches, and temporary outages.
- Type catalogue details, stock matches, related medicines, review guidance, and barcode resolution.
- Keep web navigation links optional so native clients do not depend on Rails paths.
- Document authentication, household access, missing household, rate limit, and service outage responses.

This is the second PR in the API documentation stack. It depends on #1863.

Closes #1835
