### PR TITLE
docs(compliance): clarify evidence boundaries

### DIFF
--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -9,11 +9,17 @@ MedTracker records two audit sources:
 
 Both sources use the same versioned envelope. It identifies the event, outcome, time, household, affected entity, actor account/user/membership, active role, permissions version, authentication method, opaque session reference, request and trace identifiers, IP address, Pundit policy/query, support session, source row, redacted metadata, and retention decision. Secrets, bearer tokens, cookies, passwords, OIDC tokens, and raw session identifiers are not permitted in the envelope.
 
-The web and API controllers establish and clear the request context explicitly. Background work is identified as system activity; it is not represented as user-authorized activity.
+The web and API controllers establish and clear the request context explicitly.
+Background work is identified as system activity. It is not represented as
+user-authorised activity.
 
 ## Integrity boundary
 
-PostgreSQL `SECURITY DEFINER` triggers append both source tables to `audit_ledger_entries` in the same transaction. Each household has an independent chain; events without a household use the global chain. Every entry binds the chain epoch, sequence, previous hash, canonical envelope, source payload, hash/schema versions, and retention decision into a SHA-256 hash.
+PostgreSQL `SECURITY DEFINER` triggers append both source tables to
+`audit_ledger_entries` in the same transaction. Each household has an
+independent chain. Events without a household use the global chain. Every entry
+binds the chain epoch, sequence, previous hash, canonical envelope, source
+payload, hash/schema versions, and retention decision into a SHA-256 hash.
 
 The runtime application role can insert source events but cannot update or delete source or ledger rows. Household administrators read a tenant-filtered view. The audit exporter and verifier use separate database roles and credentials:
 
@@ -28,7 +34,9 @@ The medication-take deletion step is a validated `SECURITY DEFINER` maintenance
 boundary for the existing shared login; it does not provide credential isolation or
 a general medication-history bypass.
 
-- `med_tracker_audit_exporter` reads ledger/checkpoint data, signs checkpoints through a one-way database function, and updates delivery receipts. It cannot read source or clinical tables or modify ledger history.
+- `med_tracker_audit_exporter` reads ledger and checkpoint data and signs
+  checkpoints through a one-way database function. It also updates delivery
+  receipts. It cannot read source or clinical tables or modify ledger history.
 - `med_tracker_audit_verifier` is read-only. It needs complete visibility of
   both audit sources and ledger evidence, but no clinical-table access or
   authority to alter source, ledger, checkpoint, or delivery rows. It checks
@@ -36,7 +44,10 @@ a general medication-history bypass.
   visibility or isolation is insufficient, verification fails as a
   configuration error rather than reporting valid evidence.
 
-Database-owner access remains a break-glass capability. PostgreSQL cannot independently audit a malicious database owner who controls the database and its logs. Every owner-level audit-table operation therefore requires an incident or approved change record in a separate system.
+Database-owner access remains a break-glass capability. PostgreSQL cannot
+independently audit a malicious database owner who controls the database and
+its logs. Every owner-level audit-table operation requires an incident or
+approved change record in a separate system.
 
 ## Existing history
 
@@ -55,7 +66,10 @@ The exporter writes one deterministic, content-addressed JSON object per ledger 
 
 Temporary storage failures leave the transactional outbox pending for retry. Configuration, checksum, duplicate-version, and retention failures stop automatic retry and require operator action. The web process has no signing key or WORM credential.
 
-Governance mode is the default. `COMPLIANCE` mode requires `AUDIT_WORM_COMPLIANCE_APPROVED=true` after records-governance approval because its retention cannot be shortened. Object Lock configuration and permission validation is repeated while the exporter runs.
+Governance mode is the default. `COMPLIANCE` mode requires
+`AUDIT_WORM_COMPLIANCE_APPROVED=true` after records-governance approval because
+its retention cannot be shortened. The exporter checks Object Lock settings and
+permissions each time it runs.
 
 ## Verification
 
@@ -90,7 +104,13 @@ Run:
 task audit:export
 ```
 
-Set `OUTPUT`, optional `HOUSEHOLD_ID`, `FROM`, `TO`, and `FHIR=true` as required. The export contains deterministic native NDJSON and a signed manifest. `FHIR=true` also writes a FHIR R4 `Bundle` of `AuditEvent` resources. The native envelope remains authoritative for integrity; FHIR is an interoperability representation. FHIR defines AuditEvent as a security log and advises servers not to support update/delete because that compromises audit integrity: <https://hl7.org/fhir/R4/auditevent.html>.
+Set `OUTPUT`, optional `HOUSEHOLD_ID`, `FROM`, `TO`, and `FHIR=true` as
+required. The export contains deterministic native NDJSON and a signed
+manifest. `FHIR=true` also writes a FHIR R4 `Bundle` of `AuditEvent` resources.
+The native envelope remains authoritative for integrity. FHIR provides an
+interoperability representation. FHIR defines AuditEvent as a security log and
+advises servers not to support update or delete because that compromises audit
+integrity: <https://hl7.org/fhir/R4/auditevent.html>.
 
 Creating an export is itself written to `security_audit_events` without recording output paths or clinical content.
 
@@ -103,11 +123,19 @@ verification output, and operator.
 
 ## Retention
 
-Retention policy `clinical-security-v1` applies a ten-year default floor to clinical/security audit evidence. A related record schedule, legal hold, inquiry, litigation requirement, or approved local policy may require longer retention. This is a floor, not a universal claim that every record must be destroyed after ten years or kept forever.
+Retention policy `clinical-security-v1` applies a ten-year default floor to
+clinical and security audit evidence. A related record schedule, legal hold,
+inquiry, litigation requirement, or approved local policy may require longer
+retention. The floor does not require destruction after ten years or retention
+forever.
 
 Reaching `retain_until` makes evidence eligible for records-governance review. MedTracker does not automatically destroy expired audit evidence. A future governed disposal process must verify eligibility and legal holds and create an immutable destruction manifest.
 
-The policy must be approved by the deploying organisation's records manager and DPO before production retention is locked. NHS records guidance applies different schedules to different records, requires appraisal at the end of the minimum period, and warns against unjustified continued retention: <https://transform.england.nhs.uk/media/documents/NHSX_Records_Management_CoP_V7.pdf>.
+The deploying organisation's records manager and Data Protection Officer must
+approve the policy before production retention is locked. NHS records guidance
+applies different schedules to different records. It requires appraisal at the
+end of the minimum period and warns against unjustified continued retention:
+<https://transform.england.nhs.uk/media/documents/NHSX_Records_Management_CoP_V7.pdf>.
 
 ## Limits
 

--- a/docs/compliance/audit-retention-policy.md
+++ b/docs/compliance/audit-retention-policy.md
@@ -8,11 +8,15 @@ Status: technical default awaiting deployment-specific records-manager and DPO a
 
 The default minimum retention period for clinical/security audit evidence is ten years from the recorded event. Evidence inherits a longer period when the related clinical record, contract, statutory inquiry, litigation requirement, or approved local schedule requires it.
 
-Every ledger envelope stores the policy version and calculated `retain_until`. Later policy changes create a new version; they do not rewrite past decisions.
+Every ledger envelope stores the policy version and calculated `retain_until`.
+Later policy changes create a new version. They do not rewrite past decisions.
 
 ## End-of-period review
 
-`retain_until` means eligible for review, not automatic deletion. The reviewer must confirm the governing record category, current law/policy, open incidents, inquiries, litigation, complaints, and legal holds. Continued retention needs a reason and review date.
+`retain_until` means eligible for review, not automatic deletion. The reviewer
+must confirm the governing record category and current law or policy. The
+review must also cover open incidents, inquiries, litigation, complaints, and
+legal holds. Continued retention needs a reason and review date.
 
 No automated disposal is enabled. A future disposal workflow must produce an immutable manifest identifying the approved scope, policy, approvers, time, and resulting Object Lock/database disposition.
 
@@ -22,10 +26,11 @@ When a hold is issued:
 
 1. Record its authority, scope, owner, start date, and review date in the organisation's records system.
 2. Stop disposal for every matching chain/export.
-3. Extend Object Lock retention where required; never shorten existing retention.
+3. Extend Object Lock retention where required. Never shorten existing retention.
 4. Record the change/incident reference in the signed evidence manifest.
 5. Require records-manager or legal approval to release the hold.
 
-Database-owner changes made to implement a hold require a separate external change record.
+Database-owner changes made to apply a hold require a separate external change
+record.
 
 Reference: [NHS Records Management Code of Practice 2021](https://transform.england.nhs.uk/media/documents/NHSX_Records_Management_CoP_V7.pdf).

--- a/docs/compliance/dcb0129-audit-evidence.md
+++ b/docs/compliance/dcb0129-audit-evidence.md
@@ -12,6 +12,8 @@ This record supplies technical evidence for the clinical safety case. It does no
 | Pre-migration evidence is treated as trustworthy | Incorrect historical assurance | `legacy-baseline` epoch and signed baseline limitation | Reviewers must preserve the label in reports |
 | Audit failure blocks or silently loses clinical work | Missed medication workflow or missing evidence | Local ledger is synchronous/fail-closed; WORM delivery is asynchronous and monitored | Capacity and failure-mode review before launch |
 
-The Clinical Safety Officer must link these controls to the hazard log, verify operating evidence, and assess new failure modes from storage, signing-key, and verifier dependencies.
+The Clinical Safety Officer must link these controls to the hazard log and
+verify operating evidence. The review must assess new failure modes from
+storage, signing-key, and verifier dependencies.
 
 NHS England is reviewing DCB0129 and DCB0160. The safety case owner must track the replacement/revised standard and update this evidence: <https://digital.nhs.uk/data-and-information/information-standards/governance/latest-activity/standards-and-collections/review-of-digital-clinical-safety-standards-dcb0129-and-dcb0160>.

--- a/docs/compliance/dpia-audit-evidence.md
+++ b/docs/compliance/dpia-audit-evidence.md
@@ -1,10 +1,15 @@
 # DPIA Addendum: Audit Evidence
 
-This addendum is an input to a deployment DPIA, not a completed DPIA or legal approval.
+This addendum supplies technical evidence for a deployment Data Protection
+Impact Assessment (DPIA). The deploying organisation must complete and approve
+its own DPIA.
 
 ## Processing
 
-The audit envelope processes identifiers, roles, authorization decisions, request context, IP addresses, affected-record identifiers, and redacted event metadata. Native exports can contain historical source payloads and therefore require the same or stronger protection as the underlying health data.
+The audit envelope processes identifiers, roles, authorization decisions,
+request context, IP addresses, affected-record identifiers, and redacted event
+metadata. Native exports can contain historical source payloads and require the
+same or stronger protection as the underlying health data.
 
 ## Purpose and necessity
 
@@ -19,8 +24,12 @@ The purposes are patient-safety investigation, security monitoring, access accou
 | History is changed or deleted | Immutable runtime grants, chained hashes, signed checkpoints, Object Lock copies | Database-owner activity needs external oversight |
 | Excessive retention | Versioned schedule and `retain_until`; no indefinite claim | Records manager/DPO approve production policy |
 | Existing history is overstated | Distinct `legacy-baseline` epoch and explicit limitation | Preserve baseline wording in reports |
-| Export creates another PHI copy | Signed manifest, audited export, controlled output path | Deployment must define transfer and deletion handling |
+| Export creates another health-data copy | Signed manifest and audited export to a controlled output path | Deployment must define transfer and deletion handling |
 
 ## Required approval
 
-The deploying controller must document lawful basis, access roles, retention schedule, WORM provider/region, international transfers, data-subject handling, processor terms, incident contacts, and records-manager/DPO approval before production use.
+The deploying organisation must document its lawful basis and access roles. It
+must also document the retention schedule, WORM provider and region,
+international transfers, data-subject handling, processor terms, incident
+contacts, and records-manager and Data Protection Officer approval before
+production use.


### PR DESCRIPTION
## Summary

The audit documents mixed technical guarantees with legal and clinical-safety
language. Some wording also assumed that every deployer is a data controller.

This change states the audit ledger, retention, DCB0129, and DPIA boundaries in
plain language. It replaces US health-data terminology and makes deployment
approval the responsibility of the deploying organisation.

The audit commands, evidence format, retention floor, and technical controls
remain unchanged.
