### PR TITLE
docs(contributing): simplify reference guidance

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -8,13 +8,13 @@ preserving attributable history inside a household authorization boundary.
 
 ## Architecture
 
-- Backend: Ruby on Rails
-- Frontend: Hotwire (Turbo and Stimulus) with Phlex components
-- Authentication: Rodauth accounts with password, generic OIDC, passkeys, and
-  household-bound API credentials
-- Authorization: household memberships plus person-scoped access grants
-- Database: PostgreSQL in development, test, and production
-- Audit trail: PaperTrail change history plus security and compliance evidence
+- The backend uses Ruby on Rails.
+- The frontend uses Hotwire (Turbo and Stimulus) with Phlex components.
+- Authentication uses Rodauth accounts with password, generic OIDC, passkeys,
+  and household-bound API credentials.
+- Authorisation uses household memberships plus person-scoped access grants.
+- PostgreSQL stores development, test, and production data.
+- PaperTrail change history supports security and compliance evidence.
 
 MedTracker is a modular monolith. Domain logic is enforced on the server. UI
 forms and pages render server-sent HTML and use Turbo Streams for updates.
@@ -103,7 +103,7 @@ coordinates relationship-owned access. Deactivating an account-backed self
 relationship leaves its standalone grant active. Accountless delegation,
 including self delegation, has no access records, so revocation only deactivates
 the description. Person-scoped authority comes from active grants; medication
-and inventory policies additionally recognize household `owner` and
+and inventory policies also recognise household `owner` and
 `administrator` governance and the narrow creator-owned, unlinked medication
 exception.
 

--- a/docs/mail-setup.md
+++ b/docs/mail-setup.md
@@ -36,7 +36,7 @@ Store credentials in the deployment's secret manager. Do not commit them.
 ## Local development
 
 The development stack routes outgoing messages to its Mailpit service
-automatically; no local SMTP variables are required. Start MedTracker with:
+automatically. Local SMTP variables are not required. Start MedTracker with:
 
 ```fish
 task dev:portless

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -213,9 +213,9 @@ curl -sS "$MEDTRACKER_URL/mcp" \
   --data '{"jsonrpc":"2.0","id":5,"method":"prompts/list","params":{}}' | jq
 ```
 
-In an MCP client, ask for bounded, review-oriented work, for example:
+In an MCP client, ask for bounded, review-oriented work such as:
 
-- "Use MedTracker to summarize today's medication schedule."
+- "Use MedTracker to list today's medication schedule."
 - "Use MedTracker to list low-stock or out-of-stock medicines."
 - "Use the `medtracker_household_review` prompt to prepare a caregiver review."
 
@@ -228,7 +228,7 @@ In an MCP client, ask for bounded, review-oriented work, for example:
 | `JSON-RPC body must be a single request object` | Send one JSON-RPC request object per HTTP request. Batch arrays are rejected. |
 | The client cannot see tools | Check `/api/v1/capabilities`, then list tools with the direct `curl` command to separate client configuration problems from server problems. |
 | The client still sends an old or empty token | Restart the client after changing environment variables. For VS Code, update the stored input value or reset the MCP server. |
-| A token worked before but now fails | The token may have been revoked, the account may be locked, or the household membership may no longer be active. Create a new API app token from the profile page after resolving the account state. |
+| A token worked before but now fails | Check whether the token was revoked or the account was locked. Also check that the household membership remains active. Create a new API app token from the profile page after resolving the account state. |
 
 ## Security boundary
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -67,7 +67,9 @@ If you encounter database issues or want to start fresh:
 ```fish
 task dev:rebuild
 ```
-*Warning: This removes all data and recreates the database.*
+**Warning**
+
+This command removes all data and recreates the database.
 
 ### Database migrations
 To apply new database changes without a full rebuild:

--- a/docs/ruby-ui-comparison.md
+++ b/docs/ruby-ui-comparison.md
@@ -8,7 +8,7 @@ task ruby-ui:compare COMPONENTS="Button Dialog"
 task ruby-ui:compare COMPONENTS="Button Dialog" OUTPUT=/private/tmp/ruby-ui-compare
 ```
 
-The task accepts named component families only. It runs the locked RubyUI
+The task accepts selected component families only. It runs the locked RubyUI
 generator in a fresh external copy with dependency installation disabled, then
 reports unchanged, changed, missing locally, and local-only Ruby and JavaScript
 files for those families. Dependency declarations from RubyUI's own metadata


### PR DESCRIPTION
## Summary

Several contributor references used dense or unclear wording around local mail,
MCP troubleshooting, database resets, RubyUI comparison, and the architecture
overview.

This change makes those instructions direct while keeping their commands and
runtime contracts unchanged. The destructive database warning is now visible
before its consequence, and MCP token failures are split into practical checks.

Contributors can follow these guides without decoding formal prose.
