### PR TITLE
fix(security): prevent DOM-based XSS in controllers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Vulnerability:** DOM-based Stored XSS in `app/javascript/controllers/schedule_form_controller.js`. User-controlled dosage properties were interpolated directly into a string mapped to an HTML payload which was then directly assigned to `element.innerHTML`, executing malicious inputs.
 **Learning:** Raw Javascript template literals injected into `.innerHTML` are dangerous. Even if the expected value is alphanumeric (like unit amounts), it must be treated as untrusted and safely escaped. When writing custom escape methods, ensure quotes (`"` and `'`) are covered so attribute injection attacks are also prevented.
 **Prevention:** Use a robust `escapeHtml` function that replaces `&, <, >, ", '` with their entity equivalents. Apply escaping strictly to the output context (HTML strings) while using raw values for logical internal state comparisons to avoid breaking app functionality.
+
+## 2026-10-10 - Fix DOM-based Stored XSS
+
+**Vulnerability:** DOM-based Stored XSS in `app/javascript/controllers/offline_shell_controller.js`, `app/javascript/controllers/medication_search_controller.js`, and `app/javascript/controllers/global_search_controller.js`. User-controlled properties were escaped using `document.createTextNode` combined with `.innerHTML`, which fails to escape quotes (`"` and `'`), leading to potential attribute injection attacks.
+**Learning:** `document.createTextNode` escapes `<`, `>`, and `&`, but not quotes (`"` or `'`). If an attribute value contains a quote (e.g. `data-source-type="${this.escape(sourceType)}"`), an attacker can inject malicious attributes like `onmouseover="alert(1)"`.
+**Prevention:** Use a robust `escape` or `escapeHtml` function that replaces `&, <, >, ", '` with their entity equivalents using regex `.replace()` instead of relying on `document.createTextNode` and `.innerHTML` to perform the escaping.

--- a/app/javascript/controllers/global_search_controller.js
+++ b/app/javascript/controllers/global_search_controller.js
@@ -342,9 +342,12 @@ export default class extends Controller {
   }
 
   escapeHtml(value) {
-    const div = document.createElement("div")
-    div.appendChild(document.createTextNode(String(value || "")))
-    return div.innerHTML
+    return String(value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;")
   }
 
   hrefAttribute(url) {

--- a/app/javascript/controllers/medication_search_controller.js
+++ b/app/javascript/controllers/medication_search_controller.js
@@ -534,9 +534,12 @@ export default class extends Controller {
   }
 
   escapeHtml(str) {
-    const div = document.createElement('div')
-    div.appendChild(document.createTextNode(String(str || '')))
-    return div.innerHTML
+    return String(str || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;")
   }
 
   hrefAttribute(url) {

--- a/app/javascript/controllers/offline_shell_controller.js
+++ b/app/javascript/controllers/offline_shell_controller.js
@@ -264,8 +264,11 @@ export default class extends Controller {
   }
 
   escape(value) {
-    const div = document.createElement("div")
-    div.appendChild(document.createTextNode(String(value ?? "")))
-    return div.innerHTML
+    return String(value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;")
   }
 }


### PR DESCRIPTION
## 🚨 Severity
CRITICAL

## 💡 Vulnerability
DOM-based Stored XSS via Attribute Injection. The `escapeHtml` (and `escape`) functions in `app/javascript/controllers/offline_shell_controller.js`, `app/javascript/controllers/medication_search_controller.js`, and `app/javascript/controllers/global_search_controller.js` were using `document.createTextNode` and `.innerHTML` to escape untrusted user input before rendering it to the DOM. This DOM-based escaping approach converts `<`, `>`, and `&` to their HTML entities, but critically fails to escape single (`'`) or double (`"`) quotes. As a result, when these "escaped" strings are placed inside HTML attributes in JavaScript template literals (e.g. `data-source-type="${this.escape(sourceType)}"`), an attacker can inject a quote to break out of the attribute and append malicious event handlers like `onmouseover="alert(1)"`.

## 🎯 Impact
If a malicious user manages to save a medication name, dosage unit, person name, or search query containing a crafted payload (e.g., `test" onmouseover="alert(document.cookie)`), any user viewing the Offline Dashboard, Medication Search Results, or Global Search Results could have arbitrary JavaScript executed in their browser session. This could lead to session hijacking, unauthorized actions on behalf of the victim, or exposure of highly sensitive PHI (Personal Health Information).

## 🔧 Fix
Replaced the `document.createTextNode` logic in all three Stimulus controllers with a robust standard `.replace()` regex chain that explicitly targets and escapes `&`, `<`, `>`, `"`, and `'`. This ensures that even if user input is injected inside an HTML attribute, quotes are converted to `&quot;` or `&#039;`, making it impossible to break out of the attribute context.

## ✅ Verification
- The changes have been verified manually through code review to ensure the regexes apply the correct HTML entity replacements.
- `node -c` syntax validation on the modified JS controllers successfully passes.
- Documented the vulnerability pattern and mitigation in `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [4726911551311391901](https://jules.google.com/task/4726911551311391901) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->