### PR TITLE
🎨 Palette: [UX improvement] Fix aria-label for remove from batch button

### DIFF
--- a/app/components/medications/stock_check_view.rb
+++ b/app/components/medications/stock_check_view.rb
@@ -408,12 +408,12 @@ module Components
             variant: :outlined,
             size: :sm,
             class: 'size-10 p-0 text-on-surface-variant',
-            aria_label: t('medications.stock_check.remove_from_batch', medication: medication.display_name),
+            "aria-label": t('medications.stock_check.remove_from_batch', medication: medication.display_name),
             data: {
               action: 'stock-check#removeFromBatch',
               stock_check_id_param: medication.id
             }
-          ) { render Icons::Trash.new(size: 16) }
+          ) { render Icons::Trash.new(size: 16, aria_hidden: 'true') }
         end
       end
 

--- a/app/components/medications/stock_check_view.rb
+++ b/app/components/medications/stock_check_view.rb
@@ -408,7 +408,7 @@ module Components
             variant: :outlined,
             size: :sm,
             class: 'size-10 p-0 text-on-surface-variant',
-            "aria-label": t('medications.stock_check.remove_from_batch', medication: medication.display_name),
+            'aria-label': t('medications.stock_check.remove_from_batch', medication: medication.display_name),
             data: {
               action: 'stock-check#removeFromBatch',
               stock_check_id_param: medication.id

--- a/app/components/medications/stock_check_view.rb
+++ b/app/components/medications/stock_check_view.rb
@@ -408,7 +408,7 @@ module Components
             variant: :outlined,
             size: :sm,
             class: 'size-10 p-0 text-on-surface-variant',
-            'aria-label': t('medications.stock_check.remove_from_batch', medication: medication.display_name),
+            'aria-label' => t('medications.stock_check.remove_from_batch', medication: medication.display_name),
             data: {
               action: 'stock-check#removeFromBatch',
               stock_check_id_param: medication.id


### PR DESCRIPTION
💡 What: Changed the `aria_label` attribute to `"aria-label":` on the "remove from batch" `m3_button` in the `Medications::StockCheckView` component, and added `aria_hidden: 'true'` to its nested Trash icon.
🎯 Why: Component builders like `m3_button` might not automatically convert symbol keys like `aria_label` to the hyphenated HTML attribute `aria-label`. This causes the button to lack a proper accessible name, and the screen reader to improperly announce it or announce the nested SVG. Explicitly using the string key `"aria-label":` guarantees it will render correctly.
📸 Before/After: N/A - pure HTML attribute change.
♿ Accessibility: Ensures the "remove from batch" icon-only button is properly announced by screen readers with the correct localized string, and prevents redundant announcements of the internal trash icon.

---
*PR created automatically by Jules for task [18126580251473754377](https://jules.google.com/task/18126580251473754377) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->