### PR TITLE
docs(api): type encrypted portability contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1930,9 +1930,24 @@ paths:
       summary: Export an encrypted portable household bundle.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/portable_passphrase'
       responses:
         '200':
           description: Encrypted portable bundle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortableEnvelopeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/mobile_snapshot:
     get:
       operationId: getMobileSnapshot
@@ -1954,9 +1969,32 @@ paths:
       summary: Validate an encrypted portable import without writing data.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/portable_passphrase'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PortableImportRequest'
       responses:
         '200':
           description: Import validation summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortableImportResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/portable_imports:
     post:
       operationId: createPortableImport
@@ -1966,9 +2004,38 @@ paths:
       summary: Apply an encrypted portable import transactionally.
       parameters:
         - $ref: '#/components/parameters/household_id'
+        - $ref: '#/components/parameters/portable_passphrase'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PortableImportRequest'
       responses:
         '201':
           description: Import applied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortableImportResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: The import was not applied or its encrypted bundle is invalid.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PortableImportResultResponse'
+                  - $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/data_exports/{mode}:
     get:
       operationId: getDataExport
@@ -2623,6 +2690,14 @@ components:
       required: false
       schema:
         type: string
+    portable_passphrase:
+      name: X-MedTracker-Portable-Passphrase
+      in: header
+      required: true
+      description: Passphrase used to encrypt or decrypt the portable bundle. It is never accepted in the URL.
+      schema:
+        type: string
+        minLength: 1
   headers:
     etag:
       description: Version identifier for optimistic concurrency.
@@ -5796,6 +5871,110 @@ components:
       properties:
         error:
           $ref: '#/components/schemas/RateLimitError'
+    PortableEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - format
+        - encrypted_at
+        - cipher
+        - kdf
+        - salt
+        - checksum
+        - ciphertext
+      properties:
+        format:
+          type: string
+          const: medtracker.portable.encrypted.v1
+        encrypted_at:
+          $ref: '#/components/schemas/Timestamp'
+        cipher:
+          type: string
+          const: aes-256-gcm
+        kdf:
+          type: string
+          const: pbkdf2_sha256
+        salt:
+          type: string
+          minLength: 1
+        checksum:
+          type: string
+          pattern: '^[a-f0-9]{64}$'
+        ciphertext:
+          type: string
+          minLength: 1
+    PortableEnvelopeResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/PortableEnvelope'
+    PortableImportRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - bundle
+      properties:
+        bundle:
+          $ref: '#/components/schemas/PortableEnvelope'
+    PortableImportResultResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/PortableImportResult'
+    PortableImportResult:
+      type: object
+      additionalProperties: false
+      required:
+        - applied
+        - counts
+        - conflicts
+        - errors
+      properties:
+        applied:
+          type: boolean
+        counts:
+          type: object
+          additionalProperties:
+            type: integer
+            minimum: 0
+        conflicts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortableImportConflict'
+        errors:
+          type: array
+          items:
+            type: string
+    PortableImportConflict:
+      type: object
+      additionalProperties: false
+      required:
+        - record_type
+        - portable_id
+        - field
+        - existing_portable_id
+      properties:
+        record_type:
+          type: string
+          enum:
+            - people
+            - locations
+            - medications
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        field:
+          type: string
+          enum:
+            - name
+            - email
+        existing_portable_id:
+          $ref: '#/components/schemas/PortableId'
     SyncChangesResponse:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -1314,6 +1314,33 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(described_class.schema_errors('SyncBatchRequest', request)).to be_empty
     end
 
+    it 'types encrypted portable exports and imports' do
+      export = described_class.operation('/households/{household_id}/portable_export', 'get')
+      dry_run = described_class.operation('/households/{household_id}/portable_imports/dry_run', 'post')
+      import = described_class.operation('/households/{household_id}/portable_imports', 'post')
+
+      expect(auth_response_schema(export, '200')).to eq('#/components/schemas/PortableEnvelopeResponse')
+      expect(auth_request_schema(dry_run)).to eq('#/components/schemas/PortableImportRequest')
+      expect(auth_response_schema(dry_run, '200')).to eq('#/components/schemas/PortableImportResultResponse')
+      expect(auth_request_schema(import)).to eq('#/components/schemas/PortableImportRequest')
+      expect(auth_response_schema(import, '201')).to eq('#/components/schemas/PortableImportResultResponse')
+    end
+
+    it 'accepts only the encrypted portable envelope fields' do
+      envelope = {
+        bundle: {
+          format: 'medtracker.portable.encrypted.v1', encrypted_at: Time.current.iso8601,
+          cipher: 'aes-256-gcm', kdf: 'pbkdf2_sha256', salt: 'salt', checksum: 'a' * 64,
+          ciphertext: 'secret'
+        }
+      }
+
+      expect(described_class.schema_errors('PortableImportRequest', envelope)).to be_empty
+      expect(
+        described_class.schema_errors('PortableImportRequest', envelope.deep_merge(bundle: { passphrase: 'secret' }))
+      ).to include('/bundle/passphrase')
+    end
+
     it 'references typed representative person request and response schemas' do
       create_person = described_class.operation('/households/{household_id}/people', 'post')
       show_person = described_class.operation('/households/{household_id}/people/{id}', 'get')


### PR DESCRIPTION
Encrypted household exports and imports lacked reusable OpenAPI types. Clients could not safely build the envelope or interpret import results. The required passphrase header was also unclear.

This change documents the encryption metadata, strict bundle fields, import summaries, conflict records, and endpoint errors. It also makes clear that the passphrase belongs in the dedicated header and is never accepted in the URL or JSON body.

This is the encrypted portability slice of #1656.
