### PR TITLE
docs(kubernetes): correct user seeding

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,8 +44,8 @@ task test
 
 ## Local production-image validation
 
-The `prod` profile validates that the production image builds, migrates its
-local PostgreSQL database, and starts successfully. It is not a real production
+The `prod` profile builds the production image and migrates its local PostgreSQL
+database before starting the application. It is not a real production
 deployment.
 
 ```fish
@@ -70,7 +70,8 @@ Kubernetes runbooks linked below.
 
 - All environments use PostgreSQL.
 - PostgreSQL version target is `18`.
-- Use Rails credentials and environment variables for secrets; never commit them.
+- Use Rails credentials and environment variables for secrets. Never commit
+  them.
 - Existing databases created before 0.5 need the
   [pre-0.5 database upgrade](pre-0-5-database-upgrade.md) bootstrap before
   running 0.5 migrations.
@@ -94,10 +95,10 @@ setup guide including how to request credentials.
 | `NHS_DMD_CLIENT_ID`     | Yes      | OAuth2 client ID from NHS     |
 | `NHS_DMD_CLIENT_SECRET` | Yes      | OAuth2 client secret from NHS |
 
-If either variable is absent the medicine search feature is
-disabled automatically — no API calls are made.
+If either variable is absent, the medicine search feature is disabled and does
+not make NHS API calls.
 
-## Flux GitOps: bootstrap first administrator
+## Bootstrap the first administrator
 
 Kubernetes operators should use the dedicated runbook for complete seeding
 procedures:
@@ -105,55 +106,16 @@ procedures:
 - [Kubernetes User Seeding Runbook](kubernetes-user-seeding.md)
 - [Kubernetes NHS dm+d Release Import Runbook](kubernetes-nhs-dmd-import.md)
 
+Use the runbook for both Kubernetes Jobs. It includes the required runtime
+settings, household selector, supported invitation roles, verification, and
+cleanup steps.
+
 Quick flow selection:
 
 | Goal                               | Command                             | Notes                                             |
 |------------------------------------|-------------------------------------|---------------------------------------------------|
 | Create first administrator account | `rails med_tracker:bootstrap_admin` | One-off account creation with `ADMIN_*` vars      |
 | Invite initial care-team users     | `rails db:seed`                     | Reads `/app/db/seeds/users.yml`, idempotent skips |
-
-For Kubernetes production environments managed by Flux, bootstrap the first admin
-using a one-off Job manifest committed through the normal GitOps repo path.
-
-1. Ensure the application release containing `med_tracker:bootstrap_admin` is
-   deployed.
-2. Add a Secret manifest (or SOPS-encrypted Secret) with:
-   - `ADMIN_EMAIL`
-   - `ADMIN_PASSWORD`
-   - `ADMIN_NAME`
-   - `ADMIN_DOB` (`YYYY-MM-DD`)
-3. Add a one-off Job manifest that runs:
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: med-tracker-bootstrap-admin
-spec:
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: bootstrap-admin
-          image: ghcr.io/your-org/med-tracker:<release-tag>
-          command: ["bundle", "exec", "rails", "med_tracker:bootstrap_admin"]
-          envFrom:
-            - secretRef:
-                name: med-tracker-bootstrap-admin
-```
-
-1. Commit/push the manifests and reconcile Flux for the target Kustomization.
-2. Verify completion:
-
-```bash
-kubectl get jobs -n <namespace>
-kubectl logs job/med-tracker-bootstrap-admin -n <namespace>
-```
-
-1. Confirm the admin can sign in and access `/admin`.
-2. Remove/disable bootstrap manifests in Git and reconcile Flux again.
 
 After the first admin exists, self-registration without invitations is blocked.
 

--- a/docs/kubernetes-user-seeding.md
+++ b/docs/kubernetes-user-seeding.md
@@ -1,88 +1,29 @@
-# Kubernetes User Seeding Runbook
+# Kubernetes User Seeding
 
-Use this guide to seed MedTracker users in Kubernetes quickly and safely.
+Use one-off Kubernetes Jobs to create the first household owner and invite
+initial household members. Use the same application image and runtime settings
+as the deployed MedTracker release.
 
-## TL;DR (for on-call/sysadmin use)
+## Before you begin
 
-1. **Bootstrap first admin** (first deploy only): create Secret with `ADMIN_*` vars and run bootstrap Job (`rails med_tracker:bootstrap_admin`).
-2. Create `users.yml` with invite targets (ConfigMap).
-3. Create runtime secrets (`APP_URL`, SMTP, etc.) via Secret or ExternalSecret.
-4. Run a one-off Job using the production image and `rails db:seed`.
-5. Check Job logs and confirm invited users/admin access.
-6. Remove one-off Job manifests from GitOps after success.
+The Job needs production database access and the same encryption, URL, and mail
+settings as the application. Keep credentials in a Secret or ExternalSecret.
+Do not put passwords or database URLs in a ConfigMap.
 
-## What gets seeded
+## Create the first household owner
 
-MedTracker production seeding (`db/seeds.rb`) does two things:
+Run this step only when no active household owner exists. The bootstrap task
+creates the first account, person, household, and owner membership.
 
-1. Seeds medicine reference data.
-2. Invites initial users from `db/seeds/users.yml`.
-
-Relevant behavior:
-
-- `db/seeds.rb` runs `db/seeds/seed_users.rb` in production.
-- `db/seeds/seed_users.rb` is idempotent:
-  - Skips if an account already exists for email.
-  - Skips if a pending invitation already exists for email.
-
-This means re-running the Job is safe.
-
----
-
-## Prerequisites
-
-- Kubernetes cluster + namespace for MedTracker.
-- MedTracker app image available (e.g. `ghcr.io/damacus/med-tracker:v0.3.1`).
-- Database connectivity and `DATABASE_URL` available to the Job.
-- Required mailer/env vars for sending invites.
-- If using External Secrets: External Secrets Operator installed and reconciled.
-
----
-
-## Choose the right flow
-
-| Goal                           | Command path                                       | Inputs                                                     |
-|--------------------------------|----------------------------------------------------|------------------------------------------------------------|
-| Bootstrap first admin account  | `rails med_tracker:bootstrap_admin`                | `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_NAME`, `ADMIN_DOB` |
-| Invite initial users from YAML | `rails db:seed` (or `load db/seeds/seed_users.rb`) | `db/seeds/users.yml` + mailer/app env                      |
-
-For first-time production setup, you often do both:
-
-1. Bootstrap admin.
-2. Seed invitations for the broader care team.
-
----
-
-## First system administrator bootstrap (do this first)
-
-If no administrator exists yet, run this flow before invite seeding.
-
-Required variables:
+Required values:
 
 - `ADMIN_EMAIL`
 - `ADMIN_PASSWORD`
 - `ADMIN_NAME`
-- `ADMIN_DOB` (`YYYY-MM-DD`)
+- `ADMIN_DOB` in `YYYY-MM-DD` format
 
-### Bootstrap Secret (or ExternalSecret target)
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: med-tracker-bootstrap-admin
-  namespace: <namespace>
-type: Opaque
-stringData:
-  RAILS_ENV: production
-  DATABASE_URL: postgresql://...
-  ADMIN_EMAIL: admin@yourdomain.example
-  ADMIN_PASSWORD: <strong-random-password>
-  ADMIN_NAME: System Administrator
-  ADMIN_DOB: "1980-01-01"
-```
-
-### One-off bootstrap Job
+Include `RAILS_ENV=production`, `DATABASE_URL`, and the application's normal
+production settings in the Job environment.
 
 ```yaml
 apiVersion: batch/v1
@@ -102,41 +43,37 @@ spec:
           command: ["bundle", "exec", "rails", "med_tracker:bootstrap_admin"]
           envFrom:
             - secretRef:
+                name: med-tracker-runtime
+            - secretRef:
                 name: med-tracker-bootstrap-admin
 ```
 
-Verification:
+The command refuses to run when any active owner membership already exists. It
+also refuses duplicate email addresses or incomplete input.
 
-```bash
-kubectl logs job/med-tracker-bootstrap-admin -n <namespace>
-```
+Check the Job log, confirm that the owner can sign in, then delete the bootstrap
+Secret and Job from the GitOps source.
 
-Expected output includes `Admin bootstrap successful: created <email>`.
+## Invite initial members
 
-If using External Secrets, create an `ExternalSecret` that writes to
-`med-tracker-bootstrap-admin` with the same keys above, then run the same Job.
+Production `rails db:seed` loads default locations and medication reference
+data before reading `db/seeds/users.yml`. Run the complete seed command only
+when those effects are intended.
 
----
-
-## Pattern A: ConfigMap + Secret
-
-### 1) Create `users.yml`
-
-Example `users.yml`:
+Create a `users.yml` file with the accounts to invite:
 
 ```yaml
 ---
 - email: admin@yourdomain.example
-  role: administrator
-- email: nurse.lead@yourdomain.example
-  role: nurse
-- email: carer.team@yourdomain.example
-  role: carer
+  membership_role: administrator
+- email: carer@yourdomain.example
+  membership_role: member
 ```
 
-Supported roles: `administrator`, `doctor`, `nurse`, `carer`, `parent`.
+The supported invitation roles are `administrator` and `member`. Owner access
+cannot be granted through an invitation.
 
-### 2) ConfigMap with `users.yml`
+Mount the file at `/app/db/seeds/users.yml` with a ConfigMap:
 
 ```yaml
 apiVersion: v1
@@ -148,34 +85,12 @@ data:
   users.yml: |
     ---
     - email: admin@yourdomain.example
-      role: administrator
-    - email: nurse.lead@yourdomain.example
-      role: nurse
+      membership_role: administrator
+    - email: carer@yourdomain.example
+      membership_role: member
 ```
 
-### 3) Secret for runtime env
-
-Use your existing app Secret if it already includes required env vars. Otherwise create a dedicated one:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: med-tracker-seed-env
-  namespace: <namespace>
-type: Opaque
-stringData:
-  RAILS_ENV: production
-  APP_URL: https://app.yourdomain.example
-  DATABASE_URL: postgresql://...
-  SMTP_ADDRESS: smtp.example.com
-  SMTP_PORT: "587"
-  SMTP_USER_NAME: <smtp-user>
-  SMTP_PASSWORD: <smtp-password>
-  MAILER_FROM: MedTracker <no-reply@yourdomain.example>
-```
-
-### 4) One-off seeding Job
+Run the seed Job with the normal runtime Secret:
 
 ```yaml
 apiVersion: batch/v1
@@ -193,135 +108,40 @@ spec:
         - name: seed-users
           image: ghcr.io/damacus/med-tracker:<image-tag>
           command: ["bundle", "exec", "rails", "db:seed"]
+          env:
+            - name: HOUSEHOLD_SLUG
+              value: <household-slug>
           envFrom:
             - secretRef:
-                name: med-tracker-seed-env
+                name: med-tracker-runtime
           volumeMounts:
-            - name: seed-users-file
+            - name: seed-users
               mountPath: /app/db/seeds/users.yml
               subPath: users.yml
               readOnly: true
       volumes:
-        - name: seed-users-file
+        - name: seed-users
           configMap:
             name: med-tracker-seed-users
 ```
 
----
+Set either `HOUSEHOLD_SLUG` or `HOUSEHOLD_ID`. Without a selector, the seed uses
+the oldest household, which is unsafe when more than one household exists.
 
-## Pattern B: ExternalSecret + ConfigMap
+The invitation step skips an email when its account already exists or the
+selected household already has a pending invitation for it.
 
-Use this when secrets are managed outside the cluster.
+## Verify and clean up
 
-### 1) ExternalSecret (provider-agnostic skeleton)
-
-```yaml
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: med-tracker-seed-env
-  namespace: <namespace>
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: <cluster-secret-store-name>
-    kind: ClusterSecretStore
-  target:
-    name: med-tracker-seed-env
-    creationPolicy: Owner
-  data:
-    - secretKey: APP_URL
-      remoteRef:
-        key: med-tracker/prod/app-url
-    - secretKey: DATABASE_URL
-      remoteRef:
-        key: med-tracker/prod/database-url
-    - secretKey: SMTP_ADDRESS
-      remoteRef:
-        key: med-tracker/prod/smtp-address
-    - secretKey: SMTP_PORT
-      remoteRef:
-        key: med-tracker/prod/smtp-port
-    - secretKey: SMTP_USER_NAME
-      remoteRef:
-        key: med-tracker/prod/smtp-username
-    - secretKey: SMTP_PASSWORD
-      remoteRef:
-        key: med-tracker/prod/smtp-password
-    - secretKey: MAILER_FROM
-      remoteRef:
-        key: med-tracker/prod/mailer-from
-```
-
-### 2) Reuse the same seeding Job
-
-Use the same Job manifest as Pattern A; it references `med-tracker-seed-env` via `envFrom.secretRef`.
-
-### 3) Ordering note
-
-In GitOps, ensure `ExternalSecret` reconciles before the Job runs. If needed:
-
-- Apply ExternalSecret/Kustomization first.
-- Confirm generated Secret exists.
-- Then apply the one-off Job.
-
----
-
-## Verification
-
-```bash
+```shell
 kubectl get jobs -n <namespace>
 kubectl describe job med-tracker-seed-users -n <namespace>
 kubectl logs job/med-tracker-seed-users -n <namespace>
 ```
 
-Expected log patterns include:
+Confirm that each invitation belongs to the selected household and has the
+expected membership role. Check that invitation delivery was queued or sent.
 
-- `Invited <email> as <role>.`
-- `Skipping <email> — account already exists.`
-- `Skipping <email> — pending invitation already exists.`
-- `User seeding complete: X invited, Y skipped.`
-
-Application-level checks:
-
-1. Admin can sign in and access `/admin`.
-2. Invited users received email (or queued delivery observed).
-3. No unexpected duplicate invitations.
-
----
-
-## Cleanup after success
-
-1. Remove/disable the one-off Job manifest from GitOps.
-2. Keep `users.yml` source controlled (or archived) for auditability.
-3. Rotate secrets per normal policy (especially SMTP and DB credentials if temporary).
-
----
-
-## Troubleshooting
-
-| Symptom                                   | Likely cause                                       | Action                                                        |
-|-------------------------------------------|----------------------------------------------------|---------------------------------------------------------------|
-| Job failed immediately                    | Missing env vars (`DATABASE_URL`, `APP_URL`, SMTP) | Check Secret/ExternalSecret values and re-run Job             |
-| Job cannot find `/app/db/seeds/users.yml` | ConfigMap mount path/subPath mismatch              | Verify `mountPath` and `subPath: users.yml`                   |
-| No invites sent                           | `users.yml` malformed or empty                     | Validate YAML structure and role values                       |
-| Users skipped unexpectedly                | Existing account or pending invitation             | Expected idempotent behavior; review logs                     |
-| ExternalSecret present but Secret missing | ESO reconciliation/store auth issue                | Check `kubectl describe externalsecret ...` and operator logs |
-| Mail delivery errors                      | SMTP credentials/network policy issue              | Validate SMTP env + egress/network policies                   |
-
----
-
-## Security notes
-
-- Do not store credentials in ConfigMaps.
-- Keep secrets in Secret/ExternalSecret backends.
-- Restrict Job ServiceAccount/RBAC to minimum required permissions.
-- Prefer short-lived one-off Jobs; remove manifests once complete.
-
----
-
-## Related docs
-
-- Deployment: `docs/deployment.md`
-- User model/roles: `docs/user-management.md`
-- Existing seed file template: `db/seeds/users.yml`
+Remove the one-off Job and its ConfigMap from the GitOps source after the run.
+Keep the invitation list only when your audit policy requires it, and do not
+store personal email addresses in a public repository.


### PR DESCRIPTION
The Kubernetes seeding guide used a field that the application ignores and
listed household roles that invitations reject. It also left multi-household
selection implicit and duplicated an incomplete bootstrap Job in the general
deployment guide.

This update documents the accepted membership roles, an explicit household
selector, and every effect of the production seed command. It keeps one complete
Job example in the seeding runbook and makes the deployment guide point to that
source.
