### PR TITLE
docs(api): type health event contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -906,9 +906,26 @@ paths:
       summary: List visible health events.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/updated_since'
       responses:
         '200':
           description: Health event collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthEventCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     post:
       operationId: createHealthEvent
       tags:
@@ -917,9 +934,34 @@ paths:
       summary: Create a health event.
       parameters:
         - $ref: '#/components/parameters/household_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HealthEventCreateRequest'
       responses:
         '201':
           description: Health event created.
+          headers:
+            ETag:
+              $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthEventResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/health_events/{id}:
     get:
       operationId: getHealthEvent
@@ -936,6 +978,18 @@ paths:
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthEventResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     patch:
       operationId: updateHealthEvent
       tags:
@@ -946,14 +1000,36 @@ paths:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/resource_id'
         - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HealthEventUpdateRequest'
       responses:
         '200':
           description: Health event updated.
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthEventResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
     put:
       operationId: replaceHealthEvent
       tags:
@@ -964,14 +1040,36 @@ paths:
         - $ref: '#/components/parameters/household_id'
         - $ref: '#/components/parameters/resource_id'
         - $ref: '#/components/parameters/if_match'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HealthEventUpdateRequest'
       responses:
         '200':
           description: Health event updated.
           headers:
             ETag:
               $ref: '#/components/headers/etag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthEventResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/schedules:
     get:
       operationId: listSchedules
@@ -4365,6 +4463,148 @@ components:
           $ref: '#/components/schemas/DecimalValue'
         reorder_threshold:
           $ref: '#/components/schemas/DecimalValue'
+    HealthEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - portable_id
+        - person_id
+        - person_portable_id
+        - event_kind
+        - severity
+        - title
+        - notes
+        - started_on
+        - ended_on
+        - updated_at
+        - medication_ids
+        - medication_portable_ids
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        person_id:
+          $ref: '#/components/schemas/NumericId'
+        person_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        event_kind:
+          type: string
+          enum:
+            - illness
+            - suspected_side_effect
+        severity:
+          type:
+            - string
+            - 'null'
+          enum:
+            - mild
+            - moderate
+            - severe
+            - null
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type:
+            - string
+            - 'null'
+        started_on:
+          $ref: '#/components/schemas/Date'
+        ended_on:
+          oneOf:
+            - $ref: '#/components/schemas/Date'
+            - type: 'null'
+        updated_at:
+          $ref: '#/components/schemas/Timestamp'
+        medication_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/NumericId'
+        medication_portable_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortableId'
+    HealthEventResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/HealthEvent'
+    HealthEventCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/HealthEvent'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    HealthEventCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - health_event
+      properties:
+        health_event:
+          allOf:
+            - $ref: '#/components/schemas/HealthEventAttributes'
+            - required:
+                - person_id
+                - event_kind
+                - title
+                - started_on
+    HealthEventUpdateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - health_event
+      properties:
+        health_event:
+          allOf:
+            - $ref: '#/components/schemas/HealthEventAttributes'
+            - not:
+                required:
+                  - person_id
+    HealthEventAttributes:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        person_id:
+          $ref: '#/components/schemas/ResourceIdentifier'
+        event_kind:
+          type: string
+          enum:
+            - illness
+            - suspected_side_effect
+        severity:
+          type: string
+          enum:
+            - mild
+            - moderate
+            - severe
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type: string
+        started_on:
+          $ref: '#/components/schemas/Date'
+        ended_on:
+          $ref: '#/components/schemas/Date'
+        medication_ids:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/ResourceIdentifier'
     Schedule:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -1235,6 +1235,50 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('MedicationTakeCollectionResponse', response.parsed_body)).to be_empty
     end
 
+    it 'types health event collections, resources, and writes' do
+      collection_path = '/households/{household_id}/health_events'
+      resource_path = "#{collection_path}/{id}"
+      create = described_class.operation(collection_path, 'post')
+      updates = %w[patch put].map { |method| described_class.operation(resource_path, method) }
+
+      expect(auth_response_schema(described_class.operation(collection_path, 'get'), '200')).to eq(
+        '#/components/schemas/HealthEventCollectionResponse'
+      )
+      expect(auth_response_schema(described_class.operation(resource_path, 'get'), '200')).to eq(
+        '#/components/schemas/HealthEventResponse'
+      )
+      expect(auth_request_schema(create)).to eq('#/components/schemas/HealthEventCreateRequest')
+      expect(updates).to all(satisfy do |operation|
+        auth_request_schema(operation) == '#/components/schemas/HealthEventUpdateRequest'
+      end)
+    end
+
+    it 'rejects unsupported health event fields' do
+      valid_request = {
+        health_event: {
+          person_id: SecureRandom.uuid, event_kind: 'illness', severity: 'moderate',
+          title: 'Seasonal cold', started_on: Date.current.iso8601, medication_ids: [1]
+        }
+      }
+      invalid_request = valid_request.deep_merge(health_event: { household_id: 9 })
+
+      expect(described_class.schema_errors('HealthEventCreateRequest', valid_request)).to be_empty
+      expect(described_class.schema_errors('HealthEventCreateRequest', invalid_request)).to include(
+        '/health_event/household_id'
+      )
+    end
+
+    it 'matches the Rails health event collection' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_household_health_events_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('HealthEventCollectionResponse', response.parsed_body)).to be_empty
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')


### PR DESCRIPTION
Health events were the last core mobile resource with placeholder OpenAPI responses. Clients could not generate safe types for illnesses, suspected side effects, severity, dates, or linked medications.

This change documents the collection, resource, create, and update contracts served by Rails. It includes portable identifiers, pagination, ETags, validation errors, and strict accepted fields.

The response schema also reflects optional severity, notes, and end dates for ongoing events.

Closes #1655.
