### PR TITLE
docs(operations): separate local and hosted commands

### DIFF
--- a/docs/operations/audit-evidence-runbook.md
+++ b/docs/operations/audit-evidence-runbook.md
@@ -6,14 +6,30 @@ Do not enable WORM delivery until the records manager/DPO has approved the reten
 
 Compliance mode requires a separate records-governance change approval and `AUDIT_WORM_COMPLIANCE_APPROVED=true`.
 
-The capacity record must include peak audited writes per second, p95 insert latency, daily event count, average and p95 ledger/object bytes, index and backup overhead, replication, checkpoint/export overhead, forecast assumptions, safety margin, estimated cost, and the date when the estimate must be reviewed. Do not infer production capacity from the six-thread serialization regression spec.
+The capacity record must include measured write volume and latency. Record the
+daily event count, ledger and object sizes, storage overhead, forecast
+assumptions, safety margin, estimated cost, and review date. Do not infer
+production capacity from the six-thread serialization regression spec.
+
+## Command scope
+
+The repository `task audit:*` commands start a local Docker Compose production
+service. They do not select a deployed database or Kubernetes workload.
+
+For a hosted deployment, schedule the matching `rails audit:*` task in an
+approved verifier Job. Give that Job the dedicated verifier database role and
+the required Object Lock credentials. Confirm its target environment before
+each manual run.
 
 ## Schedule
 
-- Run `SCOPE=database FORMAT=json task audit:verify` as a full daily check.
-- Run `SCOPE=worm FORMAT=json task audit:verify` on a rotating object sample daily and all objects at least monthly.
-- Run `task audit:monitor` at least once per minute.
-- Alert when the oldest pending delivery reaches five minutes; page at one hour.
+- Run `rails audit:verify` with `SCOPE=database` and `FORMAT=json` as a full
+  daily check.
+- Run `rails audit:verify` with `SCOPE=worm` and `FORMAT=json` on a rotating
+  object sample daily and all objects at least monthly.
+- Run `rails audit:monitor` at least once per minute.
+- Alert when the oldest pending delivery reaches five minutes. Page at one
+  hour.
 - Keep command output and alerts free of household, person, medication, event, and source identifiers.
 
 ## Baseline
@@ -55,7 +71,12 @@ time filtering is unchanged.
 
 ## Backlog response
 
-At five minutes, check exporter health, credentials, bucket owner/versioning/Object Lock/encryption, and delivery error codes. At one hour, page incident response. Do not discard rows, reset attempts, weaken retention, overwrite objects, or grant the exporter broader database access. Configuration/integrity failures require human resolution; temporary failures remain pending with bounded retry.
+At five minutes, check exporter health, credentials, bucket owner, versioning,
+Object Lock, encryption, and delivery error codes. At one hour, page incident
+response. Do not discard rows, reset attempts, weaken retention, overwrite
+objects, or grant the exporter broader database access. A person must resolve
+configuration and integrity failures. Temporary failures remain pending with
+bounded retry.
 
 ## Integrity incident
 
@@ -68,7 +89,11 @@ At five minutes, check exporter health, credentials, bucket owner/versioning/Obj
 
 ## Restore and disaster recovery
 
-After restoring PostgreSQL, run full database verification before enabling traffic. Compare every restored chain head and checkpoint with the latest signed WORM evidence. A backup that is internally valid but behind WORM is a restore-divergence incident; replay through an approved recovery process rather than deleting external evidence.
+After restoring PostgreSQL, run full database verification before enabling
+traffic. Compare every restored chain head and checkpoint with the latest
+signed WORM evidence. A backup that is internally valid but behind WORM is a
+restore-divergence incident. Replay through an approved recovery process rather
+than deleting external evidence.
 
 Record backup identifier, database/app version, restore point, verifier version, manifest/checkpoint IDs, result, operator, and incident/change reference. Test restore and divergence handling at least quarterly.
 

--- a/docs/operations/home-ops-portable-storage-handoff.md
+++ b/docs/operations/home-ops-portable-storage-handoff.md
@@ -30,12 +30,12 @@ not authority to alter production.
 
 The deployment value must match the operator workflow exactly:
 
-- `persistent`: Disk steady state.
-- `persistent_with_s3_mirror`: Disk primary, S3 mirror.
+- `persistent` means Disk steady state.
+- `persistent_with_s3_mirror` means Disk primary with an S3 mirror.
 - `s3_with_persistent_mirror`: S3 primary, Disk mirror.
 - `s3`: S3 steady state.
 
-Disk to S3 advances through the list; S3 to Disk moves through it in reverse.
+Disk to S3 advances through the list. S3 to Disk moves through it in reverse.
 Keep both storage systems available throughout either mirror phase and its
 rollback window.
 
@@ -47,7 +47,8 @@ export-expiry, and NHS dm+d work. Then run reconciliation, cutover eligibility,
 and the dry-run cutover command. Apply only with the direction-specific
 confirmation value.
 
-The application tasks are:
+These repository commands start a local Docker Compose production service. Use
+them only for local production-image checks:
 
 ```fish
 task prod:storage-migration-start
@@ -59,6 +60,11 @@ task prod:storage-migration-rollback
 task prod:storage-migration-finalize
 task prod:storage-migration-retirement-eligibility
 ```
+
+Home-Ops must run `rails storage:migration` in an approved Kubernetes Job for a
+deployed migration. Set `STORAGE_MIGRATION_ACTION` and the matching variables
+shown in `Taskfiles/prod.yml`. Confirm the cluster, namespace, workload,
+database, and both storage services before applying a change.
 
 The task input includes source, destination, current phase, run id where
 applicable, explicit gate values, `APPLY=true`, and `CONFIRM=persistent-to-s3`

--- a/docs/operations/upload-storage-backup-and-restore.md
+++ b/docs/operations/upload-storage-backup-and-restore.md
@@ -1,7 +1,7 @@
 # Upload Storage Backup and Restore
 
 Production supports durable Disk and S3-compatible storage. The selected
-backend and any active migration determine the recovery set; S3 is optional.
+backend and any active migration determine the recovery set. S3 is optional.
 
 ## Recovery set
 
@@ -36,6 +36,14 @@ and data-retention decision.
    passes.
 
 ## Isolated restore
+
+The `task prod:verify-storage-restore` command starts a local Docker Compose
+production service. Use it to check a local restored environment. It does not
+select a hosted restore target.
+
+For a deployed isolated restore, run `rails med_tracker:storage:verify_restore`
+inside the restored application Job or pod. Set the same evidence variables and
+confirm the target database and storage service first.
 
 1. Create an isolated database and storage destination with no production
    routes.


### PR DESCRIPTION
## Summary

Several operator guides used repository `task` commands without saying that
those commands start a local Docker Compose service. An operator could mistake
them for commands that target a deployed Kubernetes workload.

This change states the execution boundary in the audit, storage recovery, and
Home-Ops handoff guides. Hosted schedulers and Jobs now use the matching Rails
task inside the approved deployment context.

The guides also tell operators to confirm the target database and storage
services before applying a lifecycle or migration action.
