### PR TITLE
docs(integrations): document optional providers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,6 +86,9 @@ for required settings, database roles, registration policy, and process sizing.
 
 ## External API credentials
 
+See [optional integration configuration](operations/optional-integrations.md)
+for the complete service inventory and privacy boundaries.
+
 ### NHS dm+d medicine search
 
 The medicine search feature requires a system-to-system account

--- a/docs/operations/optional-integrations.md
+++ b/docs/operations/optional-integrations.md
@@ -1,0 +1,113 @@
+# Optional Integration Configuration
+
+MedTracker can call external services for medication search, public guidance,
+AI-assisted form suggestions, and browser identity. Each integration is
+optional. An absent credential must disable or limit that feature without
+blocking normal medication records.
+
+Review the provider's terms, data location, retention, and access controls
+before enabling a service. Store every API key in the deployment secret store.
+
+## NHS dm+d terminology search
+
+Live UK terminology search requires both values:
+
+| Variable | Purpose |
+| --- | --- |
+| `NHS_DMD_CLIENT_ID` | NHS England Terminology Server client ID. |
+| `NHS_DMD_CLIENT_SECRET` | NHS England Terminology Server client secret. |
+
+When either value is absent, live NHS terminology search is unavailable. Local
+catalogues, imported dm+d data, curated results, and eligible Open Food Facts
+lookups can still work.
+
+See [NHS dm+d and medication lookup](../nhs-dmd-integration.md) for account and
+import setup.
+
+## NHS website medicine guidance
+
+Medication detail pages can load public NHS medicine guidance.
+
+| Variable | Purpose |
+| --- | --- |
+| `NHS_WEBSITE_CONTENT_API_KEY` | Subscription key for the NHS Website Content API. |
+
+Without the key, MedTracker records a `not_configured` lookup outcome and shows
+no remote guidance. Successful responses are cached for twelve hours.
+
+The lookup sends a normalized medication name to the NHS service. Confirm that
+this use matches the deployment's privacy and external-service policy.
+
+## Open Food Facts
+
+Open Food Facts does not require an API key. MedTracker identifies its client
+through these optional values:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OPEN_FOOD_FACTS_APP_NAME` | `MedTracker` | Application name in the HTTP user agent. |
+| `OPEN_FOOD_FACTS_APP_VERSION` | `1.0` | Deployed application version in the HTTP user agent. |
+| `OPEN_FOOD_FACTS_CONTACT_EMAIL` | `support@medtracker.app` | Operator contact in the HTTP user agent. |
+
+Self-hosters should replace the contact email with a monitored address. Barcode
+and supplement searches can send the entered query to Open Food Facts even when
+NHS dm+d credentials are absent.
+
+## AI medication suggestions
+
+AI medication help is disabled when no supported provider key is present.
+MedTracker's initializer supports these provider settings:
+
+| Variable | Provider |
+| --- | --- |
+| `OPENAI_API_KEY` | OpenAI |
+| `ANTHROPIC_API_KEY` | Anthropic |
+| `GEMINI_API_KEY` | Google Gemini |
+| `OPENROUTER_API_KEY` | OpenRouter |
+
+Set one provider key and choose a compatible model:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MEDTRACKER_AI_MEDICATION_HELP_MODEL` | locked RubyLLM default | Model identifier passed to `RubyLLM.chat`. |
+
+Set the model explicitly in production so a RubyLLM default change cannot move
+the workload to another model. The chosen model must belong to the configured
+provider.
+
+Azure is not a documented provider yet. Issue
+[#1897](https://github.com/damacus/med-tracker/issues/1897) tracks the mismatch
+between its readiness check and initializer settings.
+
+### Data sent to the model
+
+The assistant receives the medication identity entered for the suggestion. It
+can also receive text fetched from URLs in
+`config/ai_medication_sources.yml`. Those URLs are restricted to configured
+HTTPS domains and paths.
+
+The request contract supplies medication identity rather than person, household,
+account, or dose-history data. Treat user-entered text as potentially sensitive.
+Do not enable the feature until the selected provider is approved to process
+the medication identity and public source text.
+
+MedTracker stores a hash of the requested medication identity with bounded
+result counts for audit. It does not store the prompt or model response in that
+audit record.
+
+## OpenID Connect
+
+Browser OIDC settings are documented in
+[OpenID Connect setup](../oidc-setup.md). The mobile PKCE contract is incomplete
+and tracked by issue [#1889](https://github.com/damacus/med-tracker/issues/1889).
+
+## Verification
+
+Verify one integration at a time with synthetic medication data.
+
+1. Add the credential through the deployment secret store.
+2. Restart the processes that use it.
+3. Exercise one bounded request from a test household.
+4. Confirm the response source and expected fallback behavior.
+5. Review logs and audit evidence for secret or health-data leakage.
+6. Remove test records and rotate any temporary credential.

--- a/docs/operations/production-environment.md
+++ b/docs/operations/production-environment.md
@@ -9,6 +9,8 @@ application origin, database, registration policy, and process sizing.
 
 Notification provider settings are documented in
 [Notification delivery configuration](notification-delivery.md).
+Medication data services, AI help, and OIDC settings are documented in
+[Optional integration configuration](optional-integrations.md).
 
 ## Required settings
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -28,6 +28,7 @@ nav = [
     { "Proposed record lifecycle" = "operations/record-lifecycle.md" },
     { "Production environment" = "operations/production-environment.md" },
     { "Notification delivery" = "operations/notification-delivery.md" },
+    { "Optional integrations" = "operations/optional-integrations.md" },
     { "Application observability" = "operations/application-observability.md" }
   ] },
   { "🩺 For Clinicians" = [


### PR DESCRIPTION
## Summary

MedTracker did not have one current reference for optional medication-data and
AI providers. Operators had to infer which credentials enabled each external
request and what data left the application.

This change documents NHS dm+d, NHS website guidance, Open Food Facts, and the
AI providers that are wired through the RubyLLM initializer.

It also states the external data boundary and links the two code gaps found
during the audit: mobile PKCE in #1889 and Azure AI configuration in #1897.
