### PR TITLE
fix(solid-queue): configure supervisor pid file

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.solid_queue.supervisor_pidfile = '/tmp/solid-queue-supervisor.pid'
 
   # Raise delivery errors in production so failures surface in logs/APM
   config.action_mailer.raise_delivery_errors = true

--- a/spec/config/solid_queue_runtime_spec.rb
+++ b/spec/config/solid_queue_runtime_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe SolidQueueRuntime do
     expect(deploy_config.dig('env', 'clear', 'SOLID_QUEUE_SUPERVISOR_MODE')).to eq('async')
   end
 
+  it 'configures the supervisor PID file for production monitoring' do
+    expect(production_config).to include("config.solid_queue.supervisor_pidfile = '/tmp/solid-queue-supervisor.pid'")
+  end
+
   it 'includes the Async runtime dependency' do
     expect(gemfile).to include("gem 'async', '>= 2.24'")
   end
@@ -65,6 +69,10 @@ RSpec.describe SolidQueueRuntime do
 
   def puma_config
     Rails.root.join('config/puma.rb').read
+  end
+
+  def production_config
+    Rails.root.join('config/environments/production.rb').read
   end
 
   def deploy_config


### PR DESCRIPTION
## Summary

- configure Solid Queue to write its supervisor PID to `/tmp/solid-queue-supervisor.pid` in production
- add a focused regression spec for the production setting
- keep Kubernetes probe changes for the follow-up home-ops change

## Verification

- `task test:preflight` — passed
- `task test TEST_FILE=spec/config/solid_queue_runtime_spec.rb` — 9 examples, 0 failures
- `task rubocop` — 1,779 files inspected, no offences
- `git diff --check` — passed

## Risks / follow-ups

The worker probe still needs to be changed in `home-ops` to consume this PID file without booting Rails. The focused test emits an existing Rodauth warning, but the suite passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/med-tracker/pull/1971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->