### PR TITLE
docs(integrations): clarify current architecture decision

### DIFF
--- a/docs/adrs/0007-external-app-integration-contract.md
+++ b/docs/adrs/0007-external-app-integration-contract.md
@@ -1,170 +1,35 @@
 # ADR 0007: External App Integration Contract
 
-- Status: Superseded by [ADR 0010](0010-external-integration-architecture.md)
-- Date: 2026-07-09
-
-ADR 0010 replaces this decision because SMART on FHIR support shipped after
-this document was written, leaving its deferred and implemented descriptions in
-conflict. This document remains as historical context.
+- Status
+  Superseded by [ADR 0010](0010-external-integration-architecture.md)
+- Date
+  2026-07-09
 
 ## Context
 
-MedTracker now exposes two API surfaces that solve different problems:
+MedTracker needed separate contracts for three types of integration:
 
-- `/api/v1` is the MedTracker product API. It uses portable MedTracker IDs,
-  household-scoped routes, API sessions, API app tokens, sync primitives,
-  backup/export endpoints, household administration, and hosted MCP support.
-- `/api/fhir/R4` is the interoperability API. It exposes FHIR R4 read/search
-  resources for external healthcare systems that expect FHIR resource shapes,
-  `application/fhir+json`, `OperationOutcome`, and searchset Bundles.
+- the MedTracker product API at `/api/v1`;
+- hosted MCP at `/mcp`; and
+- FHIR R4 resources at `/api/fhir/R4`.
 
-Issue #551 originally grouped OAuth API access, pragmatic JSON endpoints, and
-FHIR R4 reads into one handoff plan. Subsequent API work implemented the hosted
-MedTracker API, MCP endpoint, and FHIR R4 read/search baseline, but it did not
-implement a third-party OAuth authorization server or SMART on FHIR app launch
-contract.
+The product API supports MedTracker workflows such as household administration,
+sync, and portable data. The FHIR API supports healthcare applications that
+expect standard FHIR resources and search behaviour. MCP provides read-only
+tools over the MedTracker bearer credential boundary.
 
-Without a written split, first-party clients, automation tools, and external
-healthcare integrations could all be directed at the same endpoint family even
-though they have different identity, consent, payload, and compatibility needs.
+## Original decision
 
-## Decision
+Each audience would use its own API surface. First-party clients would use the
+product API. External healthcare applications would use FHIR. FHIR would not
+become the product synchronisation API.
 
-MedTracker will publish separate contracts by audience:
+## Superseded decision
 
-| Audience | Contract | Primary path |
-| --- | --- | --- |
-| First-party mobile clients | MedTracker hosted API with OIDC-to-API-session exchange, portable IDs, sync, backup/export, and household routes. | `/api/v1` |
-| First-party CLI and local automation | MedTracker hosted API using API sessions or API app tokens, gated by `GET /api/v1/capabilities`. | `/api/v1` |
-| Hosted MCP clients | Streamable HTTP MCP endpoint using the same bearer credentials as `/api/v1`, read-only by design. | `/mcp` |
-| External healthcare apps and provider systems | FHIR R4 read/search resources with standard FHIR HTTP semantics. | `/api/fhir/R4` |
-| Internal/admin tooling | Web UI and explicitly documented MedTracker admin API operations. | Web routes and `/api/v1` admin routes |
+This record was written while SMART on FHIR was being delivered. Later edits
+described SMART as both deferred and available. The record could no longer act
+as one clear source of truth.
 
-External healthcare integrations should use FHIR R4 first. They should not
-depend on MedTracker `/api/v1` payload shapes unless they are also acting as a
-first-party or explicitly trusted MedTracker client.
-
-First-party mobile, CLI, and MCP clients should use `/api/v1` rather than FHIR.
-Those clients need MedTracker-specific workflows such as portable export/import,
-sync batches, tombstones, app tokens, household administration, and capability
-negotiation. FHIR is not the product sync API.
-
-## Authorization Boundary
-
-The current production-ready authorization boundary is MedTracker-owned bearer
-credentials:
-
-- API sessions minted by MedTracker after password login or hosted OIDC
-  exchange.
-- API app tokens created from an authenticated MedTracker profile session.
-- Household membership and person-level grants enforced by existing policies.
-
-For `/api/v1`, the token binds to an account, household, membership, and
-permissions version. The API rejects revoked memberships, locked accounts, stale
-permissions, and cross-household route use. Person-level access continues to be
-derived from MedTracker policy scopes and access grants.
-
-For `/mcp`, the same bearer boundary applies, but the exposed tool surface is
-read-only.
-
-For `/api/fhir/R4`, the current implementation uses the same MedTracker bearer
-boundary and policy scopes. FHIR callers receive only records visible to the
-authenticated household/person access context.
-
-## Scope and Consent Model
-
-MedTracker does not yet expose a third-party OAuth authorization server. It
-therefore does not currently publish external OAuth scopes such as
-`patient/*.read`, `launch`, or `offline_access`.
-
-Until a third-party consent model exists, the implementation scope mapping is:
-
-| Access concept | Current MedTracker source of truth |
-| --- | --- |
-| Household boundary | API session or app-token household binding |
-| Person read access | `PersonPolicy` and active person access grants |
-| Medication read access | medication, schedule, person-medication, and take policies |
-| Admin actions | household manager role plus fresh MFA or OIDC MFA proof |
-| FHIR read access | current policy-scoped FHIR controller queries |
-| Sync/export access | `/api/v1` membership and grant checks |
-
-Consent for external healthcare apps remains deferred. A future third-party
-OAuth or SMART on FHIR implementation must add an explicit consent screen,
-client registration, approved redirect URIs, scopes, token revocation, audit
-events, and tests proving that scope grants cannot bypass household or
-person-level authorization.
-
-## SMART on FHIR
-
-MedTracker supports the SMART App Launch authorization-code flow for registered
-third-party clients. Public clients use PKCE with `S256`; confidential clients
-may use HTTP Basic or posted client credentials. Consent binds the grant to the
-signed-in account's active household membership and person, and FHIR reads must
-pass both the SMART resource scope and the existing policy scope.
-
-The discovery document is available at
-`/api/fhir/R4/.well-known/smart-configuration`. The FHIR `CapabilityStatement`
-advertises the authorization, token, and revocation endpoints. MedTracker does
-not advertise EHR launch because only standalone launch is implemented.
-
-Access tokens expire after 15 minutes. Refresh tokens expire after 30 days and
-rotate on use. Revoking either credential revokes the complete grant. Stored
-credentials are SHA-256 digests; raw authorization codes and tokens are not
-written to security audit metadata.
-
-## Rejected Alternatives
-
-### Use `/api/v1` for all integrations
-
-Rejected. `/api/v1` is optimized for MedTracker workflows, portable IDs, sync,
-and backup semantics. External healthcare systems expect FHIR resource shapes
-and FHIR error/search behavior.
-
-### Use FHIR for first-party mobile sync
-
-Rejected. FHIR read/search resources do not cover MedTracker's product needs
-for batch mutations, tombstones, encrypted portable imports, local sync
-conflicts, household administration, or client capability negotiation.
-
-### Claim SMART on FHIR support now
-
-Rejected. The current FHIR implementation is a read/search resource API behind
-MedTracker bearer authentication. Calling it SMART-capable would overstate the
-authorization, launch, consent, and scope behavior.
-
-## Consequences
-
-### Positive
-
-- Client teams have a clear endpoint choice.
-- FHIR docs and metadata can stay truthful and narrow.
-- First-party clients can keep using MedTracker-specific sync and export
-  features without forcing those concepts into FHIR.
-- SMART on FHIR can be implemented deliberately instead of being implied by the
-  presence of FHIR-shaped resources.
-
-### Negative
-
-- External healthcare apps that require SMART launch cannot integrate until the
-  deferred SMART work is complete.
-- MedTracker must maintain two API documentation surfaces.
-- Future external clients that need both FHIR and MedTracker-specific workflows
-  will need an explicit trust and onboarding decision.
-
-## Follow-up Work
-
-- Issue #551 remains the umbrella for OAuth API and FHIR app/LLM access history.
-- Issue #1534 tracks SMART on FHIR third-party launch, consent, scopes, and
-  discovery before MedTracker advertises SMART support.
-- Issue #1490 tracks first-party CLI and stdio MCP tooling over `/api/v1`.
-- Keep FHIR follow-up work tied to the implemented resource contract rather
-  than first-party sync needs.
-
-## Related Documents
-
-- `docs/adrs/0005-external-identity-provider.md`
-- `docs/mcp.md`
-- `docs/api/openapi.v1.yaml`
-- `app/controllers/api/v1/capabilities_controller.rb`
-- `app/controllers/api/fhir/r4/metadata_controller.rb`
-- GitHub issues #551, #1490, #1527, #1528, #1529, #1530, #1531, and #1534
+[ADR 0010](0010-external-integration-architecture.md) now defines the current
+integration architecture, credential boundaries, and SMART App Launch support.
+Use that decision for all development and operational work.

--- a/docs/adrs/0010-external-integration-architecture.md
+++ b/docs/adrs/0010-external-integration-architecture.md
@@ -1,8 +1,11 @@
 # ADR 0010: External Integration Architecture
 
-- Status: Accepted
-- Date: 2026-07-14
-- Supersedes: [ADR 0007](0007-external-app-integration-contract.md)
+- Status
+  Accepted
+- Date
+  2026-07-14
+- Supersedes
+  [ADR 0007](0007-external-app-integration-contract.md)
 
 ## Context
 
@@ -11,8 +14,8 @@ clients, and external healthcare applications. These clients require different
 payloads, compatibility guarantees, credentials, and consent boundaries.
 
 ADR 0007 established separate product and FHIR surfaces, but it was written
-across the delivery of SMART on FHIR. It consequently describes SMART support
-as both deferred and implemented. The shipped architecture now includes a
+across the delivery of SMART on FHIR. It describes SMART support as both
+deferred and implemented. The current architecture now includes a
 registered-client SMART App Launch flow, so one current decision must replace
 that contradictory record.
 
@@ -95,7 +98,7 @@ without FHIR payloads or raw credentials.
 
 ## Deliberate boundaries
 
-Only the shipped contract is advertised:
+Only the current contract is advertised:
 
 - standalone launch is supported; EHR launch is not supported;
 - read scopes are supported; FHIR write scopes are not supported;
@@ -103,9 +106,9 @@ Only the shipped contract is advertised:
 - bulk-data export is not part of the SMART contract;
 - OpenID Connect identity scopes are not part of the SMART contract; and
 - `/api/v1` credentials do not become SMART grants, and SMART grants do not
-  authorize `/api/v1` product operations.
+  authorise `/api/v1` product operations.
 
-Registered-client onboarding is therefore an explicit trust and operational
+Registered-client onboarding is an explicit trust and operational
 process. Expanding any boundary above requires a new decision or an amendment
 that covers consent, tenant isolation, revocation, audit, and compatibility.
 


### PR DESCRIPTION
## Summary

ADR 0007 described SMART on FHIR as both deferred and available. That made it
unsafe as a source for current integration decisions.

This change replaces ADR 0007 with a short historical record and points readers
to ADR 0010. It also removes stale wording from ADR 0010 while keeping its
current product API, MCP, FHIR, and SMART boundaries unchanged.

The result is one clear integration decision for developers and operators.
