### PR TITLE
docs(api): type authentication contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -91,11 +91,23 @@ paths:
         - Authentication
       summary: Exchange development or migration password credentials for API tokens.
       security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthLoginRequest'
       responses:
         '201':
           description: API session created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthLoginResponse'
         '401':
-          description: Credentials are invalid or password login is unavailable.
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/refresh:
     post:
       operationId: refreshSession
@@ -104,11 +116,23 @@ paths:
         - Authentication
       summary: Rotate an API session refresh token.
       security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthRefreshRequest'
       responses:
         '200':
           description: New access and refresh tokens.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthRefreshResponse'
         '401':
-          description: Refresh token is invalid or expired.
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/oidc_exchange:
     post:
       operationId: exchangeOidcSession
@@ -117,9 +141,23 @@ paths:
         - Authentication
       summary: Exchange a hosted OIDC ID token for an API session.
       security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthOidcExchangeRequest'
       responses:
         '201':
           description: API session created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthLoginResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/households:
     get:
       operationId: listHouseholds
@@ -130,6 +168,14 @@ paths:
       responses:
         '200':
           description: Household collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthHouseholdCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/sessions:
     get:
       operationId: listSessions
@@ -140,6 +186,14 @@ paths:
       responses:
         '200':
           description: API session collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSessionCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/sessions/{id}:
     delete:
       operationId: deleteSession
@@ -152,6 +206,12 @@ paths:
       responses:
         '204':
           description: API session revoked.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /auth/logout:
     delete:
       operationId: logoutSession
@@ -162,6 +222,8 @@ paths:
       responses:
         '204':
           description: Credential revoked.
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/me:
     get:
       operationId: getCurrentProfile
@@ -174,6 +236,18 @@ paths:
       responses:
         '200':
           description: Current user profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/people:
     get:
       operationId: listPeople
@@ -2925,6 +2999,275 @@ components:
         title:
           type: string
           minLength: 1
+    AuthLoginRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 1
+        device_name:
+          type:
+            - string
+            - 'null'
+        household_id:
+          $ref: '#/components/schemas/NumericId'
+    AuthRefreshRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - refresh_token
+      properties:
+        refresh_token:
+          type: string
+          minLength: 1
+    AuthOidcExchangeRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - id_token
+        - nonce
+        - code_verifier
+      properties:
+        id_token:
+          type: string
+          minLength: 1
+        nonce:
+          type: string
+          minLength: 1
+        code_verifier:
+          type: string
+          minLength: 1
+        device_name:
+          type:
+            - string
+            - 'null'
+        household_id:
+          $ref: '#/components/schemas/NumericId'
+        provider:
+          type: string
+          minLength: 1
+    AuthHousehold:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - name
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        slug:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+    AuthHouseholdMembership:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - name
+        - role
+        - membership_id
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        slug:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+        role:
+          type: string
+          enum:
+            - owner
+            - administrator
+            - member
+        membership_id:
+          $ref: '#/components/schemas/NumericId'
+    AuthHouseholdCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthHouseholdMembership'
+    AuthSession:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - device_name
+        - household_id
+        - last_used_at
+        - access_token_expires_at
+        - refresh_token_expires_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        device_name:
+          type:
+            - string
+            - 'null'
+        household_id:
+          $ref: '#/components/schemas/NullableNumericId'
+        last_used_at:
+          $ref: '#/components/schemas/Timestamp'
+        access_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        refresh_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        created_at:
+          $ref: '#/components/schemas/Timestamp'
+    AuthSessionCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthSession'
+    AuthRefreshData:
+      type: object
+      additionalProperties: false
+      required:
+        - access_token
+        - access_token_expires_at
+        - refresh_token
+        - refresh_token_expires_at
+        - household
+      properties:
+        access_token:
+          type: string
+          minLength: 1
+        access_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        refresh_token:
+          type: string
+          minLength: 1
+        refresh_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        household:
+          oneOf:
+            - $ref: '#/components/schemas/AuthHousehold'
+            - type: 'null'
+    AuthRefreshResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/AuthRefreshData'
+    AuthLoginData:
+      type: object
+      additionalProperties: false
+      required:
+        - access_token
+        - access_token_expires_at
+        - refresh_token
+        - refresh_token_expires_at
+        - household
+        - me
+      properties:
+        access_token:
+          type: string
+          minLength: 1
+        access_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        refresh_token:
+          type: string
+          minLength: 1
+        refresh_token_expires_at:
+          $ref: '#/components/schemas/Timestamp'
+        household:
+          oneOf:
+            - $ref: '#/components/schemas/AuthHousehold'
+            - type: 'null'
+        me:
+          $ref: '#/components/schemas/Me'
+    AuthLoginResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/AuthLoginData'
+    MeAccount:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - email
+        - status
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        email:
+          type: string
+          format: email
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - closed
+    Me:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - email_address
+        - membership_role
+        - active
+        - person
+        - account
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        email_address:
+          type: string
+          format: email
+        membership_role:
+          type:
+            - string
+            - 'null'
+          enum:
+            - owner
+            - administrator
+            - member
+            - null
+        active:
+          type: boolean
+        person:
+          $ref: '#/components/schemas/Person'
+        account:
+          $ref: '#/components/schemas/MeAccount'
+    MeResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/Me'
     Person:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -980,6 +980,81 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('ErrorEnvelope', response.parsed_body)).to be_empty
     end
 
+    it 'types login, refresh, and OIDC exchange requests' do
+      login = described_class.operation('/auth/login', 'post')
+      refresh = described_class.operation('/auth/refresh', 'post')
+      oidc = described_class.operation('/auth/oidc_exchange', 'post')
+
+      expect(auth_request_schema(login)).to eq('#/components/schemas/AuthLoginRequest')
+      expect(auth_request_schema(refresh)).to eq('#/components/schemas/AuthRefreshRequest')
+      expect(auth_request_schema(oidc)).to eq('#/components/schemas/AuthOidcExchangeRequest')
+    end
+
+    it 'types login, refresh, and OIDC exchange responses' do
+      login = described_class.operation('/auth/login', 'post')
+      refresh = described_class.operation('/auth/refresh', 'post')
+      oidc = described_class.operation('/auth/oidc_exchange', 'post')
+
+      expect(auth_response_schema(login, '201')).to eq('#/components/schemas/AuthLoginResponse')
+      expect(auth_response_schema(refresh, '200')).to eq('#/components/schemas/AuthRefreshResponse')
+      expect(auth_response_schema(oidc, '201')).to eq('#/components/schemas/AuthLoginResponse')
+      expect([login, refresh, oidc]).to all(satisfy { |operation| operation.fetch('responses').key?('429') })
+    end
+
+    it 'accepts only the supported authentication request fields' do
+      login = { email: 'admin@example.com', password: 'password', device_name: 'RSpec iPhone', household_id: 1 }
+      refresh = { refresh_token: 'mt_refresh_token' }
+      oidc = {
+        id_token: 'signed-id-token', nonce: 'nonce', code_verifier: 'pkce-verifier',
+        device_name: 'RSpec iPhone', household_id: 1, provider: 'oidc'
+      }
+
+      expect(described_class.schema_errors('AuthLoginRequest', login)).to be_empty
+      expect(described_class.schema_errors('AuthRefreshRequest', refresh)).to be_empty
+      expect(described_class.schema_errors('AuthOidcExchangeRequest', oidc)).to be_empty
+      expect(described_class.schema_errors('AuthLoginRequest', login.merge(token: 'private'))).to include('/token')
+    end
+
+    it 'types authentication management and the current household profile' do
+      households = described_class.operation('/auth/households', 'get')
+      sessions = described_class.operation('/auth/sessions', 'get')
+      revoke = described_class.operation('/auth/sessions/{id}', 'delete')
+      profile = described_class.operation('/households/{household_id}/me', 'get')
+
+      expect(auth_response_schema(households, '200')).to eq('#/components/schemas/AuthHouseholdCollectionResponse')
+      expect(auth_response_schema(sessions, '200')).to eq('#/components/schemas/AuthSessionCollectionResponse')
+      expect(revoke.fetch('responses').keys).to include('204', '401', '404', '429')
+      expect(auth_response_schema(profile, '200')).to eq('#/components/schemas/MeResponse')
+      expect(profile.fetch('responses').keys).to include('200', '401', '403', '404', '429')
+    end
+
+    it 'matches Rails login and refresh responses' do
+      login_data = api_login(users(:admin))
+
+      expect(response).to have_http_status(:created)
+      expect(described_class.schema_errors('AuthLoginResponse', response.parsed_body)).to be_empty
+
+      post api_v1_auth_refresh_path, params: { refresh_token: login_data.fetch('refresh_token') }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('AuthRefreshResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'matches Rails authentication collections and the current profile' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_auth_households_path, headers:, as: :json
+      expect(described_class.schema_errors('AuthHouseholdCollectionResponse', response.parsed_body)).to be_empty
+
+      get api_v1_auth_sessions_path, headers:, as: :json
+      expect(described_class.schema_errors('AuthSessionCollectionResponse', response.parsed_body)).to be_empty
+
+      get api_v1_household_me_path(household_id), headers:, as: :json
+      expect(described_class.schema_errors('MeResponse', response.parsed_body)).to be_empty
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')
@@ -1122,6 +1197,14 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
     def enable_ai_medication_help(household_id)
       Household.find(household_id).update!(subscription_plan: 'family_plus')
       allow(ENV).to receive(:fetch).with('MEDTRACKER_AI_MEDICATION_HELP_ENABLED', 'false').and_return('true')
+    end
+
+    def auth_request_schema(operation)
+      operation.dig('requestBody', 'content', 'application/json', 'schema', '$ref')
+    end
+
+    def auth_response_schema(operation, status)
+      operation.dig('responses', status, 'content', 'application/json', 'schema', '$ref')
     end
 
     def expect_private_audit_diagnostics(payload)


### PR DESCRIPTION
## Why

Generated clients need stable authentication and profile data before they can use household APIs. These operations previously had descriptions but no typed payloads.

## What changed

- Define strict password login, refresh, and OIDC exchange requests.
- Type access and refresh tokens, expiry times, household selection, and current-user data.
- Type household and active-session collections.
- Document session revocation, idempotent logout, authentication errors, missing resources, and rate limits.
- Match the documented data against live Rails login, refresh, session, household, and profile responses.

This is the fourth PR in the API documentation stack. It depends on #1866 and delivers the authentication slice of #1655.
