### PR TITLE
docs(openspec): clarify active contracts

### DIFF
--- a/openspec/changes/support-portable-production-storage/specs/portable-production-storage/spec.md
+++ b/openspec/changes/support-portable-production-storage/specs/portable-production-storage/spec.md
@@ -55,7 +55,7 @@ Every production job input that must survive beyond its originating request SHAL
 
 #### Scenario: S3-backed worker has no blob mount
 - **GIVEN** production selects S3-compatible storage and a worker has no persistent blob mount
-- **WHEN** it analyzes or purges an attachment, expires an export, or processes an NHS dm+d archive
+- **WHEN** it handles a stored attachment, export, or NHS dm+d archive
 - **THEN** it resolves the durable reference through the selected S3-compatible service
 
 ### Requirement: Migration is bidirectional, resumable, and idempotent
@@ -153,7 +153,7 @@ The production recovery contract SHALL coordinate PostgreSQL records with every 
 ### Requirement: Deployment topology matches the selected backend
 The deployment SHALL make the selected backend available to every process that performs storage work. Disk mode MUST NOT claim filesystem-independent scheduling unless those processes share the same durable filesystem. S3-compatible mode MUST support web and worker processes that are scheduled independently and have no shared blob mount.
 
-#### Scenario: Disk topology is declared honestly
+#### Scenario: Disk topology states its limits
 - **GIVEN** production selects Disk
 - **WHEN** deployment compatibility is evaluated
 - **THEN** each storage-dependent process is colocated with or mounted to the same durable root and no independent-scheduling claim is made without demonstrated shared access
@@ -164,7 +164,8 @@ The deployment SHALL make the selected backend available to every process that p
 - **THEN** both access the same private bucket without sharing a node-mounted blob filesystem
 
 ### Requirement: Development and test remain isolated
-Development and test SHALL continue to use environment-local Disk services and MUST NOT require production S3 credentials, production mounted storage, or access to hosted buckets.
+Development and test SHALL continue to use environment-local Disk services.
+They MUST NOT require production S3 credentials or access to production storage.
 
 #### Scenario: Test execution is isolated
 - **GIVEN** the automated test environment has no production storage credentials or mount

--- a/openspec/changes/weekly-canary-demo-reset/specs/canary-demo-reset/spec.md
+++ b/openspec/changes/weekly-canary-demo-reset/specs/canary-demo-reset/spec.md
@@ -5,7 +5,9 @@ Defines a disposable, production-data-free canary environment that returns to a 
 ## ADDED Requirements
 
 ### Requirement: Demo mode is explicit and visible
-The application SHALL enable disposable demo behavior only when explicitly configured for demo mode. While demo mode is enabled, authenticated users SHALL be told that the environment contains synthetic data and resets every Sunday at 04:15 Europe/London.
+The application SHALL enable disposable demo behavior only when explicitly
+configured for demo mode. Authenticated demo users SHALL see that the environment
+contains synthetic data and resets every Sunday at 04:15 Europe/London.
 
 #### Scenario: User visits the demo environment
 - **GIVEN** application demo mode is enabled
@@ -43,7 +45,7 @@ The reset operation SHALL require independent explicit confirmation that applica
 - **THEN** the reset is permitted to proceed
 
 #### Scenario: Production-like target is rejected
-- **GIVEN** the database host, application URL, Active Storage service, required disk root, required S3 endpoint, required S3 bucket, or environment marker does not identify the expected canary environment
+- **GIVEN** a configured database, application, storage, or environment target does not identify the expected canary environment
 - **WHEN** an operator invokes the reset
 - **THEN** the operation exits unsuccessfully before deleting database records or uploaded files
 - **AND** the failure output contains target categories and safe identifiers but no credentials, health data, subscription endpoints, or file contents

--- a/openspec/specs/api-mutation-idempotency/spec.md
+++ b/openspec/specs/api-mutation-idempotency/spec.md
@@ -5,7 +5,12 @@ Defines serialization and atomic replay behavior for concurrent idempotent API m
 ## Requirements
 
 ### Requirement: Matching concurrent mutations execute once
-The system SHALL serialize authenticated mutating API requests before controller mutation when they have the same routed household, authenticated account scope, request path, HTTP method, and `Idempotency-Key`. After the first request commits, every matching waiter SHALL replay its stored status and body with `Idempotency-Replayed: true` without executing the mutation again.
+The system SHALL serialize authenticated mutating API requests before controller
+mutation when their request identity matches. This identity contains the routed
+household and authenticated account scope. It also contains the request path,
+HTTP method, and `Idempotency-Key`. After the first request commits, every
+matching waiter SHALL replay its stored status and body with
+`Idempotency-Replayed: true` without executing the mutation again.
 
 #### Scenario: Concurrent People creates converge
 - **GIVEN** two database connections submit the same valid People create for the same household and authenticated account with the same path, method, key, and request digest
@@ -58,7 +63,11 @@ The system SHALL replay a stored response only when the authenticated account sc
 - **AND** neither request can observe the other household's response or health data
 
 ### Requirement: Failed attempts do not poison an idempotency key
-The system SHALL release transaction-scoped serialization on commit, rollback, database disconnect, or raised exception. Responses below HTTP 500 MAY be stored as completed outcomes under the existing response policy; HTTP 500 responses and raised exceptions SHALL NOT store a completed response and SHALL leave the key retryable.
+The system SHALL release transaction-scoped serialization on commit, rollback,
+database disconnect, or raised exception. Responses below HTTP 500 MAY be stored
+as completed outcomes under the existing response policy. HTTP 500 responses
+and raised exceptions SHALL NOT store a completed response and SHALL leave the
+key retryable.
 
 #### Scenario: A deterministic client error is replayed
 - **GIVEN** a keyed mutation completes with a deterministic HTTP 4xx response that is eligible for storage

--- a/openspec/specs/dmd-import-reliability/spec.md
+++ b/openspec/specs/dmd-import-reliability/spec.md
@@ -51,7 +51,7 @@ Production and canary deployments SHALL execute DM+D imports in a dedicated job 
 
 #### Scenario: Import worker exceeds its memory limit
 - **GIVEN** a DM+D import is executing in the dedicated worker
-- **WHEN** that worker is terminated or restarted because it exceeds its memory limit
+- **WHEN** that worker is stopped or restarted because it exceeds its memory limit
 - **THEN** the web process remains available and does not restart because of the worker failure
 - **AND** stale-import reconciliation can move the interrupted import to a failed state
 
@@ -101,32 +101,3 @@ The canary acceptance environment SHALL preserve durable application archive beh
 - **WHEN** operational acceptance captures evidence
 - **THEN** the record distinguishes persisted administration data from notification-event and delivery evidence
 - **AND** failures retain PHI-safe logs and traces for a separately owned follow-up rather than being silently attributed to DM+D import behavior
-
-### Requirement: Delivery is agent-orchestrated and independently reviewed
-The MedTracker-owned change SHALL be delivered through a coordinating parent agent that retains architecture, cross-repository scope, repository ownership, stacked-branch lineage, integration, and final verification authority. The parent SHALL implement the production capability across both the MedTracker application repository and its deployment repository while preserving each repository's local instructions, code ownership, commits, and pull-request lineage. Each bounded implementation task SHALL be assigned to a fresh subagent with explicit acceptance criteria and SHALL receive an independent task review before the next task begins.
-
-#### Scenario: Production delivery crosses the repository boundary
-- **GIVEN** the MedTracker capability requires both application behavior and deployment topology to ship
-- **WHEN** the coordinating agent applies this change
-- **THEN** this MedTracker OpenSpec change remains the single planning authority and progress ledger
-- **AND** application work is committed in the MedTracker repository
-- **AND** deployment work is committed in the deployment repository under that repository's own instructions
-- **AND** MedTracker artifacts do not encode deployment-repository filesystem or manifest paths
-
-#### Scenario: Bounded task is dispatched
-- **GIVEN** a task has explicit scope, owned files, constraints, acceptance evidence, and escalation conditions
-- **WHEN** the coordinating agent dispatches implementation
-- **THEN** the selected subagent receives a task-specific brief and writes a durable report with changed files, verification, and concerns
-- **AND** the coordinating agent records reviewed completion in the progress ledger
-
-#### Scenario: Task introduces cross-cutting risk
-- **GIVEN** a task exposes concurrency, deployment-control, destructive-state, public-contract, or stack-lineage ambiguity
-- **WHEN** the implementing or reviewing subagent reports that ambiguity
-- **THEN** the coordinating agent retains or resumes judgment using the highest necessary reasoning tier
-- **AND** no parallel implementation task proceeds until the decision and affected task briefs are updated
-
-#### Scenario: Task implementation is complete
-- **GIVEN** an implementing subagent reports a bounded task complete
-- **WHEN** the task diff and verification evidence are available
-- **THEN** an independent reviewer evaluates specification compliance and task quality against the task brief
-- **AND** critical or important findings are corrected and re-reviewed before another implementation task begins


### PR DESCRIPTION
## Summary

The active OpenSpec contracts now use direct language for idempotency, storage,
canary safety, and DM+D worker failure. They keep the same product requirements
while making long conditions easier to check.

The canonical DM+D specification also no longer treats agent workflow as a
product capability. Delivery process belongs in a task plan, not in the lasting
system contract.
