### PR TITLE
docs(api): define versioning policy

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,6 +5,9 @@ The OpenAPI v1 contract is defined in [openapi.v1.yaml](openapi.v1.yaml).
 The [portable data format](portable-data.md) defines record fields used by
 mobile snapshots, sync, export, and import.
 
+The [API versioning policy](versioning.md) defines compatible changes,
+deprecation, stable generated names, and generated-client ownership.
+
 ## Canonical addressing
 
 The document's first server URL is `/api/v1`. Path keys are relative to that

--- a/docs/api/client-tools.md
+++ b/docs/api/client-tools.md
@@ -1,12 +1,15 @@
 # MedTracker Client Tools
 
-MedTracker ships first-party Rust client tools for hosted API workflows.
+MedTracker provides first-party Rust client tools for hosted API workflows.
 
 - `medtracker` is a human-operated CLI.
 - `medtracker-mcp` is a stdio MCP server for agent clients.
 
-Both tools use the public `/api/v1` HTTP API. They do not read the Rails
-database, call Rails internals, shell into Rails, or depend on Rails constants.
+Both tools use the public `/api/v1` HTTP API. This keeps them outside the Rails
+database and internal code, with no Rails shell or constant dependency.
+
+The [API versioning policy](versioning.md) defines contract compatibility and
+the migration from handwritten transport types to generated bindings.
 
 ## Install
 

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,73 @@
+# API versioning and client policy
+
+The checked-in OpenAPI document is the source of truth for the MedTracker product API. First-party mobile applications, the CLI, and local automation use `/api/v1`.
+
+This policy applies to the HTTP contract. Database models, Rails classes, and web routes are not public API contracts.
+
+## Change classes
+
+### Additive changes
+
+An additive change adds an optional request field, response field, operation, enum capability, or error detail without changing existing behaviour.
+
+Clients must ignore response fields they do not understand. They must not send a new request field until their target server advertises or documents support for it.
+
+### Compatible changes
+
+A compatible change preserves every existing valid request and its documented meaning. It can clarify descriptions or widen a value constraint. It can also add an optional field or operation.
+
+A new error response is compatible only when the server could already reject that request for the same reason. The error code and recovery advice must remain stable after publication.
+
+### Deprecated changes
+
+A deprecated operation or field remains usable during its notice period. The OpenAPI document marks it as deprecated and names its replacement.
+
+MedTracker keeps deprecated `/api/v1` behaviour for at least two minor releases and 90 days after the first released replacement. Security or data-safety defects can shorten this period. The release notes must explain any exception.
+
+### Breaking changes
+
+A change is breaking when an existing conforming client must change to keep working. Examples include:
+
+- removing or renaming an operation, field, schema, enum value, or error code;
+- making an optional request field required;
+- narrowing an accepted value or changing its meaning;
+- changing authentication, authorization, pagination, or idempotency behaviour;
+- changing an operation ID or reusable schema name;
+- changing a successful response to a different shape or status.
+
+Breaking product API changes require a new major path such as `/api/v2`. Do not place them silently in `/api/v1`.
+
+## Stable names
+
+Published `operationId` values are stable client method names. Reusable schema names are stable generated type names. Do not rename either inside the same major API version.
+
+If wording improves, change the summary or description. Keep the operation ID and schema name unchanged.
+
+## Releases
+
+Every release that changes the OpenAPI document must classify the change in its release notes. The pull request must update the contract before or with the Rails code.
+
+The compatibility gate compares the proposed OpenAPI document with the released baseline. It must fail for an unapproved breaking change.
+
+Deprecation release notes include:
+
+- the deprecated operation or field;
+- the supported replacement;
+- the first deprecated release;
+- the earliest removal release and date.
+
+## Generated clients
+
+Generate client request types, response types, and operation methods from `docs/api/openapi.v1.yaml`. Do not copy JSON examples into application code as a second contract.
+
+Generated files must record the OpenAPI revision used to create them. Regenerate them when the contract changes, and review the generated diff with the OpenAPI diff.
+
+Keep handwritten code at the product boundary. Authentication storage, retries, command wording, user prompts, and domain workflows remain maintained client code. Generated code owns only HTTP transport types and operation bindings.
+
+The current Rust tools predate a checked-in generator. Until generated bindings replace their handwritten transport types, the OpenAPI contract and compatibility gate remain authoritative. New client surfaces must not add another handwritten copy of request or response schemas.
+
+## Runtime capability checks
+
+Clients use `GET /api/v1/capabilities` before relying on optional server features. Capability checks do not replace version compatibility. They report deployed features. The OpenAPI document defines their payload and meaning.
+
+Clients must handle an older compatible server that lacks a newly added capability. They must fail with a clear unsupported-server message instead of sending an unadvertised request.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,8 @@ or unredacted logs publicly.
 - [API Contract Conventions](api/README.md): use canonical API addressing,
   stable operation IDs, and audience/resource tags when extending the OpenAPI contract.
 - [API Contract](api/openapi.v1.yaml): OpenAPI contract for hosted auth, portable IDs, sync, backups, admin APIs, and FHIR R4 reads.
+- [API Versioning Policy](api/versioning.md): classify compatible changes,
+  deprecations, breaking changes, and generated-client ownership.
 - [Portable Data Format](api/portable-data.md): understand snapshot, export,
   import, and incremental sync record fields.
 - [External Integration Architecture](adrs/0010-external-integration-architecture.md): choose `/api/v1`, `/mcp`, or SMART on FHIR by client audience.


### PR DESCRIPTION
API consumers had no clear rule for compatible, deprecated, or breaking changes. Stable operation IDs and generated type names were implied but not guaranteed.

This policy defines the change classes, notice period, release-note requirements, major-version boundary, capability checks, and ownership split between generated HTTP bindings and handwritten product code.

Vale AI-tells also found two unclear sentences in the existing client-tools introduction. This change rewrites them while linking the policy from each API entry point.

Closes #1660.
