### PR TITLE
docs(api): type sync feed contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -2007,9 +2007,31 @@ paths:
       summary: Read sync changes after a cursor.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - name: cursor
+          in: query
+          required: true
+          description: Return changes and tombstones at or after this timestamp.
+          schema:
+            $ref: '#/components/schemas/Timestamp'
       responses:
         '200':
           description: Change feed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncChangesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/sync/batches:
     post:
       operationId: createSyncBatch
@@ -2028,10 +2050,26 @@ paths:
       responses:
         '201':
           description: Batch applied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncBatchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
         '428':
           $ref: '#/components/responses/PreconditionRequired'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/admin/settings:
     get:
       operationId: getHouseholdAdminSettings
@@ -5758,6 +5796,88 @@ components:
       properties:
         error:
           $ref: '#/components/schemas/RateLimitError'
+    SyncChangesResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - cursor
+            - changes
+            - tombstones
+          properties:
+            cursor:
+              $ref: '#/components/schemas/Timestamp'
+            changes:
+              type: array
+              items:
+                $ref: '#/components/schemas/SyncChange'
+            tombstones:
+              type: array
+              items:
+                $ref: '#/components/schemas/SyncTombstone'
+    SyncChange:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - record_type
+        - record_id
+        - record_portable_id
+        - action
+        - occurred_at
+        - metadata
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        record_type:
+          type: string
+          minLength: 1
+        record_id:
+          $ref: '#/components/schemas/NumericId'
+        record_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - delete
+        occurred_at:
+          $ref: '#/components/schemas/Timestamp'
+        metadata:
+          type: object
+          additionalProperties: true
+    SyncTombstone:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - record_type
+        - record_portable_id
+        - action
+        - deleted_at
+        - metadata
+      properties:
+        id:
+          $ref: '#/components/schemas/NumericId'
+        record_type:
+          type: string
+          minLength: 1
+        record_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        action:
+          type: string
+          const: delete
+        deleted_at:
+          $ref: '#/components/schemas/Timestamp'
+        metadata:
+          type: object
+          additionalProperties: true
     SyncBatchRequest:
       type: object
       additionalProperties: false
@@ -5781,12 +5901,11 @@ components:
       required:
         - action
         - resource_type
-        - id
-        - if_match
       properties:
         action:
           type: string
           enum:
+            - create
             - update
             - delete
         resource_type:
@@ -5794,11 +5913,63 @@ components:
           enum:
             - medication
             - health_event
+            - medication_take
         id:
           $ref: '#/components/schemas/ResourceIdentifier'
         if_match:
           type: string
-          description: Exact ETag from the snapshot or latest resource response.
+          description: Required for update and delete operations. Use the exact latest ETag.
         attributes:
           type: object
           additionalProperties: true
+          description: Fields accepted by the selected resource and action.
+    SyncBatchResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - applied
+            - results
+          properties:
+            applied:
+              type: boolean
+              const: true
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/SyncBatchResult'
+    SyncBatchResult:
+      type: object
+      additionalProperties: false
+      required:
+        - index
+        - action
+        - record_type
+        - record_portable_id
+      properties:
+        index:
+          type: integer
+          minimum: 0
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - delete
+        record_type:
+          type: string
+          enum:
+            - Medication
+            - HealthEvent
+            - MedicationTake
+        record_portable_id:
+          $ref: '#/components/schemas/PortableId'
+        etag:
+          type: string
+        replayed:
+          type: boolean

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -149,7 +149,9 @@ module OpenapiStructure
   AUDIENCE_TAGS = ['Public', 'Account', 'Household', 'Household administration'].freeze
   ALLOWED_FREE_FORM_PATHS = [
     '#/components/schemas/SecurityAuditEvent/properties/metadata',
-    '#/components/schemas/SyncBatchOperation/properties/attributes'
+    '#/components/schemas/SyncBatchOperation/properties/attributes',
+    '#/components/schemas/SyncChange/properties/metadata',
+    '#/components/schemas/SyncTombstone/properties/metadata'
   ].freeze
   LOCATOR_PATHS = %w[
     /households/{household_id}/locations/{id}
@@ -187,13 +189,9 @@ module OpenapiStructure
     YAML.safe_load(Rails.root.join('docs/api/openapi.v1.yaml').read)
   end
 
-  def source
-    Rails.root.join('docs/api/openapi.v1.yaml').read
-  end
+  def source = Rails.root.join('docs/api/openapi.v1.yaml').read
 
-  def paths
-    document.fetch('paths')
-  end
+  def paths = document.fetch('paths')
 
   def operations
     paths.flat_map do |path, path_item|
@@ -1277,6 +1275,43 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(described_class.schema_errors('HealthEventCollectionResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'types sync changes and batch mutations' do
+      changes = described_class.operation('/households/{household_id}/sync/changes', 'get')
+      batch = described_class.operation('/households/{household_id}/sync/batches', 'post')
+
+      expect(auth_response_schema(changes, '200')).to eq('#/components/schemas/SyncChangesResponse')
+      expect(auth_request_schema(batch)).to eq('#/components/schemas/SyncBatchRequest')
+      expect(auth_response_schema(batch, '201')).to eq('#/components/schemas/SyncBatchResponse')
+      expect(batch.fetch('responses').keys).to include('201', '400', '401', '403', '404', '409', '422', '428', '429')
+    end
+
+    it 'matches the Rails sync change feed' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_household_sync_changes_path(household_id),
+          params: { cursor: 1.minute.from_now.iso8601 }, headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('SyncChangesResponse', response.parsed_body)).to be_empty
+    end
+
+    it 'accepts medication take creation in a sync batch' do
+      request = {
+        batch: {
+          operations: [
+            {
+              action: 'create', resource_type: 'medication_take',
+              attributes: { client_uuid: SecureRandom.uuid, source_type: 'schedule', source_id: SecureRandom.uuid }
+            }
+          ]
+        }
+      }
+
+      expect(described_class.schema_errors('SyncBatchRequest', request)).to be_empty
     end
 
     it 'references typed representative person request and response schemas' do


### PR DESCRIPTION
The sync change feed and transactional batch endpoint were only partly described. Clients could not generate types for cursors, changes, tombstones, applied results, or medication-take creation in a batch.

This change documents those payloads and the errors returned by Rails. It also explains when update and delete operations need an ETag and keeps resource-specific batch attributes explicitly open for the selected operation.

This is the change-feed and batch slice of #1656.
