### PR TITLE
docs(architecture): refresh foundation decisions

### DIFF
--- a/docs/adrs/0001-adopt-adr-process-and-apache-license.md
+++ b/docs/adrs/0001-adopt-adr-process-and-apache-license.md
@@ -1,20 +1,27 @@
 # ADR 0001: Adopt ADR practice and Apache-2.0 licensing
 
-- Status: Accepted
-- Date: 2025-11-12
+- Status
+  Accepted
+- Date
+  2025-11-12
 
 ## Context
 
-MedTracker is moving toward UK health-sector compliance and broader open-source adoption. We need a consistent way to record architectural and regulatory decisions so that contributors and deployers can understand why certain approaches were taken. The new compliance plan @docs/uk-regulatory-compliance-plan.md documents a preference for a permissive licence to minimise adoption friction.
+MedTracker needs a consistent record of architectural and regulatory decisions.
+Contributors and deployers must be able to understand why the project chose an
+approach. A permissive licence also makes adoption easier.
 
 ## Decision
 
-1. All significant architectural, regulatory, security, and product decisions will be captured as Architectural Decision Records (ADRs) stored under `docs/adrs/` using sequential numbering.
-2. The project will use the Apache License 2.0 as its governing licence. A repository-level `LICENSE` and `NOTICE` file will be added to formalise this decision, and future documentation (e.g., README, deployment guides) will reference the licence accordingly.
+1. Record architectural, regulatory, security, and product decisions as ADRs
+   under `docs/adrs/`. Use sequential numbers.
+2. Use the Apache License 2.0 as the project licence. Keep the repository-level
+   `LICENSE` and `NOTICE` files as the public source.
 
 ## Consequences
 
-- Contributors must document future impactful decisions via ADRs to maintain a clear audit trail.
-- We must add supporting licence artefacts (`LICENSE`, `NOTICE`) and update public documentation to reference Apache-2.0.
+- Contributors must use ADRs for decisions that change project architecture,
+  regulation, security, or product boundaries.
+- Public documentation must refer to the `LICENSE` and `NOTICE` files.
 - The permissive licence should encourage NHS trusts, carers, and third parties to adopt MedTracker without legal barriers, while still requiring attribution through the NOTICE file.
 - ADR numbering and format become part of the contribution guidelines and review checklist going forward.

--- a/docs/adrs/0003-ui-component-library.md
+++ b/docs/adrs/0003-ui-component-library.md
@@ -1,147 +1,58 @@
 # ADR 0003: UI Component Library
 
-- Status: Accepted
-- Date: 2025-11-27
+- Status
+  Accepted
+- Date
+  2025-11-27
 
 ## Context
 
-MedTracker needs a consistent, accessible, and maintainable UI. The application serves healthcare users who may have varying technical abilities and accessibility needs. UK healthcare compliance (WCAG 2.1 AA) requires accessible interfaces.
-
-Key requirements:
-
-- Consistent design language across all views
-- Accessibility compliance (WCAG 2.1 AA)
-- Server-side rendering for performance and SEO
-- Type-safe, testable components
-- Modern, responsive design
-- Minimal JavaScript dependencies
+MedTracker needs consistent, accessible views that work well on desktop and
+mobile. The project also needs server-rendered HTML, reusable components, and a
+small client-side JavaScript surface.
 
 ## Decision
 
-### View Layer: Phlex
+Use this view stack:
 
-We adopt **Phlex** (`phlex-rails`) as the primary view layer, replacing ERB templates.
+- **Phlex Rails** for object-oriented views written in Ruby;
+- **Tailwind CSS** for utility classes and shared design tokens;
+- **RubyUI** for generated Phlex components that become part of this
+  repository; and
+- **Hotwire** for navigation, partial updates, and small Stimulus controllers.
 
-**Rationale:**
+Application views live under `app/components/`. Generated and adapted RubyUI
+components live under `app/components/ruby_ui/`. Their Stimulus controllers
+live under `app/javascript/controllers/ruby_ui/`.
 
-1. **Type-safe**: Ruby classes with compile-time checking, reducing runtime errors
-2. **Composable**: Components are plain Ruby objects, easily composed and tested
-3. **Performance**: Faster than ERB due to optimized rendering
-4. **Testable**: Components can be unit-tested in isolation
-5. **No context switching**: Write views in Ruby, not a template language
+RubyUI uses a copy-and-change model. The generated component code is local
+application code, so MedTracker owns its accessibility, maintenance, and
+upgrade checks. Use `docs/ruby-ui-comparison.md` to compare selected local
+component families with the locked gem.
 
-**Implementation:**
+Views must meet the current accessibility rules in
+[`docs/accessibility.md`](../accessibility.md). Prefer an existing RubyUI
+component before adding another UI primitive.
 
-- `Components::Base` class inheriting from `Phlex::HTML`
-- All views as Phlex components under `app/components/`
-- Organized by domain: `admin/`, `dashboard/`, `people/`, `prescriptions/`, etc.
+## Component rules
 
-### Styling: Tailwind CSS
-
-We adopt **Tailwind CSS** (`tailwindcss-rails`) for styling.
-
-**Rationale:**
-
-1. **Utility-first**: Rapid development without context switching to CSS files
-2. **Consistent**: Design tokens enforce consistency
-3. **Responsive**: Built-in responsive utilities
-4. **Accessible**: Focus states, screen reader utilities included
-5. **Rails integration**: First-class Rails support via `tailwindcss-rails`
-
-**Supporting tools:**
-
-- `tailwind_merge` - Intelligent class merging for component variants
-
-### Component Library: RubyUI
-
-We adopt **RubyUI** as our component library, providing pre-built accessible components.
-
-**Rationale:**
-
-1. **Phlex-native**: Built specifically for Phlex, not a wrapper
-2. **Accessible**: WCAG 2.1 AA compliant out of the box
-3. **Tailwind-based**: Uses Tailwind for styling, matches our stack
-4. **Comprehensive**: Buttons, forms, dialogs, tables, navigation, etc.
-5. **Customizable**: Easy to extend and theme
-
-**Components used:**
-
-- `Button` - Primary actions with variants (primary, secondary, destructive)
-- `Card` - Content containers
-- `Table` - Data display with sorting
-- `Dialog` - Modal dialogs for confirmations
-- `Form` - Form inputs with validation states
-- `Badge` - Status indicators
-- `Alert` - Notifications and messages
-
-### Frontend Interactivity: Hotwire
-
-We use **Hotwire** (Turbo + Stimulus) for interactivity.
-
-**Rationale:**
-
-1. **Server-first**: Minimal JavaScript, server renders HTML
-2. **Progressive enhancement**: Works without JavaScript
-3. **Rails default**: First-class Rails support
-4. **Simple**: No build step, no complex state management
-
-**Implementation:**
-
-- Turbo Drive for navigation
-- Turbo Frames for partial page updates
-- Turbo Streams for real-time updates
-- Stimulus for JavaScript sprinkles (dialogs, form validation)
-
-## Component Architecture
-
-```text
-app/components/
-├── base.rb                    # Base class with RubyUI, helpers
-├── admin/                     # Admin-specific components
-│   ├── dashboard/
-│   └── users/
-├── dashboard/                 # Main dashboard components
-├── layouts/                   # Layout components (navigation, etc.)
-├── people/                    # Person management components
-├── prescriptions/             # Prescription components
-├── person_medicines/          # OTC medicine components
-└── ruby_ui/                   # RubyUI component overrides
-```
-
-### Component Guidelines
-
-1. **Single responsibility**: One component, one purpose
-2. **Props over slots**: Prefer explicit props for data
-3. **Composition**: Build complex UIs from simple components
-4. **Testing**: Every component has a corresponding spec
-5. **Accessibility**: All interactive elements have proper ARIA attributes
+- Keep components focused on rendering and interaction.
+- Pass prepared data into components. Do not query the database from a view.
+- Compose larger views from smaller components.
+- Use semantic HTML and accessible names, states, errors, and focus behaviour.
+- Use Turbo for server updates and Stimulus only for browser behaviour that
+  HTML cannot provide alone.
 
 ## Consequences
 
-### Positive
+- The UI has one server-rendered component model.
+- Shared components provide consistent structure and styling.
+- Local RubyUI copies can drift from the locked gem and need explicit review.
+- Complex browser interactions may need a small MedTracker Stimulus controller.
 
-- Type-safe views catch errors at development time
-- Consistent UI through shared components
-- Accessible by default with RubyUI
-- Fast server-side rendering
-- Easy to test components in isolation
-- Minimal JavaScript reduces complexity
+## Related documents
 
-### Negative
-
-- Learning curve for Phlex syntax
-- Fewer community resources compared to ERB
-- RubyUI is newer, smaller ecosystem than React/Vue component libraries
-- Some complex interactions may require custom Stimulus controllers
-
-### Trade-offs Accepted
-
-- **No SPA**: We accept page reloads for simplicity over SPA complexity
-- **Limited animations**: Prefer functional over flashy
-- **Server rendering**: Accept slightly higher server load for simpler architecture
-
-## Related Documents
-
-- `app/components/base.rb` - Base component class
-- `app/components/ruby_ui/` - RubyUI component customizations
-- `.windsurf/rules/code-style-and-architecture.md` - Code style guidelines
+- [Accessibility guidelines](../accessibility.md)
+- [RubyUI comparison workflow](../ruby-ui-comparison.md)
+- [`app/components/base.rb`](../../app/components/base.rb)
+- [`app/components/ruby_ui/`](../../app/components/ruby_ui/)


### PR DESCRIPTION
## Summary

The first architecture records still described an old component layout and
made claims about Phlex and RubyUI that no longer matched the repository.

This change keeps the Apache licence and ADR decisions, but states them in
plain language. It also updates the UI decision to describe the current Phlex,
Tailwind, RubyUI, and Hotwire boundaries, including MedTracker's ownership of
generated RubyUI code.

Contributors now have one accurate starting point for view architecture and
RubyUI drift checks.
