### PR TITLE
docs(auth): reconcile identity decisions

### DIFF
--- a/docs/adrs/0002-authentication-and-authorization-strategy.md
+++ b/docs/adrs/0002-authentication-and-authorization-strategy.md
@@ -1,114 +1,85 @@
 # ADR 0002: Authentication and Authorization Strategy
 
-- Status: Accepted; six-role hierarchy, role-based policy examples, and obsolete
-  migration status superseded by [ADR 0009](0009-bounded-context-map.md)
+- Status: accepted and partly superseded by [ADR 0009](0009-bounded-context-map.md)
 - Date: 2025-11-27
 
-ADR 0009 supersedes this ADR's six-role authorization hierarchy, role-based
-policy examples, and obsolete migration-status section. The Rodauth
-authentication, deny-by-default Pundit framework, and base PaperTrail audit
-decisions remain accepted.
+ADR 0009 replaced the original global role hierarchy with household membership
+and person access boundaries. This record keeps the accepted identity,
+authorization, and audit decisions.
 
 ## Context
 
-MedTracker requires robust authentication and authorization to protect sensitive medication data. The application serves multiple user roles (administrators, doctors, nurses, carers, parents) with different access levels. UK healthcare compliance (GDPR, DTAC) mandates strong identity verification and audit trails.
+MedTracker must protect medication and health data without treating an account,
+a person, and a household role as the same concept.
 
-Key requirements:
-
-- Role-based access control for 6 user roles
-- Support for email/password and OAuth (Google) authentication
-- Email verification for account security
-- Audit logging of authentication events
-- Future support for two-factor authentication (2FA)
+Authentication must support account verification, recovery, multi-factor
+methods, and optional external identity providers. Authorization must apply the
+active household and person access rules to every request.
 
 ## Decision
 
-### Authentication: Rodauth
+### Rodauth manages account authentication
 
-We adopt **Rodauth** (`rodauth-rails`) as the primary authentication framework, replacing the initial `has_secure_password` implementation.
+Rodauth is the primary web authentication system. `Account` stores the
+authentication identity. `Person` stores demographic information, and `User`
+connects the person to application access.
 
-**Rationale:**
+Rodauth provides:
 
-1. **Feature-complete**: Built-in support for email verification, password reset, remember me, OAuth, and 2FA
-2. **Security-focused**: Designed with security as the primary concern, not bolted on
-3. **PostgreSQL-optimized**: Works excellently with our PostgreSQL-only strategy
-4. **Extensible**: Easy to customize flows without monkey-patching
-5. **Maintained**: Active development with strong security track record
+- verified email and password sign-in;
+- password reset and account recovery;
+- remembered and active session management;
+- TOTP, recovery codes, and passkeys;
+- optional OpenID Connect sign-in through OmniAuth.
 
-**Implementation:**
+The supported flows are documented in
+[Two-factor authentication](../two-factor-authentication.md),
+[Passkey setup](../passkey-setup.md), and
+[OpenID Connect setup](../oidc-setup.md).
 
-- `Account` model for authentication (separate from `Person` for demographics)
-- `rodauth-omniauth` for Google OAuth integration
-- Environment-specific email verification (strict in production, 7-day grace period in development)
-- Legacy `User` model retained during transition period
+### Pundit enforces household and person access
 
-### Authorization: Pundit
+Pundit policies deny access by default. Controllers use policy checks and policy
+scopes for records that belong to a household.
 
-We adopt **Pundit** for authorization with deny-by-default policies.
+Authorization uses:
 
-**Rationale:**
+- one active `HouseholdMembership` with the role `owner`, `administrator`, or
+  `member`;
+- household ownership on tenant records;
+- active person access grants for delegated care;
+- separate record and manage permissions where the workflow needs them.
 
-1. **Simple and explicit**: Plain Ruby objects, easy to test and understand
-2. **Rails conventions**: Follows Rails patterns, integrates cleanly
-3. **Flexible**: Supports complex authorization logic without framework constraints
-4. **Testable**: Policies are easily unit-tested with RSpec
+Professional titles such as doctor or nurse describe a person. They do not
+grant a household role or access to another person's records.
 
-**Implementation:**
+The current model is documented in
+[Manage people and household access](../user-management.md) and
+[ADR 0009](0009-bounded-context-map.md).
 
-- Policy classes for each resource (`UserPolicy`, `PersonPolicy`, `PrescriptionPolicy`, etc.)
-- `ApplicationPolicy` with deny-by-default approach
-- `policy_scope` for data filtering based on user role
-- Comprehensive policy tests using `pundit-matchers`
+### Audit records remain separate from access checks
 
-### Role Hierarchy
+PaperTrail records version history for audited model changes. MedTracker also
+stores append-only audit evidence for security and health-data workflows.
+Neither audit system grants access. Pundit remains the authorization boundary.
 
-| Role          | Access Level                               |
-|---------------|--------------------------------------------|
-| Administrator | Full system access, user management        |
-| Doctor        | All patients, prescriptions, clinical data |
-| Nurse         | All patients, medication recording         |
-| Carer         | Assigned patients only                     |
-| Parent        | Own children only                          |
-| Minor         | Own data only (limited)                    |
-
-### Audit Trail: PaperTrail
-
-We use **PaperTrail** for audit logging of all authentication and data changes.
-
-**Rationale:**
-
-1. **Battle-tested**: Widely used in production healthcare applications
-2. **Compliance**: Meets UK healthcare audit requirements
-3. **Integration**: Works seamlessly with Pundit and Rodauth
+See [Audit trail](../audit-trail.md) for the current evidence model.
 
 ## Consequences
 
-### Positive
+- Authentication identity stays separate from demographic and household data.
+- Household and person access can change without changing the account identity.
+- Policy scopes must be applied consistently to list and record endpoints.
+- External identity providers cannot grant MedTracker data access by themselves.
+- Authentication and data changes produce reviewable audit evidence.
 
-- Strong security foundation for healthcare compliance
-- Clear separation of authentication (Rodauth) and authorization (Pundit)
-- Comprehensive audit trail for regulatory requirements
-- Testable, maintainable authorization logic
-- Future-ready for 2FA and advanced security features
+## Superseded content
 
-### Negative
+The original six global roles, legacy authentication migration phases, and
+links to delivery plans no longer describe MedTracker. Git history keeps
+that earlier decision text.
 
-- Dual authentication systems during migration (legacy + Rodauth)
-- Learning curve for Rodauth's Roda-based DSL
-- Additional complexity in Account/Person/User relationships
+## Related decisions
 
-### Migration Path
-
-1. **Phase 1** (Complete): Pundit authorization framework
-2. **Phase 2** (In Progress): Rodauth foundation installed, login working
-3. **Phase 3** (Pending): Rodauth signup with Person creation
-4. **Phase 4** (Pending): Google OAuth integration
-5. **Phase 5** (Pending): Legacy auth removal, user migration
-
-## Related Documents
-
-- `docs/plans/USER_MANAGEMENT_PLAN.md` - Overall user management strategy
-- `docs/plans/USER_SIGNUP_PLAN.md` - Rodauth signup implementation status
-- `docs/plans/RODAUTH_SIGNUP_IMPLEMENTATION.md` - Detailed implementation plan
-- `docs/plans/USER_SIGNUP_AND_2FA_PLAN.md` - 2FA implementation plan
-- `docs/plans/AUTHORIZATION_COMPLETION_PLAN.md` - Pundit implementation details
+- [External identity provider](0005-external-identity-provider.md)
+- [Bounded context map](0009-bounded-context-map.md)

--- a/docs/adrs/0005-external-identity-provider.md
+++ b/docs/adrs/0005-external-identity-provider.md
@@ -1,99 +1,79 @@
 # ADR 0005: External Identity Provider for Web and Mobile Authentication
 
-- Status: Accepted
+- Status: accepted, with mobile PKCE delivery incomplete
 - Date: 2026-07-02
 
 ## Context
 
-MedTracker already supports web sign-in through Rodauth and an OIDC provider.
-It also exposes `POST /api/v1/auth/login`, which exchanges an email and
-password for internal API access and refresh tokens.
+MedTracker supports local Rodauth sign-in and optional browser sign-in through
+an OpenID Connect provider. It also provides internal API access and refresh
+tokens.
 
-That password-to-token endpoint is acceptable for internal transition work, but
-it should not become the primary authentication model for first-party mobile
-clients. A hosted deployment needs a dedicated identity provider for primary
-authentication, MFA, passkeys, recovery, and OAuth/OIDC client policy.
+A hosted mobile client should not collect a MedTracker password. It needs a
+provider-managed login while MedTracker keeps control of household access, API
+session revocation, and audit evidence.
 
 ## Decision
 
-External IdP owns primary authentication. Zitadel is the preferred provider for
-local and hosted deployments, but the integration remains OIDC-provider
-compatible.
+Hosted deployments can use an external OpenID Connect provider as the primary
+identity service. Zitadel is the preferred provider for MedTracker-operated
+deployments, but the browser integration remains provider-neutral.
 
-The web app remains a Rodauth OIDC client. Rodauth continues to own the browser
-session, account linking, and MedTracker-specific login lifecycle after the
-provider has authenticated the user.
+The web application remains a Rodauth OIDC client. Rodauth owns the browser
+session, account linking, and MedTracker login lifecycle after the provider
+authenticates the person.
 
-First-party mobile clients use Authorization Code with PKCE against the external
-provider; in other words, mobile clients use Authorization Code with PKCE.
-The mobile app must open the system browser or platform authentication session,
-complete the provider-managed login, and return with an authorization code
-through an app link, universal link, or custom scheme registered for that client.
+First-party mobile clients will use the authorization code flow with S256 PKCE
+against the external provider. The mobile client will use the system browser or
+platform authentication session. MedTracker will validate the provider result
+and create an internal API session linked to the eligible account and household
+membership.
 
-MedTracker will exchange external identity for internal API sessions. The API
-will validate the provider result server-side, link it to an internal account,
-and mint MedTracker access and refresh tokens backed by `ApiSession`.
+MedTracker remains responsible for:
 
-## Rationale
+- account and provider-subject linking;
+- household membership and person access;
+- internal access and refresh token rotation;
+- session revocation and lockout checks;
+- privacy-safe audit evidence.
 
-Keeping internal API sessions after external authentication fits the current
-`ApiSession` model and preserves MedTracker-owned revocation, audit logging, and
-token rotation behavior.
+## Current delivery status
 
-Directly accepting provider-issued access tokens at every API endpoint would
-push issuer, audience, scope, and key-rotation checks into the resource-server
-path before the rest of the API is ready for that responsibility.
+The browser authorization code flow is available and is documented in
+[OpenID Connect setup](../oidc-setup.md).
 
-## Implementation Notes
+The mobile API exposes an ID-token exchange, but it does not yet verify the
+relationship between `code_verifier` and an S256 challenge. Issue #1889 tracks
+the missing security contract. Until that issue is complete, clients and API
+documentation must not describe the endpoint as a complete PKCE exchange.
 
-- Register separate OIDC clients for the web app and each mobile platform.
-- Keep redirect URI configuration explicit per client and environment.
-- Require issuer, audience, expiry, nonce, and signature validation before
-  linking or provisioning a MedTracker account.
-- Store the provider subject through `AccountIdentity`; do not key access on an
-  email address alone.
-- Keep role, household, and person authorization in MedTracker policies.
-- Do not log provider tokens, authorization codes, medication data, or health
-  event payloads during the exchange.
+The password-based API login remains available for development, tests, and
+transition clients. Restricting it requires a separate compatibility decision.
 
-## Password Login Deprecation
+## Security requirements
 
-`POST /api/v1/auth/login` is deprecated as a first-party mobile authentication
-entrypoint.
+The completed mobile flow must:
 
-During transition it may remain available for local development, tests, or
-migration-only clients. Production mobile clients should move to external OIDC
-plus internal API session exchange before the endpoint is restricted further or
-removed.
+- register a separate provider client for each mobile platform;
+- use an exact redirect URI for each client and environment;
+- verify issuer, audience, expiry, nonce, signature, and the S256 PKCE
+  relationship;
+- store the provider subject in `AccountIdentity`;
+- keep provider roles separate from MedTracker access policy;
+- exclude tokens, codes, verifiers, and health data from logs and audit fields.
 
 ## Consequences
 
-### Positive
+- Browser and mobile clients can share an identity provider without sharing
+  their client credentials.
+- MedTracker keeps its existing API session and revocation model.
+- Mobile login cannot be declared complete until #1889 is resolved.
+- Local password authentication remains available where the deployment policy
+  permits it.
 
-- Authentication policy, MFA, recovery, and passkeys live in the external IdP.
-- Mobile clients avoid collecting MedTracker passwords directly.
-- MedTracker keeps existing API session revocation and audit behavior.
-- Web and mobile clients share one identity authority.
+## Related documents
 
-### Negative
-
-- Mobile login requires provider client registration and redirect URI handling.
-- The API needs a new exchange endpoint before password login can be removed.
-- Account linking and provisioning rules must be tested carefully.
-
-## Follow-up Work
-
-- Add the mobile identity-to-session exchange endpoint.
-- Register first-party mobile clients and document redirect URI conventions.
-- Add request specs for invalid issuer, audience, expiry, replay, and revoked
-  session behavior.
-- Restrict `POST /api/v1/auth/login` once mobile clients no longer depend on it.
-
-## Related Documents
-
-- `docs/oidc-setup.md`
-- `docs/zitadel-local-testing.md`
-- `docs/adrs/0002-authentication-and-authorization-strategy.md`
-- `app/misc/rodauth_main.rb`
-- `app/models/account_identity.rb`
-- `app/models/api_session.rb`
+- [OpenID Connect setup](../oidc-setup.md)
+- [Test local MedTracker with Zitadel](../zitadel-local-testing.md)
+- [Authentication and authorization](0002-authentication-and-authorization-strategy.md)
+- [External integration architecture](0010-external-integration-architecture.md)


### PR DESCRIPTION
## Summary

The original authentication decision still described six global roles, a
part-finished Rodauth migration, and delivery plans that no longer exist.

This change records the current boundary between accounts, people, household
memberships, and person access grants. It also links to the current user and
security guides.

The external identity decision now separates the accepted mobile design from
its delivery status. It points to issue #1889 instead of presenting the missing
PKCE validation as complete.
