### PR TITLE
docs(auth): correct two-factor guidance

### DIFF
--- a/docs/two-factor-authentication.md
+++ b/docs/two-factor-authentication.md
@@ -1,185 +1,98 @@
-# Two-Factor Authentication (2FA)
+# Two-Factor Authentication
 
-MedTracker supports multiple two-factor authentication methods to secure user accounts. This document describes the available 2FA options and how to manage them.
+MedTracker supports authenticator-app codes, passkeys, and recovery codes.
+Household owners and administrators must configure a second factor.
 
-## Available 2FA Methods
+## Choose your methods
 
-### 1. Authenticator App (TOTP)
+Use at least two independent ways to sign in:
 
-Time-based One-Time Password (TOTP) authentication using apps like:
+- An **authenticator app** creates a six-digit time-based code.
+- A **passkey** uses a device, password manager, or security key.
+- A **recovery code** is a single-use backup for when another method is
+  unavailable.
 
-- Google Authenticator
-- Microsoft Authenticator
-- 1Password
-- Authy
-- Any TOTP-compatible authenticator app
+Recovery codes are not a primary method. MedTracker lets you generate them only
+after you configure an authenticator app or passkey.
 
-**Setup:**
+## Set up an authenticator app
 
-1. Navigate to your profile page
-2. In the "Two-Factor Authentication" section, click "Set up authenticator app"
-3. Scan the QR code with your authenticator app
-4. Enter the 6-digit code from your app to confirm setup
+1. Sign in and open **Profile**.
+2. Under **Two-Factor Authentication**, select **Set up authenticator app**.
+3. Scan the QR code with a compatible authenticator app.
+4. Enter the current six-digit code to confirm setup.
+5. Generate recovery codes and store them safely.
 
-**Usage:**
+The code changes every 30 seconds. MedTracker labels the account as
+**MedTracker** in the authenticator app.
 
-- After entering your password during login, you'll be prompted for a 6-digit code
-- Open your authenticator app and enter the current code
-- Codes refresh every 30 seconds
+To replace a lost authenticator, sign in with another method, disable the old
+configuration, and set it up again.
 
-**Management:**
+## Set up a passkey
 
-- To disable TOTP, visit your profile and click "Disable" in the Authenticator App section
-- You can only have one TOTP configuration per account
+Open **Profile**, then select **Add a passkey** under **Two-Factor
+Authentication**. Follow the browser prompt and give the passkey a name that
+identifies where it is stored.
 
-### 2. Recovery Codes
+MedTracker requires user verification for passkeys. See the [passkey
+guide](passkey-setup.md) for deployment requirements and troubleshooting.
 
-Recovery codes are one-time use backup codes that allow you to access your account if you lose access to your primary 2FA method.
+## Generate recovery codes
 
-**Setup:**
+1. Configure an authenticator app or passkey.
+2. Open **Profile** and select **Generate recovery codes**.
+3. Complete fresh authentication when prompted.
+4. Save every code outside MedTracker.
 
-1. Navigate to your profile page
-2. In the "Two-Factor Authentication" section, click "Generate recovery codes"
-3. Save the codes in a secure location (password manager, encrypted file, etc.)
-4. Each code can only be used once
+Each code works once. Generating a replacement set invalidates all old codes.
+Treat the codes like passwords and keep them away from the device used for
+your other sign-in method.
 
-**Important:**
+MedTracker stores the recovery-code value needed for verification. Do not
+describe the database column as encrypted unless the storage design changes.
 
-- Store recovery codes securely - treat them like passwords
-- Each code can only be used once
-- Generate new codes if you've used several or suspect they've been compromised
-- Regenerating codes invalidates all previous codes
+## Sign in
 
-**Usage:**
+After password sign-in, MedTracker asks for a configured second factor. Choose
+an authenticator-app code, passkey, or recovery code from the available
+methods.
 
-- During login, if you can't access your authenticator app or passkey, click "Use recovery code"
-- Enter one of your recovery codes
-- The code will be marked as used and cannot be reused
+The login page also supports passwordless passkey sign-in through the dedicated
+WebAuthn login flow. The separate WebAuthn authentication flow confirms a
+signed-in user's identity before a protected action.
 
-### 3. Passkeys (WebAuthn)
+## Manage existing methods
 
-Passkeys provide passwordless authentication using biometrics or security keys.
+The **Two-Factor Authentication** card on **Profile** shows the current methods.
+From there you can:
 
-**Supported Methods:**
+- disable the authenticator app;
+- add or remove passkeys;
+- view the remaining recovery-code count; and
+- replace the recovery-code set.
 
-- Touch ID / Face ID (macOS, iOS)
-- Windows Hello (Windows)
-- Hardware security keys (YubiKey, etc.)
-- Android biometrics
+MedTracker asks for a password or fresh second-factor check before sensitive
+changes. Removing one method does not remove the others.
 
-**Setup:**
+## Recover access
 
-1. Navigate to your profile page
-2. In the "Two-Factor Authentication" section, click "Add a passkey"
-3. Follow your browser's prompts to create a passkey
-4. Give your passkey a memorable name (e.g., "MacBook Pro Touch ID", "YubiKey")
+If one method is unavailable, use another configured method. After signing in,
+remove the lost credential and add its replacement.
 
-**Usage:**
+If every method is unavailable, use account recovery or contact the deployment
+administrator. An administrator should verify the account holder before
+changing access.
 
-- During login, you can authenticate using your passkey instead of a password
-- Simply click "Sign in with passkey" and follow your device's prompts
+## Deployment notes
 
-**Management:**
+Passkeys use `APP_URL` as their origin and relying-party source. Production
+requires an HTTPS URL with the public host. See the [passkey
+guide](passkey-setup.md) before changing a live hostname.
 
-- You can register multiple passkeys (e.g., one for each device)
-- Remove passkeys you no longer use from your profile page
-- Each passkey is tied to a specific device or security key
+MedTracker requires passkey user verification and discoverable credentials. It
+does not request direct authenticator attestation.
 
-## Managing 2FA on Your Profile
-
-All 2FA methods can be managed from your profile page (`/profile`):
-
-1. **View Status:** See which 2FA methods are enabled
-2. **Add Methods:** Set up new 2FA methods
-3. **Remove Methods:** Disable or remove existing 2FA methods
-4. **View Recovery Codes:** Access your recovery codes (if generated)
-5. **Regenerate Recovery Codes:** Create new recovery codes (invalidates old ones)
-
-## Security Best Practices
-
-1. **Enable Multiple Methods:** Use both TOTP and passkeys for redundancy
-2. **Generate Recovery Codes:** Always have recovery codes as a backup
-3. **Store Codes Securely:** Keep recovery codes in a password manager or encrypted storage
-4. **Register Multiple Passkeys:** Add passkeys for multiple devices
-5. **Review Regularly:** Periodically review and remove unused passkeys
-6. **Update After Device Changes:** Remove passkeys for devices you no longer own
-
-## Troubleshooting
-
-### Lost Access to Authenticator App
-
-1. Use a recovery code to log in
-2. Disable TOTP from your profile
-3. Set up TOTP again with a new device
-
-### Lost Passkey Device
-
-1. Log in using password + TOTP or recovery code
-2. Remove the lost passkey from your profile
-3. Add a new passkey for your current device
-
-### Used All Recovery Codes
-
-1. Log in using password + TOTP or passkey
-2. Generate new recovery codes from your profile
-3. Save the new codes securely
-
-### Can't Access Any 2FA Method
-
-Contact your system administrator for account recovery assistance.
-
-## Technical Details
-
-### TOTP Configuration
-
-- **Algorithm:** SHA-1
-- **Digits:** 6
-- **Period:** 30 seconds
-- **Issuer:** MedTracker
-
-### WebAuthn Configuration
-
-- **RP Name:** MedTracker
-- **RP ID:** localhost (development), medtracker.com (production)
-- **Attestation:** Direct
-- **User Verification:** Preferred
-- **Authenticator Attachment:** Platform or cross-platform
-
-### Recovery Codes
-
-- **Format:** 16-character alphanumeric codes
-- **Quantity:** 10 codes generated per set
-- **Usage:** Single-use only
-- **Storage:** Encrypted in database
-
-## API Routes
-
-The following Rodauth routes are available for 2FA management:
-
-- `/otp-setup` - Set up TOTP authentication
-- `/otp-auth` - Authenticate with TOTP code
-- `/otp-disable` - Disable TOTP authentication
-- `/recovery-codes` - View/generate recovery codes
-- `/webauthn-setup` - Set up a new passkey
-- `/webauthn-auth` - Authenticate with passkey
-- `/webauthn-remove` - Remove a passkey
-- `/multifactor-manage` - Manage all 2FA methods
-- `/multifactor-auth` - Choose 2FA method during login
-
-## Database Schema
-
-### account_otp_keys
-
-Stores TOTP secrets for each account.
-
-### account_recovery_codes
-
-Stores recovery codes (hashed) for each account.
-
-### account_webauthn_keys
-
-Stores WebAuthn credentials (passkeys) for each account.
-
-### account_webauthn_user_ids
-
-Maps WebAuthn user IDs to accounts.
+Authentication setup, successful checks, failures, and credential removal are
+written to the audit trail. Secret values must not be included in application
+logs.


### PR DESCRIPTION
The two-factor guide overstated several security properties and mixed the
passwordless passkey flow with fresh authentication inside an existing
session. It also described recovery-code storage and authenticator attestation
that MedTracker does not provide.

This rewrite follows the current profile and login flows. It explains how
authenticator apps, passkeys, and recovery codes work together, how users
recover from a lost device, and which passkey settings deployment operators
must preserve.
