### PR TITLE
docs(contributing): repair setup entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 ```fish
 git clone https://github.com/damacus/med-tracker.git
 cd med-tracker
-bin/setup-claude   # installs task, gems, npm packages, Python deps, Playwright
 npm install -g portless
 portless trust
 task dev:portless  # start the dev stack at https://med-tracker.localhost
@@ -14,10 +13,9 @@ task dev:seed      # seed the database
 
 Open <https://med-tracker.localhost>.
 
-> **Note**: `bin/setup-claude` handles several environment quirks (Bundler/CGI
-> proxy issue, offline Playwright browsers, blocked `task` installer). If you
-> are setting up in a restricted network or CI environment, run this script
-> rather than installing dependencies manually.
+Install Docker, Task, Node.js, npm, and Git before running these commands. The
+[technical quick start](docs/quick-start.md) explains the local stack and its
+destructive reset command.
 
 ## Development workflow
 
@@ -37,11 +35,11 @@ task docs:serve              # serve docs locally
 ### Testing
 
 - Framework: **RSpec** (`spec/**/*_spec.rb`)
-- System/integration tests: **Capybara** (`spec/features/`, `spec/system/`)
-- Test data: **Rails fixtures** in `spec/fixtures/` and **FactoryBot** in `spec/factories/`
+- Browser tests use **Capybara and Playwright** (`spec/features/`, `spec/system/`)
+- Test data uses **Rails fixtures** in `spec/fixtures/` and **FactoryBot** in `spec/factories/`
 - External HTTP: **VCR** cassettes in `spec/vcr_cassettes/`
 - Test through public APIs only (controller actions, public model methods)
-- Tests document expected business behaviour, not implementation details
+- Tests document expected business behaviour rather than code details
 
 ### Code style
 
@@ -50,7 +48,7 @@ RuboCop enforces the standard configuration (`.rubocop.yml`). Key rules:
 - Guard clauses instead of nested `if/else`
 - Small, single-responsibility methods
 - No nested blocks deeper than 2 levels
-- No inline comments — write self-documenting code with descriptive names
+- Do not change comments unless the task requires it
 - Prefer `Enumerable` methods over imperative loops
 
 #### Naming
@@ -65,12 +63,12 @@ RuboCop enforces the standard configuration (`.rubocop.yml`). Key rules:
 
 ### Architecture
 
-- Domain logic lives on the server; the front end renders server-sent HTML via
+- Domain logic lives on the server. The front end renders server-sent HTML via
   **Hotwire** (Turbo + Stimulus)
-- Views are **Phlex** components under `app/components/` — not ERB
+- Views are **Phlex** components under `app/components/` rather than ERB
 - Complex business logic that doesn't belong in a model or controller goes in a
   **service object** (PORO) under `app/services/`
-- Authorization is handled by **Pundit** — check/update policies when touching
+- Authorization is handled by **Pundit**. Check policies when changing
   access control
 
 ### Commit messages
@@ -86,7 +84,7 @@ test: add coverage for medication take model
 chore: bump Ruby to 4.0.6
 ```
 
-- Each commit is a complete, logical unit of work — tests green before merge
+- Each commit is a complete, logical unit of work with green checks before merge
 - Avoid "initial commit" or "wip" messages
 
 ## Stack reference

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,158 +1,20 @@
-# Docker Setup for MedTracker
+# Docker Development
 
-This project includes Docker Compose configurations for both production and test environments.
+MedTracker uses one `compose.yaml` file and Task wrappers for development,
+tests, tooling, and local production-image checks.
 
-## Prerequisites
+Do not copy old `docker-compose` commands or run Compose services directly.
+Use these current guides instead:
 
-- Docker
-- Docker Compose
-- Rails master key (in `config/master.key` or as environment variable)
+- [Technical quick start](docs/quick-start.md)
+- [Testing](docs/testing.md)
+- [Deployment and local production-image checks](docs/deployment.md)
 
-## Production Environment
+List every supported command with:
 
-The production environment uses PostgreSQL and runs the Rails app in production mode.
-
-### Starting Production
-
-```bash
-# Set your Rails master key
-export RAILS_MASTER_KEY=$(cat config/master.key)
-
-# Start the services
-docker-compose up -d
-
-# View logs
-docker-compose logs -f web
+```fish
+task --list
 ```
 
-The application will be available at <http://localhost>
-
-### Production Services
-
-- **web**: Rails application (port 80)
-- **db**: PostgreSQL database (port 5432)
-
-### Production Commands
-
-```bash
-# Run migrations
-docker-compose exec web bin/rails db:migrate
-
-# Access Rails console
-docker-compose exec web bin/rails console
-
-# Stop services
-docker-compose down
-
-# Stop and remove volumes (WARNING: deletes data)
-docker-compose down -v
-```
-
-## Test Environment
-
-The test environment includes live reloading and is designed for running tests in isolation.
-
-### Starting Test Environment
-
-```bash
-# Start test database and run tests
-docker-compose -f docker-compose.test.yml up
-
-# Run tests in watch mode (requires additional setup)
-docker-compose -f docker-compose.test.yml run --rm test bundle exec rspec
-
-# Run specific test file
-docker-compose -f docker-compose.test.yml run --rm test bundle exec rspec spec/models/user_spec.rb
-```
-
-### Test Services
-
-- **test**: Rails test environment with live code reloading
-- **db_test**: PostgreSQL test database (port 5433)
-
-### Test Commands
-
-```bash
-# Run tests interactively
-docker-compose -f docker-compose.test.yml run --rm test bash
-# Then inside container:
-bundle exec rspec
-
-# Reset test database
-docker-compose -f docker-compose.test.yml run --rm test bin/rails db:test:prepare
-
-# Stop test services
-docker-compose -f docker-compose.test.yml down
-```
-
-## Live Reloading
-
-The test environment mounts your local code directory as a volume, so changes to your code are immediately reflected in the container. This allows for rapid test-driven development:
-
-1. Edit code locally
-2. Run tests in the container
-3. See results immediately
-
-## Database Access
-
-### Production Database
-
-```bash
-# Connect to production database
-docker-compose exec db psql -U medtracker -d medtracker_production
-```
-
-### Test Database
-
-```bash
-# Connect to test database
-docker-compose -f docker-compose.test.yml exec db_test psql -U medtracker_test -d medtracker_test
-```
-
-## Troubleshooting
-
-### Database Connection Issues
-
-If you see database connection errors:
-
-```bash
-# Check database is healthy
-docker-compose ps
-
-# View database logs
-docker-compose logs db
-
-# Restart database
-docker-compose restart db
-```
-
-### Permission Issues
-
-If you encounter permission issues with volumes:
-
-```bash
-# Fix ownership (run from host)
-sudo chown -R $USER:$USER storage/ log/ tmp/
-```
-
-### Clean Slate
-
-To start fresh:
-
-```bash
-# Stop all services and remove volumes
-docker-compose down -v
-docker-compose -f docker-compose.test.yml down -v
-
-# Rebuild images
-docker-compose build --no-cache
-docker-compose -f docker-compose.test.yml build --no-cache
-```
-
-## Notes
-
-- The production Dockerfile is optimized for size and security
-- The test Dockerfile includes development dependencies
-- Both environments use PostgreSQL 16 Alpine for efficiency
-- Volumes persist data between container restarts
-- The test environment uses separate ports to avoid conflicts
+Use `task dev:rebuild` or `task test:rebuild` only when a destructive database
+reset is intended.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ families, and carers. It supports household medication schedules, dose
 recording, stock tracking, reminders, and auditable history.
 
 > [!IMPORTANT]
-> MedTracker is currently in beta. It should supplement—not replace—your
+> MedTracker is currently in beta. It should supplement your
 > existing medication routine. Do not depend on it for clinical decisions,
-> emergency information, or your sole medication reminders.
+> emergency information, or your sole medication reminders, and do not use it
+> as a replacement for established care.
 
 ![MedTracker dashboard showing today's medication schedule, dose status, and stock](docs/screenshots/dashboard-desktop.png)
 
@@ -23,7 +24,7 @@ are running low, and who recorded each action. MedTracker brings that context
 together without handing control of it to a hosted service.
 
 - See today's medication routine for everyone you care for in one place
-- Replace "has anyone given this?" guesswork with a clear dose history
+- Replace uncertainty about a dose with a clear history
 - Spot low stock before it becomes a last-minute problem
 - Coordinate care for children, dependent adults, and other household members
 - Keep an attributable record of who did what and when
@@ -31,9 +32,9 @@ together without handing control of it to a hosted service.
 
 ## Try the self-hosted beta
 
-We are looking for technically confident self-hosters who are willing to deploy
-MedTracker, try the journey from household setup to recording doses, and tell us
-where it is confusing or unreliable.
+We are looking for technically confident self-hosters to run MedTracker and try
+the journey from household setup to recording doses. Tell us where the app is
+confusing or unreliable.
 
 For a private local evaluation:
 
@@ -89,7 +90,7 @@ Key pages:
 - [Glossary](docs/glossary.md)
 - [LLM Context Index (llms.txt)](https://damacus.github.io/med-tracker/llms.txt)
 - [Kubernetes User Seeding](https://damacus.github.io/med-tracker/kubernetes-user-seeding/)
-- [Carer Onboarding: First Dose](https://damacus.github.io/med-tracker/user-onboarding-carer-first-dose/)
+- [Record a First Dose](docs/families/taking-first-dose.md)
 - [Testing](https://damacus.github.io/med-tracker/testing/)
 - [Client Tools](docs/api/client-tools.md)
 - [Design](https://damacus.github.io/med-tracker/design/)
@@ -97,8 +98,7 @@ Key pages:
 
 ### Build docs locally
 
-```bash
-pip install -r requirements.txt
+```fish
 task docs:serve
 ```
 


### PR DESCRIPTION
The contributor entry points sent new users to an agent-specific setup script,
obsolete Docker Compose files, and a missing first-dose page. Those paths no
longer represent the supported development workflow.

This update points contributors at the current Task-based setup and testing
guides. The old Docker guide becomes a short route to the maintained sources,
and the root README now links to the real first-dose walkthrough.
