### PR TITLE
fix(turbo): remove stale update templates

### DIFF
--- a/app/views/people/update.turbo_stream.erb
+++ b/app/views/people/update.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace dom_id(@person) do %>
-  <%= render "person", person: @person %>
-<% end %>

--- a/app/views/schedules/update.turbo_stream.erb
+++ b/app/views/schedules/update.turbo_stream.erb
@@ -1,5 +1,0 @@
-<%= turbo_stream.remove "modal" %>
-<%= turbo_stream.replace dom_id(@person) do %>
-  <%= render @person %>
-<% end %>
-<%= turbo_stream.update "flash", Components::Layouts::Flash.new(notice: flash[:notice], alert: flash[:alert]) %>

--- a/spec/helpers/tenant_dom_targets_helper_spec.rb
+++ b/spec/helpers/tenant_dom_targets_helper_spec.rb
@@ -15,10 +15,19 @@ RSpec.describe TenantDomTargetsHelper do
 
   it 'prefixes DOM ids with household identity inside household context' do
     household = Household.create!(name: 'DOM Household', slug: 'dom-household')
+    other_household = Household.create!(name: 'Other DOM Household', slug: 'other-dom-household')
     person = build(:person, id: 123, household: household)
     Current.household = household
 
-    expect(helper.tenant_dom_id(person)).to eq("household_#{household.id}_person_123")
+    household_target = helper.tenant_dom_id(person)
+    Current.household = other_household
+    other_household_target = helper.tenant_dom_id(person)
+
+    expect(household_target).to eq("household_#{household.id}_person_123")
+    expect(other_household_target).to eq("household_#{other_household.id}_person_123")
+    expect(other_household_target).not_to eq(household_target)
+
+    Current.household = household
     expect(helper.tenant_dom_target('people')).to eq("household_#{household.id}_people")
   end
 end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -313,6 +313,25 @@ RSpec.describe 'People' do
   describe 'PATCH /people/:id with turbo_stream format' do
     before { sign_in(users(:admin)) }
 
+    it 'targets the household-qualified containers rendered on the current pages' do
+      person = people(:john)
+      card_target = household_target("person_#{person.id}")
+      show_target = household_target("person_show_#{person.id}")
+
+      get people_path
+      expect(response.body).to include(%(id="#{card_target}"))
+
+      get person_path(person)
+      expect(response.body).to include(%(id="#{show_target}"))
+
+      patch person_path(person),
+            params: { person: { name: 'Household Target Name' } },
+            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response.body).to include(%(target="#{card_target}"))
+      expect(response.body).to include(%(target="#{show_target}"))
+    end
+
     it 'returns turbo_stream and updates card, show container, and flash on success' do
       person = people(:john)
 

--- a/spec/requests/schedules_spec.rb
+++ b/spec/requests/schedules_spec.rb
@@ -105,6 +105,45 @@ RSpec.describe 'Schedules' do
       expect(response).to redirect_to(person_path(schedule.person))
       expect(schedule.reload.frequency).to eq('Twice daily')
     end
+
+    it 'replaces the household-qualified person container for a Turbo request' do
+      schedule = schedules(:john_paracetamol)
+      target = household_dom_target("person_show_#{schedule.person.id}")
+
+      get person_path(schedule.person)
+      expect(response.body).to include(%(id="#{target}"))
+
+      patch person_schedule_path(schedule.person, schedule),
+            params: { schedule: { frequency: 'Three times daily' } },
+            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      expect(response.body).to include(%(target="#{target}"))
+      expect(response.body).to include('target="modal"')
+      expect(response.body).to include('target="flash"')
+    end
+
+    it 'rejects a schedule from another household without exposing its target' do
+      foreign_household = create(:household, name: 'Foreign Schedule Household')
+      foreign_person = create(:person, household: foreign_household)
+      foreign_medication = create(:medication, household: foreign_household)
+      foreign_schedule = create(
+        :schedule,
+        household: foreign_household,
+        person: foreign_person,
+        medication: foreign_medication,
+        frequency: 'Foreign frequency'
+      )
+
+      patch person_schedule_path(foreign_person, foreign_schedule),
+            params: { schedule: { frequency: 'Leaked update' } },
+            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:not_found)
+      expect(foreign_schedule.reload.frequency).to eq('Foreign frequency')
+      expect(response.body).not_to include("person_show_#{foreign_person.id}")
+    end
   end
 
   describe 'PATCH /people/:person_id/schedules/:id/pause' do


### PR DESCRIPTION
## Summary

The household tenancy work already moved live person and schedule updates to household-qualified Turbo targets, but the old unqualified ERB templates remained in the repository.

This removes those unreachable templates and adds public request coverage that ties each Turbo response target to the container rendered for the active household. It also proves that foreign-household schedules cannot be updated or exposed through the response.

Closes #1900