### PR TITLE
docs(api): type dosage option contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -733,9 +733,26 @@ paths:
       summary: List medication dosage options.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/updated_since'
       responses:
         '200':
           description: Dosage option collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DosageOptionCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     post:
       operationId: createDosageOption
       tags:
@@ -744,9 +761,34 @@ paths:
       summary: Create a medication dosage option.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DosageOptionCreateRequest'
       responses:
         '201':
           description: Dosage option created.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DosageOptionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/dosage_options/{id}:
     get:
       operationId: getDosageOption
@@ -763,6 +805,18 @@ paths:
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DosageOptionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     patch:
       operationId: updateDosageOption
       tags:
@@ -773,14 +827,36 @@ paths:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/resource_id'
         - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DosageOptionUpdateRequest'
       responses:
         '200':
           description: Dosage option updated.
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DosageOptionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     put:
       operationId: replaceDosageOption
       tags:
@@ -791,14 +867,36 @@ paths:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/resource_id'
         - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DosageOptionUpdateRequest'
       responses:
         '200':
           description: Dosage option updated.
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DosageOptionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/health_events:
     get:
       operationId: listHealthEvents
@@ -3766,6 +3864,182 @@ components:
               $ref: '#/components/schemas/DecimalValue'
             expected_arrival_on:
               $ref: '#/components/schemas/Date'
+    DosageOption:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - portable_id
+        - medication_id
+        - medication_portable_id
+        - amount
+        - unit
+        - frequency
+        - description
+        - default_for_adults
+        - default_for_children
+        - default_max_daily_doses
+        - default_min_hours_between_doses
+        - default_dose_cycle
+        - current_supply
+        - reorder_threshold
+        - updated_at
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        medication_id:
+          $ref: '#/components/schemas/NumericId'
+        medication_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        amount:
+          $ref: '#/components/schemas/DecimalValue'
+        unit:
+          type: string
+          minLength: 1
+        frequency:
+          type: string
+          minLength: 1
+        description:
+          type:
+            - string
+            - 'null'
+        default_for_adults:
+          type: boolean
+        default_for_children:
+          type: boolean
+        default_max_daily_doses:
+          type: integer
+          minimum: 1
+        default_min_hours_between_doses:
+          $ref: '#/components/schemas/DecimalValue'
+        default_dose_cycle:
+          type: string
+          enum:
+            - daily
+            - weekly
+            - monthly
+        current_supply:
+          $ref: '#/components/schemas/NullableDecimalValue'
+        reorder_threshold:
+          $ref: '#/components/schemas/NullableDecimalValue'
+        updated_at:
+          $ref: '#/components/schemas/Timestamp'
+    DosageOptionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/DosageOption'
+    DosageOptionCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DosageOption'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    DosageOptionCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - dosage_option
+      properties:
+        dosage_option:
+          $ref: '#/components/schemas/DosageOptionCreateAttributes'
+    DosageOptionUpdateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - dosage_option
+      properties:
+        dosage_option:
+          $ref: '#/components/schemas/DosageOptionUpdateAttributes'
+    DosageOptionCreateAttributes:
+      type: object
+      additionalProperties: false
+      required:
+        - medication_id
+        - amount
+        - unit
+        - frequency
+        - default_max_daily_doses
+        - default_min_hours_between_doses
+        - default_dose_cycle
+      properties:
+        medication_id:
+          $ref: '#/components/schemas/ResourceIdentifier'
+        amount:
+          $ref: '#/components/schemas/DecimalValue'
+        unit:
+          type: string
+          minLength: 1
+        frequency:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        default_for_adults:
+          type: boolean
+        default_for_children:
+          type: boolean
+        default_max_daily_doses:
+          type: integer
+          minimum: 1
+        default_min_hours_between_doses:
+          $ref: '#/components/schemas/DecimalValue'
+        default_dose_cycle:
+          type: string
+          enum:
+            - daily
+            - weekly
+            - monthly
+        current_supply:
+          $ref: '#/components/schemas/DecimalValue'
+        reorder_threshold:
+          $ref: '#/components/schemas/DecimalValue'
+    DosageOptionUpdateAttributes:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        amount:
+          $ref: '#/components/schemas/DecimalValue'
+        unit:
+          type: string
+          minLength: 1
+        frequency:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        default_for_adults:
+          type: boolean
+        default_for_children:
+          type: boolean
+        default_max_daily_doses:
+          type: integer
+          minimum: 1
+        default_min_hours_between_doses:
+          $ref: '#/components/schemas/DecimalValue'
+        default_dose_cycle:
+          type: string
+          enum:
+            - daily
+            - weekly
+            - monthly
+        current_supply:
+          $ref: '#/components/schemas/DecimalValue'
+        reorder_threshold:
+          $ref: '#/components/schemas/DecimalValue'
     Person:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -1121,6 +1121,49 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('MedicationCollectionResponse', response.parsed_body)).to be_empty
     end
 
+    it 'types dosage option collections, resources, and writes' do
+      collection_path = '/households/{household_id}/dosage_options'
+      resource_path = "#{collection_path}/{id}"
+      collection = described_class.operation(collection_path, 'get')
+      create = described_class.operation(collection_path, 'post')
+      resource = described_class.operation(resource_path, 'get')
+      updates = %w[patch put].map { |method| described_class.operation(resource_path, method) }
+
+      expect(auth_response_schema(collection, '200')).to eq('#/components/schemas/DosageOptionCollectionResponse')
+      expect(auth_response_schema(resource, '200')).to eq('#/components/schemas/DosageOptionResponse')
+      expect(auth_request_schema(create)).to eq('#/components/schemas/DosageOptionCreateRequest')
+      expect(updates).to all(satisfy do |operation|
+        auth_request_schema(operation) == '#/components/schemas/DosageOptionUpdateRequest'
+      end)
+      expect([create, *updates]).to all(satisfy { |operation| operation.fetch('responses').key?('422') })
+    end
+
+    it 'accepts only supported dosage option write fields' do
+      valid_create = {
+        dosage_option: {
+          medication_id: SecureRandom.uuid, amount: 500, unit: 'mg', frequency: 'Twice daily',
+          default_max_daily_doses: 2, default_min_hours_between_doses: 6, default_dose_cycle: 'daily'
+        }
+      }
+      invalid_create = valid_create.deep_merge(dosage_option: { household_id: 99 })
+
+      expect(described_class.schema_errors('DosageOptionCreateRequest', valid_create)).to be_empty
+      expect(described_class.schema_errors('DosageOptionCreateRequest', invalid_create)).to include(
+        '/dosage_option/household_id'
+      )
+    end
+
+    it 'matches the Rails dosage option collection' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_household_dosage_options_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('DosageOptionCollectionResponse', response.parsed_body)).to be_empty
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')


### PR DESCRIPTION
## Why

Generated clients need reusable dose definitions before they can create schedules or as-needed medication plans. Dosage option endpoints previously had no typed data.

## What changed

- Type paginated dosage option collections and individual resources.
- Define create and update fields for dose amounts, units, frequency, limits, stock, and dose cycles.
- Support numeric and portable medication identifiers used by Rails.
- Document ETags, pagination, update filters, validation errors, access failures, missing resources, conflicts, and rate limits.
- Match the collection schema against a live Rails response.

This is the sixth PR in the API documentation stack. It depends on #1868 and delivers the dosage option slice of #1655.
