### PR TITLE
docs(api): explain portable record formats

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,11 +2,14 @@
 
 The OpenAPI v1 contract is defined in [openapi.v1.yaml](openapi.v1.yaml).
 
+The [portable data format](portable-data.md) defines record fields used by
+mobile snapshots, sync, export, and import.
+
 ## Canonical addressing
 
 The document's first server URL is `/api/v1`. Path keys are relative to that
-server and must begin with `/` without repeating `/api/v1`. For example, the
-`/households/{household_id}/people` path key resolves to
+server and must begin with `/` without repeating `/api/v1`. The
+`/households/{household_id}/people` path resolves to
 `/api/v1/households/{household_id}/people`.
 
 ## Operation IDs

--- a/docs/api/portable-data.md
+++ b/docs/api/portable-data.md
@@ -1,0 +1,116 @@
+# Portable data format
+
+MedTracker uses portable identifiers when data moves between clients or installations. Portable payloads never include Rails numeric IDs.
+
+Use the OpenAPI contract for endpoint parameters and response envelopes. This guide defines the records inside snapshots and exports.
+
+## Formats
+
+| Format | Purpose |
+|---|---|
+| `medtracker.portable.v1` | Plaintext mobile snapshot and the data encrypted inside a migration bundle. |
+| `medtracker.portable.v2` | Consistent sync snapshot with a cursor for later change-feed requests. |
+| `medtracker.portable.encrypted.v1` | AES-256-GCM envelope used for portable export and import. |
+| `medtracker.health_data.v1` | Plaintext health-data export. |
+| `medtracker.backup.v1` | JSON file stored inside a ZIP backup. |
+
+Every plaintext payload includes `scope`, `exported_at`, `source_instance_id`, and `records`. A sync snapshot also includes `cursor`.
+
+## Security rules
+
+Send the portable passphrase in `X-MedTracker-Portable-Passphrase`. Do not put it in a URL or JSON body.
+
+The encrypted envelope identifies the cipher and key derivation function. It also contains a salt, plaintext checksum, and authenticated ciphertext. Treat the complete envelope as sensitive health data even though its record values are encrypted.
+
+Mobile and sync snapshots are plaintext over the authenticated HTTPS connection. Do not log or cache their response bodies.
+
+## Common record fields
+
+Every record includes these fields:
+
+| Field | Meaning |
+|---|---|
+| `portable_id` | Stable record identity across installations. |
+| `updated_at` | Last update time in ISO 8601 format. |
+| `etag` | Version used for conflict checks and sync batch preconditions. |
+
+Nullable relationship fields contain a portable ID or `null`. Collection relationships contain arrays of portable IDs.
+
+## Record collections
+
+### People
+
+People add `name`, `email`, `date_of_birth`, `person_type`, `has_capacity`, `location_portable_ids`, and `notification_preference_portable_id`.
+
+### Locations
+
+Locations add `name` and `description`.
+
+### Medications
+
+Medications add:
+
+- `location_portable_id`, `name`, `friendly_name`, `category`, and `description`;
+- `dose_amount`, `dose_unit`, and `default_schedule_type`;
+- `current_supply` and `reorder_threshold`;
+- `barcode`, `dmd_code`, `dmd_system`, and `dmd_concept_class`.
+
+### Dosage options
+
+Dosage options add:
+
+- `medication_portable_id`, `amount`, `unit`, `frequency`, and `description`;
+- `default_for_adults` and `default_for_children`;
+- `default_max_daily_doses`, `default_min_hours_between_doses`, and `default_dose_cycle`;
+- `current_supply` and `reorder_threshold`.
+
+### Schedules
+
+Schedules add:
+
+- `source_dosage_option_portable_id` and `retired_at`;
+- `person_portable_id` and `medication_portable_id`;
+- `dose_amount`, `dose_unit`, `frequency`, and `dose_cycle`;
+- `max_daily_doses` and `min_hours_between_doses`;
+- `schedule_type`, `schedule_config`, `start_date`, and `end_date`;
+- `active` and `notes`.
+
+### Person medications
+
+Direct person-medication assignments add:
+
+- `source_dosage_option_portable_id` and `retired_at`;
+- `person_portable_id` and `medication_portable_id`;
+- `dose_amount`, `dose_unit`, and `dose_cycle`;
+- `max_daily_doses` and `min_hours_between_doses`;
+- `administration_kind`, `active`, `notes`, and `position`.
+
+### Medication takes
+
+Dose records add `client_uuid`, `source_type`, `source_portable_id`, `taken_at`, `dose_amount`, `dose_unit`, `taken_from_medication_portable_id`, and `taken_from_location_portable_id`.
+
+`source_type` is `schedule` or `person_medication`. Medication takes are immutable after import.
+
+### Notification preferences
+
+Notification preferences add `person_portable_id`, `enabled`, `dose_due_enabled`, `missed_dose_enabled`, `low_stock_enabled`, `private_text_enabled`, `morning_time`, `afternoon_time`, `evening_time`, and `night_time`.
+
+### Health events
+
+Health events add `person_portable_id`, `event_kind`, `severity`, `title`, `notes`, `started_on`, `ended_on`, and `medication_portable_ids`.
+
+The encrypted migration payload does not include health events. Mobile, sync, and household health-data snapshots include them.
+
+## Import behaviour
+
+Run the dry-run endpoint before applying an import. It returns record counts, conflicts, and validation errors without writing data.
+
+Imports reject unknown record collections, Rails numeric IDs, invalid capacity rules, and missing portable relationships. A conflict identifies the record collection and incoming portable ID. It also reports the conflicting field and existing portable ID.
+
+An applied import is transactional. If any record fails, MedTracker does not keep a partial import.
+
+## Incremental sync
+
+Start with `GET /sync/snapshot`. Store its cursor and each record ETag. Use the cursor with `GET /sync/changes` to read later changes and tombstones.
+
+Send local writes to `POST /sync/batches`. Update and delete operations need the latest ETag in `if_match`. Medication-take creation uses `client_uuid` for idempotency. A stale ETag returns a sync conflict, and the complete batch rolls back.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ families, and carers. It supports household medication schedules, dose
 recording, stock tracking, reminders, and auditable history.
 
 !!! important "MedTracker is in beta"
-    MedTracker should supplement—not replace—your existing medication routine.
+    MedTracker should supplement, not replace, your existing medication routine.
     Do not depend on it for clinical decisions, emergency information, or your
     sole medication reminders.
 
@@ -56,6 +56,8 @@ or unredacted logs publicly.
 - [API Contract Conventions](api/README.md): use canonical API addressing,
   stable operation IDs, and audience/resource tags when extending the OpenAPI contract.
 - [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
+- [Portable Data Format](api/portable-data.md): understand snapshot, export,
+  import, and incremental sync record fields.
 - [External Integration Architecture](adrs/0010-external-integration-architecture.md): choose `/api/v1`, `/mcp`, or SMART on FHIR by client audience.
 - [Production Upload Storage](adrs/0008-production-upload-storage.md): understand optional Disk and S3 modes, topology, and migration boundaries.
 - [Upload Storage Backup and Restore](operations/upload-storage-backup-and-restore.md): record and verify backend-aware recovery sets.


### PR DESCRIPTION
The OpenAPI contract now describes portable envelopes and common record identity, but developers still had to read serializers to learn each record collection.

This guide lists every portable format and record field. It explains passphrase handling, import validation, transactional writes, cursors, tombstones, ETags, and idempotent dose recording.

Vale AI-tells also found unclear punctuation in the main documentation warning and a formal transition in the API guide. This change simplifies both while adding the new guide to the documentation index.

Closes #1656.
