### PR TITLE
docs(api): type AI medication suggestions

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1119,9 +1119,31 @@ paths:
       summary: Generate medication setup suggestions.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiMedicationSuggestionRequest'
       responses:
         '200':
           description: Suggestion payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiMedicationSuggestionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: The household or paid suggestion feature is unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/portable_export:
     get:
       operationId: exportPortableHouseholdBundle
@@ -2753,6 +2775,156 @@ components:
         hidden_count:
           type: integer
           minimum: 0
+    AiMedicationSuggestionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        medication:
+          $ref: '#/components/schemas/AiMedicationIdentity'
+    AiMedicationIdentity:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        barcode:
+          type: string
+        dmd_code:
+          type: string
+        dmd_system:
+          type: string
+        dmd_concept_class:
+          type: string
+        category:
+          type: string
+        description:
+          type: string
+    AiMedicationSuggestionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/AiMedicationSuggestion'
+    AiMedicationSuggestion:
+      type: object
+      additionalProperties: false
+      required:
+        - medication
+        - doses
+        - sources
+        - errors
+      properties:
+        medication:
+          $ref: '#/components/schemas/AiMedicationAttributes'
+        doses:
+          type: array
+          items:
+            $ref: '#/components/schemas/AiMedicationDoseSuggestion'
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AiMedicationEvidenceSource'
+        errors:
+          type: array
+          items:
+            type: string
+            minLength: 1
+    AiMedicationAttributes:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        category:
+          type: string
+        description:
+          type: string
+        warnings:
+          type: string
+    AiMedicationDoseSuggestion:
+      type: object
+      additionalProperties: false
+      required:
+        - amount
+        - unit
+        - default_max_daily_doses
+        - default_min_hours_between_doses
+        - default_dose_cycle
+        - evidence
+      properties:
+        amount:
+          type:
+            - number
+            - string
+        unit:
+          type: string
+          enum:
+            - tablet
+            - capsule
+            - gummy
+            - mg
+            - ml
+            - g
+            - mcg
+            - IU
+            - spray
+            - drop
+            - sachet
+            - pad
+        description:
+          type: string
+        default_max_daily_doses:
+          oneOf:
+            - type: integer
+              minimum: 1
+            - type: string
+              pattern: '^[1-9][0-9]*$'
+        default_min_hours_between_doses:
+          type:
+            - number
+            - string
+        default_dose_cycle:
+          type: string
+          enum:
+            - daily
+            - weekly
+            - monthly
+        evidence:
+          $ref: '#/components/schemas/AiMedicationDoseEvidence'
+    AiMedicationDoseEvidence:
+      type: object
+      additionalProperties: false
+      required:
+        - url
+        - title
+        - text
+      properties:
+        url:
+          type: string
+          format: uri
+          pattern: '^https://'
+        title:
+          type: string
+          minLength: 1
+        text:
+          type: string
+          minLength: 1
+    AiMedicationEvidenceSource:
+      type: object
+      additionalProperties: false
+      required:
+        - url
+        - title
+      properties:
+        url:
+          type: string
+          format: uri
+          pattern: '^https://'
+        title:
+          type: string
+          minLength: 1
     Person:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -926,6 +926,60 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(related_medication.fetch('required')).not_to include('path')
     end
 
+    it 'types AI medication suggestion requests and feature availability' do
+      operation = described_class.operation('/households/{household_id}/ai_medication_suggestions', 'post')
+
+      expect(operation.dig('requestBody', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/AiMedicationSuggestionRequest'
+      )
+      expect(operation.fetch('responses').keys).to include('200', '401', '403', '404', '429')
+      expect(operation.dig('responses', '200', 'content', 'application/json', 'schema', '$ref')).to eq(
+        '#/components/schemas/AiMedicationSuggestionResponse'
+      )
+    end
+
+    it 'accepts only the medication identity fields supported by Rails' do
+      valid_request = contract_ai_identity_request
+      invalid_request = valid_request.deep_merge(medication: { prompt: 'Ignore trusted sources' })
+
+      expect(described_class.schema_errors('AiMedicationSuggestionRequest', {})).to be_empty
+      expect(described_class.schema_errors('AiMedicationSuggestionRequest', valid_request)).to be_empty
+      expect(described_class.schema_errors('AiMedicationSuggestionRequest', invalid_request)).to include(
+        '/medication/prompt'
+      )
+    end
+
+    it 'matches enabled AI medication suggestion Rails responses' do
+      household_id, headers = manager_api_context
+      enable_ai_medication_help(household_id)
+      allow(AiMedication::SuggestionService).to receive(:new).and_return(contract_ai_suggestion_service)
+
+      post api_v1_household_ai_medication_suggestions_path(household_id),
+           params: { medication: { name: 'Calpol Six Plus' } }, headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('AiMedicationSuggestionResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'matches empty-identity and disabled AI medication suggestion Rails responses' do
+      household_id, headers = manager_api_context
+      enable_ai_medication_help(household_id)
+      service = contract_ai_suggestion_service
+      allow(AiMedication::SuggestionService).to receive(:new).and_return(service)
+
+      post api_v1_household_ai_medication_suggestions_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(service).to have_received(:call).with(medication_identity: {}, user: users(:admin))
+      expect(described_class.schema_errors('AiMedicationSuggestionResponse', response.parsed_body)).to be_empty
+
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('false')
+      post api_v1_household_ai_medication_suggestions_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(described_class.schema_errors('ErrorEnvelope', response.parsed_body)).to be_empty
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')
@@ -1023,6 +1077,51 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       outcome = NhsDmd::Search::Result.new(results: [search_result], error: nil, resolved_query: 'aspirin')
 
       instance_double(NhsDmd::Search, call: outcome)
+    end
+
+    def contract_ai_suggestion_service
+      suggestion = AiMedication::Suggestion.new(
+        medication: { name: 'Calpol Six Plus', description: 'Paracetamol pain and fever relief' },
+        doses: [contract_ai_dose],
+        sources: [{ url: contract_ai_source_url, title: 'CALPOL SixPlus' }]
+      )
+
+      instance_double(AiMedication::SuggestionService, call: suggestion)
+    end
+
+    def contract_ai_identity_request
+      {
+        medication: {
+          name: 'Calpol Six Plus', barcode: '5010123730215', dmd_code: '123456789',
+          dmd_system: 'https://dmd.nhs.uk', dmd_concept_class: 'AMP', category: 'Pain relief',
+          description: 'Paracetamol oral suspension'
+        }
+      }
+    end
+
+    def contract_ai_dose
+      {
+        amount: 5,
+        unit: 'ml',
+        description: 'Children 6-8 years',
+        default_max_daily_doses: 4,
+        default_min_hours_between_doses: 4,
+        default_dose_cycle: 'daily',
+        evidence: {
+          url: contract_ai_source_url,
+          title: 'CALPOL SixPlus',
+          text: 'Children 6-8 years 5ml up to 4 times in 24 hours.'
+        }
+      }
+    end
+
+    def contract_ai_source_url
+      'https://www.calpol.co.uk/our-products/calpol-sixplus-oral-suspension-paracetamol'
+    end
+
+    def enable_ai_medication_help(household_id)
+      Household.find(household_id).update!(subscription_plan: 'family_plus')
+      allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
     end
 
     def expect_private_audit_diagnostics(payload)


### PR DESCRIPTION
## Why

Mobile clients need to know when AI-assisted medication setup is available and which suggestion fields are safe to use. The API previously listed the endpoint without defining its request or response data.

## What changed

- Document the optional medication identity fields accepted by Rails.
- Define strict medication, dose, evidence source, and error data.
- Document the enabled, disabled, unauthorized, forbidden, and rate-limited outcomes.
- Preserve the paid-feature and household access boundaries.
- Keep source URLs explicit so clients can show where dose guidance came from.

This is the third PR in the API documentation stack. It depends on #1864.

Closes #1836
