### PR TITLE
docs(families): correct medication walkthroughs

### DIFF
--- a/docs/families/adding-first-medicine.md
+++ b/docs/families/adding-first-medicine.md
@@ -1,7 +1,7 @@
 # Add Your First Medicine
 
-Once you've set up MedTracker, the next step is adding a medicine for
-one of your family members.
+Add a medication to a person's profile before you create a schedule or record
+a dose.
 
 ## Step 1: Log in
 Open [https://med-tracker.localhost](https://med-tracker.localhost) in your web
@@ -11,34 +11,41 @@ Sign in with the local demo account you selected during setup, or with the
 account your administrator invited. Do not use development fixture accounts on
 a public or shared server.
 
-## Step 2: Open the Dashboard
-The **Dashboard** is the main page where you see your family. You'll see
-names like "John Doe" or "Jane Doe". Click on the name of the person you want
-to add a medicine for.
+## Step 2: Open the person's profile
 
-## Step 3: Add a new medicine
-On their profile page, look for the **"Add Medicine"** or **"Add Prescription"** button.
+Open **People**, then select the person who uses the medication.
 
----
+## Step 3: Start the medication workflow
 
-## 📅 Adding a Daily Prescription
-If this is a medicine that needs to be taken regularly (like an antibiotic or blood pressure pill):
-1.  **Name:** Enter the medicine name (e.g., "Amoxicillin").
-2.  **Dosage:** How much should be taken (e.g., "500mg").
-3.  **Frequency:** How often it's taken (e.g., "Twice a day").
-4.  **Instructions:** Any special notes (e.g., "Take with food").
-
-## 💊 Adding an As-Needed Medicine
-If this is something taken only when needed (like Paracetamol for a fever):
-1.  **Name:** Enter the medicine name.
-2.  **Max Doses:** What is the maximum number of doses allowed in 24 hours? (e.g., "4").
-3.  **Wait Time:** How many hours must you wait between doses? (e.g., "4 hours").
+Select **Add Medication** on the person's profile. MedTracker asks how the
+medication is taken.
 
 ---
 
-## 💾 Save your medicine
-Once you've filled in the details, click **"Save"**.
-You'll now see this medicine listed on the person's profile, ready to use!
+## Add a prescribed or scheduled medication
 
-## What's next?
-- [**Record a dose**](taking-first-dose.md)
+Choose **Prescribed / Scheduled** when the medication has a fixed schedule.
+
+1. Search for and select the medication.
+2. Choose the dose.
+3. Set the active dates and schedule.
+4. Review the plan before you save it.
+
+## Add an as-needed medication
+
+Choose **As needed** when the medication does not have a fixed schedule.
+
+1. Search for and select the medication.
+2. Choose the dose.
+3. Add any guidance, such as a dose limit or minimum time between doses.
+4. Choose **Add Medication**.
+
+---
+
+The saved medication appears on the person's profile. A scheduled medication
+also appears as a task when a dose is due.
+
+## Record a dose
+
+Follow [Record a dose](taking-first-dose.md) when the person takes the
+medication.

--- a/docs/families/quick-setup.md
+++ b/docs/families/quick-setup.md
@@ -17,13 +17,13 @@ add or update those profiles.
 ## 2. Add a medicine
 
 Open the person's profile and follow [Add your first
-medicine](adding-first-medicine.md). Check the medicine, dose, schedule, and
-instructions before saving.
+medicine](adding-first-medicine.md). Choose whether the medication is scheduled
+or taken as needed, then check the dose and guidance before saving.
 
 ## 3. Record the first dose
 
-Follow [Record a dose](taking-first-dose.md). Confirm the person, medicine,
-dose, and time before submitting the record.
+Follow [Record a dose](taking-first-dose.md). Confirm the person, medication,
+dose, time, and stock source before submitting the record.
 
 ## 4. Verify the history
 

--- a/docs/families/taking-first-dose.md
+++ b/docs/families/taking-first-dose.md
@@ -1,44 +1,39 @@
 # Record a Dose
 
-Recording when someone takes their medicine is the core of MedTracker.
-This guide will show you how to do it safely and correctly.
+Record each dose when the person takes or receives their medication.
 
-## Step 1: Open the person's profile
-Log in to your **Dashboard** and click on the name of the person who is taking their medicine.
+## Step 1: Find the medication
 
-## Step 2: Choose the medicine
-Look for the medicine they are taking. You'll see two sections:
--   **Regular Medicines:** these are prescriptions taken at specific times.
--   **As-needed Medicines:** like pain relief for a headache.
+Use the **Dashboard** when a scheduled dose is due. You can also open the
+person's profile and find the medication there.
 
-## Step 3: Safety Checks
-MedTracker will automatically check if it's safe to give the medicine:
--   **Wait time:** Has enough time passed since the last dose? (e.g., 4 hours).
--   **Daily limit:** Has the maximum number of doses for today been reached?
+## Step 2: Check that the dose is available
 
-👉 **Note:** If it's too soon for another dose, the "Record Dose" button will be
-disabled, and you'll see a small message explaining why.
+Scheduled medication appears when it is due. As-needed medication appears
+when its dose rules allow another dose.
 
----
+MedTracker disables the action when a dose rule blocks it. The page explains
+why the dose is unavailable. Check the medicine instructions before you
+continue. MedTracker does not replace clinical advice.
 
-## 🕒 How to record a dose
-1.  **Click "Record Dose":** This will open a simple form.
-2.  **Verify the time:** The time is automatically set to "now".
-3.  **Submit:** Click the **"Save Dose"** button.
+## Step 3: Record the dose
+
+1. Select **Take** or **Give**.
+2. Confirm the person, medication, dose, and time in the **Record dose** dialog.
+3. Choose the stock source when more than one location is available.
+4. Submit the form.
 
 ---
 
-## 📈 Verify your entry
-After you've saved the dose, you'll see it appear in the **Medication History**
-on the person's profile. This creates a safe record for you and your family.
+## Step 4: Verify the record
 
-## What if you make a mistake?
-If you record a dose by mistake or with the wrong time:
--   **Edit the entry:** Use the "Edit" button next to the dose in the history.
--   **Add a note:** Briefly explain the error (e.g., "Accidentally clicked twice").
+Confirm that the dashboard and dose history show the dose. Check that the
+medicine, amount, and time are correct.
 
----
+## Record an earlier dose
 
-## You're all set!
-You've now successfully set up MedTracker, added a medicine, and recorded
-a dose. Your family's medication history is now safe and auditable.
+Open the medication's actions and select **Log a past dose**. You can record a
+dose from earlier today or a previous day.
+
+If an existing record is wrong, ask a household administrator to investigate
+it. Dose history is an audit record and should not be silently erased.


### PR DESCRIPTION
The family medication guides described an older workflow, including controls
that no longer exist and an option to edit an incorrect dose record.

This update follows the current screens. It explains the scheduled and
as-needed paths, the details shown before a dose is recorded, and how to log an
earlier dose. It also tells users to ask an administrator to investigate an
incorrect audit record instead of trying to erase it.
