### PR TITLE
docs(operations): clarify validation procedures

### DIFF
--- a/docs/pre-0-5-database-upgrade.md
+++ b/docs/pre-0-5-database-upgrade.md
@@ -171,10 +171,10 @@ Evidence that was omitted before this repair was not protected before repair.
 Integrity is established from the new repair checkpoint onward.
 
 Before accepting the repaired audit evidence, operators must sign and export
-both checkpoints, drain pending delivery records, and rerun database, WORM,
-and combined verification. Record the deployment version, migration time,
-checkpoint, key, manifest, and object identifiers, verification output, and
-operator in an external change or incident record.
+both checkpoints. They must also drain pending delivery records and rerun the
+database, WORM, and combined verification. Record the deployment version,
+migration time, checkpoint, key, manifest, and object identifiers. Include the
+verification output and operator in an external change or incident record.
 
 Verify the account access bootstrap:
 
@@ -228,8 +228,12 @@ backfills legacy rows, then restores forced RLS before it completes.
 This avoids the emergency-only workaround of granting `BYPASSRLS` to the
 migration role.
 
-If users can sign in but the app redirects to login, reports that their account
-is deactivated, or shows "You are not authorized to perform this action" for
-every account after a failed cutover, check the account access bootstrap queries
-above before changing account statuses. That symptom usually means the deployed
-app cannot see an active household membership for the signing-in account.
+After a failed cutover, users might see one of these symptoms:
+
+- the app redirects them to the login page;
+- the app reports that their account is deactivated;
+- every account gets a "You are not authorized to perform this action" message.
+
+Check the account access bootstrap queries above before changing account
+statuses. These symptoms usually mean the deployed app cannot see an active
+household membership for the signing-in account.

--- a/docs/pwa-web-push-test-plan.md
+++ b/docs/pwa-web-push-test-plan.md
@@ -1,4 +1,7 @@
-# PWA Web Push Test Plan
+# Validate PWA web push
+
+Use this procedure to check Web Push on a private test deployment. Do not use
+real medication or person data.
 
 ## Browsers
 
@@ -9,14 +12,15 @@
 
 ## Setup
 
-1. Sign in to a test household with at least one active person, one active schedule, and one stocked medication with a reorder threshold.
+1. Sign in to a test household that has an active person and schedule. The
+   household also needs a stocked medication with a reorder threshold.
 2. Open profile notification settings.
 3. Confirm the browser reports push support, then enable notifications.
 4. Send a test notification and confirm the notification opens or focuses Med Tracker.
 5. Disable notifications for the browser and confirm the current browser subscription is removed.
 6. Re-enable notifications before continuing.
 
-## Dose-Due Reminder
+## Dose-due reminder
 
 1. Set a schedule time a few minutes in the future.
 2. Confirm dose-due notifications are enabled.
@@ -24,7 +28,7 @@
 4. Confirm one notification appears.
 5. Record the dose before a later schedule time and confirm the later dose-due notification is suppressed.
 
-## Missed-Dose Reminder
+## Missed-dose reminder
 
 1. Confirm missed-dose notifications are enabled.
 2. Set a schedule time a few minutes in the future.
@@ -33,7 +37,7 @@
 5. Confirm repeating the job for the same scheduled occurrence does not send another notification.
 6. Record a take inside the expected window for a new scheduled occurrence and confirm no missed-dose notification is sent.
 
-## Low-Stock Reminder
+## Low-stock reminder
 
 1. Confirm low-stock notifications are enabled.
 2. Set medication stock just above the reorder threshold.
@@ -42,7 +46,7 @@
 5. Confirm repeating the job for the same stock event does not send another notification.
 6. Restock the medication above the threshold, cross the threshold again, and confirm a new notification can be sent.
 
-## Privacy And Preference Checks
+## Privacy and preference checks
 
 1. Confirm visible notification text does not include person name, medication name, or dose details for missed-dose and low-stock notifications.
 2. Disable missed-dose notifications and confirm overdue doses do not send push notifications.


### PR DESCRIPTION
## Summary

The database upgrade guide now separates repair steps from the symptoms that
operators might see after a failed cutover. The Web Push document is now a
direct validation procedure and warns readers to use private test data.

This makes both procedures easier to follow during an upgrade or notification
check.
