### PR TITLE
docs(api): type snapshot and export contracts

### DIFF
--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1960,6 +1960,18 @@ paths:
       responses:
         '200':
           description: Mobile snapshot payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortableSnapshotResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/portable_imports/dry_run:
     post:
       operationId: dryRunPortableImport
@@ -2050,9 +2062,37 @@ paths:
           required: true
           schema:
             type: string
+            enum:
+              - encrypted_migration_bundle
+              - backup_zip
+              - health_data_json
+        - $ref: '#/components/parameters/optional_portable_passphrase'
       responses:
         '200':
           description: Export payload.
+          headers:
+            Cache-Control:
+              required: true
+              schema:
+                type: string
+                const: no-store
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PortableEnvelopeResponse'
+                  - $ref: '#/components/schemas/BackupZipResponse'
+                  - $ref: '#/components/schemas/HealthDataExportResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/sync/snapshot:
     get:
       operationId: getSyncSnapshot
@@ -2065,6 +2105,18 @@ paths:
       responses:
         '200':
           description: Sync snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncSnapshotResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
   /households/{household_id}/sync/changes:
     get:
       operationId: getSyncChanges
@@ -2695,6 +2747,14 @@ components:
       in: header
       required: true
       description: Passphrase used to encrypt or decrypt the portable bundle. It is never accepted in the URL.
+      schema:
+        type: string
+        minLength: 1
+    optional_portable_passphrase:
+      name: X-MedTracker-Portable-Passphrase
+      in: header
+      required: false
+      description: Required only for the encrypted migration bundle mode.
       schema:
         type: string
         minLength: 1
@@ -5871,6 +5931,180 @@ components:
       properties:
         error:
           $ref: '#/components/schemas/RateLimitError'
+    PortableRecord:
+      type: object
+      description: A format-specific portable record. Every record has a portable identity and version.
+      additionalProperties: true
+      required:
+        - portable_id
+        - updated_at
+        - etag
+      properties:
+        portable_id:
+          $ref: '#/components/schemas/PortableId'
+        updated_at:
+          $ref: '#/components/schemas/Timestamp'
+        etag:
+          type: string
+          minLength: 1
+    PortableRecords:
+      type: object
+      additionalProperties: false
+      required:
+        - people
+        - locations
+        - medications
+        - dosage_options
+        - schedules
+        - person_medications
+        - medication_takes
+        - notification_preferences
+      properties:
+        people:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        locations:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        medications:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        dosage_options:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        schedules:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        person_medications:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        medication_takes:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        notification_preferences:
+          $ref: '#/components/schemas/PortableRecordCollection'
+        health_events:
+          $ref: '#/components/schemas/PortableRecordCollection'
+    PortableRecordCollection:
+      type: array
+      items:
+        $ref: '#/components/schemas/PortableRecord'
+    PortableSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - format
+        - scope
+        - exported_at
+        - source_instance_id
+        - records
+      properties:
+        format:
+          type: string
+          const: medtracker.portable.v1
+        scope:
+          type: string
+          enum:
+            - single_person
+            - household
+        exported_at:
+          $ref: '#/components/schemas/Timestamp'
+        source_instance_id:
+          type: string
+          minLength: 1
+        records:
+          $ref: '#/components/schemas/PortableRecords'
+    PortableSnapshotResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/PortableSnapshot'
+    SyncSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - format
+        - scope
+        - exported_at
+        - source_instance_id
+        - records
+        - cursor
+      properties:
+        format:
+          type: string
+          const: medtracker.portable.v2
+        scope:
+          type: string
+          enum:
+            - single_person
+            - household
+        exported_at:
+          $ref: '#/components/schemas/Timestamp'
+        source_instance_id:
+          type: string
+          minLength: 1
+        records:
+          $ref: '#/components/schemas/PortableRecords'
+        cursor:
+          $ref: '#/components/schemas/Timestamp'
+    SyncSnapshotResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/SyncSnapshot'
+    BackupZipResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - filename
+            - content_type
+            - base64
+          properties:
+            filename:
+              type: string
+              pattern: '^medtracker-backup-[0-9]{14}\\.zip$'
+            content_type:
+              type: string
+              const: application/zip
+            base64:
+              type: string
+              format: byte
+    HealthDataExportResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - format
+            - scope
+            - exported_at
+            - source_instance_id
+            - records
+          properties:
+            format:
+              type: string
+              const: medtracker.health_data.v1
+            scope:
+              type: string
+              enum:
+                - single_person
+                - household
+            exported_at:
+              $ref: '#/components/schemas/Timestamp'
+            source_instance_id:
+              type: string
+              minLength: 1
+            records:
+              $ref: '#/components/schemas/PortableRecords'
     PortableEnvelope:
       type: object
       additionalProperties: false

--- a/spec/lib/api_contract/openapi_route_coverage_spec.rb
+++ b/spec/lib/api_contract/openapi_route_coverage_spec.rb
@@ -151,7 +151,8 @@ module OpenapiStructure
     '#/components/schemas/SecurityAuditEvent/properties/metadata',
     '#/components/schemas/SyncBatchOperation/properties/attributes',
     '#/components/schemas/SyncChange/properties/metadata',
-    '#/components/schemas/SyncTombstone/properties/metadata'
+    '#/components/schemas/SyncTombstone/properties/metadata',
+    '#/components/schemas/PortableRecord'
   ].freeze
   LOCATOR_PATHS = %w[
     /households/{household_id}/locations/{id}
@@ -1339,6 +1340,45 @@ RSpec.describe OpenapiRouteCoverage, type: :request do
       expect(
         described_class.schema_errors('PortableImportRequest', envelope.deep_merge(bundle: { passphrase: 'secret' }))
       ).to include('/bundle/passphrase')
+    end
+
+    it 'types mobile and consistent sync snapshots' do
+      mobile = described_class.operation('/households/{household_id}/mobile_snapshot', 'get')
+      sync = described_class.operation('/households/{household_id}/sync/snapshot', 'get')
+
+      expect(auth_response_schema(mobile, '200')).to eq('#/components/schemas/PortableSnapshotResponse')
+      expect(auth_response_schema(sync, '200')).to eq('#/components/schemas/SyncSnapshotResponse')
+      expect(mobile.fetch('responses').keys).to include('200', '401', '403', '404', '429')
+      expect(sync.fetch('responses').keys).to include('200', '401', '403', '404', '429')
+    end
+
+    it 'types the profile export modes and response shapes' do
+      export = described_class.operation('/households/{household_id}/data_exports/{mode}', 'get')
+      mode_schema = export.fetch('parameters').find { |parameter| parameter['name'] == 'mode' }.fetch('schema')
+      response_schema = export.dig('responses', '200', 'content', 'application/json', 'schema')
+
+      expect(mode_schema.fetch('enum')).to contain_exactly(
+        'encrypted_migration_bundle', 'backup_zip', 'health_data_json'
+      )
+      expect(response_schema.fetch('oneOf').pluck('$ref')).to contain_exactly(
+        '#/components/schemas/PortableEnvelopeResponse',
+        '#/components/schemas/BackupZipResponse',
+        '#/components/schemas/HealthDataExportResponse'
+      )
+      expect(export.dig('responses', '200', 'headers', 'Cache-Control', 'schema')).to include(
+        'type' => 'string', 'const' => 'no-store'
+      )
+    end
+
+    it 'matches the Rails mobile snapshot' do
+      login_data = api_login(users(:admin))
+      household_id = login_data.dig('household', 'id')
+      headers = api_auth_headers(login_data.fetch('access_token'))
+
+      get api_v1_household_mobile_snapshot_path(household_id), headers:, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(described_class.schema_errors('PortableSnapshotResponse', response.parsed_body)).to be_empty
     end
 
     it 'references typed representative person request and response schemas' do


### PR DESCRIPTION
Mobile and consistent sync snapshots had placeholder responses. Profile exports had the same gap, so clients could not distinguish each export format.

This change documents the snapshot envelopes, collection names, portable record identity, cursor, supported export modes, no-store response, and ZIP wrapper. It keeps format-specific record fields extensible while requiring every record to carry a portable ID, update time, and ETag.

This is the snapshot and profile-export slice of #1656.
